### PR TITLE
Make sure that secret is defined before trying to decode

### DIFF
--- a/dashboard/client/components/+workloads-pods/pod-container-env.tsx
+++ b/dashboard/client/components/+workloads-pods/pod-container-env.tsx
@@ -120,8 +120,11 @@ const SecretKey = (props: SecretKeyProps) => {
     setSecret(secret)
   }
 
-  if (!secret) {
-    return (
+  if (secret?.data?.[key]) {
+    return <>{base64.decode(secret.data[key])}</>
+  }
+
+  return (
       <>
         secretKeyRef({name}.{key})&nbsp;
         <Icon
@@ -131,7 +134,5 @@ const SecretKey = (props: SecretKeyProps) => {
           onClick={showKey}
         />
       </>
-    )
-  }
-  return <>{base64.decode(secret.data[key])}</>
+  )
 }


### PR DESCRIPTION
Fixes #407 

This PR makes sure that the secret data is defined before trying to decode it into a base64 string.