### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "email": "info@lakendlabs.com"
   },
   "copyright": "© 2020, Lakend Labs, Inc.",
+  "license": "MIT",
   "description": "The Kubernetes IDE",
   "version": "3.1.0-beta.1",
   "main": "main.ts",


### PR DESCRIPTION
This is a small change, but I noticed when running `make build`, whenever yarn installs or runs, it gives an error about there not being a license in the package.json.

```
$ yarn install --frozen-lockfile
yarn install v1.22.4
warning package.json: No license field
warning kontena-lens@0.0.0: No license field
[1/4] Resolving packages...
```