### PR TITLE
Fix default workspace remove

### DIFF
--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -18,6 +18,7 @@ export class Workspace implements WorkspaceData {
 }
 
 export class WorkspaceStore {
+  public static defaultId = "default"
   private static instance: WorkspaceStore;
   public store: ElectronStore;
 
@@ -39,6 +40,9 @@ export class WorkspaceStore {
   }
 
   public removeWorkspace(workspace: Workspace) {
+    if (workspace.id === WorkspaceStore.defaultId) {
+      throw new Error("Cannot remove default workspace")
+    }
     const workspaces = this.getAllWorkspaces()
     const index = workspaces.findIndex((w) => w.id === workspace.id)
     if (index !== -1) {
@@ -64,9 +68,9 @@ export class WorkspaceStore {
 
 const workspaceStore: WorkspaceStore = WorkspaceStore.getInstance()
 
-if (workspaceStore.getAllWorkspaces().length === 0) {
+if (!workspaceStore.getAllWorkspaces().find( ws => ws.id === WorkspaceStore.defaultId)) {
   workspaceStore.storeWorkspace({
-    id: "default",
+    id: WorkspaceStore.defaultId,
     name: "default"
   })
 }

--- a/src/renderer/components/EditWorkspacePage.vue
+++ b/src/renderer/components/EditWorkspacePage.vue
@@ -37,7 +37,7 @@
                 <b-button variant="primary" type="submit">
                   Save
                 </b-button>
-                <b-button v-b-modal.bv-modal-confirm>
+                <b-button v-if="workspace.id !== 'default'" v-b-modal.bv-modal-confirm>
                   Delete
                 </b-button>
                 <b-modal id="bv-modal-confirm" @ok="deleteWorkspace" ok-title="Delete" ok-variant="danger" title-class="confirm-header" hide-backdrop title="Confirm workspace delete">


### PR DESCRIPTION
Currently app logic goes south if the default workspace is removed _and_ there are other workspaces stored. This PR fixes it and also disables workspace delete button for "default" workspace.