### PR TITLE
Fix Helm chart version comparison

### DIFF
--- a/dashboard/client/components/+apps-helm-charts/helm-chart.store.ts
+++ b/dashboard/client/components/+apps-helm-charts/helm-chart.store.ts
@@ -3,6 +3,7 @@ import { autobind } from "../../utils";
 import { HelmChart, helmChartsApi } from "../../api/endpoints/helm-charts.api";
 import { ItemStore } from "../../item.store";
 import flatten from "lodash/flatten"
+import compareVersions from 'compare-versions';
 
 export interface IChartVersion {
   repo: string;
@@ -23,11 +24,7 @@ export class HelmChartStore extends ItemStore<HelmChart> {
 
   protected sortVersions = (versions: IChartVersion[]) => {
     return versions.sort((first, second) => {
-      const firstVersion = first.version.replace(/[^\d.]/g, "").split(".").map(Number);
-      const secondVersion = second.version.replace(/[^\d.]/g, "").split(".").map(Number);
-      return firstVersion.every((version, index) => {
-        return version > secondVersion[index];
-      }) ? -1 : 0;
+      return compareVersions(second.version, first.version)
     });
   };
 

--- a/dashboard/client/components/dock/upgrade-chart.tsx
+++ b/dashboard/client/components/dock/upgrade-chart.tsx
@@ -106,8 +106,7 @@ export class UpgradeChart extends React.Component<Props> {
           themeName="outlined"
           value={version}
           options={versions}
-          formatOptionLabel={this.formatVersionLabel}
-          isOptionDisabled={({ value }: SelectOption<IChartVersion>) => value.version === currentVersion}
+          formatOptionLabel={this.formatVersionLabel}          
           onChange={({ value }: SelectOption) => this.version = value}
         />
       </div>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "chalk": "^2.4.2",
+    "compare-versions": "^3.6.0",
     "compression": "^1.7.4",
     "cookie-session": "^1.3.3",
     "cors": "^2.8.5",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -3245,6 +3245,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
This PR uses [`compare-versions`](https://www.npmjs.com/package/compare-versions) npm package to compare Helm chart versions. Also, current version is not disabled anymore when upgrading a release. This way user can switch a release to use chart from other repository.

Fixes #145 