### PR TITLE
Fix Kubectl.getDownloadMirror

### DIFF
--- a/src/main/kubectl.ts
+++ b/src/main/kubectl.ts
@@ -289,7 +289,7 @@ export class Kubectl {
   }
 
   protected getDownloadMirror() {
-    const mirror = packageMirrors.get(userStore.preferences.downloadMirror)
+    const mirror = packageMirrors.get(userStore.preferences?.downloadMirror)
     if (mirror) {
       return mirror
     }


### PR DESCRIPTION
Before:
```
 FAIL  src/main/kubectl_spec.ts
  ● Test suite failed to run

    TypeError: Cannot read property 'downloadMirror' of undefined

      290 | 
      291 |   protected getDownloadMirror() {
    > 292 |     const mirror = packageMirrors.get(userStore.preferences.downloadMirror)
          |                                                             ^
      293 |     if (mirror) {
      294 |       return mirror
      295 |     }

      at Kubectl.getDownloadMirror (src/main/kubectl.ts:292:61)
      at new Kubectl (src/main/kubectl.ts:95:24)
      at Function.bundled (src/main/kubectl.ts:65:61)
      at Object.<anonymous> (src/main/kubectl.ts:300:32)
      at Object.<anonymous> (src/main/kubectl_spec.ts:2:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.991 s, estimated 2 s
Ran all test suites matching /src\/main\/kubectl_spec.ts/i.
error Command failed with exit code 1.
```

After:
```
 PASS  src/main/kubectl_spec.ts
  kubectlVersion
    ✓ returns bundled version if exactly same version used (1 ms)
    ✓ returns bundled version if same major.minor version is used (1 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.977 s, estimated 6 s
Ran all test suites matching /src\/main\/kubectl_spec.ts/i.
✨  Done in 6.51s.
```