### PR TITLE
Remove redundant applyHeaders method

### DIFF
--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -171,10 +171,6 @@ export class ContextHandler {
     return serverPort
   }
 
-  public applyHeaders(req: http.IncomingMessage) {
-    req.headers["authorization"] = `Bearer ${this.id}`
-  }
-
   public async withTemporaryKubeconfig(callback: (kubeconfig: string) => Promise<any>) {
     try {
       await callback(this.cluster.kubeconfigPath())

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -155,13 +155,6 @@ export class LensProxy {
       return
     }
     const contextHandler = cluster.contextHandler
-    try {
-      contextHandler.applyHeaders(req)
-    } catch (error) {
-      res.statusCode = 503
-      res.end()
-      return
-    }
     contextHandler.ensureServer().then(async () => {
       const proxyTarget = await this.getProxyTarget(req, contextHandler)
       if (proxyTarget) {
@@ -174,9 +167,6 @@ export class LensProxy {
 
   protected async handleWsUpgrade(req: http.IncomingMessage, socket: Socket, head: Buffer) {
     const wsServer = this.createWsListener();
-    const cluster = this.clusterManager.getClusterForRequest(req)
-    const contextHandler = cluster.contextHandler
-    contextHandler.applyHeaders(req);
     wsServer.handleUpgrade(req, socket, head, (con) => {
       wsServer.emit("connection", con, req);
     });


### PR DESCRIPTION
`ContextHandler.applyHeaders` seems to be some legacy code that is not required anymore