### PR TITLE
Add support for Prometheus api prefix

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -46,6 +46,7 @@ export type ClusterPreferences = {
     namespace: string;
     service: string;
     port: number;
+    prefix: string;
   };
   prometheusProvider?: {
     type: string;
@@ -152,6 +153,13 @@ export class Cluster implements ClusterInfo {
 
     this.kubeConfig = kubeconfig
     this.save()
+  }
+
+  public getPrometheusApiPrefix() {
+    if (!this.preferences.prometheus?.prefix) {
+      return ""
+    }
+    return this.preferences.prometheus.prefix
   }
 
   public save() {

--- a/src/main/routes/metrics.ts
+++ b/src/main/routes/metrics.ts
@@ -2,7 +2,6 @@ import { LensApiRequest } from "../router"
 import { LensApi } from "../lens-api"
 import * as requestPromise from "request-promise-native"
 import { PrometheusProviderRegistry, PrometheusProvider, PrometheusNodeQuery, PrometheusClusterQuery, PrometheusPodQuery, PrometheusPvcQuery, PrometheusIngressQuery, PrometheusQueryOpts} from "../prometheus/provider-registry"
-import logger from "../logger"
 
 type MetricsQuery = string | string[] | {
   [metricName: string]: string;
@@ -15,7 +14,6 @@ class MetricsRoute extends LensApi {
     const query: MetricsQuery = request.payload;
     const serverUrl = `http://127.0.0.1:${cluster.port}/api-kube`
     const metricsUrl = `${serverUrl}/api/v1/namespaces/${cluster.contextHandler.getPrometheusPath()}/proxy${cluster.getPrometheusApiPrefix()}/api/v1/query_range`
-    logger.info(metricsUrl)
     const headers = {
       "Host": `${cluster.id}.localhost:${cluster.port}`,
       "Content-type": "application/json",

--- a/src/main/routes/metrics.ts
+++ b/src/main/routes/metrics.ts
@@ -2,6 +2,7 @@ import { LensApiRequest } from "../router"
 import { LensApi } from "../lens-api"
 import * as requestPromise from "request-promise-native"
 import { PrometheusProviderRegistry, PrometheusProvider, PrometheusNodeQuery, PrometheusClusterQuery, PrometheusPodQuery, PrometheusPvcQuery, PrometheusIngressQuery, PrometheusQueryOpts} from "../prometheus/provider-registry"
+import logger from "../logger"
 
 type MetricsQuery = string | string[] | {
   [metricName: string]: string;
@@ -13,7 +14,8 @@ class MetricsRoute extends LensApi {
     const { response, cluster} = request
     const query: MetricsQuery = request.payload;
     const serverUrl = `http://127.0.0.1:${cluster.port}/api-kube`
-    const metricsUrl = `${serverUrl}/api/v1/namespaces/${cluster.contextHandler.getPrometheusPath()}/proxy/api/v1/query_range`
+    const metricsUrl = `${serverUrl}/api/v1/namespaces/${cluster.contextHandler.getPrometheusPath()}/proxy${cluster.getPrometheusApiPrefix()}/api/v1/query_range`
+    logger.info(metricsUrl)
     const headers = {
       "Host": `${cluster.id}.localhost:${cluster.port}`,
       "Content-type": "application/json",

--- a/src/renderer/components/ClusterSettings/Preferences/index.vue
+++ b/src/renderer/components/ClusterSettings/Preferences/index.vue
@@ -84,7 +84,6 @@ export default {
       },
       prometheusPath: "",
       prometheusProvider: "",
-      prometheusProviders: [],
     }
   },
   mounted: async function() {
@@ -108,12 +107,13 @@ export default {
       }
     },
     parsePrometheusPath: function(path) {
-      let parsed = path.split(/\/|:/)
+      const parsed = path.split(/\/|:/, 3)
+      const apiPrefix = path.substring(parsed.join("/").length)
       return {
         namespace: parsed[0],
         service: parsed[1],
         port: parsed[2],
-        prefix: parsed[3] ? `/${parsed[3]}` : ''
+        prefix: apiPrefix
       }
     },
     expandPath: function(value, event) {

--- a/src/renderer/components/ClusterSettings/Preferences/index.vue
+++ b/src/renderer/components/ClusterSettings/Preferences/index.vue
@@ -97,7 +97,7 @@ export default {
     updateValues: function(){
       if (this.cluster.preferences.prometheus) {
         const prom = this.cluster.preferences.prometheus;
-        this.prometheusPath = `${prom.namespace}/${prom.service}:${prom.port}`
+        this.prometheusPath = `${prom.namespace}/${prom.service}:${prom.port}${prom.prefix}`
       } else {
         this.prometheusPath = ""
       }
@@ -112,7 +112,8 @@ export default {
       return {
         namespace: parsed[0],
         service: parsed[1],
-        port: parsed[2]
+        port: parsed[2],
+        prefix: parsed[3] ? `/${parsed[3]}` : ''
       }
     },
     expandPath: function(value, event) {


### PR DESCRIPTION
This PR allows user to define prometheus API prefix along prometheus service address, for example: `default/prometheus-prometheus-oper-prometheus:9090/api`.

fixes #337, fixes #258