### PR TITLE
Release v3.5.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.4.0",
+  "version": "3.5.0-beta.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.4.0 (current version)
+## 3.5.0-beta.1 (current version)
+
+- Dynamic dashboard UI based on RBAC rules
+- Show object reference for all objects
+- Unify scrollbars/paddings
+- Fix: add arch node selector for hybrid clusters
+- Fix pod shell command on Windows
+- Translation correction: transit to transmit
+- Remove Kontena reference from Lens logo
+
+## 3.4.0
 
 - Auto-detect Prometheus installation
 - Allow to select Prometheus query style


### PR DESCRIPTION
## Changes since v3.4.0

- Add arch node selector for hybrid clusters (#400)
- Dynamic dashboard UI based on RBAC rules (#366)
- Show object reference for all objects (#399)
- Fix pod shell command on Windows (#402)
- typo/translation correction: transit to transmit (#359)
- Fix @babel/preset-env version (#401)
- Unify scrollbars/paddings across supported OS (#367)
- Remove Kontena reference from Lens logo (#357)
- Replace admin check with check for access (#297)
