### PR TITLE
Fix EndpointSubset.toString() if subset is missing ports

### DIFF
--- a/dashboard/client/api/endpoints/endpoint.api.ts
+++ b/dashboard/client/api/endpoints/endpoint.api.ts
@@ -86,6 +86,9 @@ export class EndpointSubset implements IEndpointSubset {
       return ""
     }
     return this.addresses.map(address => {
+      if (!this.ports) {
+        return address.ip
+      }
       return this.ports.map(port => {
         return `${address.ip}:${port.port}`
       }).join(", ")


### PR DESCRIPTION
It might be possible that endpoint subset does not have any ports defined. This PR will return ip address on that case.

Fixes #328 