### PR TITLE
Check port checker response

### DIFF
--- a/spec/src/main/port_spec.ts
+++ b/spec/src/main/port_spec.ts
@@ -15,14 +15,18 @@ class MockServer extends EventEmitter {
   })
 }
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const net = require("net")
-jest.mock("net")
+const http = require("http")
+jest.mock("http")
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const request = require("request-promise-native")
+jest.mock("request-promise-native")
 
 import * as port from "../../../src/main/port"
 
 describe("getFreePort", () => {
   beforeEach(() => {
-    net.createServer.mockReturnValue(new MockServer)
+    http.createServer.mockReturnValue(new MockServer)
   })
 
   afterEach(() => {
@@ -34,6 +38,20 @@ describe("getFreePort", () => {
   })
 
   it("finds the next free port", async () => {
+    request.mockReturnValue(new Promise((resolve, reject) => {
+      resolve({
+        body: "lens-port-checker"
+      })
+    }))
     return expect(port.getFreePort(9000, 9005)).resolves.toBe(9003)
+  })
+
+  it("fails with invalid response", async () => {
+    request.mockReturnValue(new Promise((resolve, reject) => {
+      resolve({
+        body: "wrong"
+      })
+    }))
+    return expect(port.getFreePort(9000, 9005)).rejects.toMatch('free port')
   })
 })

--- a/src/main/port.ts
+++ b/src/main/port.ts
@@ -1,14 +1,21 @@
 import logger from "./logger"
-import { createServer } from "net"
+import { createServer, Server, IncomingMessage, ServerResponse } from "http"
+import * as request from "request-promise-native"
 
 // Adapted from https://gist.github.com/mikeal/1840641#gistcomment-2896667
 function checkPort(port: number) {
-  const server = createServer()
+  let server: Server = null
+  const checkPortHandler = (req: IncomingMessage, res: ServerResponse) => {
+    res.writeHead(200)
+    res.end("lens-port-checker")
+    server.close()
+  }
+  server = createServer(checkPortHandler)
   server.unref()
   return new Promise((resolve, reject) =>
     server
       .on('error', error => reject(error))
-      .on('listening', () => server.close(() => resolve(port)))
+      .on('listening', () => resolve(port))
       .listen({host: "127.0.0.1", port: port}))
 }
 
@@ -19,6 +26,14 @@ export async function getFreePort(firstPort: number, lastPort: number): Promise<
     try {
       logger.debug("Checking port " + port + " availability ...")
       await checkPort(port)
+      const resp = await request(`http://127.0.0.1:${port}`, {
+        timeout: 1000,
+        resolveWithFullResponse: true
+      })
+      if (resp.body !== "lens-port-checker") {
+        logger.debug(`Invalid response from ${port}, probably some other process is listening on all interfaces`)
+        throw new Error("invalid response")
+      }
       return(port)
     } catch(error) {
       if(++port > lastPort) throw("Could not find a free port")


### PR DESCRIPTION
This PR improves port checker by validating test server response. Currently we might end up listening on a port that's already used by some other process with `0.0.0.0` address.

Alternative to #333 
Related to #255 