### PR TITLE
Fix CRD api parsing

### DIFF
--- a/src/renderer/api/kube-api-parse.ts
+++ b/src/renderer/api/kube-api-parse.ts
@@ -40,6 +40,9 @@ export function parseApi(path: string): IKubeApiLinkBase {
     apiGroup = left.join("/");
   } else {
     switch (left.length) {
+    case 4:
+      [apiGroup, apiVersion, resource, name] = left
+      break;
     case 2:
       resource = left.pop();
       // fallthrough

--- a/src/renderer/api/kube-api-parse_test.ts
+++ b/src/renderer/api/kube-api-parse_test.ts
@@ -7,6 +7,19 @@ interface KubeApi_Parse_Test {
 
 const tests: KubeApi_Parse_Test[] = [
   {
+    url: "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+    expected: {
+      apiBase: "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions",
+      apiPrefix: "/apis",
+      apiGroup: "apiextensions.k8s.io",
+      apiVersion: "v1beta1",
+      apiVersionWithGroup: "apiextensions.k8s.io/v1beta1",
+      namespace: undefined,
+      resource: "customresourcedefinitions",
+      name: "prometheuses.monitoring.coreos.com"
+    },
+  },
+  {
     url: "/api/v1/namespaces/kube-system/pods/coredns-6955765f44-v8p27",
     expected: {
       apiBase: "/api/v1/pods",


### PR DESCRIPTION
Currently kube api parsing does not work with custom resource defitions, for example `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com`.

This PR will parse those api paths correctly. 

Fixes #621