### PR TITLE
Release notes for v3.5.1

### DIFF
--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,8 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.5.0 (current version)
+## 3.5.1 (current version)
+- Fix kubernetes api requests to work with non-"namespaces" pathnames
+- Fix: Handle invalid metrics responses properly
+- Fix: Display namespace defined in kubeconfig always in the namespace selector
+- Fix: Make sure that secret is defined before trying to decode
+- Update Helm to 3.2.4
+- Fix pasting unicode into terminal sometimes not working
+- Fix: Open external links in web browser
+- Fix kubectl binary version check
 
+## 3.5.0
 - Dynamic dashboard UI based on RBAC rules (hides non-accessible menus)
 - Show object reference for all objects
 - Unify scrollbars/paddings


### PR DESCRIPTION
## Changes since v3.5.0

- Add pod creation integration test (https://github.com/lensapp/lens/pull/449)
- Fix kubernetes api requests to work with non-"namespaces" pathnames (https://github.com/lensapp/lens/pull/450)
- Handle invalid metric response properly (https://github.com/lensapp/lens/pull/464)
- Display namespace defined in kubeconfig always in the namespace selector (https://github.com/lensapp/lens/pull/472)
- Make sure that secret is defined before trying to decode (https://github.com/lensapp/lens/pull/479)
- Update Helm to 3.2.4 (https://github.com/lensapp/lens/pull/487)
- Revert select component (https://github.com/lensapp/lens/pull/488)
- Fix pasting unicode into terminal sometimes not working (https://github.com/lensapp/lens/pull/492)
- fix parseApi to not throw and to match apiVersion more specifically (https://github.com/lensapp/lens/pull/496)
- Open external links in web browser (https://github.com/lensapp/lens/pull/506)
- special case */namespace/* in parseApi, add test (https://github.com/lensapp/lens/pull/509)
- Fix kubectl binary version check (https://github.com/lensapp/lens/pull/510)