### PR TITLE
Don't use hostPort or hostNetwork

### DIFF
--- a/app/manifests/metrics/10-node-exporter-ds.yml
+++ b/app/manifests/metrics/10-node-exporter-ds.yml
@@ -25,7 +25,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      hostNetwork: true
       hostPID: true
       containers:
       - name: node-exporter
@@ -39,7 +38,6 @@ spec:
         ports:
           - name: metrics
             containerPort: 9100
-            hostPort: 9100
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
There is no need to use a hostPort or the hostNetwork; avoiding hostPort allocation improves compatibility with other cluster monitoring and avoiding hostNetwork ensures public-facing clusters don't have an exploitable ports.