### PR TITLE
Handle unknown resources properly after they've been created in editor

### DIFF
--- a/src/renderer/api/endpoints/resource-applier.api.ts
+++ b/src/renderer/api/endpoints/resource-applier.api.ts
@@ -18,7 +18,11 @@ export const resourceApplierApi = {
       .then(data => {
         const items = data.map(obj => {
           const api = apiManager.getApi(obj.metadata.selfLink);
-          return new api.objectConstructor(obj);
+          if (api) {
+            return new api.objectConstructor(obj);
+          } else {
+            return new KubeObject(obj)
+          }
         });
         return items.length === 1 ? items[0] : items;
       });


### PR DESCRIPTION
This PR returns `KubeObject` to resource editor for successfully created unknown resources.

Fixes #605 