### PR TITLE
Docs/kube prometheus jsonnet

### DIFF
--- a/jsonnet/custom-prometheus.jsonnet
+++ b/jsonnet/custom-prometheus.jsonnet
@@ -28,12 +28,12 @@
     serviceMonitorKubelet+: {
       spec+: {
         metricRelabelings+: [
-	  {
-	    action: 'replace',
-	    sourceLabels: ['node'],
-	    targetLabel: 'instance',
-	  },
-	],
+          {
+            action: 'replace',
+            sourceLabels: ['node'],
+            targetLabel: 'instance',
+          },
+        ],
       },
     },
   },

--- a/jsonnet/custom-prometheus.jsonnet
+++ b/jsonnet/custom-prometheus.jsonnet
@@ -1,0 +1,40 @@
+{
+  // Add Lens metric relabelings for custom prometheus instances installed with kube-prometheus
+  // https://github.com/lensapp/lens/blob/master/troubleshooting/custom-prometheus.md
+  nodeExporter+:: {
+    serviceMonitor+: {
+      spec+: {
+        endpoints: std.map(function(endpoint)
+          if endpoint.port == "https" then
+            endpoint {
+              relabelings+: [
+                {
+                  action: 'replace',
+                  regex: '(.*)',
+                  replacement: '$1',
+                  sourceLabels: ['__meta_kubernetes_pod_node_name'],
+                  targetLabel: 'kubernetes_node',
+                }
+              ],
+            }
+          else
+            endpoint,
+          super.endpoints
+        ),
+      },
+    },
+  },
+  prometheus+:: {
+    serviceMonitorKubelet+: {
+      spec+: {
+        metricRelabelings+: [
+	  {
+	    action: 'replace',
+	    sourceLabels: ['node'],
+	    targetLabel: 'instance',
+	  },
+	],
+      },
+    },
+  },
+}

--- a/troubleshooting/custom-prometheus.md
+++ b/troubleshooting/custom-prometheus.md
@@ -32,13 +32,23 @@ metricRelabelings:
 ### Jsonnet
 
 The required label replacements are bundled in [jsonnet/custom-prometheus](../jsonnet/custom-prometheus.jsonnet). To install it copy the file or use
-[Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler):
+[Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler). For jsonnet bundler add the following dependency to your `jsonnetfile.json`:
 
 ```
-jb install github.com/lensapp/lens/jsonnet
+{
+  "name": "lens",
+  "source": {
+    "git": {
+      "remote": "https://github.com/lensapp/lens",
+      "subdir": "jsonnet"
+    }
+  },
+  "version": "master"
+}
 ```
 
-And include it into your definitions. Using the [example](https://github.com/coreos/kube-prometheus#compiling) of kube-prometheus, e.g.:
+and run `jb install`. When the installation was successful include it into your definitions. Using the [example](https://github.com/coreos/kube-prometheus#compiling)
+of kube-prometheus, e.g.:
 
 ```
 local kp =

--- a/troubleshooting/custom-prometheus.md
+++ b/troubleshooting/custom-prometheus.md
@@ -4,6 +4,8 @@ When using custom prometheus with Lens app, Lens expects certain things for prom
 
 ## kube-prometheus
 
+### Manual
+
 1. To see node metrics properly, please add
 
 ```
@@ -25,6 +27,29 @@ metricRelabelings:
   sourceLabels:
   - node
   targetLabel: instance
+```
+
+### Jsonnet
+
+The required label replacements are bundled in [jsonnet/custom-prometheus](../jsonnet/custom-prometheus.jsonnet). To install it copy the file or use
+[Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler):
+
+```
+jb install github.com/lensapp/lens/jsonnet
+```
+
+And include it into your definitions. Using the [example](https://github.com/coreos/kube-prometheus#compiling) of kube-prometheus, e.g.:
+
+```
+local kp =
+  (import 'kube-prometheus/kube-prometheus.libsonnet') +
+  (import 'lens/custom-prometheus.jsonnet') +
+  {
+    _config+:: {
+      namespace: 'monitoring',
+    },
+  };
+...
 ```
 
 ## Helm chart


### PR DESCRIPTION
Hi, first of all, nice product!

Since you are referencing kube-prometheus in the customer-prometheus troubleshooting guide I wanted to play back a small jsonnet file, which includes the changes you referenced via `kubectl edit`.
I have tested it with the following import

```
    {
      "name": "lens",
      "source": {
        "git": {
          "remote": "https://github.com/cbeneke/lens",
          "subdir": "jsonnet"
        }
      },
      "version": "kube-prometheus-jsonnet"
    }
```

(The `docs/kube-prometheus-jsonnet` and `kube-prometheus-jsonnet` are equal, I just realized too late, that the `/` in the path breaks jb when using a new installation instead of switching the branch)