### PR TITLE
Fix app freeze after closing terminal on Windows

### DIFF
--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -182,16 +182,24 @@ export class ShellSession extends EventEmitter {
 
   protected exitProcessOnWebsocketClose() {
     this.websocket.on("close", () => {
-      if (this.shellProcess) {
-        logger.debug("Killing shell process")
+      logger.debug("Killing shell process")
+      this.killShellProcess()
+    })
+  }
+
+  protected killShellProcess(){
+    if(this.running) {
+      // For windows we need to kill the shell process by pid, since Lens won't respond after a while if using `this.shellProcess.kill()`
+      if (process.platform == "win32") {
         try {
           process.kill(this.shellProcess.pid)
         } catch(e) {
           logger.debug("Process id not exist")
         }
-        this.emit('exit')
+      } else {
+        this.shellProcess.kill()
       }
-    })
+    }
   }
 
   protected sendResponse(msg: string) {


### PR DESCRIPTION
For some reason when executing `shellProcess.kill()` Lens app stops responding after a while. The issue reminds a bit https://github.com/microsoft/node-pty/issues/34, but it should have been already fixed. I tested this on early electron version found from `node-pty` examples and it was working fine there, so it's a bit mystery why it's failing.

As a workaround, terminal process is now killed by pid on Windows. It seems to work fine. I left `shellProcess.kill()` in place on other environments, since it might do some good things under the hood.

Fixes #234