### PR TITLE
Replace webview tag to iframe

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -55,7 +55,13 @@ export class WindowManager {
     // handle close event
     this.mainWindow.on("close", () => {
       this.mainWindow = null;
-    })
+    });
+
+    // open external links in default browser (target=_blank, window.open)
+    this.mainWindow.webContents.on("new-window", (event, url) => {
+      event.preventDefault();
+      shell.openExternal(url);
+    });
 
     // handle external links
     this.mainWindow.webContents.on("will-navigate", (event, link) => {

--- a/src/renderer/_vue/assets/css/app.scss
+++ b/src/renderer/_vue/assets/css/app.scss
@@ -203,4 +203,9 @@ h1, h2, h3, h4, h5, h6{
   height: 100%;
   z-index: 100;
   display: none;
+
+  > iframe {
+    height: 100%;
+    border: none;
+  }
 }

--- a/src/renderer/_vue/assets/css/app.scss
+++ b/src/renderer/_vue/assets/css/app.scss
@@ -205,7 +205,7 @@ h1, h2, h3, h4, h5, h6{
   display: none;
 
   > iframe {
-    height: 100%;
+    height: calc(100% - var(--lens-bottom-bar-height));
     border: none;
   }
 }

--- a/src/renderer/_vue/assets/css/custom.scss
+++ b/src/renderer/_vue/assets/css/custom.scss
@@ -9,7 +9,7 @@ $lens-text-color-light: #a0a0a0 !default;
 $lens-primary: #3d90ce !default;
 
 // export as css variables
-* {
+:root {
   --lens-main-bg: #{$lens-main-bg}; // dark bg
   --lens-pane-bg: #{$lens-pane-bg}; // all panels main bg
   --lens-dock-bg: #{$lens-dock-bg}; // terminal and top menu bar
@@ -18,6 +18,7 @@ $lens-primary: #3d90ce !default;
   --lens-text-color: #{$lens-text-color};
   --lens-text-color-light: #{$lens-text-color-light};
   --lens-primary: #{$lens-primary};
+  --lens-bottom-bar-height: 20px;
 }
 
 // Base grayscale colors definitions

--- a/src/renderer/_vue/components/BottomBar/BottomBar.vue
+++ b/src/renderer/_vue/components/BottomBar/BottomBar.vue
@@ -63,7 +63,7 @@ export default {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 20px;
+  height: var(--lens-bottom-bar-height);
   background-color: var(--lens-primary);
   z-index: 2000;
 }

--- a/src/renderer/_vue/components/ClusterPage.vue
+++ b/src/renderer/_vue/components/ClusterPage.vue
@@ -92,10 +92,6 @@ export default {
     lensLoaded: function() {
       console.log("lens loaded")
       this.lens.loaded = true;
-      remote.webContents.fromId(this.lens.webview.getWebContentsId()).on('new-window', (e, url) => {
-        e.preventDefault()
-        shell.openExternal(url)
-      })
       this.$store.commit("updateLens", this.lens);
     },
     // Called only when online state changes
@@ -110,9 +106,9 @@ export default {
     activateLens: async function() {
       console.log("activate lens")
       if (!this.lens.webview) {
-        console.log("create webview")
-        const webview = document.createElement('webview');
-        webview.addEventListener('did-finish-load', this.lensLoaded);
+        console.log("creating webview or iframe")
+        const webview = document.createElement('iframe');
+        webview.addEventListener('load', this.lensLoaded);
         webview.src = this.cluster.url;
         this.lens.webview = webview;
       }

--- a/src/renderer/_vue/components/ClusterPage.vue
+++ b/src/renderer/_vue/components/ClusterPage.vue
@@ -27,7 +27,6 @@
 
 <script>
 import CubeSpinner from "@/_vue/components/CubeSpinner";
-import { remote, shell } from 'electron';
 export default {
   name: "ClusterPage",
   components: {
@@ -106,7 +105,7 @@ export default {
     activateLens: async function() {
       console.log("activate lens")
       if (!this.lens.webview) {
-        console.log("creating webview or iframe")
+        console.log("creating an iframe")
         const webview = document.createElement('iframe');
         webview.addEventListener('load', this.lensLoaded);
         webview.src = this.cluster.url;

--- a/src/renderer/_vue/store/modules/clusters.ts
+++ b/src/renderer/_vue/store/modules/clusters.ts
@@ -3,7 +3,7 @@ import { ClusterInfo } from "../../../../main/cluster"
 import { MutationTree, ActionTree, GetterTree } from "vuex"
 import { PromiseIpc } from 'electron-promise-ipc'
 import { Tracker } from "../../../../common/tracker"
-import { remote, WebviewTag } from "electron"
+import { remote } from "electron"
 import { clusterStore } from "../../../../common/cluster-store"
 import { Workspace } from "../../../../common/workspace-store"
 
@@ -13,7 +13,7 @@ const tracker = new Tracker(remote.app);
 export interface LensWebview {
   id: string;
   loaded: boolean;
-  webview?: WebviewTag | HTMLIFrameElement;
+  webview?: HTMLIFrameElement;
 }
 
 export interface ClusterState {

--- a/src/renderer/_vue/store/modules/clusters.ts
+++ b/src/renderer/_vue/store/modules/clusters.ts
@@ -3,7 +3,7 @@ import { ClusterInfo } from "../../../../main/cluster"
 import { MutationTree, ActionTree, GetterTree } from "vuex"
 import { PromiseIpc } from 'electron-promise-ipc'
 import { Tracker } from "../../../../common/tracker"
-import { remote } from "electron"
+import { remote, WebviewTag } from "electron"
 import { clusterStore } from "../../../../common/cluster-store"
 import { Workspace } from "../../../../common/workspace-store"
 
@@ -13,7 +13,7 @@ const tracker = new Tracker(remote.app);
 export interface LensWebview {
   id: string;
   loaded: boolean;
-  webview?: any;
+  webview?: WebviewTag | HTMLIFrameElement;
 }
 
 export interface ClusterState {


### PR DESCRIPTION
Replacing [webview](https://www.electronjs.org/docs/api/webview-tag) to plain iframe which provide better developer experience (contents of webview is not available through renderer's devtools and require extra devtools to be opened).

In future (mostly after refactoring vue parts to react) we get rid of any webview/iframe in favour of [BrowserWindow](https://www.electronjs.org/docs/api/browser-window) or [BrowserView](https://www.electronjs.org/docs/api/browser-view) and/or manage `session`/`partition` if needed.

<img width="1536" alt="Screenshot 2020-07-02 at 15 18 21" src="https://user-images.githubusercontent.com/6377066/86358499-3d5fb000-bc78-11ea-80f7-8d10b115c3c6.png">
