### PR TITLE
Show owner reference on all resource details

### DIFF
--- a/dashboard/client/api/kube-object.ts
+++ b/dashboard/client/api/kube-object.ts
@@ -27,6 +27,14 @@ export interface IKubeObjectMetadata {
   annotations?: {
     [annotation: string]: string;
   };
+  ownerReferences?: {
+    apiVersion: string;
+    kind: string;
+    name: string;
+    uid: string;
+    controller: boolean;
+    blockOwnerDeletion: boolean;
+  }[];
 }
 
 export type IKubeMetaField = keyof KubeObject["metadata"];
@@ -111,6 +119,14 @@ export class KubeObject implements ItemObject {
       const skip = resourceApplierApi.annotations.some(key => label.startsWith(key));
       return !skip;
     })
+  }
+
+  getOwnerRefs() {
+    const refs = this.metadata.ownerReferences || [];
+    return refs.map(ownerRef => ({
+      ...ownerRef,
+      namespace: this.getNs(),
+    }))
   }
 
   getSearchFields() {

--- a/dashboard/client/api/workload-kube-object.ts
+++ b/dashboard/client/api/workload-kube-object.ts
@@ -47,27 +47,9 @@ export interface IAffinity {
 }
 
 export class WorkloadKubeObject extends KubeObject {
-  metadata: IKubeObjectMetadata & {
-    ownerReferences?: {
-      apiVersion: string;
-      kind: string;
-      name: string;
-      uid: string;
-      controller: boolean;
-      blockOwnerDeletion: boolean;
-    }[];
-  }
 
   // fixme: add type
   spec: any;
-
-  getOwnerRefs() {
-    const refs = this.metadata.ownerReferences || [];
-    return refs.map(ownerRef => ({
-      ...ownerRef,
-      namespace: this.getNs(),
-    }))
-  }
 
   getSelectors(): string[] {
     const selector = this.spec.selector;

--- a/dashboard/client/components/+workloads-pods/pod-details.tsx
+++ b/dashboard/client/components/+workloads-pods/pod-details.tsx
@@ -64,7 +64,6 @@ export class PodDetails extends React.Component<Props> {
     const { status, spec } = pod;
     const { conditions, podIP } = status;
     const { nodeName } = spec;
-    const ownerRefs = pod.getOwnerRefs();
     const nodeSelector = pod.getNodeSelectors();
     const volumes = pod.getVolumes();
     const labels = pod.getLabels();
@@ -120,21 +119,6 @@ export class PodDetails extends React.Component<Props> {
             nodeSelector.map(label => (
               <Badge key={label} label={label}/>
             ))
-          }
-        </DrawerItem>
-        }
-        {ownerRefs.length > 0 &&
-        <DrawerItem name={<Trans>Controlled By</Trans>}>
-          {
-            ownerRefs.map(ref => {
-              const { name, kind } = ref;
-              const ownerDetailsUrl = getDetailsUrl(lookupApiLink(ref, pod));
-              return (
-                <p key={name}>
-                  {kind} <Link to={ownerDetailsUrl}>{name}</Link>
-                </p>
-              );
-            })
           }
         </DrawerItem>
         }

--- a/dashboard/client/components/kube-object/kube-object-meta.tsx
+++ b/dashboard/client/components/kube-object/kube-object-meta.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { Trans } from "@lingui/macro";
 import { IKubeMetaField, KubeObject } from "../../api/kube-object";
 import { DrawerItem, DrawerItemLabels } from "../drawer";
+import { WorkloadKubeObject } from "../../api/workload-kube-object";
+import { getDetailsUrl } from "../../navigation";
+import { lookupApiLink } from "../../api/kube-api";
+import { Link } from "react-router-dom";
 
 export interface Props {
   object: KubeObject;
@@ -19,11 +23,14 @@ export class KubeObjectMeta extends React.Component<Props> {
   }
 
   render() {
+    const object = this.props.object
     const {
       getName, getNs, getLabels, getResourceVersion, selfLink,
       getAnnotations, getFinalizers, getId, getAge,
       metadata: { creationTimestamp },
-    } = this.props.object;
+    } = object;
+
+    const ownerRefs = object.getOwnerRefs();
     return (
       <>
         <DrawerItem name={<Trans>Created</Trans>} hidden={this.isHidden("creationTimestamp")}>
@@ -59,6 +66,21 @@ export class KubeObjectMeta extends React.Component<Props> {
           labels={getFinalizers()}
           hidden={this.isHidden("finalizers")}
         />
+        {ownerRefs && ownerRefs.length > 0 &&
+        <DrawerItem name={<Trans>Controlled By</Trans>} hidden={this.isHidden("ownerReferences")}>
+          {
+            ownerRefs.map(ref => {
+              const { name, kind } = ref;
+              const ownerDetailsUrl = getDetailsUrl(lookupApiLink(ref, object));
+              return (
+                <p key={name}>
+                  {kind} <Link to={ownerDetailsUrl}>{name}</Link>
+                </p>
+              );
+            })
+          }
+        </DrawerItem>
+        }
       </>
     )
   }


### PR DESCRIPTION
In theory all Kubernetes objects can have `metadata.ownerReferences`. This PR moves owner reference information to `KubeObject` and links to owners are displayed in `KubeObjectMeta` component if available.

Fixes #372 