### PR TITLE
Remove Helm release update checker

### DIFF
--- a/dashboard/client/api/endpoints/helm-releases.api.ts
+++ b/dashboard/client/api/endpoints/helm-releases.api.ts
@@ -198,21 +198,4 @@ export class HelmRelease implements ItemObject {
     const chartVersion = versions.find(chartVersion => chartVersion.version === version);
     return chartVersion ? chartVersion.repo : "";
   }
-
-  getLastVersion(): string | null {
-    const chartName = this.getChart();
-    const versions = helmChartStore.versions.get(chartName);
-    if (!versions) {
-      return null; // checking new version state
-    }
-    if (versions.length) {
-      return versions[0].version; // versions already sorted when loaded, the first is latest
-    }
-    return this.getVersion();
-  }
-
-  hasNewVersion() {
-    const lastVersion = this.getLastVersion();
-    return lastVersion && lastVersion !== this.getVersion();
-  }
 }

--- a/dashboard/client/components/+apps-releases/release-details.tsx
+++ b/dashboard/client/components/+apps-releases/release-details.tsx
@@ -19,7 +19,6 @@ import { AceEditor } from "../ace-editor";
 import { Button } from "../button";
 import { releaseStore } from "./release.store";
 import { Notifications } from "../notifications";
-import { Icon } from "../icon";
 import { createUpgradeChartTab } from "../dock/upgrade-chart.store";
 import { getDetailsUrl } from "../../navigation";
 import { _i18n } from "../../i18n";
@@ -190,14 +189,12 @@ export class ReleaseDetails extends Component<Props> {
         <DrawerItem name={<Trans>Chart</Trans>} className="chart">
           <div className="flex gaps align-center">
             <span>{release.getChart()}</span>
-            {release.hasNewVersion() && (
-              <Button
-                primary
-                label={_i18n._(t`Upgrade`)}
-                className="box right upgrade"
-                onClick={this.upgradeVersion}
-              />
-            )}
+            <Button
+              primary
+              label={_i18n._(t`Upgrade`)}
+              className="box right upgrade"
+              onClick={this.upgradeVersion}
+            />
           </div>
         </DrawerItem>
         <DrawerItem name={<Trans>Updated</Trans>}>
@@ -211,12 +208,6 @@ export class ReleaseDetails extends Component<Props> {
             <span>
               {release.getVersion()}
             </span>
-            {!release.getLastVersion() && (
-              <Icon svg="spinner" small/>
-            )}
-            {release.hasNewVersion() && (
-              <span><Trans>New version available:</Trans> <b>{release.getLastVersion()}</b></span>
-            )}
           </div>
         </DrawerItem>
         <DrawerItem name={<Trans>Status</Trans>} className="status" labelsOnly>

--- a/dashboard/client/components/+apps-releases/release-menu.tsx
+++ b/dashboard/client/components/+apps-releases/release-menu.tsx
@@ -37,19 +37,12 @@ export class HelmReleaseMenu extends React.Component<Props> {
     const { release, toolbar } = this.props;
     if (!release) return;
     const hasRollback = release && release.getRevision() > 1;
-    const hasNewVersion = release.hasNewVersion();
     return (
       <>
         {hasRollback && (
           <MenuItem onClick={this.rollback}>
             <Icon material="history" interactive={toolbar} title={_i18n._(t`Rollback`)}/>
             <span className="title"><Trans>Rollback</Trans></span>
-          </MenuItem>
-        )}
-        {hasNewVersion && (
-          <MenuItem onClick={this.upgrade}>
-            <Icon material="build" interactive={toolbar} title={_i18n._(t`Upgrade`)}/>
-            <span className="title"><Trans>Upgrade</Trans></span>
           </MenuItem>
         )}
       </>


### PR DESCRIPTION
Since Helm does not store information about repository/chart where the release is installed from, we have to remove update checker.

We can re-implement this if/after Helm will have some metadata available: https://github.com/helm/helm/issues/6464

Fixes #361 