### PR TITLE
Render colors in logs

### DIFF
--- a/dashboard/client/components/+workloads-pods/pod-logs-dialog.tsx
+++ b/dashboard/client/components/+workloads-pods/pod-logs-dialog.tsx
@@ -12,6 +12,8 @@ import { Icon } from "../icon";
 import { Select, SelectOption } from "../select";
 import { Spinner } from "../spinner";
 import { cssNames, downloadFile, interval } from "../../utils";
+import { default as AnsiUp } from "ansi_up";
+import DOMPurify from "dompurify"
 
 interface IPodLogsDialogData {
   pod: Pod;
@@ -44,6 +46,7 @@ export class PodLogsDialog extends React.Component<Props> {
   private containers: IPodContainer[] = []
   private initContainers: IPodContainer[] = []
   private lastLineIsShown = true; // used for proper auto-scroll content after refresh
+  private colorConverter = new AnsiUp();
 
   @observable logs = ""; // latest downloaded logs for pod
   @observable newLogs = ""; // new logs since dialog is open
@@ -242,11 +245,11 @@ export class PodLogsDialog extends React.Component<Props> {
     }
     return (
       <>
-        {logs}
+        <div dangerouslySetInnerHTML={{ __html:  DOMPurify.sanitize(this.colorConverter.ansi_to_html(logs))}} />
         {newLogs && (
           <>
             <p className="new-logs-sep" title={_i18n._(t`New logs since opening the dialog`)}/>
-            {newLogs}
+            <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(this.colorConverter.ansi_to_html(newLogs))}} />
           </>
         )}
       </>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -75,6 +75,7 @@
     "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.39.8",
     "ace-builds": "^1.4.7",
+    "ansi_up": "^4.0.4",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-macros": "^2.6.1",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2208,6 +2208,11 @@ ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
+ansi_up@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/ansi_up/-/ansi_up-4.0.4.tgz#5b8c35f0b02e4476f3f18cf89c3bf48d15d054f6"
+  integrity sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"


### PR DESCRIPTION
This PR converts ansi formatting to html when rendering pod logs.

![image](https://user-images.githubusercontent.com/455844/78066555-d7743b80-739d-11ea-9592-3b1d4a3536be.png)


Fixes #149