### PR TITLE
configure big folders to ignore for vscode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,13 @@
     "compilerOptions": {
       "module": "CommonJS"
     }
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "out",
+    "dist",
+    "coverage",
+    "binaries",
+    "static"
+  ]
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <smalton@mirantis.com>

Vscode typescript disables repo-wide features without this. 