### PR TITLE
use the Kubernetes regex for matching system names

### DIFF
--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2178,8 +2178,8 @@ msgid "This field is required"
 msgstr "This field is required"
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
-msgstr "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
+msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
+msgstr "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59
 msgid "To"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2178,8 +2178,8 @@ msgid "This field is required"
 msgstr "This field is required"
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "This field must contain only lowercase latin characters, numbers and dash."
-msgstr "This field must contain only lowercase latin characters, numbers and dash."
+msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
+msgstr "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59
 msgid "To"

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -2161,7 +2161,7 @@ msgid "This field is required"
 msgstr ""
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
+msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr ""
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -2161,7 +2161,7 @@ msgid "This field is required"
 msgstr ""
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "This field must contain only lowercase latin characters, numbers and dash."
+msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr ""
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -2179,7 +2179,7 @@ msgid "This field is required"
 msgstr "Это обязательное поле"
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "This field must contain only lowercase latin characters, numbers and dash."
+msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr "Это поле может содержать только латинские буквы в нижнем регистре, номера и дефис."
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -2179,7 +2179,7 @@ msgid "This field is required"
 msgstr "Это обязательное поле"
 
 #: src/renderer/components/input/input.validators.ts:39
-msgid "A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
+msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr "Это поле может содержать только латинские буквы в нижнем регистре, номера и дефис."
 
 #: src/renderer/components/+network-policies/network-policy-details.tsx:59

--- a/src/renderer/api/kube-api-parse.ts
+++ b/src/renderer/api/kube-api-parse.ts
@@ -59,7 +59,7 @@ export function parseApi(path: string): IKubeApiLinkBase {
        *  - `GROUP` is /^D(\.D)*$/ where D is `DNS_LABEL` and length <= 253
        *
        * There is no well defined selection from an array of items that were
-       * seperated by '/'
+       * separated by '/'
        *
        * Solution is to create a huristic. Namely:
        * 1. if '.' in left[0] then apiGroup <- left[0]

--- a/src/renderer/components/input/input.validators.ts
+++ b/src/renderer/components/input/input.validators.ts
@@ -55,7 +55,7 @@ export const maxLength: Validator = {
 
 const systemNameMatcher = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 export const systemName: Validator = {
-  message: () => _i18n._(t`A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.`),
+  message: () => _i18n._(t`A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.`),
   validate: value => !!value.match(systemNameMatcher),
 };
 

--- a/src/renderer/components/input/input.validators.ts
+++ b/src/renderer/components/input/input.validators.ts
@@ -53,9 +53,10 @@ export const maxLength: Validator = {
   validate: (value, { maxLength }) => value.length <= maxLength,
 };
 
+const systemNameMatcher = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 export const systemName: Validator = {
-  message: () => _i18n._(t`This field must contain only lowercase latin characters, numbers and dash.`),
-  validate: value => !!value.match(/^[a-z0-9-]+$/),
+  message: () => _i18n._(t`A System Name must be lowercase DNS labels seperated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.`),
+  validate: value => !!value.match(systemNameMatcher),
 };
 
 export const accountId: Validator = {

--- a/src/renderer/components/input/input.validators_test.ts
+++ b/src/renderer/components/input/input.validators_test.ts
@@ -1,0 +1,48 @@
+import { isEmail, systemName } from "./input.validators";
+
+describe("input validation tests", () => {
+  describe("isEmail tests", () => {
+    it("should be valid", () => {
+      expect(isEmail.validate("abc@news.com")).toBe(true);
+      expect(isEmail.validate("abc@news.co.uk")).toBe(true);
+      expect(isEmail.validate("abc1.3@news.co.uk")).toBe(true);
+      expect(isEmail.validate("abc1.3@news.name")).toBe(true);
+    });
+
+    it("should be invalid", () => {
+      expect(isEmail.validate("@news.com")).toBe(false);
+      expect(isEmail.validate("abcnews.co.uk")).toBe(false);
+      expect(isEmail.validate("abc1.3@news")).toBe(false);
+      expect(isEmail.validate("abc1.3@news.name.a.b.c.d.d")).toBe(false);
+    });
+  });
+
+  describe("systemName tests", () => {
+    it("should be valid", () => {
+      expect(systemName.validate("a")).toBe(true);
+      expect(systemName.validate("ab")).toBe(true);
+      expect(systemName.validate("abc")).toBe(true);
+      expect(systemName.validate("1")).toBe(true);
+      expect(systemName.validate("12")).toBe(true);
+      expect(systemName.validate("123")).toBe(true);
+      expect(systemName.validate("1a2")).toBe(true);
+      expect(systemName.validate("1-2")).toBe(true);
+      expect(systemName.validate("1---------------2")).toBe(true);
+      expect(systemName.validate("1---------------2.a")).toBe(true);
+      expect(systemName.validate("1---------------2.a.1")).toBe(true);
+      expect(systemName.validate("1---------------2.9-a.1")).toBe(true);
+    });
+
+    it("should be invalid", () => {
+      expect(systemName.validate("")).toBe(false);
+      expect(systemName.validate("-")).toBe(false);
+      expect(systemName.validate(".")).toBe(false);
+      expect(systemName.validate("as.")).toBe(false);
+      expect(systemName.validate(".asd")).toBe(false);
+      expect(systemName.validate("a.-")).toBe(false);
+      expect(systemName.validate("a.1-")).toBe(false);
+      expect(systemName.validate("o.2-2.")).toBe(false);
+      expect(systemName.validate("o.2-2....")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <smalton@mirantis.com>

This PR also adds some tests for input validators.

Fixes #584 