### PR TITLE
Deploy kube-state-metrics component only to amd64 nodes

### DIFF
--- a/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
+++ b/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
@@ -28,6 +28,11 @@ spec:
                   operator: In
                   values:
                   - linux
+              - matchExpressions:
+                - key: beta.kubernetes.io/arch
+                  operator: In
+                  values:
+                  - amd64
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics

--- a/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
+++ b/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
@@ -23,17 +23,15 @@ spec:
                   operator: In
                   values:
                   - linux
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
-              - matchExpressions:
                 - key: kubernetes.io/arch
                   operator: In
                   values:
                   - amd64
               - matchExpressions:
+                - key: beta.kubernetes.io/os
+                  operator: In
+                  values:
+                  - linux
                 - key: beta.kubernetes.io/arch
                   operator: In
                   values:

--- a/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
+++ b/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
@@ -29,6 +29,11 @@ spec:
                   values:
                   - linux
               - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - amd64
+              - matchExpressions:
                 - key: beta.kubernetes.io/arch
                   operator: In
                   values:


### PR DESCRIPTION
Currently, all of the lens prometheus components are multi-arch except for `kube-state-metrics`.  On a hybrid cluster this can get scheduled on arm, arm64 or other nodes and the pod will never come up.

- kube-state-metrics image only supports amd64 - https://github.com/kubernetes/kube-state-metrics/issues/1037.  There is a PR for this but it hasn't been merged yet and seems to be held up.

Alternatively I could switch to use a different image: https://hub.docker.com/r/carlosedp/kube-state-metrics/tags but just limiting the state metrics to amd64 seems like the much easier/safer option.

And just a note:  I don't see it listed anywhere what minimum version of Kubernetes is required for Lens.  It might be nice to set that up?  Somewhere in the requirements section of the readme?  I.e. if it was clear that the minimum supported version was Kubernetes 1.14 I would have updated the labels from `beta.kubernetes.io/*` to `kubernetes.io/*`.  The old `beta.kubernetes.io/[os | arch]` labels were [deprecated in 1.14 and scheduled for removal in 1.18](https://v1-14.docs.kubernetes.io/docs/setup/release/notes/#deprecations).  They didn't remove them in 1.18 but may remove them in 1.19 or 1.20.