### PR TITLE
Catch ipc errors on proxy exit

### DIFF
--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -96,7 +96,7 @@ export class KubeAuthProxy {
   }
 
   protected async sendIpcLogMessage(data: string, stream: string) {
-      await this.promiseIpc.send(`kube-auth:${this.cluster.id}`, findMainWebContents(), { data: data, stream: stream })
+    await this.promiseIpc.send(`kube-auth:${this.cluster.id}`, findMainWebContents(), { data: data, stream: stream })
   }
 
   public exit() {

--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -59,7 +59,7 @@ export class KubeAuthProxy {
     })
     this.proxyProcess.on("exit", (code) => {
       logger.error(`proxy ${this.cluster.contextName} exited with code ${code}`)
-      this.sendIpcLogMessage( `proxy exited with code ${code}`, "stderr")
+      this.sendIpcLogMessage( `proxy exited with code ${code}`, "stderr").catch((_) => {})
       this.proxyProcess = null
       configWatcher.close()
     })
@@ -95,15 +95,14 @@ export class KubeAuthProxy {
     return errorMsg
   }
 
-  protected sendIpcLogMessage(data: string, stream: string) {
-    this.promiseIpc.send(`kube-auth:${this.cluster.id}`, findMainWebContents(), { data: data, stream: stream })
+  protected async sendIpcLogMessage(data: string, stream: string) {
+      await this.promiseIpc.send(`kube-auth:${this.cluster.id}`, findMainWebContents(), { data: data, stream: stream })
   }
 
   public exit() {
     if (this.proxyProcess) {
       logger.debug(`Stopping local proxy: ${this.cluster.contextName}`)
       this.proxyProcess.kill()
-      this.proxyProcess = null
     }
   }
 }


### PR DESCRIPTION
When closing Lens app and main process is terminated, kube-auth-proxy child processes are calling `sendIpcLogMessage` on exit hook and those are erroring out. This PR will fix this just catching errors silently.

Fixes #212 