### PR TITLE
Kubeconfigs as file references

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -1,4 +1,7 @@
+import { app, remote } from "electron"
 import ElectronStore from "electron-store"
+import  { ensureDirSync, writeFileSync } from "fs-extra"
+import * as path from "path"
 import { Cluster, ClusterBaseInfo } from "../main/cluster";
 import * as version200Beta2 from "../migrations/cluster-store/2.0.0-beta.2"
 import * as version241 from "../migrations/cluster-store/2.4.1"
@@ -117,4 +120,17 @@ export class ClusterStore {
   }
 }
 
-export const clusterStore = ClusterStore.getInstance();
+export const clusterStore: ClusterStore = ClusterStore.getInstance();
+
+// Writes kubeconfigs to "embedded" store, i.e. .../Lens/kubeconfigs/
+export function writeEmbeddedKubeConfig(clusterId: string, kubeConfig: string): string {
+  // This can be called from main & renderer
+  const a = (app || remote.app)
+  const kubeConfigBase = path.join(a.getPath("userData"), "kubeconfigs")
+  ensureDirSync(kubeConfigBase)
+
+  const kubeConfigFile = path.join(kubeConfigBase, clusterId)
+  writeFileSync(kubeConfigFile, kubeConfig)
+
+  return kubeConfigFile
+}

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -1,7 +1,4 @@
-import { app, remote } from "electron"
 import ElectronStore from "electron-store"
-import  { ensureDirSync, writeFileSync } from "fs-extra"
-import * as path from "path"
 import { Cluster, ClusterBaseInfo } from "../main/cluster";
 import * as version200Beta2 from "../migrations/cluster-store/2.0.0-beta.2"
 import * as version241 from "../migrations/cluster-store/2.4.1"
@@ -9,7 +6,7 @@ import * as version260Beta2 from "../migrations/cluster-store/2.6.0-beta.2"
 import * as version260Beta3 from "../migrations/cluster-store/2.6.0-beta.3"
 import * as version270Beta0 from "../migrations/cluster-store/2.7.0-beta.0"
 import * as version270Beta1 from "../migrations/cluster-store/2.7.0-beta.1"
-import * as version350Beta1 from "../migrations/cluster-store/3.5.0-beta.1"
+import * as version360Beta1 from "../migrations/cluster-store/3.6.0-beta.1"
 import { getAppVersion } from "./utils/app-version";
 
 export class ClusterStore {
@@ -30,7 +27,7 @@ export class ClusterStore {
         "2.6.0-beta.3": version260Beta3.migration,
         "2.7.0-beta.0": version270Beta0.migration,
         "2.7.0-beta.1": version270Beta1.migration,
-        "3.5.0-beta.1": version350Beta1.migration
+        "3.6.0-beta.1": version360Beta1.migration
       }
     })
   }
@@ -121,16 +118,3 @@ export class ClusterStore {
 }
 
 export const clusterStore: ClusterStore = ClusterStore.getInstance();
-
-// Writes kubeconfigs to "embedded" store, i.e. .../Lens/kubeconfigs/
-export function writeEmbeddedKubeConfig(clusterId: string, kubeConfig: string): string {
-  // This can be called from main & renderer
-  const a = (app || remote.app)
-  const kubeConfigBase = path.join(a.getPath("userData"), "kubeconfigs")
-  ensureDirSync(kubeConfigBase)
-
-  const kubeConfigFile = path.join(kubeConfigBase, clusterId)
-  writeFileSync(kubeConfigFile, kubeConfig)
-
-  return kubeConfigFile
-}

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -6,6 +6,7 @@ import * as version260Beta2 from "../migrations/cluster-store/2.6.0-beta.2"
 import * as version260Beta3 from "../migrations/cluster-store/2.6.0-beta.3"
 import * as version270Beta0 from "../migrations/cluster-store/2.7.0-beta.0"
 import * as version270Beta1 from "../migrations/cluster-store/2.7.0-beta.1"
+import * as version350Beta1 from "../migrations/cluster-store/3.5.0-beta.1"
 import { getAppVersion } from "./utils/app-version";
 
 export class ClusterStore {
@@ -25,7 +26,8 @@ export class ClusterStore {
         "2.6.0-beta.2": version260Beta2.migration,
         "2.6.0-beta.3": version260Beta3.migration,
         "2.7.0-beta.0": version270Beta0.migration,
-        "2.7.0-beta.1": version270Beta1.migration
+        "2.7.0-beta.1": version270Beta1.migration,
+        "3.5.0-beta.1": version350Beta1.migration
       }
     })
   }
