### PR TITLE
Release v3.3.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.2.0",
+  "version": "3.3.0-rc.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,18 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.2.0 (current version)
+## 3.3.0-rc.1 (current version)
+
+- New section: endpoints
+- Initial port-forward implementation for services
+- Hide object-list applied filters by default
+- Fix default workspace remove
+- Fix issues with crd plugins
+- Fix use of bundled kubectl
+- Clean up legacy references to Kontena
+- Fix jobs sorting if condition is empty
+
+## 3.2.0
 
 - Render colors in logs
 - Add kubectl download mirror select to preferences


### PR DESCRIPTION
## Changes since v3.2.0

- New section: endpoints
- Initial port-forward implementation for services
- Hide object-list applied filters by default
- Fix default workspace remove
- Fix issues with crd plugins
- Fix use of bundled kubectl
- Clean up legacy references to Kontena
- Fix jobs sorting if condition is empty