### PR TITLE
Preventing scrollbar flickering when opening Details

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -8,6 +8,7 @@
   #lens-view {
     position: relative;
     grid-area: lens-view;
+    overflow: hidden;
 
     &.inactive {
       opacity: .85;


### PR DESCRIPTION
This prevents scrollbar flickering caused by `Animation` component
with `slide-left` appearing.

Error illustrated in following gif:
![scrollbar flickering](https://user-images.githubusercontent.com/9607060/89778562-6c3e3100-db16-11ea-9015-629299fbe4f7.gif)

Signed-off-by: alexfront <alex.andreev.email@gmail.com>