### PR TITLE
Release v3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "© 2020, Lakend Labs, Inc.",
   "license": "MIT",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.5.1-rc.1",
+  "version": "3.5.1",
   "main": "main.ts",
   "config": {
     "bundledKubectlVersion": "1.17.4",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where your might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.5.1-rc.1 (current version)
+## 3.5.1 (current version)
 - Fix kubernetes api requests to work with non-"namespaces" pathnames
 - Fix: Handle invalid metrics responses properly
 - Fix: Display namespace defined in kubeconfig always in the namespace selector


### PR DESCRIPTION
## Changes since v3.5.0

- Add pod creation integration test (https://github.com/lensapp/lens/pull/449)
- Fix kubernetes api requests to work with non-"namespaces" pathnames (https://github.com/lensapp/lens/pull/450)
- Handle invalid metric response properly (https://github.com/lensapp/lens/pull/464)
- Display namespace defined in kubeconfig always in the namespace selector (https://github.com/lensapp/lens/pull/472)
- Make sure that secret is defined before trying to decode (https://github.com/lensapp/lens/pull/479)
- Update Helm to 3.2.4 (https://github.com/lensapp/lens/pull/487)
- Revert select component (https://github.com/lensapp/lens/pull/488)
- Fix pasting unicode into terminal sometimes not working (https://github.com/lensapp/lens/pull/492)
- fix parseApi to not throw and to match apiVersion more specifically (https://github.com/lensapp/lens/pull/496)
- Open external links in web browser (https://github.com/lensapp/lens/pull/506)
- special case */namespace/* in parseApi, add test (https://github.com/lensapp/lens/pull/509)
- Fix kubectl binary version check (https://github.com/lensapp/lens/pull/510)