### PR TITLE
Better log line when quitting Lens

### DIFF
--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -45,7 +45,12 @@ export class KubeAuthProxy {
       env: this.env
     })
     this.proxyProcess.on("exit", (code) => {
-      logger.error(`proxy ${this.cluster.contextName} exited with code ${code}`)
+      if (code) {
+        logger.error(`proxy ${this.cluster.contextName} exited with code ${code}`)
+      } else {
+        logger.info(`proxy ${this.cluster.contextName} exited successfully`)
+      }
+
       this.sendIpcLogMessage( `proxy exited with code ${code}`, "stderr").catch((err: Error) => {
         logger.debug("failed to send IPC log message: " + err.message)
       })


### PR DESCRIPTION
Currently when lens quits it always outputs an `error` level log line even if the app or its window was closed successfully from the request of the user.

This PR changes it so that it still logs an error if there is one, but in the falsy case it `info` level logs a "success" line.