### PR TITLE
Display emptyDir medium and size limit

### DIFF
--- a/dashboard/client/api/endpoints/pods.api.ts
+++ b/dashboard/client/api/endpoints/pods.api.ts
@@ -175,6 +175,10 @@ export class Pod extends WorkloadKubeObject {
       persistentVolumeClaim: {
         claimName: string;
       };
+      emptyDir: {
+        medium?: string;
+        sizeLimit?: string;
+      };
       secret: {
         secretName: string;
         defaultMode: number;

--- a/dashboard/client/components/+workloads-pods/pod-details.tsx
+++ b/dashboard/client/components/+workloads-pods/pod-details.tsx
@@ -176,6 +176,8 @@ export class PodDetails extends React.Component<Props> {
             <DrawerTitle title={<Trans>Volumes</Trans>}/>
             {volumes.map(volume => {
               const claimName = volume.persistentVolumeClaim ? volume.persistentVolumeClaim.claimName : null;
+              const type = Object.keys(volume)[1]
+
               return (
                 <div key={volume.name} className="volume">
                   <div className="title flex gaps">
@@ -183,8 +185,23 @@ export class PodDetails extends React.Component<Props> {
                     <span>{volume.name}</span>
                   </div>
                   <DrawerItem name={<Trans>Type</Trans>}>
-                    {Object.keys(volume)[1]}
+                    {type}
                   </DrawerItem>
+                  { type === "emptyDir" && (
+                    <div>
+                      { volume.emptyDir.medium && (
+                      <DrawerItem name={<Trans>Medium</Trans>}>
+                        {volume.emptyDir.medium}
+                      </DrawerItem>
+                      )}
+                      { volume.emptyDir.sizeLimit && (
+                        <DrawerItem name={<Trans>Size Limit</Trans>}>
+                        {volume.emptyDir.sizeLimit}
+                        </DrawerItem>
+                      )}
+                    </div>
+                  )}
+
                   {claimName && (
                     <DrawerItem name={<Trans>Claim Name</Trans>}>
                       <Link


### PR DESCRIPTION
This PR will display values of medium and size limit if set for `emptyDir` volumes:

![image](https://user-images.githubusercontent.com/455844/79385616-940af700-7f71-11ea-8475-1b878ef8f18c.png)


Fixes #253 