### PR TITLE
Fixing broken/missing icons

### DIFF
--- a/src/renderer/components/+workloads-deployments/deployments.tsx
+++ b/src/renderer/components/+workloads-deployments/deployments.tsx
@@ -98,7 +98,7 @@ export function DeploymentMenu(props: KubeObjectMenuProps<Deployment>) {
   return (
     <KubeObjectMenu {...props}>
       <MenuItem onClick={() => DeploymentScaleDialog.open(object)}>
-        <Icon material="control_camera" title={_i18n._(t`Scale`)} interactive={toolbar}/>
+        <Icon material="open_with" title={_i18n._(t`Scale`)} interactive={toolbar}/>
         <span className="title"><Trans>Scale</Trans></span>
       </MenuItem>
     </KubeObjectMenu>

--- a/src/renderer/components/+workloads-pods/pod-logs-dialog.tsx
+++ b/src/renderer/components/+workloads-pods/pod-logs-dialog.tsx
@@ -226,7 +226,7 @@ export class PodLogsDialog extends React.Component<Props> {
             tooltip={(showTimestamps ? _i18n._(t`Hide`) : _i18n._(t`Show`)) + " " + _i18n._(t`timestamps`)}
           />
           <Icon
-            material="save_alt"
+            material="get_app"
             onClick={this.downloadLogs}
             tooltip={_i18n._(t`Save`)}
           />

--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -82,7 +82,7 @@ hr {
 h1 {
   color: white;
   font-size: 28px;
-  font-weight: 300;
+  font-weight: normal;
   letter-spacing: -.010em;
   margin: 0;
 }
@@ -105,7 +105,7 @@ h4 {
 h5 {
   @extend h4;
   padding: $padding / 2 0;
-  font-size: 14px;
+  font-size: 16px;
 }
 
 h6 {

--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -99,7 +99,7 @@ h3 {
 
 h4 {
   @extend h3;
-  font-size: 16px;
+  font-size: 18px;
 }
 
 h5 {


### PR DESCRIPTION
* Replacing icons in deployment menu and pod logs. We use `material-design-icons` library which doesn't contain all of the new material icons available. Here, I've changed icons to available ones, but we probably might need to eliminate usage of `material-design-icons` in the future.
* Normalizing `h5`, `h6` titles by increasing their size and `font-weight` value. Now they seem consistent with other typography.

Before:
![pod logs](https://user-images.githubusercontent.com/9607060/89786835-3e141d80-db25-11ea-9e3d-3411603b78b1.png)
![deployment menu](https://user-images.githubusercontent.com/9607060/89786900-53894780-db25-11ea-8103-cfe16b2fc2fa.png)

After:
![fixed logs](https://user-images.githubusercontent.com/9607060/89786922-5ab05580-db25-11ea-979e-d1a33e168041.png)
![titles](https://user-images.githubusercontent.com/9607060/89786939-60a63680-db25-11ea-9a8a-8eeb8e8f1c22.png)
![fixed dep menu](https://user-images.githubusercontent.com/9607060/89786993-70be1600-db25-11ea-92e6-29b7c58d3269.png)
