### PR TITLE
Display namespace defined in kubeconfig always in the namespace selector

### DIFF
--- a/dashboard/client/components/+namespaces/namespace-select.tsx
+++ b/dashboard/client/components/+namespaces/namespace-select.tsx
@@ -34,7 +34,7 @@ export class NamespaceSelect extends React.Component<Props> {
   private unsubscribe = noop;
 
   async componentDidMount() {
-    if (isAllowedResource("namespaces") && !namespaceStore.isLoaded) {
+    if (!namespaceStore.isLoaded) {
       await namespaceStore.loadAll();
     }
     this.unsubscribe = namespaceStore.subscribe();


### PR DESCRIPTION
Fixes #471 