### PR TITLE
fix kube-state-metrics in arm64

### DIFF
--- a/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
+++ b/src/features/metrics/14-kube-state-metrics-deployment.yml.hb
@@ -19,27 +19,22 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - amd64
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
-                - key: beta.kubernetes.io/arch
-                  operator: In
-                  values:
-                  - amd64
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - arm
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - arm
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.9.5
+        image: carlosedp/kube-state-metrics:v1.9.6
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
fix kube-state-metrics runing in arm64 issue was not runing.
image official kube-state-metrics don't have arm64 build.
now kube-state-metrics run in arm, arm64 and amd64, changed version for v1.9.6.

nodeAffinity don't need check kubernetes.io/os right? so I removed, if os is arm64 .

soon they will update to support arm64, I think that for now there is no problem using Carlos's image, so who wants to use Lens with arm64 cluster like me will be very happy :)

with these chances it will run smoothly.