### PR TITLE
Fix pasting unicode into terminal sometimes not working

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,7 +34,7 @@ const vmURL = (isDevelopment) ? `http://localhost:${process.env.ELECTRON_WEBPACK
 })
 
 async function main() {
-  await shellSync()
+  shellSync(app.getLocale())
 
   const updater = new AppUpdater()
   updater.start();

--- a/src/main/shell-sync.ts
+++ b/src/main/shell-sync.ts
@@ -1,18 +1,34 @@
 import shellEnv = require("shell-env")
 import logger from "./logger"
+import * as os from "os";
 
-export async function shellSync() {
-  const env = await shellEnv()
+interface Env {
+  [key: string]: string;
+}
+
+/**
+ * shellSync loads what would have been the environment if this application was
+ * run from the command line, into the process.env object. This is especially
+ * useful on macos where this always needs to be done.
+ * @param locale Should be electron's `app.getLocale()`
+ */
+export function shellSync(locale: string) {
+  const { shell } = os.userInfo();
+  const env: Env = JSON.parse(JSON.stringify(shellEnv.sync(shell)))
+  if (!env.LANG) {
+    // the LANG env var expects an underscore instead of electron's dash
+    env.LANG = `${locale.replace('-', '_')}.UTF-8`;
+  } else if (!env.LANG.endsWith(".UTF-8")) {
+    env.LANG += ".UTF-8"
+  }
 
   // Overwrite PATH on darwin
   if (process.env.NODE_ENV === "production" && process.platform === "darwin") {
     process.env["PATH"] = env.PATH
   }
 
-  let key = null
-  for(key in env) {
-    if(!env.hasOwnProperty(key) || process.env[key]) continue // skip existing and prototype keys
-    logger.debug("Imported " + key + " from login shell to process environment")
-    process.env[key] = env[key]
-  }
+  process.env = {
+    ...process.env,
+    ...env
+  };
 }

--- a/src/main/shell-sync.ts
+++ b/src/main/shell-sync.ts
@@ -27,8 +27,9 @@ export function shellSync(locale: string) {
     process.env["PATH"] = env.PATH
   }
 
+  // The spread operator allows joining of objects. The precidence is last to first.
   process.env = {
+    ...env,
     ...process.env,
-    ...env
   };
 }

--- a/src/main/shell-sync.ts
+++ b/src/main/shell-sync.ts
@@ -27,7 +27,7 @@ export function shellSync(locale: string) {
     process.env["PATH"] = env.PATH
   }
 
-  // The spread operator allows joining of objects. The precidence is last to first.
+  // The spread operator allows joining of objects. The precedence is last to first.
   process.env = {
     ...env,
     ...process.env,


### PR DESCRIPTION
- add LANG env with UTF-8 specified
- When Lens is run (especially on macos) the LANG env var was not being picked up (even by `shell-env`) which for some reason broke pasting utf-8 unicode into the terminal emulator.

Fixes #351 

Signed-off-by: Sebastian Malton <smalton@mirantis.com>