### PR TITLE
Release v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "The Kubernetes IDE",
-  "version": "3.1.0-rc.1",
+  "version": "3.1.0",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.3"
   },
   "engines": {
-    "node": ">=0.12 <0.13"
+    "node": ">=12.0 <13.0"
   },
   "build": {
     "afterSign": "build/notarize.js",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,9 +2,9 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.1.0-rc.1 (current version)
+## 3.1.0 (current version)
 
-- Windows pod shell (powershel)
+- Windows pod shell (powershell)
 - Simplified internal architecture (improves watch & metrics stability)
 - New icon
 - Support `kubernetes.io/role` label for node roles


### PR DESCRIPTION
## Changes since v3.1.0-rc.1
*none*

## Changes since v3.0.x
- Windows pod shell (powershell)
- Simplified internal architecture (improves watch & metrics stability)
- New icon
- Support `kubernetes.io/role` label for node roles
- Unlink binary download on error properly
- Electron v6.1.9