### PR TITLE
Release v3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,15 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.3.0 (current version)
+## 3.3.1 (current version)
+
+- Do not timeout watch requests
+- Fix pod shell error if no access to nodes
+- Fix list sort by age
+- Always refresh stores when object list is mounted
+- Update @kubernetes/client-node to 0.11.1
+
+## 3.3.0
 
 - New section: endpoints
 - Initial port-forward implementation for services


### PR DESCRIPTION
## Changes since v3.3.0

- Do not timeout watch requests (#273)
- Fix pod shell error if no access to nodes (#275)
- Fix list sort by age (#276)
- Always refresh stores when object list is mounted (#277)
- Update @kubernetes/client-node to 0.11.1 (#278)