### PR TITLE
Support kubernetes.io/role label for node roles

### DIFF
--- a/dashboard/client/api/endpoints/nodes.api.ts
+++ b/dashboard/client/api/endpoints/nodes.api.ts
@@ -109,6 +109,11 @@ export class Node extends KubeObject {
     const roleLabels = Object.keys(this.metadata.labels).filter(key =>
       key.includes("node-role.kubernetes.io")
     ).map(key => key.match(/([^/]+$)/)[0]) // all after last slash
+
+    if (this.metadata.labels["kubernetes.io/role"] != undefined) {
+      roleLabels.push(this.metadata.labels["kubernetes.io/role"])
+    }
+
     return roleLabels.join(", ")
   }
 


### PR DESCRIPTION
This PR add the `kubernetes.io/role` value to the list of role labels.

It is supported since Kubernetes v1.13: https://github.com/kubernetes/kubernetes/pull/70950/files#diff-b4a72fe3ed6cdf7ddeb21f633c87c875R34