### PR TITLE
Release v3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.5.0-rc.1",
+  "version": "3.5.0",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,18 +2,21 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.5.0-rc.1 (current version)
+## 3.5.0 (current version)
 
-- Dynamic dashboard UI based on RBAC rules
+- Dynamic dashboard UI based on RBAC rules (hides non-accessible menus)
 - Show object reference for all objects
 - Unify scrollbars/paddings
 - New logo
 - Remove Helm release update checker
 - Improve Helm release version detection
+- Show owner reference on all resource details
 - Fix: add arch node selector for hybrid clusters
 - Fix pod shell command on Windows
-- Fix: kill shell process by pid on Windows
-- Fix: close proxy server on app quit
+- Fix app freeze after closing terminal on Windows
+- Fix: use correct kubeconfig context on terminal when switching cluster
+- Fix error when closing Lens on Windows
+- Fix: deploy kube-state-metrics component only to amd64 nodes
 - Translation correction: transit to transmit
 - Remove Kontena reference from Lens logo
 - Track telemetry pref changed event
@@ -287,4 +290,3 @@ Here you can find description of changes we've built into each release. While we
 ## 2.0.0
 
 Initial release of the Lens desktop application. Basic functionality with auto-import of users local kubeconfig for cluster access.
-


### PR DESCRIPTION
## Changes since v3.4.0

- Use correct kubeconfig context on terminal when switching cluster (#461)
- Track telemetry pref changed event (#445)
- Enable win integration tests (#424)
- Fix icon.ico (#440)
- Improve Helm release version detection (#422)
- Fix error when closing Lens on Windows (#413)
- New logo (#423)
- Bump websocket-extensions from 0.1.3 to 0.1.4 (#409)
- Bump websocket-extensions from 0.1.3 to 0.1.4 in /dashboard (#408)
- Remove Helm release update checker (#420)
- Integration tests using spectron (#410)
- Fix app freeze after closing terminal on Windows (#411)
- Add download-bins target to make (#406)
- Add arch node selector for hybrid clusters (#400)
- Dynamic dashboard UI based on RBAC rules (#366)
- Show owner reference on all resource details (#399)
- Fix pod shell command on Windows (#402)
- typo/translation correction: transit to transmit (#359)
- Fix @babel/preset-env version (#401)
- Unify scrollbars/paddings across supported OS (#367)
- Remove Kontena reference from Lens logo (#357)
- Replace admin check with check for access (#297)