### PR TITLE
Release v3.4.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.4.0-beta.2",
+  "version": "3.4.0-rc.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.4.0-beta.2 (current version)
+## 3.4.0-rc.1 (current version)
+
+- Auto-detect Prometheus installation
+- Allow to select Prometheus query style
+- Fix port availability test
+- Fix EndpointSubset.toString() to work without ports
+- Return empty string if Helm release version is not detected
+- Delay webview create on cluster page
+- Fix no-drag css
+
+## 3.4.0-beta.2
 
 - Improve dashboard reload
 - Fix node shell session regression


### PR DESCRIPTION
## Changes since v3.4.0-beta.2

- Auto-detect Prometheus installation (#343)
- Allow to select Prometheus query style (#312)
- Fix port availability test (#333)
- Fix EndpointSubset.toString() to work without ports (#336)
- Return empty string if Helm release version is not detected (#342)
- Delay webview create on cluster page (#332)
- Fix no-drag css (#331)
