### PR TITLE
remove ContextHandler.withTemporaryKubeconfig()

### DIFF
--- a/src/features/metrics.ts
+++ b/src/features/metrics.ts
@@ -51,21 +51,26 @@ export class MetricsFeature extends Feature {
     storageClass: null,
   };
 
-  async install(cluster: Cluster): Promise<boolean> {
+  async install(cluster: Cluster): Promise<void> {
     // Check if there are storageclasses
-    const storageClient = cluster.proxyKubeconfig().makeApiClient(k8s.StorageV1Api)
-    const scs = await storageClient.listStorageClass();
-    scs.body.items.forEach(sc => {
-      if(sc.metadata.annotations &&
+    (await cluster
+      .proxyKubeconfig()
+      .makeApiClient(k8s.StorageV1Api)
+      .listStorageClass()
+    )
+      .body
+      .items
+      .forEach(sc => {
+        if(sc.metadata.annotations &&
           (sc.metadata.annotations['storageclass.kubernetes.io/is-default-class'] === 'true' || sc.metadata.annotations['storageclass.beta.kubernetes.io/is-default-class'] === 'true')) {
-        this.config.persistence.enabled = true;
-      }
-    });
+          this.config.persistence.enabled = true;
+        }
+      });
 
-    return super.install(cluster)
+    return super.install(cluster);
   }
 
-  async upgrade(cluster: Cluster): Promise<boolean> {
+  async upgrade(cluster: Cluster): Promise<void> {
     return this.install(cluster)
   }
 

--- a/src/features/user-mode.ts
+++ b/src/features/user-mode.ts
@@ -6,12 +6,12 @@ export class UserModeFeature extends Feature {
   name = 'user-mode';
   latestVersion = "v2.0.0"
 
-  async install(cluster: Cluster): Promise<boolean> {
+  async install(cluster: Cluster): Promise<void> {
     return super.install(cluster)
   }
 
-  async upgrade(cluster: Cluster): Promise<boolean> {
-    return true
+  async upgrade(cluster: Cluster): Promise<void> {
+    return;
   }
 
   async featureStatus(kc: KubeConfig): Promise<FeatureStatus> {

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -152,12 +152,8 @@ export class ContextHandler {
     return serverPort
   }
 
-  public async withTemporaryKubeconfig(callback: (kubeconfig: string) => Promise<any>) {
-    try {
-      await callback(this.cluster.proxyKubeconfigPath())
-    } catch (error) {
-      throw(error)
-    }
+  public applyHeaders(req: http.IncomingMessage) {
+    req.headers["authorization"] = `Bearer ${this.id}`
   }
 
   public async ensureServer() {

--- a/src/main/feature.ts
+++ b/src/main/feature.ts
@@ -29,26 +29,16 @@ export abstract class Feature {
     }
   }
 
-  // TODO Return types for these?
-  async install(cluster: Cluster): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
-      // Read and process yamls through handlebar
-      const resources = this.renderTemplates();
-
-      // Apply processed manifests
-      cluster.contextHandler.withTemporaryKubeconfig(async (kubeconfigPath) => {
-        const resourceApplier = new ResourceApplier(cluster, kubeconfigPath)
-        try {
-          await resourceApplier.kubectlApplyAll(resources)
-          resolve(true)
-        } catch(error) {
-          reject(error)
-        }
-      });
-    });
+  async install(cluster: Cluster): Promise<void> {
+    // Read and process yamls through handlebar
+    const resources = this.renderTemplates();
+    const kubeconfigPath = cluster.kubeconfigPath();
+    const resourceApplier = new ResourceApplier(cluster, kubeconfigPath)
+    
+    await resourceApplier.kubectlApplyAll(resources)
   }
 
-  abstract async upgrade(cluster: Cluster): Promise<boolean>;
+  abstract async upgrade(cluster: Cluster): Promise<void>;
 
   abstract async uninstall(cluster: Cluster): Promise<boolean>;
 


### PR DESCRIPTION
Fixes #467 

* Changes the install signature to `: Promise<void>` because the return value was never checked and the rejection represents the failure.