### PR TITLE
Always refresh stores when object list is mounted

### DIFF
--- a/dashboard/client/components/item-object-list/item-list-layout.tsx
+++ b/dashboard/client/components/item-object-list/item-list-layout.tsx
@@ -114,9 +114,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
     const { store, dependentStores, isClusterScoped } = this.props;
     const stores = [store, ...dependentStores];
     if (!isClusterScoped) stores.push(namespaceStore);
-    const loadingStores = stores.filter(store => !store.isLoaded);
-    loadingStores.forEach(store => store.loadAll());
-    await when(() => loadingStores.every(store => !store.isLoading));
+    await Promise.all(stores.map(store => store.loadAll()));
     const subscriptions = stores.map(store => store.subscribe());
     await when(() => this.isUnmounting);
     subscriptions.forEach(dispose => dispose()); // unsubscribe all


### PR DESCRIPTION
Probably fixes many (most?) issues where list does not refresh properly.

Fixes #270
