### PR TITLE
Show devtools always in menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -152,16 +152,7 @@ export default function initMenu(opts: MenuOptions, promiseIpc: any) {
           webContents.getFocusedWebContents().reload()
         }
       },
-      ...(isDevelopment ? [
-        { role: 'toggleDevTools' } as MenuItemConstructorOptions,
-        {
-          accelerator: "CmdOrCtrl+Shift+I",
-          label: 'Open Dashboard Devtools',
-          click() {
-            webContents.getFocusedWebContents().openDevTools()
-          }
-        }
-      ] : []),
+      { role: 'toggleDevTools' },
       { type: 'separator' },
       { role: 'resetZoom' },
       { role: 'zoomIn' },


### PR DESCRIPTION
Also removes dedicated "dashboard" devtools, that's not needed after #554 .

Fixes #556