### PR TITLE
Fix port availability test

### DIFF
--- a/spec/src/main/port_spec.ts
+++ b/spec/src/main/port_spec.ts
@@ -2,13 +2,10 @@ import { EventEmitter } from 'events'
 
 class MockServer extends EventEmitter {
   listen = jest.fn((obj) => {
-    if(obj.port < 9003) {
-      this.emit('error', new Error("fail!"))
-    } else {
-      this.emit('listening', {})
-    }
+    this.emit('listening', {})
     return this
   })
+  address = () => { return { port: 12345 }}
   unref = jest.fn()
   close = jest.fn((cb) => {
     cb()
@@ -29,11 +26,7 @@ describe("getFreePort", () => {
     jest.clearAllMocks()
   })
 
-  it("fails for an invalid range", async () => {
-    return expect(port.getFreePort(1, 2)).rejects.toMatch('free port')
-  })
-
   it("finds the next free port", async () => {
-    return expect(port.getFreePort(9000, 9005)).resolves.toBe(9003)
+    return expect(port.getFreePort()).resolves.toEqual(expect.any(Number))
   })
 })

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -135,7 +135,7 @@ export class ContextHandler {
 
     let serverPort: number = null
     try {
-      serverPort = await getFreePort(49901, 65535)
+      serverPort = await getFreePort()
     } catch(error) {
       logger.error(error)
       throw(error)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,7 +48,7 @@ async function main() {
   let port: number = null
   // find free port
   try {
-    port = await getFreePort(49152, 65535)
+    port = await getFreePort()
   } catch (error) {
     logger.error(error)
     await dialog.showErrorBox("Lens Error", "Could not find a free port for the cluster proxy")

--- a/src/main/port.ts
+++ b/src/main/port.ts
@@ -9,7 +9,7 @@ function checkPort(port: number) {
     server
       .on('error', error => reject(error))
       .on('listening', () => server.close(() => resolve(port)))
-      .listen({host: "127.0.0.1", port: port}))
+      .listen({host: "0.0.0.0", port: port}))
 }
 
 export async function getFreePort(firstPort: number, lastPort: number): Promise<number> {

--- a/src/main/port.ts
+++ b/src/main/port.ts
@@ -1,27 +1,30 @@
 import logger from "./logger"
 import { createServer } from "net"
+import { AddressInfo } from "net"
 
-// Adapted from https://gist.github.com/mikeal/1840641#gistcomment-2896667
-function checkPort(port: number) {
+const getNextAvailablePort = () => {
+  logger.debug("getNextAvailablePort() start")
   const server = createServer()
   server.unref()
-  return new Promise((resolve, reject) =>
+  return new Promise<number>((resolve, reject) =>
     server
-      .on('error', error => reject(error))
-      .on('listening', () => server.close(() => resolve(port)))
-      .listen({host: "0.0.0.0", port: port}))
+      .on('error', (error: any) => reject(error))
+      .on('listening', () => {
+        logger.debug("*** server listening event ***")
+        const _port = (server.address() as AddressInfo).port
+        server.close(() => resolve(_port))
+      })
+      .listen({host: "127.0.0.1", port: 0}))
 }
 
-export async function getFreePort(firstPort: number, lastPort: number): Promise<number> {
-  let port = firstPort
-
-  while(true) {
-    try {
-      logger.debug("Checking port " + port + " availability ...")
-      await checkPort(port)
-      return(port)
-    } catch(error) {
-      if(++port > lastPort) throw("Could not find a free port")
-    }
+export const getFreePort = async () => {
+  logger.debug("getFreePort() start")
+  let freePort: number = null
+  try {
+    freePort = await getNextAvailablePort()
+    logger.debug("got port : " + freePort)
+  } catch(error) {
+    throw("getNextAvailablePort() threw: '" + error + "'")
   }
+  return freePort
 }

--- a/src/main/routes/port-forward.ts
+++ b/src/main/routes/port-forward.ts
@@ -36,7 +36,7 @@ class PortForward {
   }
 
   public async start() {
-    this.localPort = await getFreePort(8000, 9999)
+    this.localPort = await getFreePort()
     const kubectlBin = await bundledKubectl.kubectlPath()
     const args = [
       "--kubeconfig", this.kubeConfig,


### PR DESCRIPTION
Problem raised on macOS where port 49152 was used by rapportd process
listening on 0.0.0.0 address and as a consequence the application proxy
server wasn't correctly setup that in turn disrupted the webview display
that wasn't served through http://&lt;uid&gt;.localhost:49152/ (#255) as the
connection was made through the rapportd server :

```shell
❯ lsof -nP -iTCP:49152 | grep LISTEN
rapportd  390 alexis    4u  IPv4 0x40fa93f08a1b8ae7      0t0  TCP *:49152 (LISTEN)
rapportd  390 alexis    5u  IPv6 0x40fa93f08c37fa77      0t0  TCP *:49152 (LISTEN)
Electron 7789 alexis   65u  IPv4 0x40fa93f095f384c7      0t0  TCP 127.0.0.1:49152 (LISTEN)
```

Indeed the `checkPort()` function is checking port availability using the
127.0.0.1 address, and in that case the test doesn't error.

The minimal fix here is to test port availability using 0.0.0.0 address.

Signed-off-by: Alexis Deruelle <alexis.deruelle@gmail.com>