### PR TITLE
Don't retry metrics on 404 status code

### DIFF
--- a/src/main/routes/metrics.ts
+++ b/src/main/routes/metrics.ts
@@ -37,7 +37,7 @@ class MetricsRoute extends LensApi {
           ...queryParams
         }
       }).catch(async (error) => {
-        if (attempt < maxAttempts) {
+        if (attempt < maxAttempts && (error.statusCode && error.statusCode != 404)) {
           await new Promise(resolve => setTimeout(resolve, attempt * 1000)); // add delay before repeating request
           return loadMetrics(query);
         }


### PR DESCRIPTION
Don't retry If prometheus does not exist.