### PR TITLE
Show system roles on Roles page

### DIFF
--- a/dashboard/client/components/+user-management-roles-bindings/add-role-binding-dialog.tsx
+++ b/dashboard/client/components/+user-management-roles-bindings/add-role-binding-dialog.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogProps } from "../dialog";
 import { Wizard, WizardStep } from "../wizard";
 import { Select, SelectOption } from "../select";
 import { SubTitle } from "../layout/sub-title";
-import { IRoleBindingSubject, RoleBinding, ServiceAccount } from "../../api/endpoints";
+import { IRoleBindingSubject, RoleBinding, ServiceAccount, Role } from "../../api/endpoints";
 import { Icon } from "../icon";
 import { Input } from "../input";
 import { NamespaceSelect } from "../+namespaces/namespace-select";
@@ -152,7 +152,7 @@ export class AddRoleBindingDialog extends React.Component<Props> {
   };
 
   @computed get roleOptions(): BindingSelectOption[] {
-    let roles = rolesStore.items.filter(KubeObject.isNonSystem);
+    let roles = rolesStore.items as Role[]
     if (this.bindContext) {
       // show only cluster-roles or roles for selected context namespace
       roles = roles.filter(role => !role.getNs() || role.getNs() === this.bindContext);

--- a/dashboard/client/components/+user-management-roles-bindings/role-bindings.tsx
+++ b/dashboard/client/components/+user-management-roles-bindings/role-bindings.tsx
@@ -42,22 +42,6 @@ export class RoleBindings extends React.Component<Props> {
           (binding: RoleBinding) => binding.getSubjectNames(),
         ]}
         renderHeaderTitle={<Trans>Role Bindings</Trans>}
-        filterItems={[
-          (items: RoleBinding[]) => items.filter(KubeObject.isNonSystem),
-        ]}
-        customizeHeader={({ info }) => ({
-          info: (
-            <>
-              {info}
-              <Icon
-                small
-                material="help_outline"
-                className="help-icon"
-                tooltip={<Trans>Excluded items with "system:" prefix</Trans>}
-              />
-            </>
-          )
-        })}
         renderTableHeader={[
           { title: <Trans>Name</Trans>, className: "name", sortBy: sortBy.name },
           { title: <Trans>Bindings</Trans>, className: "bindings", sortBy: sortBy.bindings },

--- a/dashboard/client/components/+user-management-roles/roles.tsx
+++ b/dashboard/client/components/+user-management-roles/roles.tsx
@@ -39,9 +39,6 @@ export class Roles extends React.Component<Props> {
           searchFilters={[
             (role: Role) => role.getSearchFields(),
           ]}
-          filterItems={[
-            (items: Role[]) => items.filter(KubeObject.isNonSystem),
-          ]}
           renderHeaderTitle={<Trans>Roles</Trans>}
           customizeHeader={({ info }) => ({
             info: (

--- a/dashboard/client/components/+user-management-roles/roles.tsx
+++ b/dashboard/client/components/+user-management-roles/roles.tsx
@@ -10,8 +10,6 @@ import { rolesStore } from "./roles.store";
 import { clusterRoleApi, Role, roleApi } from "../../api/endpoints";
 import { KubeObjectListLayout } from "../kube-object";
 import { AddRoleDialog } from "./add-role-dialog";
-import { Icon } from "../icon";
-import { KubeObject } from "../../api/kube-object";
 import { apiManager } from "../../api/api-manager";
 
 enum sortBy {
@@ -40,19 +38,6 @@ export class Roles extends React.Component<Props> {
             (role: Role) => role.getSearchFields(),
           ]}
           renderHeaderTitle={<Trans>Roles</Trans>}
-          customizeHeader={({ info }) => ({
-            info: (
-              <>
-                {info}
-                <Icon
-                  small
-                  material="help_outline"
-                  className="help-icon"
-                  tooltip={<Trans>Excluded items with "system:" prefix</Trans>}
-                />
-              </>
-            )
-          })}
           renderTableHeader={[
             { title: <Trans>Name</Trans>, className: "name", sortBy: sortBy.name },
             { title: <Trans>Namespace</Trans>, className: "namespace", sortBy: sortBy.namespace },


### PR DESCRIPTION
This PR will make also `system:*` roles visible on the dashboard.

Fixes #340 