### PR TITLE
Replace admin check with check for access

### DIFF
--- a/dashboard/client/components/+storage/storage.tsx
+++ b/dashboard/client/components/+storage/storage.tsx
@@ -20,7 +20,7 @@ interface Props extends RouteComponentProps<{}> {
 export class Storage extends React.Component<Props> {
   static get tabRoutes() {
     const tabRoutes: TabRoute[] = [];
-    const { isClusterAdmin } = configStore;
+    const { allowedResources } = configStore;
     const query = namespaceStore.getContextParams()
 
     tabRoutes.push({
@@ -30,7 +30,7 @@ export class Storage extends React.Component<Props> {
       path: volumeClaimsRoute.path,
     })
 
-    if (isClusterAdmin) {
+    if (allowedResources.includes('persistentvolumes')) {
       tabRoutes.push({
         title: <Trans>Persistent Volumes</Trans>,
         component: PersistentVolumes,
@@ -39,7 +39,7 @@ export class Storage extends React.Component<Props> {
       });
     }
 
-    if (isClusterAdmin) {
+    if (allowedResources.includes('storageclasses')) {
       tabRoutes.push({
         title: <Trans>Storage Classes</Trans>,
         component: StorageClasses,

--- a/dashboard/client/components/+user-management/user-management.tsx
+++ b/dashboard/client/components/+user-management/user-management.tsx
@@ -21,7 +21,7 @@ interface Props extends RouteComponentProps<{}> {
 export class UserManagement extends React.Component<Props> {
   static get tabRoutes() {
     const tabRoutes: TabRoute[] = [];
-    const { isClusterAdmin } = configStore;
+    const { allowedResources } = configStore;
     const query = namespaceStore.getContextParams()
     tabRoutes.push(
       {
@@ -43,7 +43,7 @@ export class UserManagement extends React.Component<Props> {
         path: rolesRoute.path,
       },
     )
-    if (isClusterAdmin) {
+    if (allowedResources.includes("podsecuritypolicies")) {
       tabRoutes.push({
         title: <Trans>Pod Security Policies</Trans>,
         component: PodSecurityPolicies,

--- a/dashboard/client/components/app.tsx
+++ b/dashboard/client/components/app.tsx
@@ -46,7 +46,7 @@ class App extends React.Component {
   };
 
   render() {
-    const homeUrl = configStore.isClusterAdmin ? clusterURL() : workloadsURL();
+    const homeUrl = clusterURL();
     return (
       <I18nProvider i18n={_i18n}>
         <Router history={browserHistory}>

--- a/dashboard/client/components/layout/sidebar.tsx
+++ b/dashboard/client/components/layout/sidebar.tsx
@@ -71,7 +71,7 @@ export class Sidebar extends React.Component<Props> {
 
   render() {
     const { toggle, isPinned, className } = this.props;
-    const { isClusterAdmin } = configStore;
+    const { isClusterAdmin, allowedResources } = configStore;
     const query = namespaceStore.getContextParams();
     return (
       <SidebarContext.Provider value={{ pinned: isPinned }}>
@@ -91,14 +91,13 @@ export class Sidebar extends React.Component<Props> {
           <div className="sidebar-nav flex column box grow-fixed">
             <SidebarNavItem
               id="cluster"
-              isHidden={!isClusterAdmin}
               url={clusterURL()}
               text={<Trans>Cluster</Trans>}
               icon={<Icon svg="kube"/>}
             />
             <SidebarNavItem
               id="nodes"
-              isHidden={!isClusterAdmin}
+              isHidden={!allowedResources.includes('nodes')}
               url={nodesURL()}
               text={<Trans>Nodes</Trans>}
               icon={<Icon svg="nodes"/>}
@@ -166,7 +165,7 @@ export class Sidebar extends React.Component<Props> {
             />
             <SidebarNavItem
               id="custom-resources"
-              isHidden={!isClusterAdmin}
+              isHidden={!allowedResources.includes('customresourcedefinitions')}
               url={crdURL()}
               subMenus={CustomResources.tabRoutes}
               routePath={crdRoute.path}

--- a/dashboard/client/config.store.ts
+++ b/dashboard/client/config.store.ts
@@ -45,6 +45,10 @@ export class ConfigStore {
     return this.config.allowedNamespaces || [];
   }
 
+  get allowedResources() {
+    return this.config.allowedResources;
+  }
+
   get isClusterAdmin() {
     return this.config.isClusterAdmin;
   }

--- a/dashboard/server/common/config.ts
+++ b/dashboard/server/common/config.ts
@@ -5,6 +5,7 @@ export interface IConfig extends Partial<IClusterInfo> {
   username?: string;
   token?: string;
   allowedNamespaces?: string[];
+  allowedResources?: string[];
   isClusterAdmin?: boolean;
   chartsEnabled: boolean;
   kubectlAccess?: boolean;  // User accessed via kubectl-lens plugin

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -3,7 +3,7 @@ import { FeatureStatusMap } from "./feature"
 import * as k8s from "./k8s"
 import { clusterStore } from "../common/cluster-store"
 import logger from "./logger"
-import { KubeConfig, CoreV1Api } from "@kubernetes/client-node"
+import { KubeConfig, CoreV1Api, AuthorizationV1Api, V1ResourceAttributes } from "@kubernetes/client-node"
 import * as fm from "./feature-manager";
 import { Kubectl } from "./kubectl";
 import { PromiseIpc } from "electron-promise-ipc"
@@ -129,9 +129,7 @@ export class Cluster implements ClusterInfo {
       this.distribution = this.detectKubernetesDistribution(this.version)
       this.features = await fm.getFeatures(this.contextHandler)
       this.isAdmin = await this.isClusterAdmin()
-      if (this.isAdmin) {
-        this.nodes = await this.getNodeCount()
-      }
+      this.nodes = await this.getNodeCount()
       this.kubeCtl = new Kubectl(this.version)
       this.kubeCtl.ensureKubectl()
     }
@@ -212,28 +210,27 @@ export class Cluster implements ClusterInfo {
     }
   }
 
-  protected async isClusterAdmin(): Promise<boolean> {
-    const requestOpts: request.RequestPromiseOptions = {
-      body: {
-        kind: "SelfSubjectAccessReview",
-        apiVersion: "authorization.k8s.io/v1",
-        spec: {
-          resourceAttributes: {
-            namespace: "kube-system",
-            resource: "*",
-            verb: "create",
-          }
-        }
-      },
-      method: "post"
-    }
+  public async canI(resourceAttributes: V1ResourceAttributes): Promise<boolean> {
+    const authApi = this.contextHandler.kc.makeApiClient(AuthorizationV1Api)
     try {
-      const response = await this.k8sRequest("/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", requestOpts)
-      return response.status.allowed === true
+      const accessReview = await authApi.createSelfSubjectAccessReview({
+        apiVersion: "authorization.k8s.io/v1",
+        kind: "SelfSubjectAccessReview",
+        spec: { resourceAttributes }
+      })
+      return accessReview.body.status.allowed === true
     } catch(error) {
       logger.error(`failed to request selfSubjectAccessReview: ${error.message}`)
       return false
     }
+  }
+
+  protected async isClusterAdmin(): Promise<boolean> {
+    return this.canI({
+      namespace: "kube-system",
+      resource: "*",
+      verb: "create",
+    })
   }
 
   protected detectKubernetesDistribution(kubernetesVersion: string): string {


### PR DESCRIPTION
I noticed that some features of Lens was missing when connected to our clusters even though we had access as they were being gated on the ability to write to `kube-system`. This updates those checks to instead check for access to the relevant resource to work with a wider range of RBAC rules and cluster configurations.