### PR TITLE
Added ClusterRole 

### DIFF
--- a/src/features/read-all/README.md
+++ b/src/features/read-all/README.md
@@ -4,3 +4,19 @@ The read all cluster role found in cluster-role.yaml can be bound to service acc
 
 This is ideal for giving particular users access to a read only user to use in Lens or for dashboards left up in the office.
 
+To use the cluster role bind it to a service account. In the example below we give read all access to the service account called `developer`.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: developer-read-all
+subjects:
+- kind: ServiceAccount
+  name: developer
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: read-all-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+```

--- a/src/features/read-all/README.md
+++ b/src/features/read-all/README.md
@@ -1,6 +1,6 @@
 # Read All ClusterRole
 
-The read all cluster role found in cluster-role.yaml can be bound to service accounts used  with Lens. Service Accounts with this cluster role will be able to see cluster metrics and pod metrics but will not be able to see secrets and service accounts. The cluster role does not allow for modifying K8s resources (update, create or delete). It also explicitly lists Kubernetes' little-known sub-resources (which is why the base `view` cluster role cannot see metrics).
+The read all cluster role found in cluster-role.yaml can be bound to service accounts used  with Lens. Service Accounts with this cluster role will be able to see cluster metrics and pod metrics but will not be able to see secrets and service accounts. The cluster role does not allow for modifying K8s resources (update, create or delete). It also explicitly lists Kubernetes' little-known sub-resources (which is why service accounts bound to the base `view` cluster role cannot see metrics in Lens).
 
-This is ideal for giving particular users access to the a read only user to use in Lens or for dashboards left up in the office.
+This is ideal for giving particular users access to a read only user to use in Lens or for dashboards left up in the office.
 

--- a/src/features/read-all/README.md
+++ b/src/features/read-all/README.md
@@ -1,6 +1,6 @@
 # Read All ClusterRole
 
-The read all cluster role found in cluster-role.yaml can be bound to service accounts used  with Lens. Service Accounts with this cluster role will be able to see cluster metrics and pod metrics but will not be able to see secrets and service accounts. The cluster role does not allow for modifying K8s resources. It also explicitly lists Kubernetes' little-known sub-resources (which is why the base `view` user cannot see metrics).
+The read all cluster role found in cluster-role.yaml can be bound to service accounts used  with Lens. Service Accounts with this cluster role will be able to see cluster metrics and pod metrics but will not be able to see secrets and service accounts. The cluster role does not allow for modifying K8s resources (update, create or delete). It also explicitly lists Kubernetes' little-known sub-resources (which is why the base `view` cluster role cannot see metrics).
 
 This is ideal for giving particular users access to the a read only user to use in Lens or for dashboards left up in the office.
 

--- a/src/features/read-all/README.md
+++ b/src/features/read-all/README.md
@@ -1,0 +1,6 @@
+# Read All ClusterRole
+
+The read all cluster role found in cluster-role.yaml can be bound to service accounts used  with Lens. Service Accounts with this cluster role will be able to see cluster metrics and pod metrics but will not be able to see secrets and service accounts. The cluster role does not allow for modifying K8s resources. It also explicitly lists Kubernetes' little-known sub-resources (which is why the base `view` user cannot see metrics).
+
+This is ideal for giving particular users access to the a read only user to use in Lens or for dashboards left up in the office.
+

--- a/src/features/read-all/cluster-role.yaml
+++ b/src/features/read-all/cluster-role.yaml
@@ -1,0 +1,198 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-all-clusterrole
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - componentstatuses
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - namespaces/finalize
+      - namespaces/status
+      - nodes
+      - nodes/proxy
+      - nodes/status
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - persistentvolumes
+      - persistentvolumes/status
+      - pods
+      - pods/attach
+      - pods/binding
+      - pods/eviction
+      - pods/exec
+      - pods/log
+      - pods/proxy
+      - pods/status
+      - podtemplates
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      - serviceaccounts
+      - services
+      - services/proxy
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+      - daemonsets
+      - daemonsets/status
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - replicasets
+      - replicasets/scale
+      - replicasets/status
+      - statefulsets
+      - statefulsets/scale
+      - statefulsets/status
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - jobs/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+      - horizontalpodautoscalers/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - storageclasses
+      - volumeattachments
+      - volumeattachments/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - node.k8s.io
+    resources:
+      - runtimeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+      - ingresses/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+      - customresourcedefinitions/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+      - apiservices/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+      - poddisruptionbudgets/status
+      - podsecuritypolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Greetings

Love the Lens project. Its fantastic. Thank you for creating the project.

Regarding the pull request:

Added ClusterRole that allows for read only access. This ALSO supports Lens metrics. The default **read only** ClusterRoles  do not always allow metrics to show in Lens because they do not explicitly list Kubernetes sub-resources.

See README.md in the commit for more info.

Cheers
Justin