### PR TITLE
Show always Events title in resource details

### DIFF
--- a/dashboard/client/components/+events/kube-event-details.tsx
+++ b/dashboard/client/components/+events/kube-event-details.tsx
@@ -23,12 +23,15 @@ export class KubeEventDetails extends React.Component<Props> {
     const { object } = this.props;
     const events = eventStore.getEventsByObject(object);
     if (!events.length) {
-      return null;
+      return (
+        <DrawerTitle className="flex gaps align-center">
+          <span><Trans>Events</Trans></span>
+        </DrawerTitle>
+      )
     }
     return (
       <>
         <DrawerTitle className="flex gaps align-center">
-          <Icon material="access_time"/>
           <span><Trans>Events</Trans></span>
         </DrawerTitle>
         <div className="KubeEventDetails">


### PR DESCRIPTION
This PR will show `Events` title in resource details even when no events available for the resource. Also dropped the icon for the consistency.
![image](https://user-images.githubusercontent.com/455844/79793602-841c5a00-8359-11ea-80fa-2ca0789d2c22.png)

Fixes #261 