@@ -72,7 +74,8 @@ export class ClusterStore {
     const index = clusters.findIndex((cl) => cl.id === cluster.id)
     const storable = {
       id: cluster.id,
-      kubeConfig: cluster.kubeConfig,
+      kubeConfigPath: cluster.kubeConfigPath,
+      contextName: cluster.contextName,
       preferences: cluster.preferences,
       workspace: cluster.workspace
     }
@@ -95,7 +98,8 @@ export class ClusterStore {
   public reloadCluster(cluster: ClusterBaseInfo): void {
     const storedCluster = this.getCluster(cluster.id);
     if (storedCluster) {
-      cluster.kubeConfig = storedCluster.kubeConfig
+      cluster.kubeConfigPath = storedCluster.kubeConfigPath
+      cluster.contextName = storedCluster.contextName
       cluster.preferences = storedCluster.preferences
       cluster.workspace = storedCluster.workspace
     }

--- a/src/common/cluster-store_spec.ts
+++ b/src/common/cluster-store_spec.ts
@@ -1,7 +1,18 @@
 import mockFs from "mock-fs"
 import yaml from "js-yaml"
+import * as fs from "fs"
 import { ClusterStore } from "./cluster-store";
 import { Cluster } from "../main/cluster";
+
+jest.mock("electron", () => {
+  return {
+    app: {
+      getVersion: () => '99.99.99',
+      getPath: () => 'tmp',
+      getLocale: () => 'en'
+    }
+  }
+})
 
 // Console.log needs to be called before fs-mocks, see https://github.com/tschaub/mock-fs/issues/234
 console.log("");
@@ -24,7 +35,8 @@ describe("for an empty config", () => {
   it("allows to store and retrieve a cluster", async () => {
     const cluster = new Cluster({
       id: 'foo',
-      kubeConfig: 'kubeconfig string',
+      kubeConfigPath: 'kubeconfig',
+      contextName: "foo",
       preferences: {
         terminalCWD: '/tmp',
         icon: 'path to icon'
@@ -33,7 +45,7 @@ describe("for an empty config", () => {
     const clusterStore = ClusterStore.getInstance()
     clusterStore.storeCluster(cluster);
     const storedCluster = clusterStore.getCluster(cluster.id);
-    expect(storedCluster.kubeConfig).toBe(cluster.kubeConfig)
+    expect(storedCluster.kubeConfigPath).toBe(cluster.kubeConfigPath)
     expect(storedCluster.preferences.icon).toBe(cluster.preferences.icon)
     expect(storedCluster.preferences.terminalCWD).toBe(cluster.preferences.terminalCWD)
     expect(storedCluster.id).toBe(cluster.id)
@@ -42,7 +54,8 @@ describe("for an empty config", () => {
   it("allows to delete a cluster", async () => {
     const cluster = new Cluster({
       id: 'foofoo',
-      kubeConfig: 'kubeconfig string',
+      kubeConfigPath: 'kubeconfig',
+      contextName: "foo",
       preferences: {
         terminalCWD: '/tmp'
       }
@@ -74,12 +87,12 @@ describe("for a config with existing clusters", () => {
           clusters: [
             {
               id: 'cluster1',
-              kubeConfig: 'foo',
+              kubeConfigPath: 'foo',
               preferences: { terminalCWD: '/foo' }
             },
             {
               id: 'cluster2',
-              kubeConfig: 'foo2',
+              kubeConfigPath: 'foo2',
               preferences: { terminalCWD: '/foo2' }
             }
           ]
@@ -96,12 +109,12 @@ describe("for a config with existing clusters", () => {
   it("allows to retrieve a cluster", async () => {
     const clusterStore = ClusterStore.getInstance()
     const storedCluster = clusterStore.getCluster('cluster1')
-    expect(storedCluster.kubeConfig).toBe('foo')
+    expect(storedCluster.kubeConfigPath).toBe('foo')
     expect(storedCluster.preferences.terminalCWD).toBe('/foo')
     expect(storedCluster.id).toBe('cluster1')
 
     const storedCluster2 = clusterStore.getCluster('cluster2')
-    expect(storedCluster2.kubeConfig).toBe('foo2')
+    expect(storedCluster2.kubeConfigPath).toBe('foo2')
     expect(storedCluster2.preferences.terminalCWD).toBe('/foo2')
     expect(storedCluster2.id).toBe('cluster2')
   })
@@ -122,7 +135,8 @@ describe("for a config with existing clusters", () => {
   it("allows to reload a cluster in-place", async () => {
     const cluster = new Cluster({
       id: 'cluster1',
-      kubeConfig: 'kubeconfig string',
+      kubeConfigPath: 'kubeconfig string',
+      contextName: "foo",
       preferences: {
         terminalCWD: '/tmp'
       }
@@ -131,7 +145,7 @@ describe("for a config with existing clusters", () => {
     const clusterStore = ClusterStore.getInstance()
     clusterStore.reloadCluster(cluster)
 
-    expect(cluster.kubeConfig).toBe('foo')
+    expect(cluster.kubeConfigPath).toBe('foo')
     expect(cluster.preferences.terminalCWD).toBe('/foo')
     expect(cluster.id).toBe('cluster1')
   })
@@ -142,11 +156,11 @@ describe("for a config with existing clusters", () => {
 
     expect(storedClusters[0].id).toBe('cluster1')
     expect(storedClusters[0].preferences.terminalCWD).toBe('/foo')
-    expect(storedClusters[0].kubeConfig).toBe('foo')
+    expect(storedClusters[0].kubeConfigPath).toBe('foo')
 
     expect(storedClusters[1].id).toBe('cluster2')
     expect(storedClusters[1].preferences.terminalCWD).toBe('/foo2')
-    expect(storedClusters[1].kubeConfig).toBe('foo2')
+    expect(storedClusters[1].kubeConfigPath).toBe('foo2')
   })
 
   it("allows storing the clusters in a different order", async () => {
@@ -187,7 +201,7 @@ describe("for a pre 2.0 config with an existing cluster", () => {
   it("migrates to modern format with kubeconfig under a key", async () => {
     const clusterStore = ClusterStore.getInstance()
     const storedCluster = clusterStore.store.get('clusters')[0]
-    expect(storedCluster.kubeConfig).toBe('kubeconfig content')
+    expect(storedCluster.kubeConfigPath).toBe(`tmp/kubeconfigs/${storedCluster.id}`)
   })
 })
 
@@ -254,9 +268,10 @@ describe("for a pre 2.6.0 config with a cluster that has arrays in auth config",
   it("replaces array format access token and expiry into string", async () => {
     const clusterStore = ClusterStore.getInstance()
     const storedClusterData = clusterStore.store.get('clusters')[0]
-    const kc = yaml.safeLoad(storedClusterData.kubeConfig)
+    const kc = yaml.safeLoad(fs.readFileSync(storedClusterData.kubeConfigPath).toString())
     expect(kc.users[0].user['auth-provider'].config['access-token']).toBe("should be string")
     expect(kc.users[0].user['auth-provider'].config['expiry']).toBe("should be string")
+    expect(storedClusterData.contextName).toBe("minikube")
   })
 })
 

--- a/src/common/cluster-store_spec.ts
+++ b/src/common/cluster-store_spec.ts
@@ -46,6 +46,7 @@ describe("for an empty config", () => {
     clusterStore.storeCluster(cluster);
     const storedCluster = clusterStore.getCluster(cluster.id);
     expect(storedCluster.kubeConfigPath).toBe(cluster.kubeConfigPath)
+    expect(storedCluster.contextName).toBe(cluster.contextName)
     expect(storedCluster.preferences.icon).toBe(cluster.preferences.icon)
     expect(storedCluster.preferences.terminalCWD).toBe(cluster.preferences.terminalCWD)
     expect(storedCluster.id).toBe(cluster.id)

--- a/src/common/utils/kubeconfig.ts
+++ b/src/common/utils/kubeconfig.ts
@@ -1,0 +1,16 @@
+import { app, remote } from "electron"
+import  { ensureDirSync, writeFileSync } from "fs-extra"
+import * as path from "path"
+
+// Writes kubeconfigs to "embedded" store, i.e. .../Lens/kubeconfigs/
+export function writeEmbeddedKubeConfig(clusterId: string, kubeConfig: string): string {
+  // This can be called from main & renderer
+  const a = (app || remote.app)
+  const kubeConfigBase = path.join(a.getPath("userData"), "kubeconfigs")
+  ensureDirSync(kubeConfigBase)
+
+  const kubeConfigFile = path.join(kubeConfigBase, clusterId)
+  writeFileSync(kubeConfigFile, kubeConfig)
+
+  return kubeConfigFile
+}

--- a/src/features/metrics.ts
+++ b/src/features/metrics.ts
@@ -53,7 +53,7 @@ export class MetricsFeature extends Feature {
 
   async install(cluster: Cluster): Promise<boolean> {
     // Check if there are storageclasses
-    const storageClient = cluster.contextHandler.kc.makeApiClient(k8s.StorageV1Api)
+    const storageClient = cluster.proxyKubeconfig().makeApiClient(k8s.StorageV1Api)
     const scs = await storageClient.listStorageClass();
     scs.body.items.forEach(sc => {
       if(sc.metadata.annotations &&
@@ -93,9 +93,9 @@ export class MetricsFeature extends Feature {
 
   async uninstall(cluster: Cluster): Promise<boolean> {
     return new Promise<boolean>(async (resolve, reject) => {
-      const rbacClient = cluster.contextHandler.kc.makeApiClient(RbacAuthorizationV1Api)
+      const rbacClient = cluster.proxyKubeconfig().makeApiClient(RbacAuthorizationV1Api)
       try {
-        await this.deleteNamespace(cluster.contextHandler.kc, "lens-metrics")
+        await this.deleteNamespace(cluster.proxyKubeconfig(), "lens-metrics")
         await rbacClient.deleteClusterRole("lens-prometheus");
         await rbacClient.deleteClusterRoleBinding("lens-prometheus");
         resolve(true);

--- a/src/features/user-mode.ts
+++ b/src/features/user-mode.ts
@@ -37,7 +37,7 @@ export class UserModeFeature extends Feature {
 
   async uninstall(cluster: Cluster): Promise<boolean> {
     return new Promise<boolean>(async (resolve, reject) => {
-      const rbacClient = cluster.contextHandler.kc.makeApiClient(RbacAuthorizationV1Api)
+      const rbacClient = cluster.proxyKubeconfig().makeApiClient(RbacAuthorizationV1Api)
       try {
         await rbacClient.deleteClusterRole("lens-user");
         await rbacClient.deleteClusterRoleBinding("lens-user");

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -44,12 +44,14 @@ export class ClusterManager {
     this.clusters = new Map()
     clusters.forEach((clusterInfo) => {
       try {
-        const kc = this.loadKubeConfig(clusterInfo.kubeConfig)
+        const kc = this.loadKubeConfig(clusterInfo.kubeConfigPath)
+        kc.setCurrentContext(clusterInfo.contextName)
         logger.debug(`Starting to load target definitions for ${ kc.currentContext }`)
         const cluster = new Cluster({
           id: clusterInfo.id,
           port: this.port,
-          kubeConfig: clusterInfo.kubeConfig,
+          kubeConfigPath: clusterInfo.kubeConfigPath,
+          contextName: clusterInfo.contextName,
           preferences: clusterInfo.preferences,
           workspace: clusterInfo.workspace
         })
@@ -77,33 +79,35 @@ export class ClusterManager {
     clusters.map(cluster => cluster.stopServer())
   }
 
-  protected loadKubeConfig(config: string): KubeConfig {
+  protected loadKubeConfig(configPath: string): KubeConfig {
     const kc = new KubeConfig();
-    kc.loadFromString(config);
+    kc.loadFromFile(configPath)
     return kc;
   }
 
   protected async addNewCluster(clusterData: ClusterBaseInfo): Promise<Cluster> {
     return new Promise(async (resolve, reject) => {
+
+      logger.info(`*******addNewCluster: ${JSON.stringify(clusterData)}`)
+
+
       try {
-        const configs: KubeConfig[] = k8s.loadAndSplitConfig(clusterData.kubeConfig)
-        if(configs.length == 0) {
-          reject("No cluster contexts defined")
-        }
-        configs.forEach(c => {
-          k8s.validateConfig(c)
-          const cluster = new Cluster({
-            id: uuid(),
-            port: this.port,
-            kubeConfig: k8s.dumpConfigYaml(c),
-            preferences: clusterData.preferences,
-            workspace: clusterData.workspace
-          })
-          cluster.init(c)
-          cluster.save()
-          this.clusters.set(cluster.id, cluster)
-          resolve(cluster)
-        });
+        const kc = this.loadKubeConfig(clusterData.kubeConfigPath)
+        k8s.validateConfig(kc)
+        kc.setCurrentContext(clusterData.contextName)
+        const cluster = new Cluster({
+          id: uuid(),
+          port: this.port,
+          kubeConfigPath: clusterData.kubeConfigPath,
+          contextName: clusterData.contextName,
+          preferences: clusterData.preferences,
+          workspace: clusterData.workspace
+        })
+        cluster.init(kc)
+        cluster.save()
+        this.clusters.set(cluster.id, cluster)
+        resolve(cluster)
+
       } catch(error) {
         logger.error(error)
         reject(error)

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -45,8 +45,6 @@ export class ClusterManager {
     clusters.forEach((clusterInfo) => {
       try {
         const kc = this.loadKubeConfig(clusterInfo.kubeConfigPath)
-        kc.setCurrentContext(clusterInfo.contextName)
-        logger.debug(`Starting to load target definitions for ${ kc.currentContext }`)
         const cluster = new Cluster({
           id: clusterInfo.id,
           port: this.port,

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -87,10 +87,6 @@ export class ClusterManager {
 
   protected async addNewCluster(clusterData: ClusterBaseInfo): Promise<Cluster> {
     return new Promise(async (resolve, reject) => {
-
-      logger.info(`*******addNewCluster: ${JSON.stringify(clusterData)}`)
-
-
       try {
         const kc = this.loadKubeConfig(clusterData.kubeConfigPath)
         k8s.validateConfig(kc)

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -86,7 +86,6 @@ export class Cluster implements ClusterInfo {
   constructor(clusterInfo: ClusterBaseInfo) {
     if (clusterInfo) Object.assign(this, clusterInfo)
     if (!this.preferences) this.preferences = {}
-    this.kubeconfigManager = new KubeconfigManager(this)
   }
 
   public proxyKubeconfigPath() {
@@ -95,7 +94,9 @@ export class Cluster implements ClusterInfo {
 
   public async init(kc: KubeConfig) {
     this.contextHandler = new ContextHandler(kc, this)
-    //this.contextName = kc.currentContext
+    await this.contextHandler.init() // So we get the proxy port reserved
+    this.kubeconfigManager = new KubeconfigManager(this)
+
     this.url = this.contextHandler.url
     this.apiUrl = kc.getCurrentCluster().server
   }
@@ -138,14 +139,6 @@ export class Cluster implements ClusterInfo {
     }
     this.eventCount = await this.getEventCount();
   }
-
-  // public updateKubeconfig(kubeconfig: string) {
-  //   const storedCluster = clusterStore.getCluster(this.id)
-  //   if (!storedCluster) { return }
-
-  //   this.kubeConfig = kubeconfig
-  //   this.save()
-  // }
 
   public getPrometheusApiPrefix() {
     if (!this.preferences.prometheus?.prefix) {

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -94,7 +94,7 @@ export class Cluster implements ClusterInfo {
 
   public proxyKubeconfig() {
     const kc = new KubeConfig()
-    kc.loadFromFile(this.kubeconfigManager.getPath())
+    kc.loadFromFile(this.proxyKubeconfigPath())
     return kc
   }
 

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -35,7 +35,7 @@ export class ContextHandler {
     this.id = cluster.id
 
     this.cluster = cluster
-    this.clusterUrl = url.parse(cluster.apiUrl) //url.parse(kc.getCurrentCluster().server)
+    this.clusterUrl = url.parse(cluster.apiUrl)
     this.contextName = cluster.contextName;
     this.defaultNamespace = kc.getContextObject(cluster.contextName).namespace
     this.url = `http://${this.id}.localhost:${cluster.port}/`

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -22,14 +22,14 @@ export class ContextHandler {
 
   protected apiTarget: ServerOptions
   protected proxyTarget: ServerOptions
-  protected clusterUrl: url.UrlWithStringQuery
-  protected proxyServer: KubeAuthProxy
+  public clusterUrl: url.UrlWithStringQuery
+  public proxyServer: KubeAuthProxy
 
   protected clientCert: string
   protected clientKey: string
   protected secureApiConnection = true
   protected defaultNamespace: string
-  protected proxyPort: number
+  public proxyPort: number
   protected kubernetesApi: string
   protected prometheusProvider: string
   protected prometheusPath: string
@@ -38,21 +38,6 @@ export class ContextHandler {
   constructor(kc: KubeConfig, cluster: Cluster) {
     this.id = cluster.id
     this.kc = kc
-    logger.info(`**** ctxHandler.kc: ${JSON.stringify(kc, null, 2)}`)
-    // this.kc.users = [
-    //   {
-    //     name: kc.getCurrentUser().name,
-    //     token: this.id
-    //   }
-    // ]
-    // this.kc.contexts = [
-    //   {
-    //     name: kc.currentContext,
-    //     cluster: kc.getCurrentCluster().name,
-    //     user: kc.getCurrentUser().name,
-    //     namespace: kc.getContextObject(kc.currentContext).namespace
-    //   }
-    // ]
     this.kc.setCurrentContext(cluster.contextName)
 
     this.cluster = cluster
@@ -61,14 +46,12 @@ export class ContextHandler {
     this.defaultNamespace = kc.getContextObject(kc.currentContext).namespace
     this.url = `http://${this.id}.localhost:${cluster.port}/`
     this.kubernetesApi = `http://127.0.0.1:${cluster.port}/${this.id}`
-    // this.kc.clusters = [
-    //   {
-    //     name: kc.getCurrentCluster().name,
-    //     server: this.kubernetesApi,
-    //     skipTLSVerify: true
-    //   }
-    // ]
+
     this.setClusterPreferences(cluster.preferences)
+  }
+
+  public async init() {
+    await this.resolveProxyPort()
   }
 
   public setClusterPreferences(clusterPreferences?: ClusterPreferences) {

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -8,28 +8,24 @@ import { KubeAuthProxy } from "./kube-auth-proxy"
 import { Cluster, ClusterPreferences } from "./cluster"
 import { prometheusProviders } from "../common/prometheus-providers"
 import { PrometheusService, PrometheusProvider } from "./prometheus/provider-registry"
-import { PrometheusLens } from "./prometheus/lens"
-import { KubeconfigManager } from "./kubeconfig-manager"
 
 export class ContextHandler {
   public contextName: string
   public id: string
   public url: string
-  
+  public clusterUrl: url.UrlWithStringQuery
+  public proxyServer: KubeAuthProxy
+  public proxyPort: number
   public certData: string
   public authCertData: string
   public cluster: Cluster
 
   protected apiTarget: ServerOptions
   protected proxyTarget: ServerOptions
-  public clusterUrl: url.UrlWithStringQuery
-  public proxyServer: KubeAuthProxy
-
   protected clientCert: string
   protected clientKey: string
   protected secureApiConnection = true
   protected defaultNamespace: string
-  public proxyPort: number
   protected kubernetesApi: string
   protected prometheusProvider: string
   protected prometheusPath: string

--- a/src/main/feature-manager.ts
+++ b/src/main/feature-manager.ts
@@ -1,4 +1,4 @@
-import { ContextHandler } from "./context-handler"
+import { KubeConfig } from "@kubernetes/client-node"
 import logger from "./logger";
 import { Cluster } from "./cluster";
 import { Feature, FeatureStatusMap } from "./feature"
@@ -10,17 +10,19 @@ const ALL_FEATURES: any = {
   'user-mode': new UserModeFeature(null),
 }
 
-export async function getFeatures(clusterContext: ContextHandler): Promise<FeatureStatusMap> {
+export async function getFeatures(cluster: Cluster): Promise<FeatureStatusMap> {
   return new Promise<FeatureStatusMap>(async (resolve, reject) => {
     const result: FeatureStatusMap = {};
-    logger.debug(`features for ${clusterContext.contextName}`);
+    logger.debug(`features for ${cluster.contextName}`);
     for (const key in ALL_FEATURES) {
       logger.debug(`feature ${key}`);
       if (ALL_FEATURES.hasOwnProperty(key)) {
         logger.debug("getting feature status...");
         const feature = ALL_FEATURES[key] as Feature;
-
-        const status = await feature.featureStatus(clusterContext.kc);
+        const kc = new KubeConfig()
+        kc.loadFromFile(cluster.proxyKubeconfigPath())
+        
+        const status = await feature.featureStatus(kc);
         result[feature.name] = status
 
       } else {

--- a/src/main/helm-release-manager.ts
+++ b/src/main/helm-release-manager.ts
@@ -54,7 +54,7 @@ export class HelmReleaseManager {
     await fs.promises.writeFile(fileName, yaml.safeDump(values))
 
     try {
-      const { stdout, stderr } = await promiseExec(`"${helm}" upgrade ${name} ${chart} --version ${version} -f ${fileName} --namespace ${namespace} --kubeconfig ${cluster.kubeconfigPath()}`).catch((error) => { throw(error.stderr)})
+      const { stdout, stderr } = await promiseExec(`"${helm}" upgrade ${name} ${chart} --version ${version} -f ${fileName} --namespace ${namespace} --kubeconfig ${cluster.proxyKubeconfigPath()}`).catch((error) => { throw(error.stderr)})
       return {
         log: stdout,
         release: this.getRelease(name, namespace, cluster)
@@ -66,7 +66,7 @@ export class HelmReleaseManager {
 
   public async getRelease(name: string, namespace: string, cluster: Cluster) {
     const helm = await helmCli.binaryPath()
-    const {stdout, stderr} = await promiseExec(`"${helm}" status ${name} --output json --namespace ${namespace} --kubeconfig ${cluster.kubeconfigPath()}`).catch((error) => { throw(error.stderr)})
+    const {stdout, stderr} = await promiseExec(`"${helm}" status ${name} --output json --namespace ${namespace} --kubeconfig ${cluster.proxyKubeconfigPath()}`).catch((error) => { throw(error.stderr)})
     const release = JSON.parse(stdout)
     release.resources = await this.getResources(name, namespace, cluster)
     return release
@@ -100,7 +100,7 @@ export class HelmReleaseManager {
   protected async getResources(name: string, namespace: string, cluster: Cluster) {
     const helm = await helmCli.binaryPath()
     const kubectl = await cluster.kubeCtl.kubectlPath()
-    const pathToKubeconfig = cluster.kubeconfigPath()
+    const pathToKubeconfig = cluster.proxyKubeconfigPath()
     const { stdout } = await promiseExec(`"${helm}" get manifest ${name} --namespace ${namespace} --kubeconfig ${pathToKubeconfig} | "${kubectl}" get -n ${namespace} --kubeconfig ${pathToKubeconfig} -f - -o=json`).catch((error) => {
       return { stdout: JSON.stringify({items: []})}
     })

--- a/src/main/helm-service.ts
+++ b/src/main/helm-service.ts
@@ -6,7 +6,7 @@ import { releaseManager } from "./helm-release-manager";
 
 class HelmService {
   public async installChart(cluster: Cluster, data: {chart: string; values: {}; name: string; namespace: string; version: string}) {
-    const installResult = await releaseManager.installChart(data.chart, data.values, data.name, data.namespace, data.version, cluster.kubeconfigPath())
+    const installResult = await releaseManager.installChart(data.chart, data.values, data.name, data.namespace, data.version, cluster.proxyKubeconfigPath())
     return installResult
   }
 
@@ -48,7 +48,7 @@ class HelmService {
 
   public async listReleases(cluster: Cluster, namespace: string = null) {
     await repoManager.init()
-    const releases = await releaseManager.listReleases(cluster.kubeconfigPath(), namespace)
+    const releases = await releaseManager.listReleases(cluster.proxyKubeconfigPath(), namespace)
     return releases
   }
 
@@ -60,19 +60,19 @@ class HelmService {
 
   public async getReleaseValues(cluster: Cluster, releaseName: string, namespace: string) {
     logger.debug("Fetch release values")
-    const values = await releaseManager.getValues(releaseName, namespace, cluster.kubeconfigPath())
+    const values = await releaseManager.getValues(releaseName, namespace, cluster.proxyKubeconfigPath())
     return values
   }
 
   public async getReleaseHistory(cluster: Cluster, releaseName: string, namespace: string) {
     logger.debug("Fetch release history")
-    const history = await releaseManager.getHistory(releaseName, namespace, cluster.kubeconfigPath())
+    const history = await releaseManager.getHistory(releaseName, namespace, cluster.proxyKubeconfigPath())
     return(history)
   }
 
   public async deleteRelease(cluster: Cluster, releaseName: string, namespace: string) {
     logger.debug("Delete release")
-    const release = await releaseManager.deleteRelease(releaseName, namespace, cluster.kubeconfigPath())
+    const release = await releaseManager.deleteRelease(releaseName, namespace, cluster.proxyKubeconfigPath())
     return release
   }
 
@@ -84,7 +84,7 @@ class HelmService {
 
   public async rollback(cluster: Cluster, releaseName: string, namespace: string, revision: number) {
     logger.debug("Rollback release")
-    const output = await releaseManager.rollback(releaseName, namespace, revision, cluster.kubeconfigPath())
+    const output = await releaseManager.rollback(releaseName, namespace, revision, cluster.proxyKubeconfigPath())
     return({ message: output })
   }
 

--- a/src/main/k8s.ts
+++ b/src/main/k8s.ts
@@ -70,13 +70,13 @@ export function splitConfig(kubeConfig: k8s.KubeConfig): k8s.KubeConfig[] {
 }
 
 /**
- * Loads KubeConfig from a yaml string and breaks it into several configs. Each context
+ * Loads KubeConfig from a yaml and breaks it into several configs. Each context per KubeConfig object
  *
- * @param configString yaml string of kube config
+ * @param configPath path to kube config yaml file
  */
-export function loadAndSplitConfig(configString: string): k8s.KubeConfig[] {
+export function loadAndSplitConfig(configPath: string): k8s.KubeConfig[] {
   const allConfigs = new k8s.KubeConfig();
-  allConfigs.loadFromString(configString);
+  allConfigs.loadFromFile(configPath);
   return splitConfig(allConfigs);
 }
 

--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -31,26 +31,18 @@ export class KubeAuthProxy {
       return;
     }
     const proxyBin = await this.kubectl.kubectlPath()
-    const configWatcher = watch(this.cluster.kubeconfigPath(), (eventType: string, filename: string) => {
-      if (eventType === "change") {
-        const kc = readFileSync(this.cluster.kubeconfigPath()).toString()
-        if (kc.trim().length > 0) { // Prevent updating empty configs back to store
-          this.cluster.updateKubeconfig(kc)
-        } else {
-          logger.warn(`kubeconfig watch on ${this.cluster.kubeconfigPath()} resulted into empty config, ignoring...`)
-        }
-      }
-    })
-    const clusterUrl = url.parse(this.cluster.apiUrl)
     let args = [
       "proxy",
-      "--port", this.port.toString(),
-      "--kubeconfig", this.cluster.kubeconfigPath(),
-      "--accept-hosts", clusterUrl.hostname,
+      "-p", this.port.toString(),
+      "--kubeconfig", this.cluster.kubeConfigPath,
+      "--context", this.cluster.contextName,
+      "--accept-hosts", ".*",
+      "--reject-paths", "^[^/]",
     ]
     if (process.env.DEBUG_PROXY === "true") {
       args = args.concat(["-v", "9"])
     }
+    logger.debug(`spawning kubectl proxy with args: ${args}`)
     this.proxyProcess = spawn(proxyBin, args, {
       env: this.env
     })
@@ -60,7 +52,6 @@ export class KubeAuthProxy {
         logger.debug("failed to send IPC log message: " + err.message)
       })
       this.proxyProcess = null
-      configWatcher.close()
     })
     this.proxyProcess.stdout.on('data', (data) => {
       let logItem = data.toString()

--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -35,7 +35,7 @@ export class KubeAuthProxy {
       "--kubeconfig", this.cluster.kubeConfigPath,
       "--context", this.cluster.contextName,
       "--accept-hosts", ".*",
-      "--reject-paths", "^[^/]",
+      "--reject-paths", "^[^/]"
     ]
     if (process.env.DEBUG_PROXY === "true") {
       args = args.concat(["-v", "9"])

--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -3,10 +3,8 @@ import logger from "./logger"
 import * as tcpPortUsed from "tcp-port-used"
 import { Kubectl, bundledKubectl } from "./kubectl"
 import { Cluster } from "./cluster"
-import { readFileSync, watch } from "fs"
 import { PromiseIpc } from "electron-promise-ipc"
 import { findMainWebContents } from "./webcontents"
-import * as url from "url"
 
 export class KubeAuthProxy {
   public lastError: string

--- a/src/main/kubeconfig-manager.ts
+++ b/src/main/kubeconfig-manager.ts
@@ -20,19 +20,18 @@ export class KubeconfigManager {
     return this.tempFile
   }
 
+  /**
+   * Creates new "temporary" kubeconfig that point to the kubectl-proxy. 
+   * This way any user of the config does not need to know anything about the auth etc. details.
+   */
   protected createTemporaryKubeconfig(): string {
     ensureDir(this.configDir)
     const path = `${this.configDir}/${randomFileName("kubeconfig")}`
-    logger.debug('Creating temporary kubeconfig: ' + path)
-    logger.debug(`cluster url: ${this.cluster.url}`)
-    logger.debug(`cluster api url: ${this.cluster.apiUrl}`)
-
-    // TODO Make the names come from actual cluster.name etc.
     let kc = {
       clusters: [
         {
           name: this.cluster.contextName,
-          server: `http://127.0.0.1:${this.cluster.port}/${this.cluster.id}`
+          server: `http://127.0.0.1:${this.cluster.contextHandler.proxyPort}`
         }
       ],
       users: [
@@ -44,6 +43,7 @@ export class KubeconfigManager {
         {
           name: this.cluster.contextName,
           cluster: this.cluster.contextName,
+          namespace: this.cluster.contextHandler.kc.getContextObject(this.cluster.contextName).namespace,
           user: "proxy"
         }
       ],

--- a/src/main/kubeconfig-manager.ts
+++ b/src/main/kubeconfig-manager.ts
@@ -27,7 +27,7 @@ export class KubeconfigManager {
   protected createTemporaryKubeconfig(): string {
     ensureDir(this.configDir)
     const path = `${this.configDir}/${randomFileName("kubeconfig")}`
-    let kc = {
+    const kc = {
       clusters: [
         {
           name: this.cluster.contextName,

--- a/src/main/kubeconfig-manager.ts
+++ b/src/main/kubeconfig-manager.ts
@@ -27,6 +27,8 @@ export class KubeconfigManager {
   protected createTemporaryKubeconfig(): string {
     ensureDir(this.configDir)
     const path = `${this.configDir}/${randomFileName("kubeconfig")}`
+    const originalKc = new KubeConfig()
+    originalKc.loadFromFile(this.cluster.kubeConfigPath)
     const kc = {
       clusters: [
         {
@@ -43,7 +45,7 @@ export class KubeconfigManager {
         {
           name: this.cluster.contextName,
           cluster: this.cluster.contextName,
-          namespace: this.cluster.contextHandler.kc.getContextObject(this.cluster.contextName).namespace,
+          namespace: originalKc.getContextObject(this.cluster.contextName).namespace,
           user: "proxy"
         }
       ],

--- a/src/main/kubeconfig-manager.ts
+++ b/src/main/kubeconfig-manager.ts
@@ -2,14 +2,17 @@ import { app } from "electron"
 import fs from "fs"
 import { ensureDir, randomFileName} from "./file-helpers"
 import logger from "./logger"
+import { Cluster } from "./cluster"
+import * as k8s from "./k8s"
+import { KubeConfig } from "@kubernetes/client-node"
 
 export class KubeconfigManager {
   protected configDir = app.getPath("temp")
-  protected kubeconfig: string
   protected tempFile: string
+  protected cluster: Cluster
 
-  constructor(kubeconfig: string) {
-    this.kubeconfig = kubeconfig
+  constructor(cluster: Cluster) {
+    this.cluster = cluster
     this.tempFile = this.createTemporaryKubeconfig()
   }
 
@@ -21,7 +24,32 @@ export class KubeconfigManager {
     ensureDir(this.configDir)
     const path = `${this.configDir}/${randomFileName("kubeconfig")}`
     logger.debug('Creating temporary kubeconfig: ' + path)
-    fs.writeFileSync(path, this.kubeconfig)
+    logger.debug(`cluster url: ${this.cluster.url}`)
+    logger.debug(`cluster api url: ${this.cluster.apiUrl}`)
+
+    // TODO Make the names come from actual cluster.name etc.
+    let kc = {
+      clusters: [
+        {
+          name: this.cluster.contextName,
+          server: `http://127.0.0.1:${this.cluster.port}/${this.cluster.id}`
+        }
+      ],
+      users: [
+        {
+          name: "proxy"
+        }
+      ],
+      contexts: [
+        {
+          name: this.cluster.contextName,
+          cluster: this.cluster.contextName,
+          user: "proxy"
+        }
+      ],
+      currentContext: this.cluster.contextName
+    } as KubeConfig
+    fs.writeFileSync(path, k8s.dumpConfigYaml(kc))
     return path
   }
 

--- a/src/main/node-shell-session.ts
+++ b/src/main/node-shell-session.ts
@@ -17,7 +17,7 @@ export class NodeShellSession extends ShellSession {
     super(socket, pathToKubeconfig, cluster)
     this.nodeName = nodeName
     this.podId = `node-shell-${uuid()}`
-    this.kc = cluster.contextHandler.kc
+    this.kc = cluster.proxyKubeconfig()
   }
 
   public async open() {

--- a/src/main/resource-applier-api.ts
+++ b/src/main/resource-applier-api.ts
@@ -6,7 +6,7 @@ class ResourceApplierApi extends LensApi {
   public async applyResource(request: LensApiRequest) {
     const { response, cluster, payload } = request
     try {
-      const resource = await resourceApplier.apply(cluster, cluster.kubeconfigPath(), payload)
+      const resource = await resourceApplier.apply(cluster, cluster.proxyKubeconfigPath(), payload)
       this.respondJson(response, [resource], 200)
     } catch(error) {
       this.respondText(response, error, 422)

--- a/src/main/routes/config.ts
+++ b/src/main/routes/config.ts
@@ -45,7 +45,7 @@ const apiResources = [
 ]
 
 async function getAllowedNamespaces(cluster: Cluster) {
-  const api = cluster.contextHandler.kc.makeApiClient(CoreV1Api)
+  const api = cluster.proxyKubeconfig().makeApiClient(CoreV1Api)
   try {
     const namespaceList = await api.listNamespace()
     const nsAccessStatuses = await Promise.all(
@@ -58,9 +58,8 @@ async function getAllowedNamespaces(cluster: Cluster) {
     return namespaceList.body.items
       .filter((ns, i) => nsAccessStatuses[i])
       .map(ns => ns.metadata.name)
-  } catch (error) {
-    const kc = cluster.contextHandler.kc
-    const ctx = kc.getContextObject(kc.currentContext)
+  } catch(error) {
+    const ctx = cluster.proxyKubeconfig().getContextObject(cluster.contextName)
     if (ctx.namespace) {
       return [ctx.namespace]
     }

--- a/src/main/routes/kubeconfig.ts
+++ b/src/main/routes/kubeconfig.ts
@@ -12,7 +12,7 @@ function generateKubeConfig(username: string, secret: V1Secret, cluster: Cluster
       {
         'name': cluster.contextName,
         'cluster': {
-          'server': cluster.contextHandler.kc.getCurrentCluster().server,
+          'server': cluster.apiUrl,
           'certificate-authority-data': secret.data["ca.crt"]
         }
       }
@@ -44,7 +44,7 @@ class KubeconfigRoute extends LensApi {
   public async routeServiceAccountRoute(request: LensApiRequest) {
     const { params, response, cluster} = request
 
-    const client = cluster.contextHandler.kc.makeApiClient(CoreV1Api);
+    const client = cluster.proxyKubeconfig().makeApiClient(CoreV1Api);
     const secretList = await client.listNamespacedSecret(params.namespace)
     const secret = secretList.body.items.find(secret => {
       const { annotations } = secret.metadata;

--- a/src/main/routes/port-forward.ts
+++ b/src/main/routes/port-forward.ts
@@ -87,7 +87,7 @@ class PortForwardRoute extends LensApi {
         namespace: params.namespace,
         name: params.service,
         port: params.port,
-        kubeConfig: cluster.kubeconfigPath()
+        kubeConfig: cluster.proxyKubeconfigPath()
       })
       const started = await portForward.start()
       if (!started) {

--- a/src/main/routes/watch.ts
+++ b/src/main/routes/watch.ts
@@ -60,12 +60,7 @@ class ApiWatcher {
 
   private doneHandler(error: Error) {
     if (error) logger.warn("watch ended: " + error.toString())
-
-    this.sendEvent({
-      type: "STREAM_END",
-      url: this.apiUrl,
-      status: 410,
-    })
+    this.watchRequest.abort()
   }
 
   private sendEvent(evt: any) {

--- a/src/main/routes/watch.ts
+++ b/src/main/routes/watch.ts
@@ -59,7 +59,6 @@ class ApiWatcher {
   }
 
   private doneHandler(error: Error) {
-    logger.debug("********** watch.doneHandler")
     if (error) logger.warn("watch ended: " + error.toString())
 
     this.sendEvent({
@@ -96,7 +95,7 @@ class WatchRoute extends LensApi {
     logger.debug("watch using kubeconfig:" + JSON.stringify(cluster.proxyKubeconfig(), null, 2))
 
     apis.forEach(apiUrl => {
-      const watcher = new ApiWatcher(apiUrl, cluster.proxyKubeconfig() /*cluster.contextHandler.kc*/, response)
+      const watcher = new ApiWatcher(apiUrl, cluster.proxyKubeconfig(), response)
       watcher.start()
       watchers.push(watcher)
     })

--- a/src/migrations/cluster-store/3.5.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.5.0-beta.1.ts
@@ -2,6 +2,8 @@
 import { app } from "electron"
 import  { ensureDirSync, writeFileSync } from "fs-extra"
 import * as path from "path"
+import { KubeConfig } from "@kubernetes/client-node";
+import * as clusterStore from "../../cluster-store"
 
 export function migration(store: any) {
   console.log("CLUSTER STORE, MIGRATION: 3.5.0-beta.1");
@@ -11,21 +13,23 @@ export function migration(store: any) {
   ensureDirSync(kubeConfigBase)
   let storedClusters = store.get("clusters") as any[]
   if (!storedClusters) return
-  
+
   console.log("num clusters to migrate: ", storedClusters.length)
   for (let cluster of storedClusters ) {
+    // TODO Should probably guard this, not to make the whole migration fail if one cluster fails!?
     // take the embedded kubeconfig and dump it into a file
-    const kubeConfigFile = path.join(kubeConfigBase, cluster.id)
-    writeFileSync(kubeConfigFile, cluster.kubeConfig)
-    delete cluster.kubeConfig
+    const kubeConfigFile = clusterStore.writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
     cluster.kubeConfigPath = kubeConfigFile
-    // TODO Need to parse the context name from the config
-
-
-    // "overwrite" the cluster configs
+    
+    const kc = new KubeConfig()
+    kc.loadFromFile(cluster.kubeConfigPath)
+    cluster.contextName = kc.getCurrentContext()
+    
+    delete cluster.kubeConfig
     clusters.push(cluster)
   }
 
+  // "overwrite" the cluster configs
   if (clusters.length > 0) {
     store.set("clusters", clusters)
   }

--- a/src/migrations/cluster-store/3.5.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.5.0-beta.1.ts
@@ -11,11 +11,11 @@ export function migration(store: any) {
   
   const kubeConfigBase = path.join(app.getPath("userData"), "kubeconfigs")
   ensureDirSync(kubeConfigBase)
-  let storedClusters = store.get("clusters") as any[]
+  const storedClusters = store.get("clusters") as any[]
   if (!storedClusters) return
 
   console.log("num clusters to migrate: ", storedClusters.length)
-  for (let cluster of storedClusters ) {
+  for (const cluster of storedClusters ) {
     // TODO Should probably guard this, not to make the whole migration fail if one cluster fails!?
     // take the embedded kubeconfig and dump it into a file
     const kubeConfigFile = clusterStore.writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)

--- a/src/migrations/cluster-store/3.5.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.5.0-beta.1.ts
@@ -1,0 +1,32 @@
+// move embedded kubeconfig into separate file and add reference to it to cluster settings
+import { app } from "electron"
+import  { ensureDirSync, writeFileSync } from "fs-extra"
+import * as path from "path"
+
+export function migration(store: any) {
+  console.log("CLUSTER STORE, MIGRATION: 3.5.0-beta.1");
+  const clusters: any[] = []
+  
+  const kubeConfigBase = path.join(app.getPath("userData"), "kubeconfigs")
+  ensureDirSync(kubeConfigBase)
+  let storedClusters = store.get("clusters") as any[]
+  if (!storedClusters) return
+  
+  console.log("num clusters to migrate: ", storedClusters.length)
+  for (let cluster of storedClusters ) {
+    // take the embedded kubeconfig and dump it into a file
+    const kubeConfigFile = path.join(kubeConfigBase, cluster.id)
+    writeFileSync(kubeConfigFile, cluster.kubeConfig)
+    delete cluster.kubeConfig
+    cluster.kubeConfigPath = kubeConfigFile
+    // TODO Need to parse the context name from the config
+
+
+    // "overwrite" the cluster configs
+    clusters.push(cluster)
+  }
+
+  if (clusters.length > 0) {
+    store.set("clusters", clusters)
+  }
+}

--- a/src/migrations/cluster-store/3.6.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.6.0-beta.1.ts
@@ -17,6 +17,7 @@ export function migration(store: any) {
   console.log("num clusters to migrate: ", storedClusters.length)
   for (const cluster of storedClusters ) {
     // TODO Should probably guard this, not to make the whole migration fail if one cluster fails!?
+    
     // take the embedded kubeconfig and dump it into a file
     const kubeConfigFile = writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
     cluster.kubeConfigPath = kubeConfigFile

--- a/src/migrations/cluster-store/3.6.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.6.0-beta.1.ts
@@ -1,14 +1,14 @@
 // move embedded kubeconfig into separate file and add reference to it to cluster settings
 import { app } from "electron"
-import  { ensureDirSync, writeFileSync } from "fs-extra"
+import  { ensureDirSync } from "fs-extra"
 import * as path from "path"
 import { KubeConfig } from "@kubernetes/client-node";
-import * as clusterStore from "../../cluster-store"
+import { writeEmbeddedKubeConfig } from "../../common/utils/kubeconfig"
 
 export function migration(store: any) {
-  console.log("CLUSTER STORE, MIGRATION: 3.5.0-beta.1");
+  console.log("CLUSTER STORE, MIGRATION: 3.6.0-beta.1");
   const clusters: any[] = []
-  
+
   const kubeConfigBase = path.join(app.getPath("userData"), "kubeconfigs")
   ensureDirSync(kubeConfigBase)
   const storedClusters = store.get("clusters") as any[]
@@ -18,13 +18,13 @@ export function migration(store: any) {
   for (const cluster of storedClusters ) {
     // TODO Should probably guard this, not to make the whole migration fail if one cluster fails!?
     // take the embedded kubeconfig and dump it into a file
-    const kubeConfigFile = clusterStore.writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
+    const kubeConfigFile = writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
     cluster.kubeConfigPath = kubeConfigFile
-    
+
     const kc = new KubeConfig()
     kc.loadFromFile(cluster.kubeConfigPath)
     cluster.contextName = kc.getCurrentContext()
-    
+
     delete cluster.kubeConfig
     clusters.push(cluster)
   }

--- a/src/migrations/cluster-store/3.6.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.6.0-beta.1.ts
@@ -16,18 +16,20 @@ export function migration(store: any) {
 
   console.log("num clusters to migrate: ", storedClusters.length)
   for (const cluster of storedClusters ) {
-    // TODO Should probably guard this, not to make the whole migration fail if one cluster fails!?
-    
-    // take the embedded kubeconfig and dump it into a file
-    const kubeConfigFile = writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
-    cluster.kubeConfigPath = kubeConfigFile
+    try {
+      // take the embedded kubeconfig and dump it into a file
+      const kubeConfigFile = writeEmbeddedKubeConfig(cluster.id, cluster.kubeConfig)
+      cluster.kubeConfigPath = kubeConfigFile
 
-    const kc = new KubeConfig()
-    kc.loadFromFile(cluster.kubeConfigPath)
-    cluster.contextName = kc.getCurrentContext()
+      const kc = new KubeConfig()
+      kc.loadFromFile(cluster.kubeConfigPath)
+      cluster.contextName = kc.getCurrentContext()
 
-    delete cluster.kubeConfig
-    clusters.push(cluster)
+      delete cluster.kubeConfig
+      clusters.push(cluster)
+    } catch(error) {
+      console.error("failed to migrate kubeconfig for cluster:", cluster.id)
+    }
   }
 
   // "overwrite" the cluster configs

--- a/src/renderer/_vue/components/AddClusterPage.vue
+++ b/src/renderer/_vue/components/AddClusterPage.vue
@@ -16,8 +16,11 @@
                     placeholder="Choose a file or drop it here..."
                     drop-placeholder="Drop file here..."
                     @input="reloadKubeContexts()"
-                  ></b-form-file>
-                  <div class="mt-3">Selected file: {{ file ? file.name : '' }}</div>
+                  />
+
+                  <div class="mt-3">
+                    Selected file: {{ file ? file.name : '' }}
+                  </div>
 
                   <b-form-select
                     id="kubecontext-select"

--- a/src/renderer/_vue/components/AddClusterPage.vue
+++ b/src/renderer/_vue/components/AddClusterPage.vue
@@ -129,6 +129,7 @@ import * as path from "path"
 import fs from 'fs'
 import { v4 as uuidv4 } from 'uuid';
 import * as clusterStore from "../../common/cluster-store"
+import { writeEmbeddedKubeConfig} from "../../common/app-utils"
 
 class ClusterAccessError extends Error {}
 

--- a/src/renderer/_vue/components/AddClusterPage.vue
+++ b/src/renderer/_vue/components/AddClusterPage.vue
@@ -113,6 +113,7 @@ import * as PrismEditor from 'vue-prism-editor'
 import * as k8s from "@kubernetes/client-node"
 import { dumpConfigYaml } from "../../../main/k8s"
 import ClustersMixin from "@/_vue/mixins/ClustersMixin";
+import * as path from "path"
 
 class ClusterAccessError extends Error {}
 
@@ -196,8 +197,13 @@ export default {
       try {
         const kc = new k8s.KubeConfig();
         kc.loadFromString(this.clusterconfig); // throws TypeError if we cannot parse kubeconfig
+
+        // TODO Remove hardcoded path
+        const configPath = path.join(process.env.HOME, '.kube', 'config');
+
         const clusterInfo = {
-          kubeConfig: dumpConfigYaml(kc),
+          kubeConfigPath: configPath,
+          contextName: kc.currentContext,
           preferences: {
             clusterName: kc.currentContext
           },

--- a/src/renderer/_vue/components/AddClusterPage.vue
+++ b/src/renderer/_vue/components/AddClusterPage.vue
@@ -10,6 +10,15 @@
                 <b-form-group
                   label="Choose config:"
                 >
+                  <b-form-file
+                    v-model="file"
+                    :state="Boolean(file)"
+                    placeholder="Choose a file or drop it here..."
+                    drop-placeholder="Drop file here..."
+                    @input="reloadKubeContexts()"
+                  ></b-form-file>
+                  <div class="mt-3">Selected file: {{ file ? file.name : '' }}</div>
+
                   <b-form-select
                     id="kubecontext-select"
                     v-model="kubecontext"
@@ -114,6 +123,9 @@ import * as k8s from "@kubernetes/client-node"
 import { dumpConfigYaml } from "../../../main/k8s"
 import ClustersMixin from "@/_vue/mixins/ClustersMixin";
 import * as path from "path"
+import fs from 'fs'
+import { v4 as uuidv4 } from 'uuid';
+import * as clusterStore from "../../common/cluster-store"
 
 class ClusterAccessError extends Error {}
 
@@ -126,6 +138,8 @@ export default {
   },
   data(){
     return {
+      file: null,
+      filepath: null,
       clusterconfig: "",
       httpsProxy: "",
       kubecontext: "",
@@ -137,7 +151,10 @@ export default {
     }
   },
   mounted: function() {
-    this.$store.dispatch("reloadAvailableKubeContexts");
+    const kubeConfigPath = path.join(process.env.HOME, '.kube', 'config')
+    this.filepath = kubeConfigPath
+    this.file = new File(fs.readFileSync(this.filepath), this.filepath)
+    this.$store.dispatch("reloadAvailableKubeContexts", this.filepath);
     this.seenContexts = JSON.parse(JSON.stringify(this.$store.getters.seenContexts)) // clone seenContexts from store
     this.storeSeenContexts()
   },
@@ -164,6 +181,10 @@ export default {
     },
   },
   methods: {
+    reloadKubeContexts() {
+      this.filepath = this.file.path
+      this.$store.dispatch("reloadAvailableKubeContexts", this.file.path);
+    },
     isNewContext(context) {
       return this.newContexts.indexOf(context) > -1
     },
@@ -197,12 +218,15 @@ export default {
       try {
         const kc = new k8s.KubeConfig();
         kc.loadFromString(this.clusterconfig); // throws TypeError if we cannot parse kubeconfig
-
-        // TODO Remove hardcoded path
-        const configPath = path.join(process.env.HOME, '.kube', 'config');
-
+        const clusterId = uuidv4();
+        // We need to store the kubeconfig to "app-home"/
+        if (this.kubecontext === "custom") {
+          // TODO Call "writeEmbeddedKubeConfig"
+          this.filepath = clusterStore.writeEmbeddedKubeConfig(clusterId, this.clusterconfig)
+        }
         const clusterInfo = {
-          kubeConfigPath: configPath,
+          id: clusterId,
+          kubeConfigPath: this.filepath,
           contextName: kc.currentContext,
           preferences: {
             clusterName: kc.currentContext
@@ -212,6 +236,7 @@ export default {
         if (this.httpsProxy) {
           clusterInfo.preferences.httpsProxy = this.httpsProxy
         }
+        console.log("sending clusterInfo:", clusterInfo)
         let res = await this.$store.dispatch('addCluster', clusterInfo)
         console.log("addCluster result:", res)
         if(!res){

--- a/src/renderer/_vue/components/AddClusterPage.vue
+++ b/src/renderer/_vue/components/AddClusterPage.vue
@@ -128,8 +128,7 @@ import ClustersMixin from "@/_vue/mixins/ClustersMixin";
 import * as path from "path"
 import fs from 'fs'
 import { v4 as uuidv4 } from 'uuid';
-import * as clusterStore from "../../common/cluster-store"
-import { writeEmbeddedKubeConfig} from "../../common/app-utils"
+import { writeEmbeddedKubeConfig} from "../../../common/utils/kubeconfig"
 
 class ClusterAccessError extends Error {}
 
@@ -225,8 +224,7 @@ export default {
         const clusterId = uuidv4();
         // We need to store the kubeconfig to "app-home"/
         if (this.kubecontext === "custom") {
-          // TODO Call "writeEmbeddedKubeConfig"
-          this.filepath = clusterStore.writeEmbeddedKubeConfig(clusterId, this.clusterconfig)
+          this.filepath = writeEmbeddedKubeConfig(clusterId, this.clusterconfig)
         }
         const clusterInfo = {
           id: clusterId,

--- a/src/renderer/_vue/store/modules/kube-contexts.js
+++ b/src/renderer/_vue/store/modules/kube-contexts.js
@@ -6,10 +6,10 @@ const state = {
 }
 
 const actions = {
-  reloadAvailableKubeContexts: ({commit}) => {
+  reloadAvailableKubeContexts({commit}, file) {
     let kc = new k8s.KubeConfig();
     try {
-      kc.loadFromDefault();
+      kc.loadFromFile(file);
     } catch (error) {
       console.error("Failed to read default kubeconfig: " + error.message);
     }


### PR DESCRIPTION
This PR changes the way how we use user provided kubeconfigs. Instead of storing them in electron store (as embedded yaml) we use them as real files from the original location. The general idea is that kubectl-proxy should be pretty much the only thing actually using the config, all other k8s access should be going through it.

## Cluster store after migration to this model

```
$ cat ~/Library/Application\ Support/Electron/lens-cluster-store.json 
{
	"__internal__": {
		"migrations": {
			"version": "3.5.0-beta.1"
		}
	},
	"clusters": [
		{
			"id": "487cb2a9-29a5-4e84-b678-e7f3f6264130",
			"preferences": {
				"clusterName": "minikube"
			},
			"workspace": "default",
			"kubeConfigPath": "/Users/jussi/Library/Application Support/Electron/kubeconfigs/487cb2a9-29a5-4e84-b678-e7f3f6264130",
			"contextName": "minikube"
		},
		{
			"id": "9b5092fe-432c-48cf-8501-e0002c634541",
			"kubeConfigPath": "/Users/jussi/Library/Application Support/Electron/kubeconfigs/9b5092fe-432c-48cf-8501-e0002c634541",
			"contextName": "kubesail-jnummelin",
			"preferences": {
				"clusterName": "kubesail-jnummelin",
				"icon": null
			},
			"workspace": "default"
		},
		{
			"id": "8ae5d4f2-7bb6-4feb-a835-8eee75704924",
			"kubeConfigPath": "/Users/jussi/kuber.host",
			"contextName": "kuber.host",
			"preferences": {
				"clusterName": "kuber.host"
			},
			"workspace": "default"
		}
	]
}
```

The two first cluster we're clusters that I had imported already before this PR. So in the cluster store migration, we dump the embedded kubeconfigs into files. We can't make them to reference the original files/contexts as we have no idea which files those were. `kuber.host` cluster I imported using the new file-picker way, so the cluster config in Lens references the original config file always.

## Notes on testing

If you are brave enough to test this, you might want to take a backup of the cluster store file. on osx that's `~/Library/Application\ Support/Electron/lens-cluster-store.json ` when running in dev mode. The migration should work, but there can be some corner cases... :)

# TODOs

- [x] try to remove many more references to things like `this.kc`, `cluster.kc` and alike. Eventually kubectl-proxy should be the only thing really needing the config.
- [x] rename the migration as 3.5.0 already shipped
- [x] refactor features and all other electron side kubeconfig usages to go through the proxy
- [x] cleanup some leftover overly verbose logging stuff
- [ ] Some finetuning needed on "Add cluster" page UI components (maybe separate PR?) This changes quite a bit the way user can import the clusters, hence some re-thinking on the UI flow should be done. Now especially the "custom" option is IMO in wrong place.




fixes #415 