### PR TITLE
Release v3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.4.0-rc.1",
+  "version": "3.4.0",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,27 +2,23 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.4.0-rc.1 (current version)
+## 3.4.0 (current version)
 
 - Auto-detect Prometheus installation
 - Allow to select Prometheus query style
+- Show node events in node details
+- Enable code folding in resource editor
+- Improve dashboard reload
+- Provide link to configMap from pod details
+- Show system roles on Roles page
+- Terminal dock tab improvements
 - Fix port availability test
 - Fix EndpointSubset.toString() to work without ports
 - Return empty string if Helm release version is not detected
 - Delay webview create on cluster page
 - Fix no-drag css
-
-## 3.4.0-beta.2
-
-- Improve dashboard reload
 - Fix node shell session regression
 - Rebuild locales & fix translation bugs
-
-## 3.4.0-beta.1
-
-- Show node events in node details
-- Enable code folding in resource editor
-- Terminal dock tab improvements
 - Show always Events title in resource details
 - Fix missing spaces in container command
 - Check also beta.kubernetes.io/os selector for windows pod shell


### PR DESCRIPTION
## Changes since v3.3.1

- Show system roles on Roles page (#355)
- Prometheus provider/path related ui fixes (#354)
- Provide link to configMap from pod details (#352)
- Add support for Prometheus api prefix (#341)
- Auto-detect prometheus installation (#343)
- Fix port availability test (#333)
- Fix EndpointSubset.toString() to work without ports (#336)
- Return empty string if Helm release version is not detected (#342)
- Delay webview create on cluster page (#332)
- Fix no-drag css (#331)
- Allow to select Prometheus query style (#312)
- Rebuild locales & fix translation bugs (#325)
- Fix node shell session regression (#326)
- improve dashboard reload (#327)
- Fix typo in documentation (#316)
- Update metrics feature components (#301)
- Terminal tab auto-close fixes (#314)
- Cleanup cluster webview loading (#313)
- Terminal dock tab improvements (#294)
- Check also beta.kubernetes.io/os selector for windows pod shell  (#293)
- Fix missing spaces in container command #251 (#284)
- Enable code folding in resource editor (#292)
- Show always Events title in resource details (#286)
- Show node events in node details (#285)
- Update dashboard packages for vulnerabilities (#281)
- Cache terminall shell env (#274)
