### PR TITLE
Change owner of minikube config files to $USER

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -128,8 +128,9 @@ jobs:
           sudo apt-get install libgconf-2-4 conntrack -y
           curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
-          export CHANGE_MINIKUBE_NONE_USER=true
           sudo minikube start --driver=none
+          # Although the kube and minikube config files are in placed $HOME they are owned by root
+          sudo chown -R $USER $HOME/.kube $HOME/.minikube
         displayName: Install integration test dependencies
       - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' make integration-linux
         displayName: Run integration tests


### PR DESCRIPTION
For CI linux job minikube is started with kube and minikube config
in $HOME, but they are owned by root. This causes non-root
uses, like 'minikube status', to fail.

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

fixes #522 however the tests were failing subsequently for another reason 