### PR TITLE
Fix serviceMonitorKubelet's metricRelabelings

### DIFF
--- a/jsonnet/custom-prometheus.jsonnet
+++ b/jsonnet/custom-prometheus.jsonnet
@@ -27,13 +27,21 @@
   prometheus+:: {
     serviceMonitorKubelet+: {
       spec+: {
-        metricRelabelings+: [
-          {
-            action: 'replace',
-            sourceLabels: ['node'],
-            targetLabel: 'instance',
-          },
-        ],
+        endpoints: std.map(function(endpoint)
+          if endpoint.port == "https-metrics" then
+            endpoint {
+              metricRelabelings+: [
+                {
+                  action: 'replace',
+                  sourceLabels: ['node'],
+                  targetLabel: 'instance',
+                },
+              ],
+            }
+          else
+            endpoint,
+          super.endpoints
+        ),
       },
     },
   },


### PR DESCRIPTION
Insert the metricRelabelings at the proper level.

Signed-off-by: Jetchko Jekov <jetchko.jekov@gmail.com>