### PR TITLE
Release v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "The Kubernetes IDE",
-  "version": "3.2.0-rc.2",
+  "version": "3.2.0",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.3",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.2.0-rc.2 (current version)
+## 3.2.0 (current version)
 
 - Render colors in logs
 - Add kubectl download mirror select to preferences


### PR DESCRIPTION
## Changes since v3.2.0-rc.2

- Fix bundled helm3 binary on windows

## Changes since v3.1.0

- Render colors in logs
- Add kubectl download mirror select to preferences
- Bundle helm3 binary
- Catch ipc errors on proxy exit
- SelfSubjectAccessReview use 'pods' resource
- Send Content-Type header on response for asset request
- Fix Helm chart version comparison
- Don't close namespace menu on select
- Change terminal fit-to-window icon
- Silence terminal websocket connection errors
- Always end watch stream if connection to kube-api ends
- Xterm v4.4.0