### PR TITLE
Release v3.5.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.5.0-beta.1",
+  "version": "3.5.0-rc.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,15 +2,22 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.5.0-beta.1 (current version)
+## 3.5.0-rc.1 (current version)
 
 - Dynamic dashboard UI based on RBAC rules
 - Show object reference for all objects
 - Unify scrollbars/paddings
+- New logo
+- Remove Helm release update checker
+- Improve Helm release version detection
 - Fix: add arch node selector for hybrid clusters
 - Fix pod shell command on Windows
+- Fix: kill shell process by pid on Windows
+- Fix: close proxy server on app quit
 - Translation correction: transit to transmit
 - Remove Kontena reference from Lens logo
+- Track telemetry pref changed event
+- Integration tests using spectron
 
 ## 3.4.0
 


### PR DESCRIPTION
## Changes since v3.5.0-beta.1

- Fix resource lists auto-refresh (#447)
- Track telemetry pref changed event (#445)
- Enable win integration tests (#424)
- Fix icon.ico (#440)
- Improve Helm release version detection (#422)
- Close proxy server on app quit (#413)
- New logo (#423)
- Bump websocket-extensions from 0.1.3 to 0.1.4 (#409)
- Bump websocket-extensions from 0.1.3 to 0.1.4 in /dashboard (#408)
- Remove Helm release update checker (#420)
- Integration tests using spectron (#410)
- Kill shell process by pid on Windows (#411)
- Add download-bins target to make (#406)
