### PR TITLE
Terminal tab auto-close fixes

### DIFF
--- a/dashboard/client/components/dock/terminal-tab.tsx
+++ b/dashboard/client/components/dock/terminal-tab.tsx
@@ -16,7 +16,7 @@ interface Props extends DockTabProps {
 @observer
 export class TerminalTab extends React.Component<Props> {
   componentDidMount() {
-    reaction(() => this.isDisconnected, () => {
+    reaction(() => this.isDisconnected === true, () => {
       dockStore.closeTab(this.tabId)
     })
   }


### PR DESCRIPTION
Fixes bugs introduced in #294.

- close only on disconnect
- leave terminal open for 15s if process exits with an error code (so that user can see the error)