### PR TITLE
Mock imported styles for jest

### DIFF
--- a/__mocks__/styleMock.ts
+++ b/__mocks__/styleMock.ts
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.ts"
     }
   },
   "build": {


### PR DESCRIPTION
Not sure if this is a correct way to fix the issue with tests: 
```
● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/lauri/Projects/lens/src/renderer/components/notifications/notifications.scss:1
    .Notifications {
    ^

    SyntaxError: Unexpected token '.'

    > 1 | import './notifications.scss';
        | ^
      2 | 
      3 | import React from 'react'
      4 | import { reaction } from "mobx";

      at Runtime._execModule (node_modules/jest-runtime/build/index.js:1166:56)
      at Object.<anonymous> (src/renderer/components/notifications/notifications.tsx:1:1)
      at Object.<anonymous> (src/renderer/components/notifications/index.ts:1:1)
      at Object.<anonymous> (src/renderer/api/index.ts:3:1)
      at Object.<anonymous> (src/renderer/api/kube-object.ts:7:1)
      at Object.<anonymous> (src/renderer/api/kube-api.ts:5:1)
      at Object.<anonymous> (src/renderer/api/api-manager.ts:7:1)
      at Object.<anonymous> (src/renderer/api/kube-api-parse.ts:5:1)
      at Object.<anonymous> (src/renderer/api/kube-api-parse_test.ts:1:1)● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/lauri/Projects/lens/src/renderer/components/notifications/notifications.scss:1
    .Notifications {
    ^

    SyntaxError: Unexpected token '.'

    > 1 | import './notifications.scss';
        | ^
      2 | 
      3 | import React from 'react'
      4 | import { reaction } from "mobx";

      at Runtime._execModule (node_modules/jest-runtime/build/index.js:1166:56)
      at Object.<anonymous> (src/renderer/components/notifications/notifications.tsx:1:1)
      at Object.<anonymous> (src/renderer/components/notifications/index.ts:1:1)
      at Object.<anonymous> (src/renderer/api/index.ts:3:1)
      at Object.<anonymous> (src/renderer/api/kube-object.ts:7:1)
      at Object.<anonymous> (src/renderer/api/kube-api.ts:5:1)
      at Object.<anonymous> (src/renderer/api/api-manager.ts:7:1)
      at Object.<anonymous> (src/renderer/api/kube-api-parse.ts:5:1)
      at Object.<anonymous> (src/renderer/api/kube-api-parse_test.ts:1:1)
```

This PR will mock imported styles in tests.

