### PR TITLE
Remove related pods when removing Job resource

### DIFF
--- a/dashboard/client/api/endpoints/job.api.ts
+++ b/dashboard/client/api/endpoints/job.api.ts
@@ -3,6 +3,7 @@ import { autobind } from "../../utils";
 import { IAffinity, WorkloadKubeObject } from "../workload-kube-object";
 import { IPodContainer } from "./pods.api";
 import { KubeApi } from "../kube-api";
+import { JsonApiParams } from "../json-api";
 
 @autobind()
 export class Job extends WorkloadKubeObject {
@@ -87,6 +88,13 @@ export class Job extends WorkloadKubeObject {
   getImages() {
     const containers: IPodContainer[] = get(this, "spec.template.spec.containers", [])
     return [...containers].map(container => container.image)
+  }
+
+  delete() {
+    const params: JsonApiParams = {
+      query: { propagationPolicy: "Background" }
+    }
+    return super.delete(params)
   }
 }
 

--- a/dashboard/client/api/kube-object.ts
+++ b/dashboard/client/api/kube-object.ts
@@ -5,6 +5,7 @@ import { KubeJsonApiData, KubeJsonApiDataList } from "./kube-json-api";
 import { autobind, formatDuration } from "../utils";
 import { ItemObject } from "../item.store";
 import { apiKube } from "./index";
+import { JsonApiParams } from "./json-api";
 import { resourceApplierApi } from "./endpoints/resource-applier.api";
 
 export type IKubeObjectConstructor<T extends KubeObject = any> = (new (data: KubeJsonApiData | any) => T) & {
@@ -152,7 +153,7 @@ export class KubeObject implements ItemObject {
     });
   }
 
-  delete() {
-    return apiKube.del(this.selfLink);
+  delete(params?: JsonApiParams) {
+    return apiKube.del(this.selfLink, params);
   }
 }


### PR DESCRIPTION
This changes the behaviour of removing the selected job(s) in the dashboard. Now, all pods owned by the job(s) will also be removed, in line with kubectl behaviour.

Perhaps this should just be the default behaviour, and the Lens user should be given the option of removing the pods or not? The "Remove item" dialog could be subclassed to add a checkbox for removing the associated pods?

Fixes #393 