### PR TITLE
Revert imports

### DIFF
--- a/src/main/shell-sync.ts
+++ b/src/main/shell-sync.ts
@@ -1,5 +1,5 @@
-import shellEnv from "shell-env"
-import os from "os";
+import shellEnv = require("shell-env")
+import * as os from "os";
 import { app } from "electron";
 import logger from "./logger";
 


### PR DESCRIPTION
After cherry-picking #630 to release branch, the following imports does not work since the release branch is using outdated typescript config.
```
import shellEnv from "shell-env"
import os from "os";
```
So, we need to revert them.