### PR TITLE
Change terminal fit-to-window icon

### DIFF
--- a/dashboard/client/components/dock/dock.tsx
+++ b/dashboard/client/components/dock/dock.tsx
@@ -133,7 +133,7 @@ export class Dock extends React.Component<Props> {
             {hasTabs() && (
               <>
                 <Icon
-                  material="aspect_ratio"
+                  material={fullSize ? "fullscreen_exit": "fullscreen"}
                   tooltip={fullSize ? <Trans>Exit full size mode</Trans> : <Trans>Fit to window</Trans>}
                   onClick={toggleFillSize}
                 />


### PR DESCRIPTION
Previously:
![image](https://user-images.githubusercontent.com/1446224/77844175-cdd7b180-71ac-11ea-9014-6c75ecbd56c3.png)

Now:
![image](https://user-images.githubusercontent.com/1446224/77844181-e21bae80-71ac-11ea-8c6e-4d8c93432909.png)


