### PR TITLE
Fix pod shell command on Windows

### DIFF
--- a/dashboard/client/components/+workloads-pods/pod-menu.tsx
+++ b/dashboard/client/components/+workloads-pods/pod-menu.tsx
@@ -22,7 +22,7 @@ export class PodMenu extends React.Component<Props> {
     const { object: pod } = this.props
     const containerParam = container ? `-c ${container}` : ""
     let command = `kubectl exec -i -t -n ${pod.getNs()} ${pod.getName()} ${containerParam} "--"`
-    if (process.platform !== "win32") {
+    if (window.navigator.platform !== "Win32") {
       command = `exec ${command}`
     }
     if (pod.getSelectedNodeOs() === "windows") {


### PR DESCRIPTION
This PR detect Windows OS for pod shell command based on `window.navigator.platform` since `process.platform` is not available on sandbox.

Fixes #338 