### PR TITLE
Fix getFreePort()

### DIFF
--- a/src/main/port.ts
+++ b/src/main/port.ts
@@ -6,7 +6,8 @@ import logger from "./logger"
 export async function getFreePort(): Promise<number> {
   logger.debug("Lookup new free port..");
   return new Promise((resolve, reject) => {
-    const server = net.createServer().unref().listen({ port: 0 });
+    const server = net.createServer()
+    server.unref()
     server.on("listening", () => {
       const port = (server.address() as AddressInfo).port
       server.close(() => resolve(port));
@@ -16,5 +17,6 @@ export async function getFreePort(): Promise<number> {
       logger.error(`Can't resolve new port: "${error}"`);
       reject(error);
     });
+    server.listen({ host: "127.0.0.1", port: 0 })
   })
 }


### PR DESCRIPTION
```
PASS  src/main/port_spec.ts
  getFreePort
    ✓ finds the next free port (4 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.028 s, estimated 10 s
Ran all test suites matching /src\/main\/port_spec.ts/i.
✨  Done in 3.54s.
```