### PR TITLE
Fix Helm pre-release version detection

### DIFF
--- a/dashboard/client/api/endpoints/helm-releases.api.ts
+++ b/dashboard/client/api/endpoints/helm-releases.api.ts
@@ -156,9 +156,12 @@ export class HelmRelease implements ItemObject {
   }
 
   getChart(withVersion = false) {
-    return withVersion ?
-      this.chart :
-      this.chart.substr(0, this.chart.lastIndexOf("-"));
+    let chart = this.chart
+    if(!withVersion && this.getVersion() != "" ) {
+      const search = new RegExp(`-${this.getVersion()}`)
+      chart = chart.replace(search, "");
+    }
+    return chart
   }
 
   getRevision() {
@@ -170,7 +173,7 @@ export class HelmRelease implements ItemObject {
   }
 
   getVersion() {
-    const versions = this.chart.match(/(\d+)[^-]*$/)
+    const versions = this.chart.match(/(v?\d+)[^-].*$/)
     if (versions) {
       return versions[0]
     } else {


### PR DESCRIPTION
This PR will improve Helm release version detection if chart version is for example pre-release 

Old:
![image](https://user-images.githubusercontent.com/455844/84164246-f74d6d00-aa7a-11ea-9e9f-19116374b4c3.png)

New:
![image](https://user-images.githubusercontent.com/455844/84150097-0f68c080-aa6a-11ea-9073-c170f1b35381.png)

Fixes #363 