### PR TITLE
Add mechanism for users to specify accessible namespaces

### DIFF
--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -25,11 +25,11 @@ msgstr ""
 msgid "(as a percentage of request)"
 msgstr "(as a percentage of request)"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:121
+#: src/renderer/components/+workspaces/workspaces.tsx:126
 msgid "(current)"
 msgstr "(current)"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:88
+#: src/renderer/components/+network-policies/network-policy-details.tsx:87
 msgid "(empty) (Allowing the specific traffic to all pods in this namespace)"
 msgstr "(empty) (Allowing the specific traffic to all pods in this namespace)"
 
@@ -61,19 +61,19 @@ msgstr "<0>{0}</0> successfully created"
 msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 
-#: src/renderer/components/+workspaces/workspaces.tsx:93
+#: src/renderer/components/+workspaces/workspaces.tsx:97
 msgid "A single workspaces contains a list of clusters and their full configuration."
 msgstr "A single workspaces contains a list of clusters and their full configuration."
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:81
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
 msgid "API Group"
 msgstr "API Group"
 
-#: src/renderer/components/layout/sidebar.tsx:88
+#: src/renderer/components/layout/sidebar.tsx:89
 msgid "Access Control"
 msgstr "Access Control"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:51
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:50
 #: src/renderer/components/+storage-volumes/volume-details.tsx:37
 msgid "Access Modes"
 msgstr "Access Modes"
@@ -82,17 +82,17 @@ msgstr "Access Modes"
 msgid "Account Name"
 msgstr "Account Name"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:51
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
 msgid "Active"
 msgstr "Active"
 
 #: src/renderer/components/+add-cluster/add-cluster.tsx:310
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:127
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
 msgid "Add Cluster"
 msgstr "Add Cluster"
 
-#: src/renderer/components/+namespaces/namespaces.tsx:43
+#: src/renderer/components/+namespaces/namespaces.tsx:39
 msgid "Add Namespace"
 msgstr "Add Namespace"
 
@@ -100,11 +100,11 @@ msgstr "Add Namespace"
 msgid "Add RoleBinding"
 msgstr "Add RoleBinding"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:138
+#: src/renderer/components/+workspaces/workspaces.tsx:143
 msgid "Add Workspace"
 msgstr "Add Workspace"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Add bindings to {name}"
 msgstr "Add bindings to {name}"
 
@@ -136,7 +136,7 @@ msgstr "Add field"
 #~ msgid "Adding clusters: <0>{0}</0>"
 #~ msgstr "Adding clusters: <0>{0}</0>"
 
-#: src/renderer/components/+preferences/preferences.tsx:111
+#: src/renderer/components/+preferences/preferences.tsx:101
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr "Adding helm branch <0>{0}</0> has failed: {1}"
 
@@ -144,13 +144,13 @@ msgstr "Adding helm branch <0>{0}</0> has failed: {1}"
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr "Adding repo <0>{0}</0> has failed: {1}"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:78
+#: src/renderer/components/+custom-resources/crd-details.tsx:77
 msgid "Additional Printer Columns"
 msgstr "Additional Printer Columns"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:60
-#: src/renderer/components/+nodes/node-details.tsx:83
+#: src/renderer/components/+nodes/node-details.tsx:82
 msgid "Addresses"
 msgstr "Addresses"
 
@@ -158,36 +158,34 @@ msgstr "Addresses"
 msgid "Affinities"
 msgstr "Affinities"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:51
-#: src/renderer/components/+config-maps/config-maps.tsx:37
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:45
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:46
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:66
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:67
-#: src/renderer/components/+custom-resources/crd-list.tsx:77
-#: src/renderer/components/+custom-resources/crd-resources.tsx:73
+#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-maps/config-maps.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-resources.tsx:70
 #: src/renderer/components/+events/events.tsx:68
-#: src/renderer/components/+namespaces/namespaces.tsx:33
-#: src/renderer/components/+network-endpoints/endpoints.tsx:34
-#: src/renderer/components/+network-ingresses/ingresses.tsx:35
-#: src/renderer/components/+network-policies/network-policies.tsx:34
-#: src/renderer/components/+network-services/services.tsx:51
-#: src/renderer/components/+nodes/nodes.tsx:126
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:38
-#: src/renderer/components/+storage-classes/storage-classes.tsx:38
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:51
-#: src/renderer/components/+storage-volumes/volumes.tsx:44
-#: src/renderer/components/+user-management-roles/roles.tsx:35
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:38
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:38
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:52
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:50
-#: src/renderer/components/+workloads-deployments/deployments.tsx:63
-#: src/renderer/components/+workloads-jobs/jobs.tsx:41
-#: src/renderer/components/+workloads-pods/pods.tsx:81
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:44
+#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-services/services.tsx:48
+#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
+#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
+#: src/renderer/components/+workloads-deployments/deployments.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:38
+#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
 msgid "Age"
 msgstr "Age"
 
@@ -199,68 +197,68 @@ msgstr "All clusters within workspace will be cleared as well"
 #~ msgid "All clusters within workspace will be cleared as well."
 #~ msgstr "All clusters within workspace will be cleared as well."
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:56
+#: src/renderer/components/+custom-resources/crd-list.tsx:53
 msgid "All groups"
 msgstr "All groups"
 
 #: src/renderer/components/dock/pod-logs.tsx:37
-msgid "All logs"
-msgstr "All logs"
+#~ msgid "All logs"
+#~ msgstr "All logs"
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:95
 msgid "All namespaces"
 msgstr "All namespaces"
 
-#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/node-details.tsx:76
 msgid "Allocatable"
 msgstr "Allocatable"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:70
 msgid "Allow Privilege Escalation"
 msgstr "Allow Privilege Escalation"
 
 #: src/renderer/components/+preferences/preferences.tsx:172
-msgid "Allow telemetry & usage tracking"
-msgstr "Allow telemetry & usage tracking"
+#~ msgid "Allow telemetry & usage tracking"
+#~ msgstr "Allow telemetry & usage tracking"
 
-#: src/renderer/components/+preferences/preferences.tsx:164
+#: src/renderer/components/+preferences/preferences.tsx:150
 msgid "Allow untrusted Certificate Authorities"
 msgstr "Allow untrusted Certificate Authorities"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:51
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:50
 msgid "Allowed CSI Drivers"
 msgstr "Allowed CSI Drivers"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:42
 msgid "Allowed Capabilities"
 msgstr "Allowed Capabilities"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:55
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:54
 msgid "Allowed Flex Volumes"
 msgstr "Allowed Flex Volumes"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:110
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:109
 msgid "Allowed Host Paths"
 msgstr "Allowed Host Paths"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:59
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:58
 msgid "Allowed Proc Mount Types"
 msgstr "Allowed Proc Mount Types"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:132
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
 msgid "Allowed Runtime Class Names"
 msgstr "Allowed Runtime Class Names"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:63
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:62
 msgid "Allowed Unsafe Sysctls"
 msgstr "Allowed Unsafe Sysctls"
 
-#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/node-details.tsx:101
 #: src/renderer/components/kube-object/kube-object-meta.tsx:36
 msgid "Annotations"
 msgstr "Annotations"
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:37
+#: src/renderer/components/+user-management-roles/role-details.tsx:36
 msgid "Api Groups"
 msgstr "Api Groups"
 
@@ -277,7 +275,7 @@ msgstr "App crash at <0>{pageUrl}</0>"
 msgid "Applying.."
 msgstr "Applying.."
 
-#: src/renderer/components/layout/sidebar.tsx:87
+#: src/renderer/components/layout/sidebar.tsx:88
 msgid "Apps"
 msgstr "Apps"
 
@@ -286,10 +284,10 @@ msgid "Are you sure you want remove workspace <0>{0}</0>?"
 msgstr "Are you sure you want remove workspace <0>{0}</0>?"
 
 #: src/renderer/components/+nodes/node-menu.tsx:41
-msgid "Are you sure you want to drain <0>{nodeName}</0>?"
-msgstr "Are you sure you want to drain <0>{nodeName}</0>?"
+#~ msgid "Are you sure you want to drain <0>{nodeName}</0>?"
+#~ msgstr "Are you sure you want to drain <0>{nodeName}</0>?"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:84
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:103
 msgid "Arguments"
 msgstr "Arguments"
 
@@ -298,14 +296,14 @@ msgid "Associate clusters and choose the ones you want to access via quick launc
 msgstr "Associate clusters and choose the ones you want to access via quick launch menu by clicking the + button."
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:101
-msgid "Auth App Role"
-msgstr "Auth App Role"
+#~ msgid "Auth App Role"
+#~ msgstr "Auth App Role"
 
-#: src/renderer/components/+preferences/preferences.tsx:160
+#: src/renderer/components/+preferences/preferences.tsx:146
 msgid "Auto start-up"
 msgstr "Auto start-up"
 
-#: src/renderer/components/+preferences/preferences.tsx:161
+#: src/renderer/components/+preferences/preferences.tsx:147
 msgid "Automatically start Lens on login"
 msgstr "Automatically start Lens on login"
 
@@ -314,11 +312,11 @@ msgstr "Automatically start Lens on login"
 msgid "Back"
 msgstr "Back"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:43
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
 msgid "Backends"
 msgstr "Backends"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:93
 msgid "Binding"
 msgstr "Binding"
 
@@ -326,8 +324,8 @@ msgstr "Binding"
 msgid "Binding targets"
 msgstr "Binding targets"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:90
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:36
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:89
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:33
 msgid "Bindings"
 msgstr "Bindings"
 
@@ -370,17 +368,17 @@ msgstr "Bytes transmitted from all containers"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:97
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:129
-msgid "CA Bundle"
-msgstr "CA Bundle"
+#~ msgid "CA Bundle"
+#~ msgstr "CA Bundle"
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:24
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:140
-#: src/renderer/components/+nodes/node-details.tsx:62
-#: src/renderer/components/+nodes/node-details.tsx:73
-#: src/renderer/components/+nodes/node-details.tsx:78
-#: src/renderer/components/+nodes/nodes.tsx:120
+#: src/renderer/components/+nodes/node-details.tsx:61
+#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/nodes.tsx:117
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:11
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:44
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:53
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:95
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:13
@@ -406,11 +404,11 @@ msgstr "CPU limits"
 msgid "CPU requests"
 msgstr "CPU requests"
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "CPU:"
 msgstr "CPU:"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:133
+#: src/renderer/components/+workspaces/workspaces.tsx:138
 #: src/renderer/components/confirm-dialog/confirm-dialog.tsx:44
 #: src/renderer/components/dock/info-panel.tsx:86
 #: src/renderer/components/wizard/wizard.tsx:130
@@ -423,20 +421,20 @@ msgstr "Cancel"
 #: src/renderer/components/+nodes/node-charts.tsx:39
 #: src/renderer/components/+nodes/node-charts.tsx:63
 #: src/renderer/components/+nodes/node-charts.tsx:97
-#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:71
 #: src/renderer/components/+storage-volume-claims/volume-claim-disk-chart.tsx:31
 #: src/renderer/components/+storage-volumes/volume-details.tsx:29
-#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+storage-volumes/volumes.tsx:39
 msgid "Capacity"
 msgstr "Capacity"
 
-#: src/renderer/components/+preferences/preferences.tsx:163
+#: src/renderer/components/+preferences/preferences.tsx:149
 msgid "Certificate Trust"
 msgstr "Certificate Trust"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:59
-msgid "Certificates"
-msgstr "Certificates"
+#~ msgid "Certificates"
+#~ msgstr "Certificates"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:173
 #: src/renderer/components/+apps-releases/releases.tsx:89
@@ -473,7 +471,7 @@ msgstr "Charts"
 #~ msgstr "Choose how to import clusters: from selected kube-config file or from pasted yaml configuration"
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:68
-#: src/renderer/components/+storage-volumes/volumes.tsx:43
+#: src/renderer/components/+storage-volumes/volumes.tsx:40
 msgid "Claim"
 msgstr "Claim"
 
@@ -491,42 +489,42 @@ msgid "Close (Ctrl+W)"
 msgstr "Close (Ctrl+W)"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:121
-msgid "Cloud API Token Secret"
-msgstr "Cloud API Token Secret"
+#~ msgid "Cloud API Token Secret"
+#~ msgstr "Cloud API Token Secret"
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:43
-#: src/renderer/components/layout/sidebar.tsx:79
+#: src/renderer/components/layout/sidebar.tsx:80
 msgid "Cluster"
 msgstr "Cluster"
 
 #: src/renderer/components/+network-services/service-details.tsx:51
-#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+network-services/services.tsx:44
 msgid "Cluster IP"
 msgstr "Cluster IP"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:40
-msgid "Cluster Issuers"
-msgstr "Cluster Issuers"
+#~ msgid "Cluster Issuers"
+#~ msgstr "Cluster Issuers"
 
-#: src/renderer/components/+preferences/preferences.tsx:134
+#: src/renderer/components/+preferences/preferences.tsx:120
 msgid "Color Theme"
 msgstr "Color Theme"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:79
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:98
 msgid "Command"
 msgstr "Command"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:47
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:62
-msgid "Common Name"
-msgstr "Common Name"
+#~ msgid "Common Name"
+#~ msgstr "Common Name"
 
-#: src/renderer/components/layout/sidebar.tsx:76
+#: src/renderer/components/layout/sidebar.tsx:77
 msgid "Compact view"
 msgstr "Compact view"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:80
-#: src/renderer/components/+workloads-jobs/jobs.tsx:39
+#: src/renderer/components/+workloads-jobs/job-details.tsx:79
+#: src/renderer/components/+workloads-jobs/jobs.tsx:36
 msgid "Completions"
 msgstr "Completions"
 
@@ -534,17 +532,17 @@ msgstr "Completions"
 msgid "Component stack"
 msgstr "Component stack"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:72
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:71
 msgid "Condition"
 msgstr "Condition"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:52
-#: src/renderer/components/+nodes/node-details.tsx:107
-#: src/renderer/components/+nodes/nodes.tsx:127
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:79
-#: src/renderer/components/+workloads-deployments/deployments.tsx:64
-#: src/renderer/components/+workloads-jobs/job-details.tsx:77
-#: src/renderer/components/+workloads-jobs/jobs.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:51
+#: src/renderer/components/+nodes/node-details.tsx:106
+#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:78
+#: src/renderer/components/+workloads-deployments/deployments.tsx:62
+#: src/renderer/components/+workloads-jobs/job-details.tsx:76
+#: src/renderer/components/+workloads-jobs/jobs.tsx:39
 #: src/renderer/components/+workloads-pods/pod-details.tsx:100
 msgid "Conditions"
 msgstr "Conditions"
@@ -558,6 +556,7 @@ msgid "Are you sure you want to restart deployment <0>{0}</0>?"
 msgstr "Are you sure you want to restart deployment <0>{0}</0>?"
 
 #: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-maps/config-maps.tsx:30
 msgid "Config Maps"
 msgstr "Config Maps"
 
@@ -565,7 +564,7 @@ msgstr "Config Maps"
 msgid "Config copied to clipboard"
 msgstr "Config copied to clipboard"
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:41
+#: src/renderer/components/+config-maps/config-map-details.tsx:40
 msgid "ConfigMap <0>{0}</0> successfully updated."
 msgstr "ConfigMap <0>{0}</0> successfully updated."
 
@@ -573,7 +572,7 @@ msgstr "ConfigMap <0>{0}</0> successfully updated."
 msgid "ConfigMaps"
 msgstr "ConfigMaps"
 
-#: src/renderer/components/layout/sidebar.tsx:82
+#: src/renderer/components/layout/sidebar.tsx:83
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -581,7 +580,7 @@ msgstr "Configuration"
 msgid "Connection"
 msgstr "Connection"
 
-#: src/renderer/components/dock/pod-logs.tsx:148
+#: src/renderer/components/dock/pod-log-controls.tsx:63
 msgid "Container"
 msgstr "Container"
 
@@ -605,13 +604,13 @@ msgstr "Container memory requests"
 msgid "Container memory usage"
 msgstr "Container memory usage"
 
-#: src/renderer/components/+nodes/node-details.tsx:95
+#: src/renderer/components/+nodes/node-details.tsx:94
 msgid "Container runtime"
 msgstr "Container runtime"
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:122
-#: src/renderer/components/+workloads-pods/pods.tsx:77
-#: src/renderer/components/dock/pod-logs.tsx:129
+#: src/renderer/components/+workloads-pods/pods.tsx:74
+#: src/renderer/components/dock/pod-log-controls.tsx:43
 msgid "Containers"
 msgstr "Containers"
 
@@ -627,16 +626,16 @@ msgstr "Context"
 #~ msgid "Contexts: {0}"
 #~ msgstr "Contexts: {0}"
 
-#: src/renderer/components/+workloads-pods/pods.tsx:79
+#: src/renderer/components/+workloads-pods/pods.tsx:76
 #: src/renderer/components/kube-object/kube-object-meta.tsx:39
 msgid "Controlled By"
 msgstr "Controlled By"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:67
 msgid "Controlled by"
 msgstr "Controlled by"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:49
+#: src/renderer/components/+custom-resources/crd-details.tsx:48
 msgid "Conversion"
 msgstr "Conversion"
 
@@ -647,10 +646,10 @@ msgstr "Copy to clipboard"
 
 #: src/renderer/components/+nodes/node-menu.tsx:51
 #: src/renderer/components/+nodes/node-menu.tsx:52
-msgid "Cordon"
-msgstr "Cordon"
+#~ msgid "Cordon"
+#~ msgstr "Cordon"
 
-#: src/renderer/components/+events/event-details.tsx:45
+#: src/renderer/components/+events/event-details.tsx:44
 #: src/renderer/components/+events/events.tsx:67
 #: src/renderer/components/+events/kube-event-details.tsx:51
 msgid "Count"
@@ -686,23 +685,23 @@ msgstr "Create Secret"
 msgid "Create Service Account"
 msgstr "Create Service Account"
 
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:45
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:40
 msgid "Create new ResourceQuota"
 msgstr "Create new ResourceQuota"
 
-#: src/renderer/components/+user-management-roles/roles.tsx:44
+#: src/renderer/components/+user-management-roles/roles.tsx:39
 msgid "Create new Role"
 msgstr "Create new Role"
 
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:48
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:43
 msgid "Create new RoleBinding"
 msgstr "Create new RoleBinding"
 
-#: src/renderer/components/+config-secrets/secrets.tsx:58
+#: src/renderer/components/+config-secrets/secrets.tsx:53
 msgid "Create new Secret"
 msgstr "Create new Secret"
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:47
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:45
 msgid "Create new Service Account"
 msgstr "Create new Service Account"
 
@@ -719,10 +718,10 @@ msgid "Created at"
 msgstr "Created at"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:132
-msgid "Credentials Ref"
-msgstr "Credentials Ref"
+#~ msgid "Credentials Ref"
+#~ msgstr "Credentials Ref"
 
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:44
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:42
 msgid "Cron Jobs"
 msgstr "Cron Jobs"
 
@@ -734,8 +733,8 @@ msgstr "CronJobs"
 msgid "Current / Target"
 msgstr "Current / Target"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:39
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:43
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
 msgid "Current Healthy"
 msgstr "Current Healthy"
 
@@ -751,8 +750,8 @@ msgstr "Currently applied filters:"
 #~ msgid "Custom"
 #~ msgstr "Custom"
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:55
-#: src/renderer/components/layout/sidebar.tsx:89
+#: src/renderer/components/+custom-resources/crd-list.tsx:52
+#: src/renderer/components/layout/sidebar.tsx:90
 msgid "Custom Resources"
 msgstr "Custom Resources"
 
@@ -761,14 +760,14 @@ msgstr "Custom Resources"
 #~ msgstr "Custom.."
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:95
-msgid "DNS Provider"
-msgstr "DNS Provider"
+#~ msgid "DNS Provider"
+#~ msgstr "DNS Provider"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:50
-msgid "DNS names"
-msgstr "DNS names"
+#~ msgid "DNS names"
+#~ msgstr "DNS names"
 
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:41
 msgid "Daemon Sets"
 msgstr "Daemon Sets"
 
@@ -780,20 +779,20 @@ msgstr "DaemonSets"
 #~ msgid "Dark"
 #~ msgstr "Dark"
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:69
-#: src/renderer/components/+config-secrets/secret-details.tsx:78
+#: src/renderer/components/+config-maps/config-map-details.tsx:68
+#: src/renderer/components/+config-secrets/secret-details.tsx:77
 msgid "Data"
 msgstr "Data"
 
-#: src/renderer/components/+storage-classes/storage-classes.tsx:37
+#: src/renderer/components/+storage-classes/storage-classes.tsx:34
 msgid "Default"
 msgstr "Default"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:83
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:82
 msgid "Default Add Capabilities"
 msgstr "Default Add Capabilities"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:135
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:134
 msgid "Default Runtime Class Name"
 msgstr "Default Runtime Class Name"
 
@@ -805,27 +804,27 @@ msgstr "Default Runtime Class Name"
 msgid "Definitions"
 msgstr "Definitions"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:126
+#: src/renderer/components/+workspaces/workspaces.tsx:131
 #: src/renderer/components/menu/menu-actions.tsx:84
 msgid "Delete"
 msgstr "Delete"
 
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:47
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:45
 msgid "Deploy Revisions"
 msgstr "Deploy Revisions"
 
 #: src/renderer/components/+workloads/workloads.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-deployments/deployments.tsx:55
 msgid "Deployments"
 msgstr "Deployments"
 
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:65
-#: src/renderer/components/+workspaces/workspaces.tsx:131
+#: src/renderer/components/+workspaces/workspaces.tsx:136
 msgid "Description"
 msgstr "Description"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:43
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:44
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
 msgstr "Desired Healthy"
 
@@ -833,27 +832,27 @@ msgstr "Desired Healthy"
 msgid "Desired number of replicas"
 msgstr "Desired number of replicas"
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:62
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:63
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: src/renderer/components/+nodes/node-details.tsx:64
-#: src/renderer/components/+nodes/nodes.tsx:122
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:44
+#: src/renderer/components/+nodes/node-details.tsx:63
+#: src/renderer/components/+nodes/nodes.tsx:119
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:43
 msgid "Disk"
 msgstr "Disk"
 
-#: src/renderer/components/+nodes/nodes.tsx:79
+#: src/renderer/components/+nodes/nodes.tsx:76
 msgid "Disk:"
 msgstr "Disk:"
 
-#: src/renderer/components/+preferences/preferences.tsx:168
+#: src/renderer/components/+preferences/preferences.tsx:154
 msgid "Does not affect cluster communications!"
 msgstr "Does not affect cluster communications!"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:89
-msgid "Domains"
-msgstr "Domains"
+#~ msgid "Domains"
+#~ msgstr "Domains"
 
 #: src/renderer/components/+preferences/preferences.tsx:129
 #~ msgid "Download Mirror"
@@ -881,27 +880,26 @@ msgstr "Download mirror for kubectl"
 
 #: src/renderer/components/+nodes/node-menu.tsx:59
 #: src/renderer/components/+nodes/node-menu.tsx:60
-msgid "Drain"
-msgstr "Drain"
+#~ msgid "Drain"
+#~ msgstr "Drain"
 
 #: src/renderer/components/+nodes/node-menu.tsx:39
-msgid "Drain Node"
-msgstr "Drain Node"
+#~ msgid "Drain Node"
+#~ msgstr "Drain Node"
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:59
 msgid "Driver"
 msgstr "Driver"
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:59
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:87
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
 msgid "Duration"
 msgstr "Duration"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:58
-msgid "E-mail"
-msgstr "E-mail"
+#~ msgid "E-mail"
+#~ msgstr "E-mail"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:125
+#: src/renderer/components/+workspaces/workspaces.tsx:130
 #: src/renderer/components/menu/menu-actions.tsx:80
 #: src/renderer/components/menu/menu-actions.tsx:81
 msgid "Edit"
@@ -916,7 +914,7 @@ msgstr "Edit RoleBinding <0>{roleBindingName}</0>"
 msgid "Effect"
 msgstr "Effect"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:105
+#: src/renderer/components/+network-policies/network-policy-details.tsx:104
 msgid "Egress"
 msgstr "Egress"
 
@@ -925,8 +923,8 @@ msgid "Endpoint"
 msgstr "Endpoint"
 
 #: src/renderer/components/+network/network.tsx:35
+#: src/renderer/components/+network-endpoints/endpoints.tsx:27
 #: src/renderer/components/+network-endpoints/endpoints.tsx:30
-#: src/renderer/components/+network-endpoints/endpoints.tsx:33
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:27
 msgid "Endpoints"
 msgstr "Endpoints"
@@ -935,7 +933,7 @@ msgstr "Endpoints"
 msgid "Enter a name"
 msgstr "Enter a name"
 
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:79
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:80
 msgid "Environment"
 msgstr "Environment"
 
@@ -951,7 +949,7 @@ msgstr "Error while adding cluster(s): {0}"
 #: src/renderer/components/+events/events.tsx:56
 #: src/renderer/components/+events/kube-event-details.tsx:34
 #: src/renderer/components/+events/kube-event-details.tsx:39
-#: src/renderer/components/layout/sidebar.tsx:86
+#: src/renderer/components/layout/sidebar.tsx:87
 msgid "Events"
 msgstr "Events"
 
@@ -972,7 +970,7 @@ msgstr "Exit full size mode"
 #~ msgid "Extended view"
 #~ msgstr "Extended view"
 
-#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+network-services/services.tsx:46
 msgid "External IP"
 msgstr "External IP"
 
@@ -980,16 +978,16 @@ msgstr "External IP"
 msgid "External IPs"
 msgstr "External IPs"
 
-#: src/renderer/components/dock/pod-logs.store.ts:65
+#: src/renderer/components/dock/pod-logs.store.ts:56
 msgid "Failed to load logs: {0}"
 msgstr "Failed to load logs: {0}"
 
-#: src/renderer/components/+events/event-details.tsx:58
+#: src/renderer/components/+events/event-details.tsx:57
 msgid "Field Path"
 msgstr "Field Path"
 
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:14
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:28
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:46
 msgid "Filesystem"
 msgstr "Filesystem"
 
@@ -1001,7 +999,11 @@ msgstr "Filters ({0}/{1})"
 msgid "Finalizers"
 msgstr "Finalizers"
 
-#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+msgid "Finished at"
+msgstr "Finished at"
+
+#: src/renderer/components/+events/event-details.tsx:38
 msgid "First seen"
 msgstr "First seen"
 
@@ -1013,11 +1015,11 @@ msgstr "Fit to window"
 msgid "FlexVolume"
 msgstr "FlexVolume"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:67
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:66
 msgid "Forbidden Sysctls"
 msgstr "Forbidden Sysctls"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:26
+#: src/renderer/components/+network-policies/network-policy-details.tsx:25
 msgid "From"
 msgstr "From"
 
@@ -1025,7 +1027,7 @@ msgstr "From"
 #~ msgid "From <0>{from}</0> to <1>{to}</1>"
 #~ msgstr "From <0>{from}</0> to <1>{to}</1>"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:124
 msgid "Fs Group"
 msgstr "Fs Group"
 
@@ -1037,13 +1039,13 @@ msgstr "Get started by associating one or more clusters to Lens."
 #~ msgid "Global Lens Settings page"
 #~ msgstr "Global Lens Settings page"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:32
-#: src/renderer/components/+custom-resources/crd-list.tsx:58
-#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-details.tsx:31
+#: src/renderer/components/+custom-resources/crd-list.tsx:55
+#: src/renderer/components/+custom-resources/crd-list.tsx:71
 msgid "Group"
 msgstr "Group"
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:60
+#: src/renderer/components/+custom-resources/crd-list.tsx:57
 msgid "Groups"
 msgstr "Groups"
 
@@ -1051,7 +1053,7 @@ msgstr "Groups"
 msgid "HPA"
 msgstr "HPA"
 
-#: src/renderer/components/+preferences/preferences.tsx:137
+#: src/renderer/components/+preferences/preferences.tsx:123
 msgid "HTTP Proxy"
 msgstr "HTTP Proxy"
 
@@ -1059,7 +1061,7 @@ msgstr "HTTP Proxy"
 #~ msgid "HTTP Proxy server. Used for communicating with Kubernetes API."
 #~ msgstr "HTTP Proxy server. Used for communicating with Kubernetes API."
 
-#: src/renderer/components/+preferences/preferences.tsx:145
+#: src/renderer/components/+preferences/preferences.tsx:131
 msgid "Helm"
 msgstr "Helm"
 
@@ -1079,12 +1081,12 @@ msgstr "Helm Install: {repo}/{name}"
 msgid "Helm Upgrade: {0}"
 msgstr "Helm Upgrade: {0}"
 
-#: src/renderer/components/+preferences/preferences.tsx:51
+#: src/renderer/components/+preferences/preferences.tsx:45
 msgid "Helm branch <0>{0}</0> already in use"
 msgstr "Helm branch <0>{0}</0> already in use"
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Hide"
 msgstr "Hide"
@@ -1097,54 +1099,54 @@ msgstr "High number of replicas may cause cluster performance issues"
 msgid "Home"
 msgstr "Home"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:44
+#: src/renderer/components/+config-autoscalers/hpa.tsx:41
 msgid "Horizontal Pod Autoscalers"
 msgstr "Horizontal Pod Autoscalers"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:90
 msgid "Host IPC"
 msgstr "Host IPC"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:94
 msgid "Host Network"
 msgstr "Host Network"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:98
 msgid "Host PID"
 msgstr "Host PID"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:103
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:102
 msgid "Host Ports (Min-Max)"
 msgstr "Host Ports (Min-Max)"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:38
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:37
 msgid "Host: {0}"
 msgstr "Host: {0}"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:33
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:64
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:76
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:63
 msgid "Hostname"
 msgstr "Hostname"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:92
-msgid "Http01"
-msgstr "Http01"
+#~ msgid "Http01"
+#~ msgstr "Http01"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:65
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
 msgid "IP"
 msgstr "IP"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:53
-msgid "IP addresses"
-msgstr "IP addresses"
+#~ msgid "IP addresses"
+#~ msgstr "IP addresses"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:64
 msgid "Image"
 msgstr "Image"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:49
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:68
 msgid "ImagePullPolicy"
 msgstr "ImagePullPolicy"
 
@@ -1152,24 +1154,24 @@ msgstr "ImagePullPolicy"
 msgid "ImagePullSecrets"
 msgstr "ImagePullSecrets"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:65
-#: src/renderer/components/+workloads-jobs/job-details.tsx:64
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:77
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:64
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:64
+#: src/renderer/components/+workloads-jobs/job-details.tsx:63
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:76
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:63
 msgid "Images"
 msgstr "Images"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:92
+#: src/renderer/components/+network-policies/network-policy-details.tsx:91
 msgid "Ingress"
 msgstr "Ingress"
 
 #: src/renderer/components/+network/network.tsx:43
-#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:28
 msgid "Ingresses"
 msgstr "Ingresses"
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:118
-#: src/renderer/components/dock/pod-logs.tsx:135
+#: src/renderer/components/dock/pod-log-controls.tsx:49
 msgid "Init Containers"
 msgstr "Init Containers"
 
@@ -1198,24 +1200,24 @@ msgstr "Invalid number"
 msgid "Involved Object"
 msgstr "Involved Object"
 
-#: src/renderer/components/+events/event-details.tsx:52
+#: src/renderer/components/+events/event-details.tsx:51
 msgid "Involved object"
 msgstr "Involved object"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:31
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:64
-msgid "Issuer"
-msgstr "Issuer"
+#~ msgid "Issuer"
+#~ msgstr "Issuer"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:53
-msgid "Issuers"
-msgstr "Issuers"
+#~ msgid "Issuers"
+#~ msgstr "Issuers"
 
 #: src/renderer/components/no-items/no-items.tsx:9
 msgid "Item list is empty"
 msgstr "Item list is empty"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:83
+#: src/renderer/components/+custom-resources/crd-details.tsx:82
 msgid "JSON Path"
 msgstr "JSON Path"
 
@@ -1224,30 +1226,34 @@ msgid "Job name"
 msgstr "Job name"
 
 #: src/renderer/components/+workloads/workloads.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:62
-#: src/renderer/components/+workloads-jobs/jobs.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:33
 msgid "Jobs"
 msgstr "Jobs"
 
-#: src/renderer/components/+nodes/node-details.tsx:92
+#: src/renderer/components/dock/pod-logs.tsx:151
+msgid "Jump to bottom"
+msgstr "Jump to bottom"
+
+#: src/renderer/components/+nodes/node-details.tsx:91
 msgid "Kernel version"
 msgstr "Kernel version"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:76
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:16
 msgid "Key"
 msgstr "Key"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:68
-msgid "Key Algorithm"
-msgstr "Key Algorithm"
+#~ msgid "Key Algorithm"
+#~ msgstr "Key Algorithm"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:65
-msgid "Key Size"
-msgstr "Key Size"
+#~ msgid "Key Size"
+#~ msgstr "Key Size"
 
-#: src/renderer/components/+config-maps/config-maps.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:44
+#: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:41
 msgid "Keys"
 msgstr "Keys"
 
@@ -1255,13 +1261,13 @@ msgstr "Keys"
 msgid "Keywords"
 msgstr "Keywords"
 
-#: src/renderer/components/+events/event-details.tsx:57
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:78
 #: src/renderer/components/dock/edit-resource.tsx:88
 msgid "Kind"
 msgstr "Kind"
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:62
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:59
 msgid "Kubeconfig"
 msgstr "Kubeconfig"
 
@@ -1273,34 +1279,37 @@ msgstr "Kubeconfig File"
 msgid "Kubectl Binary"
 msgstr "Kubectl Binary"
 
-#: src/renderer/components/+nodes/node-details.tsx:98
+#: src/renderer/components/+nodes/node-details.tsx:97
 msgid "Kubelet version"
 msgstr "Kubelet version"
 
-#: src/renderer/components/+config-secrets/secrets.tsx:43
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:65
-#: src/renderer/components/+namespaces/namespaces.tsx:32
-#: src/renderer/components/+nodes/node-details.tsx:101
+#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+namespaces/namespaces.tsx:30
+#: src/renderer/components/+nodes/node-details.tsx:100
 #: src/renderer/components/kube-object/kube-object-meta.tsx:35
 msgid "Labels"
 msgstr "Labels"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:76
-msgid "Last Failure Time"
-msgstr "Last Failure Time"
+#~ msgid "Last Failure Time"
+#~ msgstr "Last Failure Time"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:57
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:51
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+msgid "Last Status"
+msgstr "Last Status"
+
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:56
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
 msgid "Last schedule"
 msgstr "Last schedule"
 
-#: src/renderer/components/+events/event-details.tsx:42
+#: src/renderer/components/+events/event-details.tsx:41
 #: src/renderer/components/+events/kube-event-details.tsx:57
 msgid "Last seen"
 msgstr "Last seen"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:84
+#: src/renderer/components/+custom-resources/crd-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:83
 #: src/renderer/components/+workloads-pods/pod-details.tsx:103
 msgid "Last transition time: {lastTransitionTime}"
 msgstr "Last transition time: {lastTransitionTime}"
@@ -1309,7 +1318,7 @@ msgstr "Last transition time: {lastTransitionTime}"
 #~ msgid "Lens Global Settings"
 #~ msgstr "Lens Global Settings"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:146
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:145
 msgid "Level"
 msgstr "Level"
 
@@ -1331,14 +1340,14 @@ msgid "Limits"
 msgstr "Limits"
 
 #: src/renderer/components/dock/pod-logs.tsx:150
-msgid "Lines"
-msgstr "Lines"
+#~ msgid "Lines"
+#~ msgstr "Lines"
 
 #: src/renderer/components/kube-object/kube-object-meta.tsx:29
 msgid "Link"
 msgstr "Link"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:71
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:90
 msgid "Liveness"
 msgstr "Liveness"
 
@@ -1346,9 +1355,13 @@ msgstr "Liveness"
 msgid "Load Balancer IP"
 msgstr "Load Balancer IP"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:108
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:107
 msgid "Load-Balancer Ingress Points"
 msgstr "Load-Balancer Ingress Points"
+
+#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+msgid "LoadBalancers"
+msgstr "LoadBalancers"
 
 #: src/renderer/components/app-init/app-init.tsx:43
 msgid "Loading"
@@ -1356,8 +1369,8 @@ msgstr "Loading"
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:100
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:101
-msgid "Logs"
-msgstr "Logs"
+#~ msgid "Logs"
+#~ msgstr "Logs"
 
 #: src/renderer/components/dialog/logs-dialog.tsx:27
 msgid "Logs copied to clipboard."
@@ -1371,21 +1384,21 @@ msgstr "Maintainers"
 msgid "Master"
 msgstr "Master"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:75
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:74
 msgid "Match Expressions"
 msgstr "Match Expressions"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:71
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:70
 msgid "Match Labels"
 msgstr "Match Labels"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:80
-#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+config-autoscalers/hpa.tsx:46
 msgid "Max Pods"
 msgstr "Max Pods"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
 msgid "Max Unavailable"
 msgstr "Max Unavailable"
 
@@ -1399,12 +1412,12 @@ msgstr "Medium"
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:25
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:144
-#: src/renderer/components/+nodes/node-details.tsx:63
-#: src/renderer/components/+nodes/node-details.tsx:74
-#: src/renderer/components/+nodes/node-details.tsx:79
-#: src/renderer/components/+nodes/nodes.tsx:121
+#: src/renderer/components/+nodes/node-details.tsx:62
+#: src/renderer/components/+nodes/node-details.tsx:73
+#: src/renderer/components/+nodes/node-details.tsx:78
+#: src/renderer/components/+nodes/nodes.tsx:118
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:12
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:63
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:96
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:18
@@ -1429,17 +1442,17 @@ msgstr "Memory requests"
 msgid "Memory usage"
 msgstr "Memory usage"
 
-#: src/renderer/components/+nodes/nodes.tsx:68
+#: src/renderer/components/+nodes/nodes.tsx:65
 msgid "Memory:"
 msgstr "Memory:"
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:100
-#: src/renderer/components/+events/event-details.tsx:30
+#: src/renderer/components/+events/event-details.tsx:29
 #: src/renderer/components/+events/events.tsx:62
 msgid "Message"
 msgstr "Message"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+config-autoscalers/hpa.tsx:44
 msgid "Metrics"
 msgstr "Metrics"
 
@@ -1451,13 +1464,13 @@ msgstr "Metrics are not available due to missing or invalid Prometheus configura
 msgid "Metrics not available at the moment"
 msgstr "Metrics not available at the moment"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:31
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:30
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
 msgid "Min Available"
 msgstr "Min Available"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:76
-#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-autoscalers/hpa.tsx:45
 msgid "Min Pods"
 msgstr "Min Pods"
 
@@ -1469,7 +1482,7 @@ msgstr "Minimize"
 msgid "Minimum length is {minLength}"
 msgstr "Minimum length is {minLength}"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:38
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:37
 #: src/renderer/components/+storage-volumes/volume-details.tsx:33
 msgid "Mount Options"
 msgstr "Mount Options"
@@ -1478,7 +1491,7 @@ msgstr "Mount Options"
 msgid "Mountable secrets"
 msgstr "Mountable secrets"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:80
 msgid "Mounts"
 msgstr "Mounts"
 
@@ -1489,47 +1502,45 @@ msgstr "Mounts"
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:64
 #: src/renderer/components/+apps-releases/releases.tsx:87
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:49
-#: src/renderer/components/+config-autoscalers/hpa.tsx:45
-#: src/renderer/components/+config-maps/config-maps.tsx:34
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:34
+#: src/renderer/components/+config-autoscalers/hpa.tsx:42
+#: src/renderer/components/+config-maps/config-maps.tsx:31
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:36
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:31
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:131
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:148
-#: src/renderer/components/+config-secrets/secrets.tsx:41
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:60
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:63
-#: src/renderer/components/+custom-resources/crd-details.tsx:81
-#: src/renderer/components/+custom-resources/crd-resources.tsx:63
-#: src/renderer/components/+events/event-details.tsx:55
-#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+config-secrets/secrets.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:80
+#: src/renderer/components/+custom-resources/crd-resources.tsx:60
+#: src/renderer/components/+events/event-details.tsx:54
+#: src/renderer/components/+namespaces/namespaces.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:87
-#: src/renderer/components/+network-endpoints/endpoints.tsx:31
-#: src/renderer/components/+network-ingresses/ingresses.tsx:32
-#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:28
+#: src/renderer/components/+network-ingresses/ingresses.tsx:29
+#: src/renderer/components/+network-policies/network-policies.tsx:28
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:26
-#: src/renderer/components/+network-services/services.tsx:44
-#: src/renderer/components/+nodes/nodes.tsx:119
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
-#: src/renderer/components/+storage-classes/storage-classes.tsx:34
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
+#: src/renderer/components/+network-services/services.tsx:41
+#: src/renderer/components/+nodes/nodes.tsx:116
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:32
+#: src/renderer/components/+storage-classes/storage-classes.tsx:31
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:43
 #: src/renderer/components/+storage-volumes/volume-details.tsx:72
-#: src/renderer/components/+storage-volumes/volumes.tsx:40
-#: src/renderer/components/+user-management-roles/roles.tsx:33
+#: src/renderer/components/+storage-volumes/volumes.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:30
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:191
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:32
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:29
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:58
-#: src/renderer/components/+workloads-jobs/jobs.tsx:37
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:34
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:43
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:42
+#: src/renderer/components/+workloads-deployments/deployments.tsx:56
+#: src/renderer/components/+workloads-jobs/jobs.tsx:34
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:92
 #: src/renderer/components/+workloads-pods/pod-details.tsx:144
-#: src/renderer/components/+workloads-pods/pods.tsx:74
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:40
-#: src/renderer/components/+workspaces/workspaces.tsx:130
+#: src/renderer/components/+workloads-pods/pods.tsx:71
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:48
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:37
+#: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
 msgid "Name"
@@ -1539,45 +1550,44 @@ msgstr "Name"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:61
+#: src/renderer/components/+custom-resources/crd-details.tsx:60
 msgid "Names"
 msgstr "Names"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:182
 #: src/renderer/components/+apps-releases/releases.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:46
-#: src/renderer/components/+config-maps/config-maps.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
+#: src/renderer/components/+config-autoscalers/hpa.tsx:43
+#: src/renderer/components/+config-maps/config-maps.tsx:32
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:37
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:129
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:130
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:35
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:32
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:152
-#: src/renderer/components/+config-secrets/secrets.tsx:42
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:61
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:64
-#: src/renderer/components/+custom-resources/crd-resources.tsx:64
-#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+config-secrets/secrets.tsx:39
+#: src/renderer/components/+custom-resources/crd-resources.tsx:61
+#: src/renderer/components/+events/event-details.tsx:55
 #: src/renderer/components/+events/events.tsx:63
 #: src/renderer/components/+namespaces/add-namespace-dialog.tsx:73
-#: src/renderer/components/+network-endpoints/endpoints.tsx:32
-#: src/renderer/components/+network-ingresses/ingresses.tsx:33
-#: src/renderer/components/+network-policies/network-policies.tsx:32
-#: src/renderer/components/+network-services/services.tsx:45
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
+#: src/renderer/components/+network-endpoints/endpoints.tsx:29
+#: src/renderer/components/+network-ingresses/ingresses.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:29
+#: src/renderer/components/+network-services/services.tsx:42
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:44
 #: src/renderer/components/+storage-volumes/volume-details.tsx:77
-#: src/renderer/components/+user-management-roles/roles.tsx:34
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:96
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:31
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
 #: src/renderer/components/+user-management-service-accounts/create-service-account-dialog.tsx:79
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:37
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
-#: src/renderer/components/+workloads-deployments/deployments.tsx:59
-#: src/renderer/components/+workloads-jobs/jobs.tsx:38
-#: src/renderer/components/+workloads-pods/pods.tsx:76
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:43
+#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-jobs/jobs.tsx:35
+#: src/renderer/components/+workloads-pods/pods.tsx:73
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:38
 #: src/renderer/components/dock/edit-resource.tsx:90
 #: src/renderer/components/dock/install-chart.tsx:122
+#: src/renderer/components/dock/pod-log-controls.tsx:62
 #: src/renderer/components/dock/upgrade-chart.tsx:98
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
@@ -1588,8 +1598,8 @@ msgstr "Namespace"
 msgid "Namespace: {0}"
 msgstr "Namespace: {0}"
 
-#: src/renderer/components/+namespaces/namespaces.tsx:30
-#: src/renderer/components/layout/sidebar.tsx:85
+#: src/renderer/components/+namespaces/namespaces.tsx:28
+#: src/renderer/components/layout/sidebar.tsx:86
 msgid "Namespaces"
 msgstr "Namespaces"
 
@@ -1597,13 +1607,13 @@ msgstr "Namespaces"
 msgid "Namespaces: {0}"
 msgstr "Namespaces: {0}"
 
-#: src/renderer/components/+preferences/preferences.tsx:167
+#: src/renderer/components/+preferences/preferences.tsx:153
 msgid "Needed with some corporate proxies that do certificate re-writing."
 msgstr "Needed with some corporate proxies that do certificate re-writing."
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:85
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:13
-#: src/renderer/components/layout/sidebar.tsx:83
+#: src/renderer/components/layout/sidebar.tsx:84
 msgid "Network"
 msgstr "Network"
 
@@ -1612,13 +1622,17 @@ msgid "Network File System"
 msgstr "Network File System"
 
 #: src/renderer/components/+network/network.tsx:51
-#: src/renderer/components/+network-policies/network-policies.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:27
 msgid "Network Policies"
 msgstr "Network Policies"
 
+#: src/renderer/components/dock/pod-logs.tsx:171
+msgid "New logs since opening logs tab"
+msgstr "New logs since opening logs tab"
+
 #: src/renderer/components/dock/pod-logs.tsx:178
-msgid "New logs since opening the dialog"
-msgstr "New logs since opening the dialog"
+#~ msgid "New logs since opening the dialog"
+#~ msgstr "New logs since opening the dialog"
 
 #: src/renderer/components/dock/dock.tsx:92
 msgid "New tab"
@@ -1637,16 +1651,14 @@ msgid "Next"
 msgstr "Next"
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:29
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
 msgid "No"
 msgstr "No"
 
@@ -1678,7 +1690,6 @@ msgstr "No items found."
 msgid "No revisions to rollback."
 msgstr "No revisions to rollback."
 
-#: src/renderer/components/+nodes/node-menu.tsx:24
 #: src/renderer/components/+workloads-pods/pod-details.tsx:85
 msgid "Node"
 msgstr "Node"
@@ -1687,13 +1698,13 @@ msgstr "Node"
 msgid "Node Pods capacity"
 msgstr "Node Pods capacity"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:61
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:49
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:59
 #: src/renderer/components/+workloads-pods/pod-details.tsx:107
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:73
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:60
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:72
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:59
 msgid "Node Selector"
 msgstr "Node Selector"
 
@@ -1706,17 +1717,17 @@ msgid "Node filesystem usage in bytes"
 msgstr "Node filesystem usage in bytes"
 
 #: src/renderer/components/+nodes/node-menu.tsx:47
-msgid "Node shell"
-msgstr "Node shell"
+#~ msgid "Node shell"
+#~ msgstr "Node shell"
 
-#: src/renderer/components/+nodes/nodes.tsx:118
-#: src/renderer/components/layout/sidebar.tsx:80
+#: src/renderer/components/+nodes/nodes.tsx:115
+#: src/renderer/components/layout/sidebar.tsx:81
 msgid "Nodes"
 msgstr "Nodes"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:72
-msgid "Not After"
-msgstr "Not After"
+#~ msgid "Not After"
+#~ msgstr "Not After"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:72
 msgid "Not Ready Addresses"
@@ -1734,11 +1745,11 @@ msgstr "Notes"
 msgid "Number of running Pods"
 msgstr "Number of running Pods"
 
-#: src/renderer/components/+nodes/node-details.tsx:86
+#: src/renderer/components/+nodes/node-details.tsx:85
 msgid "OS"
 msgstr "OS"
 
-#: src/renderer/components/+nodes/node-details.tsx:89
+#: src/renderer/components/+nodes/node-details.tsx:88
 msgid "OS Image"
 msgstr "OS Image"
 
@@ -1764,14 +1775,14 @@ msgid "Open in a browser"
 msgstr "Open in a browser"
 
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:17
 msgid "Operator"
 msgstr "Operator"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:56
-msgid "Organization"
-msgstr "Organization"
+#~ msgid "Organization"
+#~ msgstr "Organization"
 
 #: src/renderer/components/+workloads/workloads.tsx:29
 #: src/renderer/components/+workloads-overview/overview-statuses.tsx:45
@@ -1782,11 +1793,11 @@ msgstr "Overview"
 msgid "Page not found"
 msgstr "Page not found"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:83
+#: src/renderer/components/+workloads-jobs/job-details.tsx:82
 msgid "Parallelism"
 msgstr "Parallelism"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:42
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:41
 msgid "Parameters"
 msgstr "Parameters"
 
@@ -1794,23 +1805,21 @@ msgstr "Parameters"
 msgid "Paste as text"
 msgstr "Paste as text"
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:94
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:102
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:41
 msgid "Path"
 msgstr "Path"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:112
 msgid "Path Prefix"
 msgstr "Path Prefix"
 
 #: src/renderer/components/+storage/storage.tsx:25
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:42
 msgid "Persistent Volume Claims"
 msgstr "Persistent Volume Claims"
 
 #: src/renderer/components/+storage/storage.tsx:32
-#: src/renderer/components/+storage-volumes/volumes.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:36
 msgid "Persistent Volumes"
 msgstr "Persistent Volumes"
 
@@ -1838,12 +1847,12 @@ msgstr "Please select at least one cluster context"
 #~ msgid "Please select kubeconfig's context"
 #~ msgstr "Please select kubeconfig's context"
 
-#: src/renderer/components/+workloads-pods/pod-menu.tsx:50
+#: src/renderer/components/dock/pod-log-controls.tsx:61
 msgid "Pod"
 msgstr "Pod"
 
 #: src/renderer/components/+config/config.tsx:63
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:35
 msgid "Pod Disruption Budgets"
 msgstr "Pod Disruption Budgets"
 
@@ -1851,43 +1860,43 @@ msgstr "Pod Disruption Budgets"
 msgid "Pod IP"
 msgstr "Pod IP"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:31
 #: src/renderer/components/+user-management/user-management.tsx:43
 msgid "Pod Security Policies"
 msgstr "Pod Security Policies"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:85
+#: src/renderer/components/+network-policies/network-policy-details.tsx:84
 msgid "Pod Selector"
 msgstr "Pod Selector"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:88
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:85
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:69
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:87
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:84
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:68
 msgid "Pod Status"
 msgstr "Pod Status"
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:77
-msgid "Pod shell"
-msgstr "Pod shell"
+#~ msgid "Pod shell"
+#~ msgstr "Pod shell"
 
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:148
-#: src/renderer/components/+nodes/node-details.tsx:65
-#: src/renderer/components/+nodes/node-details.tsx:75
-#: src/renderer/components/+nodes/node-details.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:50
+#: src/renderer/components/+nodes/node-details.tsx:64
+#: src/renderer/components/+nodes/node-details.tsx:74
+#: src/renderer/components/+nodes/node-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:59
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
 #: src/renderer/components/+workloads/workloads.tsx:37
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
-#: src/renderer/components/+workloads-deployments/deployments.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-deployments/deployments.tsx:58
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:89
-#: src/renderer/components/+workloads-pods/pods.tsx:73
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:42
+#: src/renderer/components/+workloads-pods/pods.tsx:70
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
 msgid "Pods"
 msgstr "Pods"
 
-#: src/renderer/components/+network-policies/network-policies.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:30
 msgid "Policy Types"
 msgstr "Policy Types"
 
@@ -1896,29 +1905,29 @@ msgid "Port"
 msgstr "Port"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:83
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:94
-#: src/renderer/components/+network-policies/network-policy-details.tsx:96
-#: src/renderer/components/+network-policies/network-policy-details.tsx:109
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:93
+#: src/renderer/components/+network-policies/network-policy-details.tsx:95
+#: src/renderer/components/+network-policies/network-policy-details.tsx:108
 #: src/renderer/components/+network-services/service-details.tsx:59
-#: src/renderer/components/+network-services/services.tsx:48
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:53
+#: src/renderer/components/+network-services/services.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:72
 msgid "Ports"
 msgstr "Ports"
 
-#: src/renderer/components/+preferences/preferences.tsx:121
-#~ msgid "Preferences"
-#~ msgstr "Preferences"
+#: src/renderer/components/+preferences/preferences.tsx:118
+msgid "Preferences"
+msgstr "Preferences"
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:93
 msgid "Priority Class"
 msgstr "Priority Class"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:67
-msgid "Private Key Secret"
-msgstr "Private Key Secret"
+#~ msgid "Private Key Secret"
+#~ msgstr "Private Key Secret"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:36
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:33
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:74
 msgid "Privileged"
 msgstr "Privileged"
 
@@ -1950,12 +1959,12 @@ msgstr "Pro-Tip: you can also drag-n-drop kubeconfig file to this area"
 #~ msgid "Pro-tip: you can also drag-n-drop kube-config file to this area"
 #~ msgstr "Pro-tip: you can also drag-n-drop kube-config file to this area"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:28
-#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:27
+#: src/renderer/components/+storage-classes/storage-classes.tsx:32
 msgid "Provisioner"
 msgstr "Provisioner"
 
-#: src/renderer/components/+preferences/preferences.tsx:140
+#: src/renderer/components/+preferences/preferences.tsx:126
 msgid "Proxy is used only for non-cluster communication."
 msgstr "Proxy is used only for non-cluster communication."
 
@@ -1963,7 +1972,7 @@ msgstr "Proxy is used only for non-cluster communication."
 msgid "Proxy settings"
 msgstr "Proxy settings"
 
-#: src/renderer/components/+workloads-pods/pods.tsx:80
+#: src/renderer/components/+workloads-pods/pods.tsx:77
 msgid "QoS"
 msgstr "QoS"
 
@@ -1975,27 +1984,28 @@ msgstr "QoS Class"
 msgid "Quotas"
 msgstr "Quotas"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:27
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:26
 msgid "Ranges (Min-Max)"
 msgstr "Ranges (Min-Max)"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:114
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
 msgid "Read-only"
 msgstr "Read-only"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:78
 msgid "Read-only Root Filesystem"
 msgstr "Read-only Root Filesystem"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:75
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:94
 msgid "Readiness"
 msgstr "Readiness"
 
-#: src/renderer/components/+events/event-details.tsx:33
+#: src/renderer/components/+events/event-details.tsx:32
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "Reason"
 msgstr "Reason"
 
-#: src/renderer/components/dock/pod-logs.store.ts:66
+#: src/renderer/components/dock/pod-logs.store.ts:57
 msgid "Reason: {0} ({1})"
 msgstr "Reason: {0} ({1})"
 
@@ -2003,8 +2013,8 @@ msgstr "Reason: {0} ({1})"
 msgid "Receive"
 msgstr "Receive"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:34
-#: src/renderer/components/+storage-classes/storage-classes.tsx:36
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:33
 #: src/renderer/components/+storage-volumes/volume-details.tsx:40
 msgid "Reclaim Policy"
 msgstr "Reclaim Policy"
@@ -2014,7 +2024,7 @@ msgstr "Reclaim Policy"
 #~ msgstr "Reconnect"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:70
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:76
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:75
 msgid "Reference"
 msgstr "Reference"
 
@@ -2039,10 +2049,10 @@ msgstr "Release: {0}"
 msgid "Releases"
 msgstr "Releases"
 
-#: src/renderer/components/+preferences/preferences.tsx:152
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:73
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:79
+#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:59
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:74
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:80
 #: src/renderer/components/item-object-list/item-list-layout.tsx:179
 #: src/renderer/components/menu/menu-actions.tsx:49
 #: src/renderer/components/menu/menu-actions.tsx:85
@@ -2065,11 +2075,11 @@ msgstr "Remove field"
 msgid "Remove item?"
 msgstr "Remove item?"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:61
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
 msgid "Remove selected bindings for <0>{0}</0>?"
 msgstr "Remove selected bindings for <0>{0}</0>?"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Remove selected bindings from ${name}"
 msgstr "Remove selected bindings from ${name}"
 
@@ -2077,11 +2087,11 @@ msgstr "Remove selected bindings from ${name}"
 msgid "Remove selected items ({0})"
 msgstr "Remove selected items ({0})"
 
-#: src/renderer/components/kube-object/kube-object-menu.tsx:69
+#: src/renderer/components/kube-object/kube-object-menu.tsx:70
 msgid "Remove {resourceKind} <0>{resourceName}</0>?"
 msgstr "Remove {resourceKind} <0>{resourceName}</0>?"
 
-#: src/renderer/components/+preferences/preferences.tsx:122
+#: src/renderer/components/+preferences/preferences.tsx:112
 msgid "Removing helm branch <0>{0}</0> has failed: {1}"
 msgstr "Removing helm branch <0>{0}</0> has failed: {1}"
 
@@ -2090,14 +2100,14 @@ msgstr "Removing helm branch <0>{0}</0> has failed: {1}"
 #~ msgstr "Removing repo <0>{0}</0> has failed: {1}"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:62
-msgid "Renew Before"
-msgstr "Renew Before"
+#~ msgid "Renew Before"
+#~ msgstr "Renew Before"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:84
-#: src/renderer/components/+config-autoscalers/hpa.tsx:50
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
-#: src/renderer/components/+workloads-deployments/deployments.tsx:61
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:80
+#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:62
+#: src/renderer/components/+workloads-deployments/deployments.tsx:59
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
 msgstr "Replicas"
 
@@ -2105,7 +2115,7 @@ msgstr "Replicas"
 msgid "Repo/Name"
 msgstr "Repo/Name"
 
-#: src/renderer/components/+preferences/preferences.tsx:146
+#: src/renderer/components/+preferences/preferences.tsx:132
 msgid "Repositories"
 msgstr "Repositories"
 
@@ -2132,7 +2142,7 @@ msgstr "Request duration in seconds"
 msgid "Requests"
 msgstr "Requests"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:87
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:86
 msgid "Required Drop Capabilities"
 msgstr "Required Drop Capabilities"
 
@@ -2161,18 +2171,18 @@ msgstr "Reset filters?"
 #~ msgid "Resetting kube-config to default: {kubeConfigDefaultPath}"
 #~ msgstr "Resetting kube-config to default: {kubeConfigDefaultPath}"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:44
-#: src/renderer/components/+custom-resources/crd-list.tsx:73
+#: src/renderer/components/+custom-resources/crd-details.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:70
 msgid "Resource"
 msgstr "Resource"
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:45
+#: src/renderer/components/+user-management-roles/role-details.tsx:44
 msgid "Resource Names"
 msgstr "Resource Names"
 
 #: src/renderer/components/+config/config.tsx:47
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
-#: src/renderer/components/+namespaces/namespace-details.tsx:41
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:30
+#: src/renderer/components/+namespaces/namespace-details.tsx:40
 msgid "Resource Quotas"
 msgstr "Resource Quotas"
 
@@ -2180,7 +2190,7 @@ msgstr "Resource Quotas"
 msgid "Resource Version"
 msgstr "Resource Version"
 
-#: src/renderer/components/kube-object/kube-object-details.tsx:46
+#: src/renderer/components/kube-object/kube-object-details.tsx:48
 msgid "Resource loading has failed: <0>{0}</0>"
 msgstr "Resource loading has failed: <0>{0}</0>"
 
@@ -2193,7 +2203,7 @@ msgid "ResourceQuota name"
 msgstr "ResourceQuota name"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:198
-#: src/renderer/components/+user-management-roles/role-details.tsx:29
+#: src/renderer/components/+user-management-roles/role-details.tsx:28
 msgid "Resources"
 msgstr "Resources"
 
@@ -2209,7 +2219,7 @@ msgstr "Response duration in seconds"
 msgid "Restart session"
 msgstr "Restart session"
 
-#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-pods/pods.tsx:75
 msgid "Restarts"
 msgstr "Restarts"
 
@@ -2222,27 +2232,27 @@ msgstr "Revision"
 msgid "Right click cluster icon to open cluster settings."
 msgstr "Right click cluster icon to open cluster settings."
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:149
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:148
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:187
 msgid "Role"
 msgstr "Role"
 
 #: src/renderer/components/+user-management/user-management.tsx:31
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:31
 msgid "Role Bindings"
 msgstr "Role Bindings"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:105
-msgid "Role ID"
-msgstr "Role ID"
+#~ msgid "Role ID"
+#~ msgstr "Role ID"
 
 #: src/renderer/components/+user-management-roles/add-role-dialog.tsx:74
 msgid "Role name"
 msgstr "Role name"
 
-#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+nodes/nodes.tsx:121
 #: src/renderer/components/+user-management/user-management.tsx:36
-#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles/roles.tsx:29
 msgid "Roles"
 msgstr "Roles"
 
@@ -2256,41 +2266,41 @@ msgstr "Rollback"
 msgid "Rollback <0>{releaseName}</0>"
 msgstr "Rollback <0>{releaseName}</0>"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:24
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:142
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:23
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
 msgid "Rule"
 msgstr "Rule"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:105
-#: src/renderer/components/+network-ingresses/ingresses.tsx:34
-#: src/renderer/components/+user-management-roles/role-details.tsx:25
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:104
+#: src/renderer/components/+network-ingresses/ingresses.tsx:32
+#: src/renderer/components/+user-management-roles/role-details.tsx:24
 msgid "Rules"
 msgstr "Rules"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
 msgid "Run As Group"
 msgstr "Run As Group"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
 msgid "Run As User"
 msgstr "Run As User"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:130
 msgid "Runtime Class"
 msgstr "Runtime Class"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:114
-#: src/renderer/components/+config-maps/config-map-details.tsx:78
-#: src/renderer/components/+config-secrets/secret-details.tsx:97
-#: src/renderer/components/+workspaces/workspaces.tsx:132
+#: src/renderer/components/+config-maps/config-map-details.tsx:77
+#: src/renderer/components/+config-secrets/secret-details.tsx:96
+#: src/renderer/components/+workspaces/workspaces.tsx:137
 #: src/renderer/components/dock/edit-resource.tsx:87
-#: src/renderer/components/dock/pod-logs.tsx:161
+#: src/renderer/components/dock/pod-log-controls.tsx:74
 msgid "Save"
 msgstr "Save"
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
-#: src/renderer/components/+workloads-deployments/deployments.tsx:86
-#: src/renderer/components/+workloads-deployments/deployments.tsx:87
+#: src/renderer/components/+workloads-deployments/deployments.tsx:83
+#: src/renderer/components/+workloads-deployments/deployments.tsx:84
 msgid "Scale"
 msgstr "Scale"
 
@@ -2298,13 +2308,13 @@ msgstr "Scale"
 msgid "Scale Deployment <0>{deploymentName}</0>"
 msgstr "Scale Deployment <0>{deploymentName}</0>"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:46
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:45
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:46
 msgid "Schedule"
 msgstr "Schedule"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:41
-#: src/renderer/components/+custom-resources/crd-list.tsx:76
+#: src/renderer/components/+custom-resources/crd-details.tsx:40
+#: src/renderer/components/+custom-resources/crd-list.tsx:73
 msgid "Scope"
 msgstr "Scope"
 
@@ -2316,7 +2326,7 @@ msgstr "Scope Selector"
 msgid "Scope name"
 msgstr "Scope name"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:140
 msgid "Se Linux"
 msgstr "Se Linux"
 
@@ -2330,13 +2340,13 @@ msgstr "Search..."
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:65
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:108
-msgid "Secret"
-msgstr "Secret"
+#~ msgid "Secret"
+#~ msgstr "Secret"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:37
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:80
-msgid "Secret Name"
-msgstr "Secret Name"
+#~ msgid "Secret Name"
+#~ msgstr "Secret Name"
 
 #: src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx:72
 msgid "Secret is not found"
@@ -2346,7 +2356,7 @@ msgstr "Secret is not found"
 msgid "Secret name"
 msgstr "Secret name"
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:44
+#: src/renderer/components/+config-secrets/secret-details.tsx:43
 msgid "Secret successfully updated."
 msgstr "Secret successfully updated."
 
@@ -2355,7 +2365,7 @@ msgid "Secret type"
 msgstr "Secret type"
 
 #: src/renderer/components/+config/config.tsx:39
-#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+config-secrets/secrets.tsx:37
 #: src/renderer/components/+workloads-pods/pod-details.tsx:113
 msgid "Secrets"
 msgstr "Secrets"
@@ -2442,35 +2452,35 @@ msgstr "Selected contexts: <0>{0}</0>"
 #~ msgid "Selected contexts: {0}"
 #~ msgstr "Selected contexts: {0}"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:27
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:26
 #: src/renderer/components/+network-services/service-details.tsx:37
-#: src/renderer/components/+network-services/services.tsx:50
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:75
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:69
-#: src/renderer/components/+workloads-jobs/job-details.tsx:56
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:69
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:56
+#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:68
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:74
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:55
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:68
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:55
 msgid "Selector"
 msgstr "Selector"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:61
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:91
-msgid "Server"
-msgstr "Server"
+#~ msgid "Server"
+#~ msgstr "Server"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:102
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:101
 msgid "Service"
 msgstr "Service"
 
 #: src/renderer/components/+user-management/user-management.tsx:26
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:33
 msgid "Service Accounts"
 msgstr "Service Accounts"
 
 #: src/renderer/components/+network/network.tsx:27
-#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+network-services/services.tsx:40
 msgid "Services"
 msgstr "Services"
 
@@ -2486,18 +2496,18 @@ msgstr "Set"
 msgid "Set quota"
 msgstr "Set quota"
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:51
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:52
 msgid "Settings"
 msgstr "Settings"
 
 #: src/renderer/components/+nodes/node-menu.tsx:48
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:78
-msgid "Shell"
-msgstr "Shell"
+#~ msgid "Shell"
+#~ msgstr "Shell"
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:101
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:102
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Show"
 msgstr "Show"
@@ -2506,11 +2516,11 @@ msgstr "Show"
 msgid "Show Notes"
 msgstr "Show Notes"
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show current logs"
 msgstr "Show current logs"
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show previous terminated container logs"
 msgstr "Show previous terminated container logs"
 
@@ -2518,12 +2528,12 @@ msgstr "Show previous terminated container logs"
 msgid "Show value"
 msgstr "Show value"
 
-#: src/renderer/components/dock/pod-logs.tsx:154
+#: src/renderer/components/dock/pod-log-controls.tsx:67
 msgid "Since"
 msgstr "Since"
 
 #: src/renderer/components/+nodes/node-charts.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
 msgid "Size"
 msgstr "Size"
 
@@ -2532,10 +2542,10 @@ msgid "Size Limit"
 msgstr "Size Limit"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:70
-msgid "Skip TLS Verify"
-msgstr "Skip TLS Verify"
+#~ msgid "Skip TLS Verify"
+#~ msgstr "Skip TLS Verify"
 
-#: src/renderer/components/+events/event-details.tsx:36
+#: src/renderer/components/+events/event-details.tsx:35
 #: src/renderer/components/+events/events.tsx:66
 #: src/renderer/components/+events/kube-event-details.tsx:48
 msgid "Source"
@@ -2545,7 +2555,11 @@ msgstr "Source"
 msgid "Specified limits are higher than node capacity!"
 msgstr "Specified limits are higher than node capacity!"
 
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+msgid "Started at"
+msgstr "Started at"
+
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:36
 msgid "Stateful Sets"
 msgstr "Stateful Sets"
 
@@ -2556,59 +2570,55 @@ msgstr "StatefulSets"
 #: src/renderer/components/+apps-releases/release-details.tsx:192
 #: src/renderer/components/+apps-releases/releases.tsx:93
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:52
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:79
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:67
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:48
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:68
-#: src/renderer/components/+custom-resources/crd-resource-details.tsx:56
-#: src/renderer/components/+namespaces/namespace-details.tsx:37
-#: src/renderer/components/+namespaces/namespaces.tsx:34
-#: src/renderer/components/+network-services/services.tsx:52
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:65
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:52
+#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+custom-resources/crd-resource-details.tsx:49
+#: src/renderer/components/+namespaces/namespace-details.tsx:36
+#: src/renderer/components/+namespaces/namespaces.tsx:32
+#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:64
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
 #: src/renderer/components/+storage-volumes/volume-details.tsx:46
-#: src/renderer/components/+storage-volumes/volumes.tsx:45
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:57
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:97
 #: src/renderer/components/+workloads-pods/pod-details.tsx:82
-#: src/renderer/components/+workloads-pods/pods.tsx:82
+#: src/renderer/components/+workloads-pods/pods.tsx:79
 msgid "Status"
 msgstr "Status"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:64
-msgid "Status URI"
-msgstr "Status URI"
+#~ msgid "Status URI"
+#~ msgstr "Status URI"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:57
-#: src/renderer/components/layout/sidebar.tsx:84
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
+#: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"
 msgstr "Storage"
 
-#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+storage-volumes/volumes.tsx:38
 msgid "Storage Class"
 msgstr "Storage Class"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:54
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:53
 #: src/renderer/components/+storage-volumes/volume-details.tsx:43
 msgid "Storage Class Name"
 msgstr "Storage Class Name"
 
 #: src/renderer/components/+storage/storage.tsx:40
-#: src/renderer/components/+storage-classes/storage-classes.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:30
 msgid "Storage Classes"
 msgstr "Storage Classes"
 
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
 msgid "Storage class"
 msgstr "Storage class"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:37
 msgid "Stored versions"
 msgstr "Stored versions"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:68
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:76
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:67
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:75
 msgid "Strategy Type"
 msgstr "Strategy Type"
 
@@ -2625,7 +2635,7 @@ msgstr "Submit"
 msgid "Submitting.."
 msgstr "Submitting.."
 
-#: src/renderer/components/+network-endpoints/endpoint-details.tsx:24
+#: src/renderer/components/+network-endpoints/endpoint-details.tsx:23
 msgid "Subsets"
 msgstr "Subsets"
 
@@ -2633,31 +2643,31 @@ msgstr "Subsets"
 msgid "Successfully imported <0>{0}</0> cluster(s)"
 msgstr "Successfully imported <0>{0}</0> cluster(s)"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:128
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
 msgid "Supplemental Groups"
 msgstr "Supplemental Groups"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:54
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:53
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
 msgid "Suspend"
 msgstr "Suspend"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:98
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:97
 msgid "TLS"
 msgstr "TLS"
 
-#: src/renderer/components/+nodes/node-details.tsx:103
-#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/nodes.tsx:120
 msgid "Taints"
 msgstr "Taints"
 
 #: src/renderer/components/+preferences/preferences.tsx:171
-msgid "Telemetry & Usage Tracking"
-msgstr "Telemetry & Usage Tracking"
+#~ msgid "Telemetry & Usage Tracking"
+#~ msgstr "Telemetry & Usage Tracking"
 
 #: src/renderer/components/+preferences/preferences.tsx:174
-msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
-msgstr "Telemetry & usage data is collected to continuously improve the Lens experience."
+#~ msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
+#~ msgstr "Telemetry & usage data is collected to continuously improve the Lens experience."
 
 #: src/renderer/components/dock/terminal.store.ts:28
 msgid "Terminal"
@@ -2671,7 +2681,7 @@ msgstr "Terminal session"
 msgid "The path to the kubectl binary on the system."
 msgstr "The path to the kubectl binary on the system."
 
-#: src/renderer/components/dock/pod-logs.tsx:172
+#: src/renderer/components/dock/pod-logs.tsx:162
 msgid "There are no logs available for container."
 msgstr "There are no logs available for container."
 
@@ -2691,11 +2701,15 @@ msgstr "This field must be a valid path"
 msgid "This is the quick launch menu."
 msgstr "This is the quick launch menu."
 
-#: src/renderer/components/+preferences/preferences.tsx:166
+#: src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx:22
+msgid "This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces."
+msgstr "This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces."
+
+#: src/renderer/components/+preferences/preferences.tsx:152
 msgid "This will make Lens to trust ANY certificate authority without any validations."
 msgstr "This will make Lens to trust ANY certificate authority without any validations."
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:59
+#: src/renderer/components/+network-policies/network-policy-details.tsx:58
 msgid "To"
 msgstr "To"
 
@@ -2716,8 +2730,8 @@ msgid "Transmit"
 msgstr "Transmit"
 
 #: src/renderer/components/+workloads-cronjobs/cronjob-trigger-dialog.tsx:106
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:79
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:80
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:76
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:77
 msgid "Trigger"
 msgstr "Trigger"
 
@@ -2726,25 +2740,22 @@ msgid "Trigger CronJob <0>{cronjobName}</0>"
 msgstr "Trigger CronJob <0>{cronjobName}</0>"
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:102
-#: src/renderer/components/+config-secrets/secret-details.tsx:74
-#: src/renderer/components/+config-secrets/secrets.tsx:45
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:63
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:66
-#: src/renderer/components/+custom-resources/crd-details.tsx:82
-#: src/renderer/components/+events/event-details.tsx:48
+#: src/renderer/components/+config-secrets/secret-details.tsx:73
+#: src/renderer/components/+config-secrets/secrets.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:81
+#: src/renderer/components/+events/event-details.tsx:47
 #: src/renderer/components/+events/events.tsx:64
 #: src/renderer/components/+network-services/service-details.tsx:41
-#: src/renderer/components/+network-services/services.tsx:46
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:152
+#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:151
 #: src/renderer/components/+storage-volumes/volume-details.tsx:69
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:43
 #: src/renderer/components/+workloads-pods/pod-details.tsx:140
 msgid "Type"
 msgstr "Type"
 
-#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+preferences/preferences.tsx:124
 msgid "Type HTTP proxy url (example: http://proxy.acme.org:8080)"
 msgstr "Type HTTP proxy url (example: http://proxy.acme.org:8080)"
 
@@ -2753,13 +2764,13 @@ msgid "UID"
 msgstr "UID"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:126
-msgid "URL"
-msgstr "URL"
+#~ msgid "URL"
+#~ msgstr "URL"
 
 #: src/renderer/components/+nodes/node-menu.tsx:55
 #: src/renderer/components/+nodes/node-menu.tsx:56
-msgid "Uncordon"
-msgstr "Uncordon"
+#~ msgid "Uncordon"
+#~ msgstr "Uncordon"
 
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:212
 msgid "Update"
@@ -2814,11 +2825,11 @@ msgstr "Use same name for RoleBinding"
 #~ msgid "Used"
 #~ msgstr "Used"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:155
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:154
 msgid "User"
 msgstr "User"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:99
+#: src/renderer/components/+custom-resources/crd-details.tsx:98
 msgid "Validation"
 msgstr "Validation"
 
@@ -2831,11 +2842,11 @@ msgstr "Value"
 #: src/renderer/components/+apps-releases/release-details.tsx:111
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:132
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:62
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
 msgid "Values"
 msgstr "Values"
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:33
+#: src/renderer/components/+user-management-roles/role-details.tsx:32
 msgid "Verbs"
 msgstr "Verbs"
 
@@ -2843,9 +2854,9 @@ msgstr "Verbs"
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:66
 #: src/renderer/components/+apps-releases/release-details.tsx:185
 #: src/renderer/components/+apps-releases/releases.tsx:91
-#: src/renderer/components/+custom-resources/crd-details.tsx:35
-#: src/renderer/components/+custom-resources/crd-list.tsx:75
-#: src/renderer/components/+nodes/nodes.tsx:125
+#: src/renderer/components/+custom-resources/crd-details.tsx:34
+#: src/renderer/components/+custom-resources/crd-list.tsx:72
+#: src/renderer/components/+nodes/nodes.tsx:122
 #: src/renderer/components/dock/install-chart.tsx:120
 #: src/renderer/components/dock/upgrade-chart.tsx:99
 msgid "Version"
@@ -2855,7 +2866,7 @@ msgstr "Version"
 msgid "View Helm Release"
 msgstr "View Helm Release"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:31
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:30
 msgid "Volume Binding Mode"
 msgstr "Volume Binding Mode"
 
@@ -2867,8 +2878,8 @@ msgstr "Volume disk capacity"
 msgid "Volume disk usage"
 msgstr "Volume disk usage"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:37
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:47
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:46
 #: src/renderer/components/+workloads-pods/pod-details.tsx:130
 msgid "Volumes"
 msgstr "Volumes"
@@ -2885,7 +2896,7 @@ msgstr "Warnings: {0}"
 msgid "Welcome!"
 msgstr "Welcome!"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:88
+#: src/renderer/components/+workspaces/workspaces.tsx:92
 msgid "What is a Workspace?"
 msgstr "What is a Workspace?"
 
@@ -2893,16 +2904,16 @@ msgstr "What is a Workspace?"
 msgid "Worker"
 msgstr "Worker"
 
-#: src/renderer/components/layout/sidebar.tsx:81
+#: src/renderer/components/layout/sidebar.tsx:82
 msgid "Workloads"
 msgstr "Workloads"
 
 #: src/renderer/components/+workspaces/workspace-menu.tsx:39
-#: src/renderer/components/+workspaces/workspaces.tsx:100
+#: src/renderer/components/+workspaces/workspaces.tsx:104
 msgid "Workspaces"
 msgstr "Workspaces"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:90
+#: src/renderer/components/+workspaces/workspaces.tsx:94
 msgid "Workspaces are used to organize number of clusters into logical groups."
 msgstr "Workspaces are used to organize number of clusters into logical groups."
 
@@ -2915,27 +2926,25 @@ msgid "Wrong url format"
 msgstr "Wrong url format"
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:28
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
-#: src/renderer/components/+storage-classes/storage-classes.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
+#: src/renderer/components/+storage-classes/storage-classes.tsx:40
 msgid "Yes"
 msgstr "Yes"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:118
-msgid "Zone"
-msgstr "Zone"
+#~ msgid "Zone"
+#~ msgstr "Zone"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:180
-#: src/renderer/components/+events/event-details.tsx:40
-#: src/renderer/components/+events/event-details.tsx:43
+#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+events/event-details.tsx:42
 #: src/renderer/components/kube-object/kube-object-meta.tsx:18
 msgid "ago"
 msgstr "ago"
@@ -2948,36 +2957,37 @@ msgstr "and <0>{tailCount}</0> more"
 #~ msgid "applicable to all clusters"
 #~ msgstr "applicable to all clusters"
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "cores:"
 msgstr "cores:"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:18
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "exit code"
 msgstr "exit code"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:66
+#: src/renderer/components/+custom-resources/crd-details.tsx:65
 msgid "kind"
 msgstr "kind"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:67
+#: src/renderer/components/+custom-resources/crd-details.tsx:66
 msgid "listKind"
 msgstr "listKind"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:48
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:61
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:47
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:59
 msgid "never"
 msgstr "never"
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:133
 msgid "new"
 msgstr "new"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:64
+#: src/renderer/components/+custom-resources/crd-details.tsx:63
 msgid "plural"
 msgstr "plural"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:41
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:17
 msgid "ready"
 msgstr "ready"
 
@@ -2985,11 +2995,11 @@ msgstr "ready"
 msgid "sec"
 msgstr "sec"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:65
+#: src/renderer/components/+custom-resources/crd-details.tsx:64
 msgid "singular"
 msgstr "singular"
 
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 msgid "timestamps"
 msgstr "timestamps"
 
@@ -2997,7 +3007,7 @@ msgstr "timestamps"
 msgid "{0, plural, one {Resource} other {Resources}}"
 msgstr "{0, plural, one {Resource} other {Resources}}"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
 msgid "{0} desired, {1} updated"
 msgstr "{0} desired, {1} updated"
 
@@ -3013,11 +3023,11 @@ msgstr "{0} on Pods"
 msgid "{0} on {1}"
 msgstr "{0} on {1}"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
 msgid "{0} total, {1} available"
 msgstr "{0} total, {1} available"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:66
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
 msgid "{0} unavailable"
 msgstr "{0} unavailable"
 
@@ -3029,7 +3039,7 @@ msgstr "{accountName} kubeconfig"
 msgid "{allItemsCount, plural, one {# item} other {# items}}"
 msgstr "{allItemsCount, plural, one {# item} other {# items}}"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:31
+#: src/renderer/components/+config-autoscalers/hpa.tsx:28
 msgid "{metricsRemainCount} more..."
 msgstr "{metricsRemainCount} more..."
 

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -25,11 +25,11 @@ msgstr ""
 msgid "(as a percentage of request)"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:121
+#: src/renderer/components/+workspaces/workspaces.tsx:126
 msgid "(current)"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:88
+#: src/renderer/components/+network-policies/network-policy-details.tsx:87
 msgid "(empty) (Allowing the specific traffic to all pods in this namespace)"
 msgstr ""
 
@@ -61,19 +61,19 @@ msgstr ""
 msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:93
+#: src/renderer/components/+workspaces/workspaces.tsx:97
 msgid "A single workspaces contains a list of clusters and their full configuration."
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:81
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
 msgid "API Group"
 msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:88
+#: src/renderer/components/layout/sidebar.tsx:89
 msgid "Access Control"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:51
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:50
 #: src/renderer/components/+storage-volumes/volume-details.tsx:37
 msgid "Access Modes"
 msgstr ""
@@ -82,17 +82,17 @@ msgstr ""
 msgid "Account Name"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:51
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
 msgid "Active"
 msgstr ""
 
 #: src/renderer/components/+add-cluster/add-cluster.tsx:310
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:127
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
 msgid "Add Cluster"
 msgstr ""
 
-#: src/renderer/components/+namespaces/namespaces.tsx:43
+#: src/renderer/components/+namespaces/namespaces.tsx:39
 msgid "Add Namespace"
 msgstr ""
 
@@ -100,11 +100,11 @@ msgstr ""
 msgid "Add RoleBinding"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:138
+#: src/renderer/components/+workspaces/workspaces.tsx:143
 msgid "Add Workspace"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Add bindings to {name}"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 #~ msgid "Adding clusters: <0>{0}</0>"
 #~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:111
+#: src/renderer/components/+preferences/preferences.tsx:101
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
@@ -144,13 +144,13 @@ msgstr ""
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:78
+#: src/renderer/components/+custom-resources/crd-details.tsx:77
 msgid "Additional Printer Columns"
 msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:60
-#: src/renderer/components/+nodes/node-details.tsx:83
+#: src/renderer/components/+nodes/node-details.tsx:82
 msgid "Addresses"
 msgstr ""
 
@@ -158,36 +158,34 @@ msgstr ""
 msgid "Affinities"
 msgstr ""
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:51
-#: src/renderer/components/+config-maps/config-maps.tsx:37
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:45
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:46
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:66
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:67
-#: src/renderer/components/+custom-resources/crd-list.tsx:77
-#: src/renderer/components/+custom-resources/crd-resources.tsx:73
+#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-maps/config-maps.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-resources.tsx:70
 #: src/renderer/components/+events/events.tsx:68
-#: src/renderer/components/+namespaces/namespaces.tsx:33
-#: src/renderer/components/+network-endpoints/endpoints.tsx:34
-#: src/renderer/components/+network-ingresses/ingresses.tsx:35
-#: src/renderer/components/+network-policies/network-policies.tsx:34
-#: src/renderer/components/+network-services/services.tsx:51
-#: src/renderer/components/+nodes/nodes.tsx:126
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:38
-#: src/renderer/components/+storage-classes/storage-classes.tsx:38
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:51
-#: src/renderer/components/+storage-volumes/volumes.tsx:44
-#: src/renderer/components/+user-management-roles/roles.tsx:35
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:38
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:38
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:52
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:50
-#: src/renderer/components/+workloads-deployments/deployments.tsx:63
-#: src/renderer/components/+workloads-jobs/jobs.tsx:41
-#: src/renderer/components/+workloads-pods/pods.tsx:81
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:44
+#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-services/services.tsx:48
+#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
+#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
+#: src/renderer/components/+workloads-deployments/deployments.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:38
+#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
 msgid "Age"
 msgstr ""
 
@@ -199,68 +197,68 @@ msgstr ""
 #~ msgid "All clusters within workspace will be cleared as well."
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:56
+#: src/renderer/components/+custom-resources/crd-list.tsx:53
 msgid "All groups"
 msgstr ""
 
 #: src/renderer/components/dock/pod-logs.tsx:37
-msgid "All logs"
-msgstr ""
+#~ msgid "All logs"
+#~ msgstr ""
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:95
 msgid "All namespaces"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/node-details.tsx:76
 msgid "Allocatable"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:70
 msgid "Allow Privilege Escalation"
 msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:172
-msgid "Allow telemetry & usage tracking"
-msgstr ""
+#~ msgid "Allow telemetry & usage tracking"
+#~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:164
+#: src/renderer/components/+preferences/preferences.tsx:150
 msgid "Allow untrusted Certificate Authorities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:51
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:50
 msgid "Allowed CSI Drivers"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:42
 msgid "Allowed Capabilities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:55
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:54
 msgid "Allowed Flex Volumes"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:110
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:109
 msgid "Allowed Host Paths"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:59
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:58
 msgid "Allowed Proc Mount Types"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:132
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
 msgid "Allowed Runtime Class Names"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:63
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:62
 msgid "Allowed Unsafe Sysctls"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/node-details.tsx:101
 #: src/renderer/components/kube-object/kube-object-meta.tsx:36
 msgid "Annotations"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:37
+#: src/renderer/components/+user-management-roles/role-details.tsx:36
 msgid "Api Groups"
 msgstr ""
 
@@ -277,7 +275,7 @@ msgstr ""
 msgid "Applying.."
 msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:87
+#: src/renderer/components/layout/sidebar.tsx:88
 msgid "Apps"
 msgstr ""
 
@@ -286,10 +284,10 @@ msgid "Are you sure you want remove workspace <0>{0}</0>?"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:41
-msgid "Are you sure you want to drain <0>{nodeName}</0>?"
-msgstr ""
+#~ msgid "Are you sure you want to drain <0>{nodeName}</0>?"
+#~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:84
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:103
 msgid "Arguments"
 msgstr ""
 
@@ -298,14 +296,14 @@ msgid "Associate clusters and choose the ones you want to access via quick launc
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:101
-msgid "Auth App Role"
-msgstr ""
+#~ msgid "Auth App Role"
+#~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:160
+#: src/renderer/components/+preferences/preferences.tsx:146
 msgid "Auto start-up"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:161
+#: src/renderer/components/+preferences/preferences.tsx:147
 msgid "Automatically start Lens on login"
 msgstr ""
 
@@ -314,11 +312,11 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:43
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
 msgid "Backends"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:93
 msgid "Binding"
 msgstr ""
 
@@ -326,8 +324,8 @@ msgstr ""
 msgid "Binding targets"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:90
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:36
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:89
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:33
 msgid "Bindings"
 msgstr ""
 
@@ -370,17 +368,17 @@ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:97
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:129
-msgid "CA Bundle"
-msgstr ""
+#~ msgid "CA Bundle"
+#~ msgstr ""
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:24
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:140
-#: src/renderer/components/+nodes/node-details.tsx:62
-#: src/renderer/components/+nodes/node-details.tsx:73
-#: src/renderer/components/+nodes/node-details.tsx:78
-#: src/renderer/components/+nodes/nodes.tsx:120
+#: src/renderer/components/+nodes/node-details.tsx:61
+#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/nodes.tsx:117
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:11
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:44
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:53
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:95
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:13
@@ -406,11 +404,11 @@ msgstr ""
 msgid "CPU requests"
 msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "CPU:"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:133
+#: src/renderer/components/+workspaces/workspaces.tsx:138
 #: src/renderer/components/confirm-dialog/confirm-dialog.tsx:44
 #: src/renderer/components/dock/info-panel.tsx:86
 #: src/renderer/components/wizard/wizard.tsx:130
@@ -423,20 +421,20 @@ msgstr ""
 #: src/renderer/components/+nodes/node-charts.tsx:39
 #: src/renderer/components/+nodes/node-charts.tsx:63
 #: src/renderer/components/+nodes/node-charts.tsx:97
-#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:71
 #: src/renderer/components/+storage-volume-claims/volume-claim-disk-chart.tsx:31
 #: src/renderer/components/+storage-volumes/volume-details.tsx:29
-#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+storage-volumes/volumes.tsx:39
 msgid "Capacity"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:163
+#: src/renderer/components/+preferences/preferences.tsx:149
 msgid "Certificate Trust"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:59
-msgid "Certificates"
-msgstr ""
+#~ msgid "Certificates"
+#~ msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:173
 #: src/renderer/components/+apps-releases/releases.tsx:89
@@ -469,7 +467,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:68
-#: src/renderer/components/+storage-volumes/volumes.tsx:43
+#: src/renderer/components/+storage-volumes/volumes.tsx:40
 msgid "Claim"
 msgstr ""
 
@@ -487,42 +485,42 @@ msgid "Close (Ctrl+W)"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:121
-msgid "Cloud API Token Secret"
-msgstr ""
+#~ msgid "Cloud API Token Secret"
+#~ msgstr ""
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:43
-#: src/renderer/components/layout/sidebar.tsx:79
+#: src/renderer/components/layout/sidebar.tsx:80
 msgid "Cluster"
 msgstr ""
 
 #: src/renderer/components/+network-services/service-details.tsx:51
-#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+network-services/services.tsx:44
 msgid "Cluster IP"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:40
-msgid "Cluster Issuers"
-msgstr ""
+#~ msgid "Cluster Issuers"
+#~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:134
+#: src/renderer/components/+preferences/preferences.tsx:120
 msgid "Color Theme"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:79
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:98
 msgid "Command"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:47
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:62
-msgid "Common Name"
-msgstr ""
+#~ msgid "Common Name"
+#~ msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:76
+#: src/renderer/components/layout/sidebar.tsx:77
 msgid "Compact view"
 msgstr ""
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:80
-#: src/renderer/components/+workloads-jobs/jobs.tsx:39
+#: src/renderer/components/+workloads-jobs/job-details.tsx:79
+#: src/renderer/components/+workloads-jobs/jobs.tsx:36
 msgid "Completions"
 msgstr ""
 
@@ -530,17 +528,17 @@ msgstr ""
 msgid "Component stack"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:72
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:71
 msgid "Condition"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:52
-#: src/renderer/components/+nodes/node-details.tsx:107
-#: src/renderer/components/+nodes/nodes.tsx:127
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:79
-#: src/renderer/components/+workloads-deployments/deployments.tsx:64
-#: src/renderer/components/+workloads-jobs/job-details.tsx:77
-#: src/renderer/components/+workloads-jobs/jobs.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:51
+#: src/renderer/components/+nodes/node-details.tsx:106
+#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:78
+#: src/renderer/components/+workloads-deployments/deployments.tsx:62
+#: src/renderer/components/+workloads-jobs/job-details.tsx:76
+#: src/renderer/components/+workloads-jobs/jobs.tsx:39
 #: src/renderer/components/+workloads-pods/pod-details.tsx:100
 msgid "Conditions"
 msgstr ""
@@ -554,6 +552,7 @@ msgid "Are you sure you want to restart deployment <0>{0}</0>?"
 msgstr ""
 
 #: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-maps/config-maps.tsx:30
 msgid "Config Maps"
 msgstr ""
 
@@ -561,7 +560,7 @@ msgstr ""
 msgid "Config copied to clipboard"
 msgstr ""
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:41
+#: src/renderer/components/+config-maps/config-map-details.tsx:40
 msgid "ConfigMap <0>{0}</0> successfully updated."
 msgstr ""
 
@@ -569,7 +568,7 @@ msgstr ""
 msgid "ConfigMaps"
 msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:82
+#: src/renderer/components/layout/sidebar.tsx:83
 msgid "Configuration"
 msgstr ""
 
@@ -577,7 +576,7 @@ msgstr ""
 msgid "Connection"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:148
+#: src/renderer/components/dock/pod-log-controls.tsx:63
 msgid "Container"
 msgstr ""
 
@@ -601,13 +600,13 @@ msgstr ""
 msgid "Container memory usage"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:95
+#: src/renderer/components/+nodes/node-details.tsx:94
 msgid "Container runtime"
 msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:122
-#: src/renderer/components/+workloads-pods/pods.tsx:77
-#: src/renderer/components/dock/pod-logs.tsx:129
+#: src/renderer/components/+workloads-pods/pods.tsx:74
+#: src/renderer/components/dock/pod-log-controls.tsx:43
 msgid "Containers"
 msgstr ""
 
@@ -623,16 +622,16 @@ msgstr ""
 #~ msgid "Contexts: {0}"
 #~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pods.tsx:79
+#: src/renderer/components/+workloads-pods/pods.tsx:76
 #: src/renderer/components/kube-object/kube-object-meta.tsx:39
 msgid "Controlled By"
 msgstr ""
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:67
 msgid "Controlled by"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:49
+#: src/renderer/components/+custom-resources/crd-details.tsx:48
 msgid "Conversion"
 msgstr ""
 
@@ -643,10 +642,10 @@ msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:51
 #: src/renderer/components/+nodes/node-menu.tsx:52
-msgid "Cordon"
-msgstr ""
+#~ msgid "Cordon"
+#~ msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:45
+#: src/renderer/components/+events/event-details.tsx:44
 #: src/renderer/components/+events/events.tsx:67
 #: src/renderer/components/+events/kube-event-details.tsx:51
 msgid "Count"
@@ -682,23 +681,23 @@ msgstr ""
 msgid "Create Service Account"
 msgstr ""
 
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:45
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:40
 msgid "Create new ResourceQuota"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles/roles.tsx:44
+#: src/renderer/components/+user-management-roles/roles.tsx:39
 msgid "Create new Role"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:48
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:43
 msgid "Create new RoleBinding"
 msgstr ""
 
-#: src/renderer/components/+config-secrets/secrets.tsx:58
+#: src/renderer/components/+config-secrets/secrets.tsx:53
 msgid "Create new Secret"
 msgstr ""
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:47
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:45
 msgid "Create new Service Account"
 msgstr ""
 
@@ -715,10 +714,10 @@ msgid "Created at"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:132
-msgid "Credentials Ref"
-msgstr ""
+#~ msgid "Credentials Ref"
+#~ msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:44
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:42
 msgid "Cron Jobs"
 msgstr ""
 
@@ -730,8 +729,8 @@ msgstr ""
 msgid "Current / Target"
 msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:39
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:43
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
 msgid "Current Healthy"
 msgstr ""
 
@@ -747,8 +746,8 @@ msgstr ""
 #~ msgid "Custom"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:55
-#: src/renderer/components/layout/sidebar.tsx:89
+#: src/renderer/components/+custom-resources/crd-list.tsx:52
+#: src/renderer/components/layout/sidebar.tsx:90
 msgid "Custom Resources"
 msgstr ""
 
@@ -757,14 +756,14 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:95
-msgid "DNS Provider"
-msgstr ""
+#~ msgid "DNS Provider"
+#~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:50
-msgid "DNS names"
-msgstr ""
+#~ msgid "DNS names"
+#~ msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:41
 msgid "Daemon Sets"
 msgstr ""
 
@@ -776,20 +775,20 @@ msgstr ""
 #~ msgid "Dark"
 #~ msgstr ""
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:69
-#: src/renderer/components/+config-secrets/secret-details.tsx:78
+#: src/renderer/components/+config-maps/config-map-details.tsx:68
+#: src/renderer/components/+config-secrets/secret-details.tsx:77
 msgid "Data"
 msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-classes.tsx:37
+#: src/renderer/components/+storage-classes/storage-classes.tsx:34
 msgid "Default"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:83
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:82
 msgid "Default Add Capabilities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:135
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:134
 msgid "Default Runtime Class Name"
 msgstr ""
 
@@ -801,27 +800,27 @@ msgstr ""
 msgid "Definitions"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:126
+#: src/renderer/components/+workspaces/workspaces.tsx:131
 #: src/renderer/components/menu/menu-actions.tsx:84
 msgid "Delete"
 msgstr ""
 
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:47
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:45
 msgid "Deploy Revisions"
 msgstr ""
 
 #: src/renderer/components/+workloads/workloads.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-deployments/deployments.tsx:55
 msgid "Deployments"
 msgstr ""
 
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:65
-#: src/renderer/components/+workspaces/workspaces.tsx:131
+#: src/renderer/components/+workspaces/workspaces.tsx:136
 msgid "Description"
 msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:43
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:44
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
 msgstr ""
 
@@ -829,27 +828,27 @@ msgstr ""
 msgid "Desired number of replicas"
 msgstr ""
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:62
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:63
 msgid "Disconnect"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:64
-#: src/renderer/components/+nodes/nodes.tsx:122
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:44
+#: src/renderer/components/+nodes/node-details.tsx:63
+#: src/renderer/components/+nodes/nodes.tsx:119
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:43
 msgid "Disk"
 msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:79
+#: src/renderer/components/+nodes/nodes.tsx:76
 msgid "Disk:"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:168
+#: src/renderer/components/+preferences/preferences.tsx:154
 msgid "Does not affect cluster communications!"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:89
-msgid "Domains"
-msgstr ""
+#~ msgid "Domains"
+#~ msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:129
 #~ msgid "Download Mirror"
@@ -877,27 +876,26 @@ msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:59
 #: src/renderer/components/+nodes/node-menu.tsx:60
-msgid "Drain"
-msgstr ""
+#~ msgid "Drain"
+#~ msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:39
-msgid "Drain Node"
-msgstr ""
+#~ msgid "Drain Node"
+#~ msgstr ""
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:59
 msgid "Driver"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:59
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:87
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
 msgid "Duration"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:58
-msgid "E-mail"
-msgstr ""
+#~ msgid "E-mail"
+#~ msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:125
+#: src/renderer/components/+workspaces/workspaces.tsx:130
 #: src/renderer/components/menu/menu-actions.tsx:80
 #: src/renderer/components/menu/menu-actions.tsx:81
 msgid "Edit"
@@ -912,7 +910,7 @@ msgstr ""
 msgid "Effect"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:105
+#: src/renderer/components/+network-policies/network-policy-details.tsx:104
 msgid "Egress"
 msgstr ""
 
@@ -921,8 +919,8 @@ msgid "Endpoint"
 msgstr ""
 
 #: src/renderer/components/+network/network.tsx:35
+#: src/renderer/components/+network-endpoints/endpoints.tsx:27
 #: src/renderer/components/+network-endpoints/endpoints.tsx:30
-#: src/renderer/components/+network-endpoints/endpoints.tsx:33
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:27
 msgid "Endpoints"
 msgstr ""
@@ -931,7 +929,7 @@ msgstr ""
 msgid "Enter a name"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:79
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:80
 msgid "Environment"
 msgstr ""
 
@@ -947,7 +945,7 @@ msgstr ""
 #: src/renderer/components/+events/events.tsx:56
 #: src/renderer/components/+events/kube-event-details.tsx:34
 #: src/renderer/components/+events/kube-event-details.tsx:39
-#: src/renderer/components/layout/sidebar.tsx:86
+#: src/renderer/components/layout/sidebar.tsx:87
 msgid "Events"
 msgstr ""
 
@@ -963,7 +961,7 @@ msgstr ""
 #~ msgid "Extended view"
 #~ msgstr ""
 
-#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+network-services/services.tsx:46
 msgid "External IP"
 msgstr ""
 
@@ -971,16 +969,16 @@ msgstr ""
 msgid "External IPs"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.store.ts:65
+#: src/renderer/components/dock/pod-logs.store.ts:56
 msgid "Failed to load logs: {0}"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:58
+#: src/renderer/components/+events/event-details.tsx:57
 msgid "Field Path"
 msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:14
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:28
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:46
 msgid "Filesystem"
 msgstr ""
 
@@ -992,7 +990,11 @@ msgstr ""
 msgid "Finalizers"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+msgid "Finished at"
+msgstr ""
+
+#: src/renderer/components/+events/event-details.tsx:38
 msgid "First seen"
 msgstr ""
 
@@ -1004,11 +1006,11 @@ msgstr ""
 msgid "FlexVolume"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:67
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:66
 msgid "Forbidden Sysctls"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:26
+#: src/renderer/components/+network-policies/network-policy-details.tsx:25
 msgid "From"
 msgstr ""
 
@@ -1016,7 +1018,7 @@ msgstr ""
 #~ msgid "From <0>{from}</0> to <1>{to}</1>"
 #~ msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:124
 msgid "Fs Group"
 msgstr ""
 
@@ -1028,13 +1030,13 @@ msgstr ""
 #~ msgid "Global Lens Settings page"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:32
-#: src/renderer/components/+custom-resources/crd-list.tsx:58
-#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-details.tsx:31
+#: src/renderer/components/+custom-resources/crd-list.tsx:55
+#: src/renderer/components/+custom-resources/crd-list.tsx:71
 msgid "Group"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:60
+#: src/renderer/components/+custom-resources/crd-list.tsx:57
 msgid "Groups"
 msgstr ""
 
@@ -1042,7 +1044,7 @@ msgstr ""
 msgid "HPA"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:137
+#: src/renderer/components/+preferences/preferences.tsx:123
 msgid "HTTP Proxy"
 msgstr ""
 
@@ -1050,7 +1052,7 @@ msgstr ""
 #~ msgid "HTTP Proxy server. Used for communicating with Kubernetes API."
 #~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:145
+#: src/renderer/components/+preferences/preferences.tsx:131
 msgid "Helm"
 msgstr ""
 
@@ -1070,12 +1072,12 @@ msgstr ""
 msgid "Helm Upgrade: {0}"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:51
+#: src/renderer/components/+preferences/preferences.tsx:45
 msgid "Helm branch <0>{0}</0> already in use"
 msgstr ""
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Hide"
 msgstr ""
@@ -1088,54 +1090,54 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:44
+#: src/renderer/components/+config-autoscalers/hpa.tsx:41
 msgid "Horizontal Pod Autoscalers"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:90
 msgid "Host IPC"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:94
 msgid "Host Network"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:98
 msgid "Host PID"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:103
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:102
 msgid "Host Ports (Min-Max)"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:38
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:37
 msgid "Host: {0}"
 msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:33
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:64
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:76
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:63
 msgid "Hostname"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:92
-msgid "Http01"
-msgstr ""
+#~ msgid "Http01"
+#~ msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:65
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
 msgid "IP"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:53
-msgid "IP addresses"
-msgstr ""
+#~ msgid "IP addresses"
+#~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:64
 msgid "Image"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:49
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:68
 msgid "ImagePullPolicy"
 msgstr ""
 
@@ -1143,24 +1145,24 @@ msgstr ""
 msgid "ImagePullSecrets"
 msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:65
-#: src/renderer/components/+workloads-jobs/job-details.tsx:64
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:77
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:64
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:64
+#: src/renderer/components/+workloads-jobs/job-details.tsx:63
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:76
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:63
 msgid "Images"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:92
+#: src/renderer/components/+network-policies/network-policy-details.tsx:91
 msgid "Ingress"
 msgstr ""
 
 #: src/renderer/components/+network/network.tsx:43
-#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:28
 msgid "Ingresses"
 msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:118
-#: src/renderer/components/dock/pod-logs.tsx:135
+#: src/renderer/components/dock/pod-log-controls.tsx:49
 msgid "Init Containers"
 msgstr ""
 
@@ -1189,24 +1191,24 @@ msgstr ""
 msgid "Involved Object"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:52
+#: src/renderer/components/+events/event-details.tsx:51
 msgid "Involved object"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:31
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:64
-msgid "Issuer"
-msgstr ""
+#~ msgid "Issuer"
+#~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:53
-msgid "Issuers"
-msgstr ""
+#~ msgid "Issuers"
+#~ msgstr ""
 
 #: src/renderer/components/no-items/no-items.tsx:9
 msgid "Item list is empty"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:83
+#: src/renderer/components/+custom-resources/crd-details.tsx:82
 msgid "JSON Path"
 msgstr ""
 
@@ -1215,30 +1217,34 @@ msgid "Job name"
 msgstr ""
 
 #: src/renderer/components/+workloads/workloads.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:62
-#: src/renderer/components/+workloads-jobs/jobs.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:33
 msgid "Jobs"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:92
+#: src/renderer/components/dock/pod-logs.tsx:151
+msgid "Jump to bottom"
+msgstr ""
+
+#: src/renderer/components/+nodes/node-details.tsx:91
 msgid "Kernel version"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:76
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:16
 msgid "Key"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:68
-msgid "Key Algorithm"
-msgstr ""
+#~ msgid "Key Algorithm"
+#~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:65
-msgid "Key Size"
-msgstr ""
+#~ msgid "Key Size"
+#~ msgstr ""
 
-#: src/renderer/components/+config-maps/config-maps.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:44
+#: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:41
 msgid "Keys"
 msgstr ""
 
@@ -1246,13 +1252,13 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:57
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:78
 #: src/renderer/components/dock/edit-resource.tsx:88
 msgid "Kind"
 msgstr ""
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:62
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:59
 msgid "Kubeconfig"
 msgstr ""
 
@@ -1264,34 +1270,37 @@ msgstr ""
 msgid "Kubectl Binary"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:98
+#: src/renderer/components/+nodes/node-details.tsx:97
 msgid "Kubelet version"
 msgstr ""
 
-#: src/renderer/components/+config-secrets/secrets.tsx:43
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:65
-#: src/renderer/components/+namespaces/namespaces.tsx:32
-#: src/renderer/components/+nodes/node-details.tsx:101
+#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+namespaces/namespaces.tsx:30
+#: src/renderer/components/+nodes/node-details.tsx:100
 #: src/renderer/components/kube-object/kube-object-meta.tsx:35
 msgid "Labels"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:76
-msgid "Last Failure Time"
+#~ msgid "Last Failure Time"
+#~ msgstr ""
+
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+msgid "Last Status"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:57
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:51
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:56
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
 msgid "Last schedule"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:42
+#: src/renderer/components/+events/event-details.tsx:41
 #: src/renderer/components/+events/kube-event-details.tsx:57
 msgid "Last seen"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:84
+#: src/renderer/components/+custom-resources/crd-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:83
 #: src/renderer/components/+workloads-pods/pod-details.tsx:103
 msgid "Last transition time: {lastTransitionTime}"
 msgstr ""
@@ -1300,7 +1309,7 @@ msgstr ""
 #~ msgid "Lens Global Settings"
 #~ msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:146
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:145
 msgid "Level"
 msgstr ""
 
@@ -1322,14 +1331,14 @@ msgid "Limits"
 msgstr ""
 
 #: src/renderer/components/dock/pod-logs.tsx:150
-msgid "Lines"
-msgstr ""
+#~ msgid "Lines"
+#~ msgstr ""
 
 #: src/renderer/components/kube-object/kube-object-meta.tsx:29
 msgid "Link"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:71
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:90
 msgid "Liveness"
 msgstr ""
 
@@ -1337,8 +1346,12 @@ msgstr ""
 msgid "Load Balancer IP"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:108
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:107
 msgid "Load-Balancer Ingress Points"
+msgstr ""
+
+#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+msgid "LoadBalancers"
 msgstr ""
 
 #: src/renderer/components/app-init/app-init.tsx:43
@@ -1347,8 +1360,8 @@ msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:100
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:101
-msgid "Logs"
-msgstr ""
+#~ msgid "Logs"
+#~ msgstr ""
 
 #: src/renderer/components/dialog/logs-dialog.tsx:27
 msgid "Logs copied to clipboard."
@@ -1362,21 +1375,21 @@ msgstr ""
 msgid "Master"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:75
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:74
 msgid "Match Expressions"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:71
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:70
 msgid "Match Labels"
 msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:80
-#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+config-autoscalers/hpa.tsx:46
 msgid "Max Pods"
 msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
 msgid "Max Unavailable"
 msgstr ""
 
@@ -1390,12 +1403,12 @@ msgstr ""
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:25
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:144
-#: src/renderer/components/+nodes/node-details.tsx:63
-#: src/renderer/components/+nodes/node-details.tsx:74
-#: src/renderer/components/+nodes/node-details.tsx:79
-#: src/renderer/components/+nodes/nodes.tsx:121
+#: src/renderer/components/+nodes/node-details.tsx:62
+#: src/renderer/components/+nodes/node-details.tsx:73
+#: src/renderer/components/+nodes/node-details.tsx:78
+#: src/renderer/components/+nodes/nodes.tsx:118
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:12
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:63
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:96
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:18
@@ -1420,17 +1433,17 @@ msgstr ""
 msgid "Memory usage"
 msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:68
+#: src/renderer/components/+nodes/nodes.tsx:65
 msgid "Memory:"
 msgstr ""
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:100
-#: src/renderer/components/+events/event-details.tsx:30
+#: src/renderer/components/+events/event-details.tsx:29
 #: src/renderer/components/+events/events.tsx:62
 msgid "Message"
 msgstr ""
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+config-autoscalers/hpa.tsx:44
 msgid "Metrics"
 msgstr ""
 
@@ -1442,13 +1455,13 @@ msgstr ""
 msgid "Metrics not available at the moment"
 msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:31
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:30
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
 msgid "Min Available"
 msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:76
-#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-autoscalers/hpa.tsx:45
 msgid "Min Pods"
 msgstr ""
 
@@ -1460,7 +1473,7 @@ msgstr ""
 msgid "Minimum length is {minLength}"
 msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:38
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:37
 #: src/renderer/components/+storage-volumes/volume-details.tsx:33
 msgid "Mount Options"
 msgstr ""
@@ -1469,7 +1482,7 @@ msgstr ""
 msgid "Mountable secrets"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:80
 msgid "Mounts"
 msgstr ""
 
@@ -1480,47 +1493,45 @@ msgstr ""
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:64
 #: src/renderer/components/+apps-releases/releases.tsx:87
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:49
-#: src/renderer/components/+config-autoscalers/hpa.tsx:45
-#: src/renderer/components/+config-maps/config-maps.tsx:34
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:34
+#: src/renderer/components/+config-autoscalers/hpa.tsx:42
+#: src/renderer/components/+config-maps/config-maps.tsx:31
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:36
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:31
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:131
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:148
-#: src/renderer/components/+config-secrets/secrets.tsx:41
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:60
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:63
-#: src/renderer/components/+custom-resources/crd-details.tsx:81
-#: src/renderer/components/+custom-resources/crd-resources.tsx:63
-#: src/renderer/components/+events/event-details.tsx:55
-#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+config-secrets/secrets.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:80
+#: src/renderer/components/+custom-resources/crd-resources.tsx:60
+#: src/renderer/components/+events/event-details.tsx:54
+#: src/renderer/components/+namespaces/namespaces.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:87
-#: src/renderer/components/+network-endpoints/endpoints.tsx:31
-#: src/renderer/components/+network-ingresses/ingresses.tsx:32
-#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:28
+#: src/renderer/components/+network-ingresses/ingresses.tsx:29
+#: src/renderer/components/+network-policies/network-policies.tsx:28
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:26
-#: src/renderer/components/+network-services/services.tsx:44
-#: src/renderer/components/+nodes/nodes.tsx:119
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
-#: src/renderer/components/+storage-classes/storage-classes.tsx:34
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
+#: src/renderer/components/+network-services/services.tsx:41
+#: src/renderer/components/+nodes/nodes.tsx:116
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:32
+#: src/renderer/components/+storage-classes/storage-classes.tsx:31
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:43
 #: src/renderer/components/+storage-volumes/volume-details.tsx:72
-#: src/renderer/components/+storage-volumes/volumes.tsx:40
-#: src/renderer/components/+user-management-roles/roles.tsx:33
+#: src/renderer/components/+storage-volumes/volumes.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:30
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:191
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:32
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:29
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:58
-#: src/renderer/components/+workloads-jobs/jobs.tsx:37
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:34
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:43
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:42
+#: src/renderer/components/+workloads-deployments/deployments.tsx:56
+#: src/renderer/components/+workloads-jobs/jobs.tsx:34
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:92
 #: src/renderer/components/+workloads-pods/pod-details.tsx:144
-#: src/renderer/components/+workloads-pods/pods.tsx:74
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:40
-#: src/renderer/components/+workspaces/workspaces.tsx:130
+#: src/renderer/components/+workloads-pods/pods.tsx:71
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:48
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:37
+#: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
 msgid "Name"
@@ -1530,45 +1541,44 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:61
+#: src/renderer/components/+custom-resources/crd-details.tsx:60
 msgid "Names"
 msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:182
 #: src/renderer/components/+apps-releases/releases.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:46
-#: src/renderer/components/+config-maps/config-maps.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
+#: src/renderer/components/+config-autoscalers/hpa.tsx:43
+#: src/renderer/components/+config-maps/config-maps.tsx:32
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:37
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:129
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:130
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:35
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:32
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:152
-#: src/renderer/components/+config-secrets/secrets.tsx:42
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:61
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:64
-#: src/renderer/components/+custom-resources/crd-resources.tsx:64
-#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+config-secrets/secrets.tsx:39
+#: src/renderer/components/+custom-resources/crd-resources.tsx:61
+#: src/renderer/components/+events/event-details.tsx:55
 #: src/renderer/components/+events/events.tsx:63
 #: src/renderer/components/+namespaces/add-namespace-dialog.tsx:73
-#: src/renderer/components/+network-endpoints/endpoints.tsx:32
-#: src/renderer/components/+network-ingresses/ingresses.tsx:33
-#: src/renderer/components/+network-policies/network-policies.tsx:32
-#: src/renderer/components/+network-services/services.tsx:45
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
+#: src/renderer/components/+network-endpoints/endpoints.tsx:29
+#: src/renderer/components/+network-ingresses/ingresses.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:29
+#: src/renderer/components/+network-services/services.tsx:42
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:44
 #: src/renderer/components/+storage-volumes/volume-details.tsx:77
-#: src/renderer/components/+user-management-roles/roles.tsx:34
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:96
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:31
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
 #: src/renderer/components/+user-management-service-accounts/create-service-account-dialog.tsx:79
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:37
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
-#: src/renderer/components/+workloads-deployments/deployments.tsx:59
-#: src/renderer/components/+workloads-jobs/jobs.tsx:38
-#: src/renderer/components/+workloads-pods/pods.tsx:76
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:43
+#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-jobs/jobs.tsx:35
+#: src/renderer/components/+workloads-pods/pods.tsx:73
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:38
 #: src/renderer/components/dock/edit-resource.tsx:90
 #: src/renderer/components/dock/install-chart.tsx:122
+#: src/renderer/components/dock/pod-log-controls.tsx:62
 #: src/renderer/components/dock/upgrade-chart.tsx:98
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
@@ -1579,8 +1589,8 @@ msgstr ""
 msgid "Namespace: {0}"
 msgstr ""
 
-#: src/renderer/components/+namespaces/namespaces.tsx:30
-#: src/renderer/components/layout/sidebar.tsx:85
+#: src/renderer/components/+namespaces/namespaces.tsx:28
+#: src/renderer/components/layout/sidebar.tsx:86
 msgid "Namespaces"
 msgstr ""
 
@@ -1588,13 +1598,13 @@ msgstr ""
 msgid "Namespaces: {0}"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:167
+#: src/renderer/components/+preferences/preferences.tsx:153
 msgid "Needed with some corporate proxies that do certificate re-writing."
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:85
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:13
-#: src/renderer/components/layout/sidebar.tsx:83
+#: src/renderer/components/layout/sidebar.tsx:84
 msgid "Network"
 msgstr ""
 
@@ -1603,13 +1613,17 @@ msgid "Network File System"
 msgstr ""
 
 #: src/renderer/components/+network/network.tsx:51
-#: src/renderer/components/+network-policies/network-policies.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:27
 msgid "Network Policies"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:178
-msgid "New logs since opening the dialog"
+#: src/renderer/components/dock/pod-logs.tsx:171
+msgid "New logs since opening logs tab"
 msgstr ""
+
+#: src/renderer/components/dock/pod-logs.tsx:178
+#~ msgid "New logs since opening the dialog"
+#~ msgstr ""
 
 #: src/renderer/components/dock/dock.tsx:92
 msgid "New tab"
@@ -1620,16 +1634,14 @@ msgid "Next"
 msgstr ""
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:29
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
 msgid "No"
 msgstr ""
 
@@ -1661,7 +1673,6 @@ msgstr ""
 msgid "No revisions to rollback."
 msgstr ""
 
-#: src/renderer/components/+nodes/node-menu.tsx:24
 #: src/renderer/components/+workloads-pods/pod-details.tsx:85
 msgid "Node"
 msgstr ""
@@ -1670,13 +1681,13 @@ msgstr ""
 msgid "Node Pods capacity"
 msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:61
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:49
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:59
 #: src/renderer/components/+workloads-pods/pod-details.tsx:107
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:73
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:60
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:72
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:59
 msgid "Node Selector"
 msgstr ""
 
@@ -1689,17 +1700,17 @@ msgid "Node filesystem usage in bytes"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:47
-msgid "Node shell"
-msgstr ""
+#~ msgid "Node shell"
+#~ msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:118
-#: src/renderer/components/layout/sidebar.tsx:80
+#: src/renderer/components/+nodes/nodes.tsx:115
+#: src/renderer/components/layout/sidebar.tsx:81
 msgid "Nodes"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:72
-msgid "Not After"
-msgstr ""
+#~ msgid "Not After"
+#~ msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:72
 msgid "Not Ready Addresses"
@@ -1717,11 +1728,11 @@ msgstr ""
 msgid "Number of running Pods"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:86
+#: src/renderer/components/+nodes/node-details.tsx:85
 msgid "OS"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:89
+#: src/renderer/components/+nodes/node-details.tsx:88
 msgid "OS Image"
 msgstr ""
 
@@ -1747,14 +1758,14 @@ msgid "Open in a browser"
 msgstr ""
 
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:17
 msgid "Operator"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:56
-msgid "Organization"
-msgstr ""
+#~ msgid "Organization"
+#~ msgstr ""
 
 #: src/renderer/components/+workloads/workloads.tsx:29
 #: src/renderer/components/+workloads-overview/overview-statuses.tsx:45
@@ -1765,11 +1776,11 @@ msgstr ""
 msgid "Page not found"
 msgstr ""
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:83
+#: src/renderer/components/+workloads-jobs/job-details.tsx:82
 msgid "Parallelism"
 msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:42
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:41
 msgid "Parameters"
 msgstr ""
 
@@ -1777,23 +1788,21 @@ msgstr ""
 msgid "Paste as text"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:94
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:102
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:41
 msgid "Path"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:112
 msgid "Path Prefix"
 msgstr ""
 
 #: src/renderer/components/+storage/storage.tsx:25
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:42
 msgid "Persistent Volume Claims"
 msgstr ""
 
 #: src/renderer/components/+storage/storage.tsx:32
-#: src/renderer/components/+storage-volumes/volumes.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:36
 msgid "Persistent Volumes"
 msgstr ""
 
@@ -1821,12 +1830,12 @@ msgstr ""
 #~ msgid "Please select kubeconfig's context"
 #~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-menu.tsx:50
+#: src/renderer/components/dock/pod-log-controls.tsx:61
 msgid "Pod"
 msgstr ""
 
 #: src/renderer/components/+config/config.tsx:63
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:35
 msgid "Pod Disruption Budgets"
 msgstr ""
 
@@ -1834,43 +1843,43 @@ msgstr ""
 msgid "Pod IP"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:31
 #: src/renderer/components/+user-management/user-management.tsx:43
 msgid "Pod Security Policies"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:85
+#: src/renderer/components/+network-policies/network-policy-details.tsx:84
 msgid "Pod Selector"
 msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:88
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:85
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:69
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:87
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:84
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:68
 msgid "Pod Status"
 msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:77
-msgid "Pod shell"
-msgstr ""
+#~ msgid "Pod shell"
+#~ msgstr ""
 
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:148
-#: src/renderer/components/+nodes/node-details.tsx:65
-#: src/renderer/components/+nodes/node-details.tsx:75
-#: src/renderer/components/+nodes/node-details.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:50
+#: src/renderer/components/+nodes/node-details.tsx:64
+#: src/renderer/components/+nodes/node-details.tsx:74
+#: src/renderer/components/+nodes/node-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:59
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
 #: src/renderer/components/+workloads/workloads.tsx:37
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
-#: src/renderer/components/+workloads-deployments/deployments.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-deployments/deployments.tsx:58
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:89
-#: src/renderer/components/+workloads-pods/pods.tsx:73
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:42
+#: src/renderer/components/+workloads-pods/pods.tsx:70
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
 msgid "Pods"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policies.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:30
 msgid "Policy Types"
 msgstr ""
 
@@ -1879,29 +1888,29 @@ msgid "Port"
 msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:83
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:94
-#: src/renderer/components/+network-policies/network-policy-details.tsx:96
-#: src/renderer/components/+network-policies/network-policy-details.tsx:109
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:93
+#: src/renderer/components/+network-policies/network-policy-details.tsx:95
+#: src/renderer/components/+network-policies/network-policy-details.tsx:108
 #: src/renderer/components/+network-services/service-details.tsx:59
-#: src/renderer/components/+network-services/services.tsx:48
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:53
+#: src/renderer/components/+network-services/services.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:72
 msgid "Ports"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:121
-#~ msgid "Preferences"
-#~ msgstr ""
+#: src/renderer/components/+preferences/preferences.tsx:118
+msgid "Preferences"
+msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:93
 msgid "Priority Class"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:67
-msgid "Private Key Secret"
-msgstr ""
+#~ msgid "Private Key Secret"
+#~ msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:36
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:33
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:74
 msgid "Privileged"
 msgstr ""
 
@@ -1933,12 +1942,12 @@ msgstr ""
 #~ msgid "Pro-tip: you can also drag-n-drop kube-config file to this area"
 #~ msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:28
-#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:27
+#: src/renderer/components/+storage-classes/storage-classes.tsx:32
 msgid "Provisioner"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:140
+#: src/renderer/components/+preferences/preferences.tsx:126
 msgid "Proxy is used only for non-cluster communication."
 msgstr ""
 
@@ -1946,7 +1955,7 @@ msgstr ""
 msgid "Proxy settings"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pods.tsx:80
+#: src/renderer/components/+workloads-pods/pods.tsx:77
 msgid "QoS"
 msgstr ""
 
@@ -1958,27 +1967,28 @@ msgstr ""
 msgid "Quotas"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:27
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:26
 msgid "Ranges (Min-Max)"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:114
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
 msgid "Read-only"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:78
 msgid "Read-only Root Filesystem"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:75
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:94
 msgid "Readiness"
 msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:33
+#: src/renderer/components/+events/event-details.tsx:32
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "Reason"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.store.ts:66
+#: src/renderer/components/dock/pod-logs.store.ts:57
 msgid "Reason: {0} ({1})"
 msgstr ""
 
@@ -1986,8 +1996,8 @@ msgstr ""
 msgid "Receive"
 msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:34
-#: src/renderer/components/+storage-classes/storage-classes.tsx:36
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:33
 #: src/renderer/components/+storage-volumes/volume-details.tsx:40
 msgid "Reclaim Policy"
 msgstr ""
@@ -1997,7 +2007,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:70
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:76
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:75
 msgid "Reference"
 msgstr ""
 
@@ -2022,10 +2032,10 @@ msgstr ""
 msgid "Releases"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:152
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:73
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:79
+#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:59
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:74
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:80
 #: src/renderer/components/item-object-list/item-list-layout.tsx:179
 #: src/renderer/components/menu/menu-actions.tsx:49
 #: src/renderer/components/menu/menu-actions.tsx:85
@@ -2048,11 +2058,11 @@ msgstr ""
 msgid "Remove item?"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:61
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
 msgid "Remove selected bindings for <0>{0}</0>?"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Remove selected bindings from ${name}"
 msgstr ""
 
@@ -2060,11 +2070,11 @@ msgstr ""
 msgid "Remove selected items ({0})"
 msgstr ""
 
-#: src/renderer/components/kube-object/kube-object-menu.tsx:69
+#: src/renderer/components/kube-object/kube-object-menu.tsx:70
 msgid "Remove {resourceKind} <0>{resourceName}</0>?"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:122
+#: src/renderer/components/+preferences/preferences.tsx:112
 msgid "Removing helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
@@ -2073,14 +2083,14 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:62
-msgid "Renew Before"
-msgstr ""
+#~ msgid "Renew Before"
+#~ msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:84
-#: src/renderer/components/+config-autoscalers/hpa.tsx:50
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
-#: src/renderer/components/+workloads-deployments/deployments.tsx:61
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:80
+#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:62
+#: src/renderer/components/+workloads-deployments/deployments.tsx:59
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
 msgstr ""
 
@@ -2088,7 +2098,7 @@ msgstr ""
 msgid "Repo/Name"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:146
+#: src/renderer/components/+preferences/preferences.tsx:132
 msgid "Repositories"
 msgstr ""
 
@@ -2115,7 +2125,7 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:87
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:86
 msgid "Required Drop Capabilities"
 msgstr ""
 
@@ -2144,18 +2154,18 @@ msgstr ""
 #~ msgid "Resetting kube-config to default: {kubeConfigDefaultPath}"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:44
-#: src/renderer/components/+custom-resources/crd-list.tsx:73
+#: src/renderer/components/+custom-resources/crd-details.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:70
 msgid "Resource"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:45
+#: src/renderer/components/+user-management-roles/role-details.tsx:44
 msgid "Resource Names"
 msgstr ""
 
 #: src/renderer/components/+config/config.tsx:47
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
-#: src/renderer/components/+namespaces/namespace-details.tsx:41
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:30
+#: src/renderer/components/+namespaces/namespace-details.tsx:40
 msgid "Resource Quotas"
 msgstr ""
 
@@ -2163,7 +2173,7 @@ msgstr ""
 msgid "Resource Version"
 msgstr ""
 
-#: src/renderer/components/kube-object/kube-object-details.tsx:46
+#: src/renderer/components/kube-object/kube-object-details.tsx:48
 msgid "Resource loading has failed: <0>{0}</0>"
 msgstr ""
 
@@ -2176,7 +2186,7 @@ msgid "ResourceQuota name"
 msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:198
-#: src/renderer/components/+user-management-roles/role-details.tsx:29
+#: src/renderer/components/+user-management-roles/role-details.tsx:28
 msgid "Resources"
 msgstr ""
 
@@ -2192,7 +2202,7 @@ msgstr ""
 msgid "Restart session"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-pods/pods.tsx:75
 msgid "Restarts"
 msgstr ""
 
@@ -2205,27 +2215,27 @@ msgstr ""
 msgid "Right click cluster icon to open cluster settings."
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:149
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:148
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:187
 msgid "Role"
 msgstr ""
 
 #: src/renderer/components/+user-management/user-management.tsx:31
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:31
 msgid "Role Bindings"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:105
-msgid "Role ID"
-msgstr ""
+#~ msgid "Role ID"
+#~ msgstr ""
 
 #: src/renderer/components/+user-management-roles/add-role-dialog.tsx:74
 msgid "Role name"
 msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+nodes/nodes.tsx:121
 #: src/renderer/components/+user-management/user-management.tsx:36
-#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles/roles.tsx:29
 msgid "Roles"
 msgstr ""
 
@@ -2239,41 +2249,41 @@ msgstr ""
 msgid "Rollback <0>{releaseName}</0>"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:24
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:142
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:23
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
 msgid "Rule"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:105
-#: src/renderer/components/+network-ingresses/ingresses.tsx:34
-#: src/renderer/components/+user-management-roles/role-details.tsx:25
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:104
+#: src/renderer/components/+network-ingresses/ingresses.tsx:32
+#: src/renderer/components/+user-management-roles/role-details.tsx:24
 msgid "Rules"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
 msgid "Run As Group"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
 msgid "Run As User"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:130
 msgid "Runtime Class"
 msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:114
-#: src/renderer/components/+config-maps/config-map-details.tsx:78
-#: src/renderer/components/+config-secrets/secret-details.tsx:97
-#: src/renderer/components/+workspaces/workspaces.tsx:132
+#: src/renderer/components/+config-maps/config-map-details.tsx:77
+#: src/renderer/components/+config-secrets/secret-details.tsx:96
+#: src/renderer/components/+workspaces/workspaces.tsx:137
 #: src/renderer/components/dock/edit-resource.tsx:87
-#: src/renderer/components/dock/pod-logs.tsx:161
+#: src/renderer/components/dock/pod-log-controls.tsx:74
 msgid "Save"
 msgstr ""
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
-#: src/renderer/components/+workloads-deployments/deployments.tsx:86
-#: src/renderer/components/+workloads-deployments/deployments.tsx:87
+#: src/renderer/components/+workloads-deployments/deployments.tsx:83
+#: src/renderer/components/+workloads-deployments/deployments.tsx:84
 msgid "Scale"
 msgstr ""
 
@@ -2281,13 +2291,13 @@ msgstr ""
 msgid "Scale Deployment <0>{deploymentName}</0>"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:46
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:45
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:46
 msgid "Schedule"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:41
-#: src/renderer/components/+custom-resources/crd-list.tsx:76
+#: src/renderer/components/+custom-resources/crd-details.tsx:40
+#: src/renderer/components/+custom-resources/crd-list.tsx:73
 msgid "Scope"
 msgstr ""
 
@@ -2299,7 +2309,7 @@ msgstr ""
 msgid "Scope name"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:140
 msgid "Se Linux"
 msgstr ""
 
@@ -2313,13 +2323,13 @@ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:65
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:108
-msgid "Secret"
-msgstr ""
+#~ msgid "Secret"
+#~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:37
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:80
-msgid "Secret Name"
-msgstr ""
+#~ msgid "Secret Name"
+#~ msgstr ""
 
 #: src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx:72
 msgid "Secret is not found"
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Secret name"
 msgstr ""
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:44
+#: src/renderer/components/+config-secrets/secret-details.tsx:43
 msgid "Secret successfully updated."
 msgstr ""
 
@@ -2338,7 +2348,7 @@ msgid "Secret type"
 msgstr ""
 
 #: src/renderer/components/+config/config.tsx:39
-#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+config-secrets/secrets.tsx:37
 #: src/renderer/components/+workloads-pods/pod-details.tsx:113
 msgid "Secrets"
 msgstr ""
@@ -2425,35 +2435,35 @@ msgstr ""
 #~ msgid "Selected contexts: {0}"
 #~ msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:27
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:26
 #: src/renderer/components/+network-services/service-details.tsx:37
-#: src/renderer/components/+network-services/services.tsx:50
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:75
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:69
-#: src/renderer/components/+workloads-jobs/job-details.tsx:56
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:69
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:56
+#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:68
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:74
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:55
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:68
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:55
 msgid "Selector"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:61
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:91
-msgid "Server"
-msgstr ""
+#~ msgid "Server"
+#~ msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:102
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:101
 msgid "Service"
 msgstr ""
 
 #: src/renderer/components/+user-management/user-management.tsx:26
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:33
 msgid "Service Accounts"
 msgstr ""
 
 #: src/renderer/components/+network/network.tsx:27
-#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+network-services/services.tsx:40
 msgid "Services"
 msgstr ""
 
@@ -2469,18 +2479,18 @@ msgstr ""
 msgid "Set quota"
 msgstr ""
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:51
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:52
 msgid "Settings"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:48
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:78
-msgid "Shell"
-msgstr ""
+#~ msgid "Shell"
+#~ msgstr ""
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:101
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:102
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Show"
 msgstr ""
@@ -2489,11 +2499,11 @@ msgstr ""
 msgid "Show Notes"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show current logs"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show previous terminated container logs"
 msgstr ""
 
@@ -2501,12 +2511,12 @@ msgstr ""
 msgid "Show value"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:154
+#: src/renderer/components/dock/pod-log-controls.tsx:67
 msgid "Since"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-charts.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
 msgid "Size"
 msgstr ""
 
@@ -2515,10 +2525,10 @@ msgid "Size Limit"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:70
-msgid "Skip TLS Verify"
-msgstr ""
+#~ msgid "Skip TLS Verify"
+#~ msgstr ""
 
-#: src/renderer/components/+events/event-details.tsx:36
+#: src/renderer/components/+events/event-details.tsx:35
 #: src/renderer/components/+events/events.tsx:66
 #: src/renderer/components/+events/kube-event-details.tsx:48
 msgid "Source"
@@ -2528,7 +2538,11 @@ msgstr ""
 msgid "Specified limits are higher than node capacity!"
 msgstr ""
 
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+msgid "Started at"
+msgstr ""
+
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:36
 msgid "Stateful Sets"
 msgstr ""
 
@@ -2539,59 +2553,55 @@ msgstr ""
 #: src/renderer/components/+apps-releases/release-details.tsx:192
 #: src/renderer/components/+apps-releases/releases.tsx:93
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:52
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:79
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:67
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:48
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:68
-#: src/renderer/components/+custom-resources/crd-resource-details.tsx:56
-#: src/renderer/components/+namespaces/namespace-details.tsx:37
-#: src/renderer/components/+namespaces/namespaces.tsx:34
-#: src/renderer/components/+network-services/services.tsx:52
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:65
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:52
+#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+custom-resources/crd-resource-details.tsx:49
+#: src/renderer/components/+namespaces/namespace-details.tsx:36
+#: src/renderer/components/+namespaces/namespaces.tsx:32
+#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:64
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
 #: src/renderer/components/+storage-volumes/volume-details.tsx:46
-#: src/renderer/components/+storage-volumes/volumes.tsx:45
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:57
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:97
 #: src/renderer/components/+workloads-pods/pod-details.tsx:82
-#: src/renderer/components/+workloads-pods/pods.tsx:82
+#: src/renderer/components/+workloads-pods/pods.tsx:79
 msgid "Status"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:64
-msgid "Status URI"
-msgstr ""
+#~ msgid "Status URI"
+#~ msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:57
-#: src/renderer/components/layout/sidebar.tsx:84
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
+#: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"
 msgstr ""
 
-#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+storage-volumes/volumes.tsx:38
 msgid "Storage Class"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:54
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:53
 #: src/renderer/components/+storage-volumes/volume-details.tsx:43
 msgid "Storage Class Name"
 msgstr ""
 
 #: src/renderer/components/+storage/storage.tsx:40
-#: src/renderer/components/+storage-classes/storage-classes.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:30
 msgid "Storage Classes"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
 msgid "Storage class"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:37
 msgid "Stored versions"
 msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:68
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:76
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:67
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:75
 msgid "Strategy Type"
 msgstr ""
 
@@ -2608,7 +2618,7 @@ msgstr ""
 msgid "Submitting.."
 msgstr ""
 
-#: src/renderer/components/+network-endpoints/endpoint-details.tsx:24
+#: src/renderer/components/+network-endpoints/endpoint-details.tsx:23
 msgid "Subsets"
 msgstr ""
 
@@ -2616,31 +2626,31 @@ msgstr ""
 msgid "Successfully imported <0>{0}</0> cluster(s)"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:128
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
 msgid "Supplemental Groups"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:54
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:53
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
 msgid "Suspend"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:98
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:97
 msgid "TLS"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:103
-#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/nodes.tsx:120
 msgid "Taints"
 msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:171
-msgid "Telemetry & Usage Tracking"
-msgstr ""
+#~ msgid "Telemetry & Usage Tracking"
+#~ msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:174
-msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
-msgstr ""
+#~ msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
+#~ msgstr ""
 
 #: src/renderer/components/dock/terminal.store.ts:28
 msgid "Terminal"
@@ -2654,7 +2664,7 @@ msgstr ""
 msgid "The path to the kubectl binary on the system."
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:172
+#: src/renderer/components/dock/pod-logs.tsx:162
 msgid "There are no logs available for container."
 msgstr ""
 
@@ -2674,11 +2684,15 @@ msgstr ""
 msgid "This is the quick launch menu."
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:166
+#: src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx:22
+msgid "This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces."
+msgstr ""
+
+#: src/renderer/components/+preferences/preferences.tsx:152
 msgid "This will make Lens to trust ANY certificate authority without any validations."
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:59
+#: src/renderer/components/+network-policies/network-policy-details.tsx:58
 msgid "To"
 msgstr ""
 
@@ -2699,8 +2713,8 @@ msgid "Transmit"
 msgstr ""
 
 #: src/renderer/components/+workloads-cronjobs/cronjob-trigger-dialog.tsx:106
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:79
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:80
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:76
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:77
 msgid "Trigger"
 msgstr ""
 
@@ -2709,25 +2723,22 @@ msgid "Trigger CronJob <0>{cronjobName}</0>"
 msgstr ""
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:102
-#: src/renderer/components/+config-secrets/secret-details.tsx:74
-#: src/renderer/components/+config-secrets/secrets.tsx:45
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:63
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:66
-#: src/renderer/components/+custom-resources/crd-details.tsx:82
-#: src/renderer/components/+events/event-details.tsx:48
+#: src/renderer/components/+config-secrets/secret-details.tsx:73
+#: src/renderer/components/+config-secrets/secrets.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:81
+#: src/renderer/components/+events/event-details.tsx:47
 #: src/renderer/components/+events/events.tsx:64
 #: src/renderer/components/+network-services/service-details.tsx:41
-#: src/renderer/components/+network-services/services.tsx:46
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:152
+#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:151
 #: src/renderer/components/+storage-volumes/volume-details.tsx:69
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:43
 #: src/renderer/components/+workloads-pods/pod-details.tsx:140
 msgid "Type"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+preferences/preferences.tsx:124
 msgid "Type HTTP proxy url (example: http://proxy.acme.org:8080)"
 msgstr ""
 
@@ -2736,13 +2747,13 @@ msgid "UID"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:126
-msgid "URL"
-msgstr ""
+#~ msgid "URL"
+#~ msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:55
 #: src/renderer/components/+nodes/node-menu.tsx:56
-msgid "Uncordon"
-msgstr ""
+#~ msgid "Uncordon"
+#~ msgstr ""
 
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:212
 msgid "Update"
@@ -2797,11 +2808,11 @@ msgstr ""
 #~ msgid "Used"
 #~ msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:155
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:154
 msgid "User"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:99
+#: src/renderer/components/+custom-resources/crd-details.tsx:98
 msgid "Validation"
 msgstr ""
 
@@ -2814,11 +2825,11 @@ msgstr ""
 #: src/renderer/components/+apps-releases/release-details.tsx:111
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:132
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:62
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
 msgid "Values"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:33
+#: src/renderer/components/+user-management-roles/role-details.tsx:32
 msgid "Verbs"
 msgstr ""
 
@@ -2826,9 +2837,9 @@ msgstr ""
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:66
 #: src/renderer/components/+apps-releases/release-details.tsx:185
 #: src/renderer/components/+apps-releases/releases.tsx:91
-#: src/renderer/components/+custom-resources/crd-details.tsx:35
-#: src/renderer/components/+custom-resources/crd-list.tsx:75
-#: src/renderer/components/+nodes/nodes.tsx:125
+#: src/renderer/components/+custom-resources/crd-details.tsx:34
+#: src/renderer/components/+custom-resources/crd-list.tsx:72
+#: src/renderer/components/+nodes/nodes.tsx:122
 #: src/renderer/components/dock/install-chart.tsx:120
 #: src/renderer/components/dock/upgrade-chart.tsx:99
 msgid "Version"
@@ -2838,7 +2849,7 @@ msgstr ""
 msgid "View Helm Release"
 msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:31
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:30
 msgid "Volume Binding Mode"
 msgstr ""
 
@@ -2850,8 +2861,8 @@ msgstr ""
 msgid "Volume disk usage"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:37
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:47
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:46
 #: src/renderer/components/+workloads-pods/pod-details.tsx:130
 msgid "Volumes"
 msgstr ""
@@ -2868,7 +2879,7 @@ msgstr ""
 msgid "Welcome!"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:88
+#: src/renderer/components/+workspaces/workspaces.tsx:92
 msgid "What is a Workspace?"
 msgstr ""
 
@@ -2876,16 +2887,16 @@ msgstr ""
 msgid "Worker"
 msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:81
+#: src/renderer/components/layout/sidebar.tsx:82
 msgid "Workloads"
 msgstr ""
 
 #: src/renderer/components/+workspaces/workspace-menu.tsx:39
-#: src/renderer/components/+workspaces/workspaces.tsx:100
+#: src/renderer/components/+workspaces/workspaces.tsx:104
 msgid "Workspaces"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:90
+#: src/renderer/components/+workspaces/workspaces.tsx:94
 msgid "Workspaces are used to organize number of clusters into logical groups."
 msgstr ""
 
@@ -2898,27 +2909,25 @@ msgid "Wrong url format"
 msgstr ""
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:28
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
-#: src/renderer/components/+storage-classes/storage-classes.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
+#: src/renderer/components/+storage-classes/storage-classes.tsx:40
 msgid "Yes"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:118
-msgid "Zone"
-msgstr ""
+#~ msgid "Zone"
+#~ msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:180
-#: src/renderer/components/+events/event-details.tsx:40
-#: src/renderer/components/+events/event-details.tsx:43
+#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+events/event-details.tsx:42
 #: src/renderer/components/kube-object/kube-object-meta.tsx:18
 msgid "ago"
 msgstr ""
@@ -2931,36 +2940,37 @@ msgstr ""
 #~ msgid "applicable to all clusters"
 #~ msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "cores:"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:18
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "exit code"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:66
+#: src/renderer/components/+custom-resources/crd-details.tsx:65
 msgid "kind"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:67
+#: src/renderer/components/+custom-resources/crd-details.tsx:66
 msgid "listKind"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:48
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:61
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:47
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:59
 msgid "never"
 msgstr ""
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:133
 msgid "new"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:64
+#: src/renderer/components/+custom-resources/crd-details.tsx:63
 msgid "plural"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:41
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:17
 msgid "ready"
 msgstr ""
 
@@ -2968,11 +2978,11 @@ msgstr ""
 msgid "sec"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:65
+#: src/renderer/components/+custom-resources/crd-details.tsx:64
 msgid "singular"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 msgid "timestamps"
 msgstr ""
 
@@ -2980,7 +2990,7 @@ msgstr ""
 msgid "{0, plural, one {Resource} other {Resources}}"
 msgstr ""
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
 msgid "{0} desired, {1} updated"
 msgstr ""
 
@@ -2996,11 +3006,11 @@ msgstr ""
 msgid "{0} on {1}"
 msgstr ""
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
 msgid "{0} total, {1} available"
 msgstr ""
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:66
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
 msgid "{0} unavailable"
 msgstr ""
 
@@ -3012,7 +3022,7 @@ msgstr ""
 msgid "{allItemsCount, plural, one {# item} other {# items}}"
 msgstr ""
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:31
+#: src/renderer/components/+config-autoscalers/hpa.tsx:28
 msgid "{metricsRemainCount} more..."
 msgstr ""
 

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -26,11 +26,11 @@ msgstr ""
 msgid "(as a percentage of request)"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:121
+#: src/renderer/components/+workspaces/workspaces.tsx:126
 msgid "(current)"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:88
+#: src/renderer/components/+network-policies/network-policy-details.tsx:87
 msgid "(empty) (Allowing the specific traffic to all pods in this namespace)"
 msgstr "(Пусто) (Допускается трафик ко всем подам в данной области имен)"
 
@@ -62,19 +62,19 @@ msgstr ""
 msgid "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics."
 msgstr "Это поле может содержать только латинские буквы в нижнем регистре, номера и дефис."
 
-#: src/renderer/components/+workspaces/workspaces.tsx:93
+#: src/renderer/components/+workspaces/workspaces.tsx:97
 msgid "A single workspaces contains a list of clusters and their full configuration."
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:81
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
 msgid "API Group"
 msgstr ""
 
-#: src/renderer/components/layout/sidebar.tsx:88
+#: src/renderer/components/layout/sidebar.tsx:89
 msgid "Access Control"
 msgstr "Контроль доступа"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:51
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:50
 #: src/renderer/components/+storage-volumes/volume-details.tsx:37
 msgid "Access Modes"
 msgstr "Режимы доступа"
@@ -83,17 +83,17 @@ msgstr "Режимы доступа"
 msgid "Account Name"
 msgstr "Название аккаунта"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:51
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:50
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
 msgid "Active"
 msgstr "Активный"
 
 #: src/renderer/components/+add-cluster/add-cluster.tsx:310
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:127
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
 msgid "Add Cluster"
 msgstr ""
 
-#: src/renderer/components/+namespaces/namespaces.tsx:43
+#: src/renderer/components/+namespaces/namespaces.tsx:39
 msgid "Add Namespace"
 msgstr "Добавить Namespace"
 
@@ -101,11 +101,11 @@ msgstr "Добавить Namespace"
 msgid "Add RoleBinding"
 msgstr "Добавить привязку ролей"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:138
+#: src/renderer/components/+workspaces/workspaces.tsx:143
 msgid "Add Workspace"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Add bindings to {name}"
 msgstr "Добавить привязки к {name}"
 
@@ -137,7 +137,7 @@ msgstr "Добавить поле"
 #~ msgid "Adding clusters: <0>{0}</0>"
 #~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:111
+#: src/renderer/components/+preferences/preferences.tsx:101
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
@@ -145,13 +145,13 @@ msgstr ""
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:78
+#: src/renderer/components/+custom-resources/crd-details.tsx:77
 msgid "Additional Printer Columns"
 msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:60
-#: src/renderer/components/+nodes/node-details.tsx:83
+#: src/renderer/components/+nodes/node-details.tsx:82
 msgid "Addresses"
 msgstr "Адреса"
 
@@ -159,36 +159,34 @@ msgstr "Адреса"
 msgid "Affinities"
 msgstr "Аффинитеты"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:51
-#: src/renderer/components/+config-maps/config-maps.tsx:37
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:45
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:46
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:66
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:67
-#: src/renderer/components/+custom-resources/crd-list.tsx:77
-#: src/renderer/components/+custom-resources/crd-resources.tsx:73
+#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-maps/config-maps.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-resources.tsx:70
 #: src/renderer/components/+events/events.tsx:68
-#: src/renderer/components/+namespaces/namespaces.tsx:33
-#: src/renderer/components/+network-endpoints/endpoints.tsx:34
-#: src/renderer/components/+network-ingresses/ingresses.tsx:35
-#: src/renderer/components/+network-policies/network-policies.tsx:34
-#: src/renderer/components/+network-services/services.tsx:51
-#: src/renderer/components/+nodes/nodes.tsx:126
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:38
-#: src/renderer/components/+storage-classes/storage-classes.tsx:38
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:51
-#: src/renderer/components/+storage-volumes/volumes.tsx:44
-#: src/renderer/components/+user-management-roles/roles.tsx:35
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:38
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:38
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:52
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:50
-#: src/renderer/components/+workloads-deployments/deployments.tsx:63
-#: src/renderer/components/+workloads-jobs/jobs.tsx:41
-#: src/renderer/components/+workloads-pods/pods.tsx:81
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:44
+#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-services/services.tsx:48
+#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
+#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:50
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
+#: src/renderer/components/+workloads-deployments/deployments.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:38
+#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
 msgid "Age"
 msgstr "Возраст"
 
@@ -200,68 +198,68 @@ msgstr ""
 #~ msgid "All clusters within workspace will be cleared as well."
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:56
+#: src/renderer/components/+custom-resources/crd-list.tsx:53
 msgid "All groups"
 msgstr ""
 
 #: src/renderer/components/dock/pod-logs.tsx:37
-msgid "All logs"
-msgstr "Все логи"
+#~ msgid "All logs"
+#~ msgstr "Все логи"
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:95
 msgid "All namespaces"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/node-details.tsx:76
 msgid "Allocatable"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:70
 msgid "Allow Privilege Escalation"
 msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:172
-msgid "Allow telemetry & usage tracking"
-msgstr ""
+#~ msgid "Allow telemetry & usage tracking"
+#~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:164
+#: src/renderer/components/+preferences/preferences.tsx:150
 msgid "Allow untrusted Certificate Authorities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:51
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:50
 msgid "Allowed CSI Drivers"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:42
 msgid "Allowed Capabilities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:55
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:54
 msgid "Allowed Flex Volumes"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:110
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:109
 msgid "Allowed Host Paths"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:59
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:58
 msgid "Allowed Proc Mount Types"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:132
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
 msgid "Allowed Runtime Class Names"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:63
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:62
 msgid "Allowed Unsafe Sysctls"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/node-details.tsx:101
 #: src/renderer/components/kube-object/kube-object-meta.tsx:36
 msgid "Annotations"
 msgstr "Аннотации"
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:37
+#: src/renderer/components/+user-management-roles/role-details.tsx:36
 msgid "Api Groups"
 msgstr "API группы"
 
@@ -278,7 +276,7 @@ msgstr "Сбой работы приложения на <0>{pageUrl}</0>"
 msgid "Applying.."
 msgstr "Применение.."
 
-#: src/renderer/components/layout/sidebar.tsx:87
+#: src/renderer/components/layout/sidebar.tsx:88
 msgid "Apps"
 msgstr "Приложения"
 
@@ -287,10 +285,10 @@ msgid "Are you sure you want remove workspace <0>{0}</0>?"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:41
-msgid "Are you sure you want to drain <0>{nodeName}</0>?"
-msgstr "Выполнить команду drain для ноды <0>{nodeName}</0>?"
+#~ msgid "Are you sure you want to drain <0>{nodeName}</0>?"
+#~ msgstr "Выполнить команду drain для ноды <0>{nodeName}</0>?"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:84
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:103
 msgid "Arguments"
 msgstr "Аргументы"
 
@@ -299,14 +297,14 @@ msgid "Associate clusters and choose the ones you want to access via quick launc
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:101
-msgid "Auth App Role"
-msgstr "Auth App Role"
+#~ msgid "Auth App Role"
+#~ msgstr "Auth App Role"
 
-#: src/renderer/components/+preferences/preferences.tsx:160
+#: src/renderer/components/+preferences/preferences.tsx:146
 msgid "Auto start-up"
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:161
+#: src/renderer/components/+preferences/preferences.tsx:147
 msgid "Automatically start Lens on login"
 msgstr ""
 
@@ -315,11 +313,11 @@ msgstr ""
 msgid "Back"
 msgstr "Назад"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:43
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
 msgid "Backends"
 msgstr "Бэкенды"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:93
 msgid "Binding"
 msgstr "Привязка"
 
@@ -327,8 +325,8 @@ msgstr "Привязка"
 msgid "Binding targets"
 msgstr "Цели привязки"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:90
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:36
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:89
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:33
 msgid "Bindings"
 msgstr "Привязки"
 
@@ -371,17 +369,17 @@ msgstr "Байты, отправленные всеми контейнерами
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:97
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:129
-msgid "CA Bundle"
-msgstr "CA Bundle"
+#~ msgid "CA Bundle"
+#~ msgstr "CA Bundle"
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:24
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:140
-#: src/renderer/components/+nodes/node-details.tsx:62
-#: src/renderer/components/+nodes/node-details.tsx:73
-#: src/renderer/components/+nodes/node-details.tsx:78
-#: src/renderer/components/+nodes/nodes.tsx:120
+#: src/renderer/components/+nodes/node-details.tsx:61
+#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:77
+#: src/renderer/components/+nodes/nodes.tsx:117
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:11
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:44
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:53
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:95
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:13
@@ -407,11 +405,11 @@ msgstr "Лимиты процессора"
 msgid "CPU requests"
 msgstr "Запросы к процессору"
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "CPU:"
 msgstr "CPU:"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:133
+#: src/renderer/components/+workspaces/workspaces.tsx:138
 #: src/renderer/components/confirm-dialog/confirm-dialog.tsx:44
 #: src/renderer/components/dock/info-panel.tsx:86
 #: src/renderer/components/wizard/wizard.tsx:130
@@ -424,20 +422,20 @@ msgstr "Отмена"
 #: src/renderer/components/+nodes/node-charts.tsx:39
 #: src/renderer/components/+nodes/node-charts.tsx:63
 #: src/renderer/components/+nodes/node-charts.tsx:97
-#: src/renderer/components/+nodes/node-details.tsx:72
+#: src/renderer/components/+nodes/node-details.tsx:71
 #: src/renderer/components/+storage-volume-claims/volume-claim-disk-chart.tsx:31
 #: src/renderer/components/+storage-volumes/volume-details.tsx:29
-#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+storage-volumes/volumes.tsx:39
 msgid "Capacity"
 msgstr "Емкость"
 
-#: src/renderer/components/+preferences/preferences.tsx:163
+#: src/renderer/components/+preferences/preferences.tsx:149
 msgid "Certificate Trust"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:59
-msgid "Certificates"
-msgstr "Сертификаты"
+#~ msgid "Certificates"
+#~ msgstr "Сертификаты"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:173
 #: src/renderer/components/+apps-releases/releases.tsx:89
@@ -474,7 +472,7 @@ msgstr "Чарты"
 #~ msgstr ""
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:68
-#: src/renderer/components/+storage-volumes/volumes.tsx:43
+#: src/renderer/components/+storage-volumes/volumes.tsx:40
 msgid "Claim"
 msgstr "Запрос"
 
@@ -492,42 +490,42 @@ msgid "Close (Ctrl+W)"
 msgstr "Закрыть (Ctrl+W)"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:121
-msgid "Cloud API Token Secret"
-msgstr "Cloud API Token Secret"
+#~ msgid "Cloud API Token Secret"
+#~ msgstr "Cloud API Token Secret"
 
 #: src/renderer/components/+namespaces/namespace-select.tsx:43
-#: src/renderer/components/layout/sidebar.tsx:79
+#: src/renderer/components/layout/sidebar.tsx:80
 msgid "Cluster"
 msgstr "Кластер"
 
 #: src/renderer/components/+network-services/service-details.tsx:51
-#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+network-services/services.tsx:44
 msgid "Cluster IP"
 msgstr "IP-адрес кластера"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:40
-msgid "Cluster Issuers"
-msgstr ""
+#~ msgid "Cluster Issuers"
+#~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:134
+#: src/renderer/components/+preferences/preferences.tsx:120
 msgid "Color Theme"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:79
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:98
 msgid "Command"
 msgstr "Команда"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:47
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:62
-msgid "Common Name"
-msgstr "Общее имя"
+#~ msgid "Common Name"
+#~ msgstr "Общее имя"
 
-#: src/renderer/components/layout/sidebar.tsx:76
+#: src/renderer/components/layout/sidebar.tsx:77
 msgid "Compact view"
 msgstr "Компактный вид"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:80
-#: src/renderer/components/+workloads-jobs/jobs.tsx:39
+#: src/renderer/components/+workloads-jobs/job-details.tsx:79
+#: src/renderer/components/+workloads-jobs/jobs.tsx:36
 msgid "Completions"
 msgstr "Завершения"
 
@@ -535,17 +533,17 @@ msgstr "Завершения"
 msgid "Component stack"
 msgstr "Стэк компонентов"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:72
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:71
 msgid "Condition"
 msgstr "Состояние"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:52
-#: src/renderer/components/+nodes/node-details.tsx:107
-#: src/renderer/components/+nodes/nodes.tsx:127
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:79
-#: src/renderer/components/+workloads-deployments/deployments.tsx:64
-#: src/renderer/components/+workloads-jobs/job-details.tsx:77
-#: src/renderer/components/+workloads-jobs/jobs.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:51
+#: src/renderer/components/+nodes/node-details.tsx:106
+#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:78
+#: src/renderer/components/+workloads-deployments/deployments.tsx:62
+#: src/renderer/components/+workloads-jobs/job-details.tsx:76
+#: src/renderer/components/+workloads-jobs/jobs.tsx:39
 #: src/renderer/components/+workloads-pods/pod-details.tsx:100
 msgid "Conditions"
 msgstr "Состояния"
@@ -559,6 +557,7 @@ msgid "Are you sure you want to restart deployment <0>{0}</0>?"
 msgstr "Выполнить перезагрузку деплоймента <0>{0}</0>?"
 
 #: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-maps/config-maps.tsx:30
 msgid "Config Maps"
 msgstr ""
 
@@ -566,7 +565,7 @@ msgstr ""
 msgid "Config copied to clipboard"
 msgstr "Конфигурация скопирована в буфер"
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:41
+#: src/renderer/components/+config-maps/config-map-details.tsx:40
 msgid "ConfigMap <0>{0}</0> successfully updated."
 msgstr "ConfigMap <0>{0}</0> успешно обновлена."
 
@@ -574,7 +573,7 @@ msgstr "ConfigMap <0>{0}</0> успешно обновлена."
 msgid "ConfigMaps"
 msgstr "ConfigMaps"
 
-#: src/renderer/components/layout/sidebar.tsx:82
+#: src/renderer/components/layout/sidebar.tsx:83
 msgid "Configuration"
 msgstr "Конфигурация"
 
@@ -582,7 +581,7 @@ msgstr "Конфигурация"
 msgid "Connection"
 msgstr "Соединение"
 
-#: src/renderer/components/dock/pod-logs.tsx:148
+#: src/renderer/components/dock/pod-log-controls.tsx:63
 msgid "Container"
 msgstr "Контейнер"
 
@@ -606,13 +605,13 @@ msgstr "Запросы памяти от контейнеров"
 msgid "Container memory usage"
 msgstr "Использование памяти"
 
-#: src/renderer/components/+nodes/node-details.tsx:95
+#: src/renderer/components/+nodes/node-details.tsx:94
 msgid "Container runtime"
 msgstr "Среда контейнеров"
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:122
-#: src/renderer/components/+workloads-pods/pods.tsx:77
-#: src/renderer/components/dock/pod-logs.tsx:129
+#: src/renderer/components/+workloads-pods/pods.tsx:74
+#: src/renderer/components/dock/pod-log-controls.tsx:43
 msgid "Containers"
 msgstr "Контейнеры"
 
@@ -628,16 +627,16 @@ msgstr "Контекст"
 #~ msgid "Contexts: {0}"
 #~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pods.tsx:79
+#: src/renderer/components/+workloads-pods/pods.tsx:76
 #: src/renderer/components/kube-object/kube-object-meta.tsx:39
 msgid "Controlled By"
 msgstr "Управляемый"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:67
 msgid "Controlled by"
 msgstr "Контролируется"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:49
+#: src/renderer/components/+custom-resources/crd-details.tsx:48
 msgid "Conversion"
 msgstr ""
 
@@ -648,10 +647,10 @@ msgstr "Копировать"
 
 #: src/renderer/components/+nodes/node-menu.tsx:51
 #: src/renderer/components/+nodes/node-menu.tsx:52
-msgid "Cordon"
-msgstr "Блокировка"
+#~ msgid "Cordon"
+#~ msgstr "Блокировка"
 
-#: src/renderer/components/+events/event-details.tsx:45
+#: src/renderer/components/+events/event-details.tsx:44
 #: src/renderer/components/+events/events.tsx:67
 #: src/renderer/components/+events/kube-event-details.tsx:51
 msgid "Count"
@@ -687,23 +686,23 @@ msgstr "Создать секрет"
 msgid "Create Service Account"
 msgstr "Создать Service Account"
 
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:45
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:40
 msgid "Create new ResourceQuota"
 msgstr "Создать новую ResourceQuota"
 
-#: src/renderer/components/+user-management-roles/roles.tsx:44
+#: src/renderer/components/+user-management-roles/roles.tsx:39
 msgid "Create new Role"
 msgstr "Создать новую роль"
 
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:48
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:43
 msgid "Create new RoleBinding"
 msgstr "Создать новый билдинг роли"
 
-#: src/renderer/components/+config-secrets/secrets.tsx:58
+#: src/renderer/components/+config-secrets/secrets.tsx:53
 msgid "Create new Secret"
 msgstr "Создать новый секрет"
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:47
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:45
 msgid "Create new Service Account"
 msgstr "Создать новый Service Account"
 
@@ -720,10 +719,10 @@ msgid "Created at"
 msgstr "Создано"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:132
-msgid "Credentials Ref"
-msgstr "Credentials Ref"
+#~ msgid "Credentials Ref"
+#~ msgstr "Credentials Ref"
 
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:44
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:42
 msgid "Cron Jobs"
 msgstr ""
 
@@ -735,8 +734,8 @@ msgstr "CronJobs"
 msgid "Current / Target"
 msgstr "Текущее / Цель"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:39
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:43
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
 msgid "Current Healthy"
 msgstr ""
 
@@ -752,8 +751,8 @@ msgstr "Текущие фильтры:"
 #~ msgid "Custom"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:55
-#: src/renderer/components/layout/sidebar.tsx:89
+#: src/renderer/components/+custom-resources/crd-list.tsx:52
+#: src/renderer/components/layout/sidebar.tsx:90
 msgid "Custom Resources"
 msgstr ""
 
@@ -762,14 +761,14 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:95
-msgid "DNS Provider"
-msgstr "DNS провайдер"
+#~ msgid "DNS Provider"
+#~ msgstr "DNS провайдер"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:50
-msgid "DNS names"
-msgstr "DNS имена"
+#~ msgid "DNS names"
+#~ msgstr "DNS имена"
 
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:41
 msgid "Daemon Sets"
 msgstr ""
 
@@ -781,20 +780,20 @@ msgstr "DaemonSets"
 #~ msgid "Dark"
 #~ msgstr ""
 
-#: src/renderer/components/+config-maps/config-map-details.tsx:69
-#: src/renderer/components/+config-secrets/secret-details.tsx:78
+#: src/renderer/components/+config-maps/config-map-details.tsx:68
+#: src/renderer/components/+config-secrets/secret-details.tsx:77
 msgid "Data"
 msgstr "Данные"
 
-#: src/renderer/components/+storage-classes/storage-classes.tsx:37
+#: src/renderer/components/+storage-classes/storage-classes.tsx:34
 msgid "Default"
 msgstr "По умолчанию"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:83
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:82
 msgid "Default Add Capabilities"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:135
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:134
 msgid "Default Runtime Class Name"
 msgstr ""
 
@@ -806,27 +805,27 @@ msgstr ""
 msgid "Definitions"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:126
+#: src/renderer/components/+workspaces/workspaces.tsx:131
 #: src/renderer/components/menu/menu-actions.tsx:84
 msgid "Delete"
 msgstr "Удалить"
 
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:47
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:45
 msgid "Deploy Revisions"
 msgstr ""
 
 #: src/renderer/components/+workloads/workloads.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-deployments/deployments.tsx:55
 msgid "Deployments"
 msgstr "Deployments"
 
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:65
-#: src/renderer/components/+workspaces/workspaces.tsx:131
+#: src/renderer/components/+workspaces/workspaces.tsx:136
 msgid "Description"
 msgstr "Описание"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:43
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:44
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
 msgstr ""
 
@@ -834,27 +833,27 @@ msgstr ""
 msgid "Desired number of replicas"
 msgstr "Нужный уровень реплик"
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:62
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:63
 msgid "Disconnect"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:64
-#: src/renderer/components/+nodes/nodes.tsx:122
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:44
+#: src/renderer/components/+nodes/node-details.tsx:63
+#: src/renderer/components/+nodes/nodes.tsx:119
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:43
 msgid "Disk"
 msgstr "Диск"
 
-#: src/renderer/components/+nodes/nodes.tsx:79
+#: src/renderer/components/+nodes/nodes.tsx:76
 msgid "Disk:"
 msgstr "Диск:"
 
-#: src/renderer/components/+preferences/preferences.tsx:168
+#: src/renderer/components/+preferences/preferences.tsx:154
 msgid "Does not affect cluster communications!"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:89
-msgid "Domains"
-msgstr "Домены"
+#~ msgid "Domains"
+#~ msgstr "Домены"
 
 #: src/renderer/components/+preferences/preferences.tsx:129
 #~ msgid "Download Mirror"
@@ -882,27 +881,26 @@ msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:59
 #: src/renderer/components/+nodes/node-menu.tsx:60
-msgid "Drain"
-msgstr "Очистка"
+#~ msgid "Drain"
+#~ msgstr "Очистка"
 
 #: src/renderer/components/+nodes/node-menu.tsx:39
-msgid "Drain Node"
-msgstr "Очистить Node"
+#~ msgid "Drain Node"
+#~ msgstr "Очистить Node"
 
 #: src/renderer/components/+storage-volumes/volume-details.tsx:59
 msgid "Driver"
 msgstr "Драйвер"
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:59
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:87
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
 msgid "Duration"
 msgstr "Продолжительность"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:58
-msgid "E-mail"
-msgstr "Эл. почта"
+#~ msgid "E-mail"
+#~ msgstr "Эл. почта"
 
-#: src/renderer/components/+workspaces/workspaces.tsx:125
+#: src/renderer/components/+workspaces/workspaces.tsx:130
 #: src/renderer/components/menu/menu-actions.tsx:80
 #: src/renderer/components/menu/menu-actions.tsx:81
 msgid "Edit"
@@ -917,7 +915,7 @@ msgstr "Редактировать RoleBinding <0>{roleBindingName}</0>"
 msgid "Effect"
 msgstr "Эффект"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:105
+#: src/renderer/components/+network-policies/network-policy-details.tsx:104
 msgid "Egress"
 msgstr "Egress"
 
@@ -926,8 +924,8 @@ msgid "Endpoint"
 msgstr ""
 
 #: src/renderer/components/+network/network.tsx:35
+#: src/renderer/components/+network-endpoints/endpoints.tsx:27
 #: src/renderer/components/+network-endpoints/endpoints.tsx:30
-#: src/renderer/components/+network-endpoints/endpoints.tsx:33
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:27
 msgid "Endpoints"
 msgstr ""
@@ -936,7 +934,7 @@ msgstr ""
 msgid "Enter a name"
 msgstr "Название"
 
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:79
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:80
 msgid "Environment"
 msgstr "Среда"
 
@@ -952,7 +950,7 @@ msgstr ""
 #: src/renderer/components/+events/events.tsx:56
 #: src/renderer/components/+events/kube-event-details.tsx:34
 #: src/renderer/components/+events/kube-event-details.tsx:39
-#: src/renderer/components/layout/sidebar.tsx:86
+#: src/renderer/components/layout/sidebar.tsx:87
 msgid "Events"
 msgstr "События"
 
@@ -973,7 +971,7 @@ msgstr "Выйти из полного размера"
 #~ msgid "Extended view"
 #~ msgstr "Расширенный вид"
 
-#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+network-services/services.tsx:46
 msgid "External IP"
 msgstr "Внешний IP"
 
@@ -981,16 +979,16 @@ msgstr "Внешний IP"
 msgid "External IPs"
 msgstr "Внешние IP"
 
-#: src/renderer/components/dock/pod-logs.store.ts:65
+#: src/renderer/components/dock/pod-logs.store.ts:56
 msgid "Failed to load logs: {0}"
 msgstr "Ошибка загрузки логов: {0}"
 
-#: src/renderer/components/+events/event-details.tsx:58
+#: src/renderer/components/+events/event-details.tsx:57
 msgid "Field Path"
 msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:14
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:28
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:46
 msgid "Filesystem"
 msgstr "Файловая система"
 
@@ -1002,7 +1000,11 @@ msgstr "Фильтры ({0}/{1})"
 msgid "Finalizers"
 msgstr "Финализаторы"
 
-#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+msgid "Finished at"
+msgstr ""
+
+#: src/renderer/components/+events/event-details.tsx:38
 msgid "First seen"
 msgstr "Увиденно впервые"
 
@@ -1014,11 +1016,11 @@ msgstr "По размеру окна"
 msgid "FlexVolume"
 msgstr "FlexVolume"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:67
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:66
 msgid "Forbidden Sysctls"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:26
+#: src/renderer/components/+network-policies/network-policy-details.tsx:25
 msgid "From"
 msgstr "От"
 
@@ -1026,7 +1028,7 @@ msgstr "От"
 #~ msgid "From <0>{from}</0> to <1>{to}</1>"
 #~ msgstr "От <0>{from}</0> до <1>{to}</1>"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:124
 msgid "Fs Group"
 msgstr ""
 
@@ -1038,13 +1040,13 @@ msgstr ""
 #~ msgid "Global Lens Settings page"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:32
-#: src/renderer/components/+custom-resources/crd-list.tsx:58
-#: src/renderer/components/+custom-resources/crd-list.tsx:74
+#: src/renderer/components/+custom-resources/crd-details.tsx:31
+#: src/renderer/components/+custom-resources/crd-list.tsx:55
+#: src/renderer/components/+custom-resources/crd-list.tsx:71
 msgid "Group"
 msgstr "Группа"
 
-#: src/renderer/components/+custom-resources/crd-list.tsx:60
+#: src/renderer/components/+custom-resources/crd-list.tsx:57
 msgid "Groups"
 msgstr "Группы"
 
@@ -1052,7 +1054,7 @@ msgstr "Группы"
 msgid "HPA"
 msgstr "HPA"
 
-#: src/renderer/components/+preferences/preferences.tsx:137
+#: src/renderer/components/+preferences/preferences.tsx:123
 msgid "HTTP Proxy"
 msgstr ""
 
@@ -1060,7 +1062,7 @@ msgstr ""
 #~ msgid "HTTP Proxy server. Used for communicating with Kubernetes API."
 #~ msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:145
+#: src/renderer/components/+preferences/preferences.tsx:131
 msgid "Helm"
 msgstr ""
 
@@ -1080,12 +1082,12 @@ msgstr "Helm установка: {repo}/{name}"
 msgid "Helm Upgrade: {0}"
 msgstr "Helm обновление: {0}"
 
-#: src/renderer/components/+preferences/preferences.tsx:51
+#: src/renderer/components/+preferences/preferences.tsx:45
 msgid "Helm branch <0>{0}</0> already in use"
 msgstr ""
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Hide"
 msgstr "Скрыть"
@@ -1098,54 +1100,54 @@ msgstr "Большое количество реплик может вызват
 msgid "Home"
 msgstr "Ссылка"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:44
+#: src/renderer/components/+config-autoscalers/hpa.tsx:41
 msgid "Horizontal Pod Autoscalers"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:90
 msgid "Host IPC"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:94
 msgid "Host Network"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:98
 msgid "Host PID"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:103
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:102
 msgid "Host Ports (Min-Max)"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:38
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:37
 msgid "Host: {0}"
 msgstr "Хост: {0}"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:33
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:64
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:76
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:63
 msgid "Hostname"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:92
-msgid "Http01"
-msgstr "Http01"
+#~ msgid "Http01"
+#~ msgstr "Http01"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:65
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:64
 msgid "IP"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:53
-msgid "IP addresses"
-msgstr "IP-адреса"
+#~ msgid "IP addresses"
+#~ msgstr "IP-адреса"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:64
 msgid "Image"
 msgstr "Изображение"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:49
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:68
 msgid "ImagePullPolicy"
 msgstr "ImagePullPolicy"
 
@@ -1153,24 +1155,24 @@ msgstr "ImagePullPolicy"
 msgid "ImagePullSecrets"
 msgstr "ImagePullSecrets"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:65
-#: src/renderer/components/+workloads-jobs/job-details.tsx:64
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:77
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:64
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:64
+#: src/renderer/components/+workloads-jobs/job-details.tsx:63
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:76
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:63
 msgid "Images"
 msgstr "Изображения"
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:92
+#: src/renderer/components/+network-policies/network-policy-details.tsx:91
 msgid "Ingress"
 msgstr "Ingress"
 
 #: src/renderer/components/+network/network.tsx:43
-#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+#: src/renderer/components/+network-ingresses/ingresses.tsx:28
 msgid "Ingresses"
 msgstr "Ingresses"
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:118
-#: src/renderer/components/dock/pod-logs.tsx:135
+#: src/renderer/components/dock/pod-log-controls.tsx:49
 msgid "Init Containers"
 msgstr "Контейнеры инициализации"
 
@@ -1199,24 +1201,24 @@ msgstr "Неверный номер"
 msgid "Involved Object"
 msgstr "Затронутый объект"
 
-#: src/renderer/components/+events/event-details.tsx:52
+#: src/renderer/components/+events/event-details.tsx:51
 msgid "Involved object"
 msgstr "Затронутый объект"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:31
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:64
-msgid "Issuer"
-msgstr "Issuer"
+#~ msgid "Issuer"
+#~ msgstr "Issuer"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:53
-msgid "Issuers"
-msgstr "Issuers"
+#~ msgid "Issuers"
+#~ msgstr "Issuers"
 
 #: src/renderer/components/no-items/no-items.tsx:9
 msgid "Item list is empty"
 msgstr "Список пуст"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:83
+#: src/renderer/components/+custom-resources/crd-details.tsx:82
 msgid "JSON Path"
 msgstr ""
 
@@ -1225,30 +1227,34 @@ msgid "Job name"
 msgstr ""
 
 #: src/renderer/components/+workloads/workloads.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:62
-#: src/renderer/components/+workloads-jobs/jobs.tsx:36
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:61
+#: src/renderer/components/+workloads-jobs/jobs.tsx:33
 msgid "Jobs"
 msgstr "Jobs"
 
-#: src/renderer/components/+nodes/node-details.tsx:92
+#: src/renderer/components/dock/pod-logs.tsx:151
+msgid "Jump to bottom"
+msgstr ""
+
+#: src/renderer/components/+nodes/node-details.tsx:91
 msgid "Kernel version"
 msgstr "Версия Kernel"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:76
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:16
 msgid "Key"
 msgstr "Ключ"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:68
-msgid "Key Algorithm"
-msgstr "Алгоритм ключа"
+#~ msgid "Key Algorithm"
+#~ msgstr "Алгоритм ключа"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:65
-msgid "Key Size"
-msgstr "Размер ключа"
+#~ msgid "Key Size"
+#~ msgstr "Размер ключа"
 
-#: src/renderer/components/+config-maps/config-maps.tsx:36
-#: src/renderer/components/+config-secrets/secrets.tsx:44
+#: src/renderer/components/+config-maps/config-maps.tsx:33
+#: src/renderer/components/+config-secrets/secrets.tsx:41
 msgid "Keys"
 msgstr "Ключи"
 
@@ -1256,13 +1262,13 @@ msgstr "Ключи"
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: src/renderer/components/+events/event-details.tsx:57
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:78
 #: src/renderer/components/dock/edit-resource.tsx:88
 msgid "Kind"
 msgstr "Тип"
 
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:62
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:59
 msgid "Kubeconfig"
 msgstr "Файл конфигурации"
 
@@ -1274,34 +1280,37 @@ msgstr "Файл конфигурации"
 msgid "Kubectl Binary"
 msgstr ""
 
-#: src/renderer/components/+nodes/node-details.tsx:98
+#: src/renderer/components/+nodes/node-details.tsx:97
 msgid "Kubelet version"
 msgstr "Версия Kubelet"
 
-#: src/renderer/components/+config-secrets/secrets.tsx:43
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:65
-#: src/renderer/components/+namespaces/namespaces.tsx:32
-#: src/renderer/components/+nodes/node-details.tsx:101
+#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+namespaces/namespaces.tsx:30
+#: src/renderer/components/+nodes/node-details.tsx:100
 #: src/renderer/components/kube-object/kube-object-meta.tsx:35
 msgid "Labels"
 msgstr "Метки"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:76
-msgid "Last Failure Time"
-msgstr "Время последнего сбоя"
+#~ msgid "Last Failure Time"
+#~ msgstr "Время последнего сбоя"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:57
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:51
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+msgid "Last Status"
+msgstr ""
+
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:56
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
 msgid "Last schedule"
 msgstr "Последний запуск"
 
-#: src/renderer/components/+events/event-details.tsx:42
+#: src/renderer/components/+events/event-details.tsx:41
 #: src/renderer/components/+events/kube-event-details.tsx:57
 msgid "Last seen"
 msgstr "Увиденно в последний раз"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:84
+#: src/renderer/components/+custom-resources/crd-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:83
 #: src/renderer/components/+workloads-pods/pod-details.tsx:103
 msgid "Last transition time: {lastTransitionTime}"
 msgstr "Последнее изменение: {lastTransitionTime}"
@@ -1310,7 +1319,7 @@ msgstr "Последнее изменение: {lastTransitionTime}"
 #~ msgid "Lens Global Settings"
 #~ msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:146
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:145
 msgid "Level"
 msgstr ""
 
@@ -1332,14 +1341,14 @@ msgid "Limits"
 msgstr "Лимиты"
 
 #: src/renderer/components/dock/pod-logs.tsx:150
-msgid "Lines"
-msgstr "Строки"
+#~ msgid "Lines"
+#~ msgstr "Строки"
 
 #: src/renderer/components/kube-object/kube-object-meta.tsx:29
 msgid "Link"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:71
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:90
 msgid "Liveness"
 msgstr "Живучесть"
 
@@ -1347,8 +1356,12 @@ msgstr "Живучесть"
 msgid "Load Balancer IP"
 msgstr "IP балансировщика нагрузки"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:108
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:107
 msgid "Load-Balancer Ingress Points"
+msgstr ""
+
+#: src/renderer/components/+network-ingresses/ingresses.tsx:31
+msgid "LoadBalancers"
 msgstr ""
 
 #: src/renderer/components/app-init/app-init.tsx:43
@@ -1357,8 +1370,8 @@ msgstr "Загрузка"
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:100
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:101
-msgid "Logs"
-msgstr "Логи"
+#~ msgid "Logs"
+#~ msgstr "Логи"
 
 #: src/renderer/components/dialog/logs-dialog.tsx:27
 msgid "Logs copied to clipboard."
@@ -1372,21 +1385,21 @@ msgstr "Создатели"
 msgid "Master"
 msgstr "Мастера"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:75
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:74
 msgid "Match Expressions"
 msgstr "Совпадения выражений"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:71
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:70
 msgid "Match Labels"
 msgstr "Совпадения меток"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:80
-#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+config-autoscalers/hpa.tsx:46
 msgid "Max Pods"
 msgstr "Макс. подов"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:42
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:34
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
 msgid "Max Unavailable"
 msgstr ""
 
@@ -1400,12 +1413,12 @@ msgstr ""
 
 #: src/renderer/components/+cluster/cluster-metric-switchers.tsx:25
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:144
-#: src/renderer/components/+nodes/node-details.tsx:63
-#: src/renderer/components/+nodes/node-details.tsx:74
-#: src/renderer/components/+nodes/node-details.tsx:79
-#: src/renderer/components/+nodes/nodes.tsx:121
+#: src/renderer/components/+nodes/node-details.tsx:62
+#: src/renderer/components/+nodes/node-details.tsx:73
+#: src/renderer/components/+nodes/node-details.tsx:78
+#: src/renderer/components/+nodes/nodes.tsx:118
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:12
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:27
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:45
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:63
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:96
 #: src/renderer/components/resource-metrics/resource-metrics-text.tsx:18
@@ -1430,17 +1443,17 @@ msgstr "Запросы к памяти"
 msgid "Memory usage"
 msgstr "Использование памяти"
 
-#: src/renderer/components/+nodes/nodes.tsx:68
+#: src/renderer/components/+nodes/nodes.tsx:65
 msgid "Memory:"
 msgstr "Память:"
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:100
-#: src/renderer/components/+events/event-details.tsx:30
+#: src/renderer/components/+events/event-details.tsx:29
 #: src/renderer/components/+events/events.tsx:62
 msgid "Message"
 msgstr "Сообщение"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+config-autoscalers/hpa.tsx:44
 msgid "Metrics"
 msgstr "Метрики"
 
@@ -1452,13 +1465,13 @@ msgstr ""
 msgid "Metrics not available at the moment"
 msgstr "В данный момент метрики недоступны"
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:31
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:30
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
 msgid "Min Available"
 msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:76
-#: src/renderer/components/+config-autoscalers/hpa.tsx:48
+#: src/renderer/components/+config-autoscalers/hpa.tsx:45
 msgid "Min Pods"
 msgstr "Мин. подов"
 
@@ -1470,7 +1483,7 @@ msgstr "Минимизировать"
 msgid "Minimum length is {minLength}"
 msgstr "Минимальная длина {minLength}"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:38
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:37
 #: src/renderer/components/+storage-volumes/volume-details.tsx:33
 msgid "Mount Options"
 msgstr "Опции монтирования"
@@ -1479,7 +1492,7 @@ msgstr "Опции монтирования"
 msgid "Mountable secrets"
 msgstr "Монтируемые секреты"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:61
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:80
 msgid "Mounts"
 msgstr "Установки"
 
@@ -1490,47 +1503,45 @@ msgstr "Установки"
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:64
 #: src/renderer/components/+apps-releases/releases.tsx:87
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:49
-#: src/renderer/components/+config-autoscalers/hpa.tsx:45
-#: src/renderer/components/+config-maps/config-maps.tsx:34
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:39
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:34
+#: src/renderer/components/+config-autoscalers/hpa.tsx:42
+#: src/renderer/components/+config-maps/config-maps.tsx:31
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:36
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:31
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:131
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:148
-#: src/renderer/components/+config-secrets/secrets.tsx:41
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:60
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:63
-#: src/renderer/components/+custom-resources/crd-details.tsx:81
-#: src/renderer/components/+custom-resources/crd-resources.tsx:63
-#: src/renderer/components/+events/event-details.tsx:55
-#: src/renderer/components/+namespaces/namespaces.tsx:31
+#: src/renderer/components/+config-secrets/secrets.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:80
+#: src/renderer/components/+custom-resources/crd-resources.tsx:60
+#: src/renderer/components/+events/event-details.tsx:54
+#: src/renderer/components/+namespaces/namespaces.tsx:29
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:87
-#: src/renderer/components/+network-endpoints/endpoints.tsx:31
-#: src/renderer/components/+network-ingresses/ingresses.tsx:32
-#: src/renderer/components/+network-policies/network-policies.tsx:31
+#: src/renderer/components/+network-endpoints/endpoints.tsx:28
+#: src/renderer/components/+network-ingresses/ingresses.tsx:29
+#: src/renderer/components/+network-policies/network-policies.tsx:28
 #: src/renderer/components/+network-services/service-details-endpoint.tsx:26
-#: src/renderer/components/+network-services/services.tsx:44
-#: src/renderer/components/+nodes/nodes.tsx:119
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:35
-#: src/renderer/components/+storage-classes/storage-classes.tsx:34
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
+#: src/renderer/components/+network-services/services.tsx:41
+#: src/renderer/components/+nodes/nodes.tsx:116
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:32
+#: src/renderer/components/+storage-classes/storage-classes.tsx:31
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:43
 #: src/renderer/components/+storage-volumes/volume-details.tsx:72
-#: src/renderer/components/+storage-volumes/volumes.tsx:40
-#: src/renderer/components/+user-management-roles/roles.tsx:33
+#: src/renderer/components/+storage-volumes/volumes.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:30
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:191
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:80
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:35
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:79
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:32
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:29
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:36
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:45
-#: src/renderer/components/+workloads-deployments/deployments.tsx:58
-#: src/renderer/components/+workloads-jobs/jobs.tsx:37
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:34
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:43
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:42
+#: src/renderer/components/+workloads-deployments/deployments.tsx:56
+#: src/renderer/components/+workloads-jobs/jobs.tsx:34
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:92
 #: src/renderer/components/+workloads-pods/pod-details.tsx:144
-#: src/renderer/components/+workloads-pods/pods.tsx:74
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:40
-#: src/renderer/components/+workspaces/workspaces.tsx:130
+#: src/renderer/components/+workloads-pods/pods.tsx:71
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:48
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:37
+#: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
 msgid "Name"
@@ -1540,45 +1551,44 @@ msgstr "Имя"
 msgid "Name (optional)"
 msgstr "Название (необязательно)"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:61
+#: src/renderer/components/+custom-resources/crd-details.tsx:60
 msgid "Names"
 msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:182
 #: src/renderer/components/+apps-releases/releases.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:46
-#: src/renderer/components/+config-maps/config-maps.tsx:35
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:40
+#: src/renderer/components/+config-autoscalers/hpa.tsx:43
+#: src/renderer/components/+config-maps/config-maps.tsx:32
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:37
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:129
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:130
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:35
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:32
 #: src/renderer/components/+config-secrets/add-secret-dialog.tsx:152
-#: src/renderer/components/+config-secrets/secrets.tsx:42
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:61
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:64
-#: src/renderer/components/+custom-resources/crd-resources.tsx:64
-#: src/renderer/components/+events/event-details.tsx:56
+#: src/renderer/components/+config-secrets/secrets.tsx:39
+#: src/renderer/components/+custom-resources/crd-resources.tsx:61
+#: src/renderer/components/+events/event-details.tsx:55
 #: src/renderer/components/+events/events.tsx:63
 #: src/renderer/components/+namespaces/add-namespace-dialog.tsx:73
-#: src/renderer/components/+network-endpoints/endpoints.tsx:32
-#: src/renderer/components/+network-ingresses/ingresses.tsx:33
-#: src/renderer/components/+network-policies/network-policies.tsx:32
-#: src/renderer/components/+network-services/services.tsx:45
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
+#: src/renderer/components/+network-endpoints/endpoints.tsx:29
+#: src/renderer/components/+network-ingresses/ingresses.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:29
+#: src/renderer/components/+network-services/services.tsx:42
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:44
 #: src/renderer/components/+storage-volumes/volume-details.tsx:77
-#: src/renderer/components/+user-management-roles/roles.tsx:34
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:96
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:37
+#: src/renderer/components/+user-management-roles/roles.tsx:31
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
 #: src/renderer/components/+user-management-service-accounts/create-service-account-dialog.tsx:79
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:37
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
-#: src/renderer/components/+workloads-deployments/deployments.tsx:59
-#: src/renderer/components/+workloads-jobs/jobs.tsx:38
-#: src/renderer/components/+workloads-pods/pods.tsx:76
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:45
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:43
+#: src/renderer/components/+workloads-deployments/deployments.tsx:57
+#: src/renderer/components/+workloads-jobs/jobs.tsx:35
+#: src/renderer/components/+workloads-pods/pods.tsx:73
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:38
 #: src/renderer/components/dock/edit-resource.tsx:90
 #: src/renderer/components/dock/install-chart.tsx:122
+#: src/renderer/components/dock/pod-log-controls.tsx:62
 #: src/renderer/components/dock/upgrade-chart.tsx:98
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
@@ -1589,8 +1599,8 @@ msgstr "Namespace"
 msgid "Namespace: {0}"
 msgstr "Namespace: {0}"
 
-#: src/renderer/components/+namespaces/namespaces.tsx:30
-#: src/renderer/components/layout/sidebar.tsx:85
+#: src/renderer/components/+namespaces/namespaces.tsx:28
+#: src/renderer/components/layout/sidebar.tsx:86
 msgid "Namespaces"
 msgstr "Namespaces"
 
@@ -1598,13 +1608,13 @@ msgstr "Namespaces"
 msgid "Namespaces: {0}"
 msgstr "Namespaces: {0}"
 
-#: src/renderer/components/+preferences/preferences.tsx:167
+#: src/renderer/components/+preferences/preferences.tsx:153
 msgid "Needed with some corporate proxies that do certificate re-writing."
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:86
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:85
 #: src/renderer/components/+workloads-pods/pod-charts.tsx:13
-#: src/renderer/components/layout/sidebar.tsx:83
+#: src/renderer/components/layout/sidebar.tsx:84
 msgid "Network"
 msgstr "Сеть"
 
@@ -1613,13 +1623,17 @@ msgid "Network File System"
 msgstr "Сетевая файловая система"
 
 #: src/renderer/components/+network/network.tsx:51
-#: src/renderer/components/+network-policies/network-policies.tsx:30
+#: src/renderer/components/+network-policies/network-policies.tsx:27
 msgid "Network Policies"
 msgstr "Network Policies"
 
+#: src/renderer/components/dock/pod-logs.tsx:171
+msgid "New logs since opening logs tab"
+msgstr ""
+
 #: src/renderer/components/dock/pod-logs.tsx:178
-msgid "New logs since opening the dialog"
-msgstr "Новые логи с момента открытия диалога"
+#~ msgid "New logs since opening the dialog"
+#~ msgstr "Новые логи с момента открытия диалога"
 
 #: src/renderer/components/dock/dock.tsx:92
 msgid "New tab"
@@ -1638,16 +1652,14 @@ msgid "Next"
 msgstr "Далее"
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:29
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
 msgid "No"
 msgstr "Нет"
 
@@ -1679,7 +1691,6 @@ msgstr "Ничего не найдено."
 msgid "No revisions to rollback."
 msgstr "Нет изменений для отката."
 
-#: src/renderer/components/+nodes/node-menu.tsx:24
 #: src/renderer/components/+workloads-pods/pod-details.tsx:85
 msgid "Node"
 msgstr "Нода"
@@ -1688,13 +1699,13 @@ msgstr "Нода"
 msgid "Node Pods capacity"
 msgstr "Емкость подов"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:61
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:49
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:46
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:59
 #: src/renderer/components/+workloads-pods/pod-details.tsx:107
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:73
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:60
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:72
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:59
 msgid "Node Selector"
 msgstr "Селектор ноды"
 
@@ -1707,17 +1718,17 @@ msgid "Node filesystem usage in bytes"
 msgstr "Использование файловой системы ноды в байтах"
 
 #: src/renderer/components/+nodes/node-menu.tsx:47
-msgid "Node shell"
-msgstr "Командная строка ноды"
+#~ msgid "Node shell"
+#~ msgstr "Командная строка ноды"
 
-#: src/renderer/components/+nodes/nodes.tsx:118
-#: src/renderer/components/layout/sidebar.tsx:80
+#: src/renderer/components/+nodes/nodes.tsx:115
+#: src/renderer/components/layout/sidebar.tsx:81
 msgid "Nodes"
 msgstr "Ноды"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:72
-msgid "Not After"
-msgstr "Не позже"
+#~ msgid "Not After"
+#~ msgstr "Не позже"
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:72
 msgid "Not Ready Addresses"
@@ -1735,11 +1746,11 @@ msgstr "Заметки"
 msgid "Number of running Pods"
 msgstr "Кол-во работающих подов"
 
-#: src/renderer/components/+nodes/node-details.tsx:86
+#: src/renderer/components/+nodes/node-details.tsx:85
 msgid "OS"
 msgstr "ОС"
 
-#: src/renderer/components/+nodes/node-details.tsx:89
+#: src/renderer/components/+nodes/node-details.tsx:88
 msgid "OS Image"
 msgstr "Образ ОС"
 
@@ -1765,14 +1776,14 @@ msgid "Open in a browser"
 msgstr ""
 
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:77
 #: src/renderer/components/+workloads-pods/pod-details-tolerations.tsx:17
 msgid "Operator"
 msgstr "Оператор"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:56
-msgid "Organization"
-msgstr "Организация"
+#~ msgid "Organization"
+#~ msgstr "Организация"
 
 #: src/renderer/components/+workloads/workloads.tsx:29
 #: src/renderer/components/+workloads-overview/overview-statuses.tsx:45
@@ -1783,11 +1794,11 @@ msgstr "Обзор"
 msgid "Page not found"
 msgstr "Страница не найдена"
 
-#: src/renderer/components/+workloads-jobs/job-details.tsx:83
+#: src/renderer/components/+workloads-jobs/job-details.tsx:82
 msgid "Parallelism"
 msgstr "Параллелизм"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:42
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:41
 msgid "Parameters"
 msgstr "Параметры"
 
@@ -1795,23 +1806,21 @@ msgstr "Параметры"
 msgid "Paste as text"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:94
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:102
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:42
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:41
 msgid "Path"
 msgstr "Путь"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:112
 msgid "Path Prefix"
 msgstr ""
 
 #: src/renderer/components/+storage/storage.tsx:25
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:42
 msgid "Persistent Volume Claims"
 msgstr "Persistent Volume Claims"
 
 #: src/renderer/components/+storage/storage.tsx:32
-#: src/renderer/components/+storage-volumes/volumes.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:36
 msgid "Persistent Volumes"
 msgstr "Persistent Volumes"
 
@@ -1839,12 +1848,12 @@ msgstr ""
 #~ msgid "Please select kubeconfig's context"
 #~ msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-menu.tsx:50
+#: src/renderer/components/dock/pod-log-controls.tsx:61
 msgid "Pod"
 msgstr ""
 
 #: src/renderer/components/+config/config.tsx:63
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:38
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:35
 msgid "Pod Disruption Budgets"
 msgstr ""
 
@@ -1852,43 +1861,43 @@ msgstr ""
 msgid "Pod IP"
 msgstr "IP пода"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:31
 #: src/renderer/components/+user-management/user-management.tsx:43
 msgid "Pod Security Policies"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:85
+#: src/renderer/components/+network-policies/network-policy-details.tsx:84
 msgid "Pod Selector"
 msgstr "Селектор подов"
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:73
-#: src/renderer/components/+workloads-jobs/job-details.tsx:88
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:85
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:69
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:72
+#: src/renderer/components/+workloads-jobs/job-details.tsx:87
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:84
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:68
 msgid "Pod Status"
 msgstr "Статус подов"
 
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:77
-msgid "Pod shell"
-msgstr "Командная строка пода"
+#~ msgid "Pod shell"
+#~ msgstr "Командная строка пода"
 
 #: src/renderer/components/+cluster/cluster-pie-charts.tsx:148
-#: src/renderer/components/+nodes/node-details.tsx:65
-#: src/renderer/components/+nodes/node-details.tsx:75
-#: src/renderer/components/+nodes/node-details.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:60
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:50
+#: src/renderer/components/+nodes/node-details.tsx:64
+#: src/renderer/components/+nodes/node-details.tsx:74
+#: src/renderer/components/+nodes/node-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:59
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:47
 #: src/renderer/components/+workloads/workloads.tsx:37
-#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:47
-#: src/renderer/components/+workloads-deployments/deployments.tsx:60
+#: src/renderer/components/+workloads-daemonsets/daemonsets.tsx:44
+#: src/renderer/components/+workloads-deployments/deployments.tsx:58
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:89
-#: src/renderer/components/+workloads-pods/pods.tsx:73
-#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:42
+#: src/renderer/components/+workloads-pods/pods.tsx:70
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
 msgid "Pods"
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policies.tsx:33
+#: src/renderer/components/+network-policies/network-policies.tsx:30
 msgid "Policy Types"
 msgstr "Типы политик"
 
@@ -1897,29 +1906,29 @@ msgid "Port"
 msgstr ""
 
 #: src/renderer/components/+network-endpoints/endpoint-subset-list.tsx:83
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:94
-#: src/renderer/components/+network-policies/network-policy-details.tsx:96
-#: src/renderer/components/+network-policies/network-policy-details.tsx:109
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:93
+#: src/renderer/components/+network-policies/network-policy-details.tsx:95
+#: src/renderer/components/+network-policies/network-policy-details.tsx:108
 #: src/renderer/components/+network-services/service-details.tsx:59
-#: src/renderer/components/+network-services/services.tsx:48
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:53
+#: src/renderer/components/+network-services/services.tsx:45
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:72
 msgid "Ports"
 msgstr "Порты"
 
-#: src/renderer/components/+preferences/preferences.tsx:121
-#~ msgid "Preferences"
-#~ msgstr ""
+#: src/renderer/components/+preferences/preferences.tsx:118
+msgid "Preferences"
+msgstr ""
 
 #: src/renderer/components/+workloads-pods/pod-details.tsx:93
 msgid "Priority Class"
 msgstr "Класс приоритета"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:67
-msgid "Private Key Secret"
-msgstr "Секрет приватного ключа"
+#~ msgid "Private Key Secret"
+#~ msgstr "Секрет приватного ключа"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:36
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:33
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:74
 msgid "Privileged"
 msgstr ""
 
@@ -1951,12 +1960,12 @@ msgstr ""
 #~ msgid "Pro-tip: you can also drag-n-drop kube-config file to this area"
 #~ msgstr ""
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:28
-#: src/renderer/components/+storage-classes/storage-classes.tsx:35
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:27
+#: src/renderer/components/+storage-classes/storage-classes.tsx:32
 msgid "Provisioner"
 msgstr "Комиссия"
 
-#: src/renderer/components/+preferences/preferences.tsx:140
+#: src/renderer/components/+preferences/preferences.tsx:126
 msgid "Proxy is used only for non-cluster communication."
 msgstr ""
 
@@ -1964,7 +1973,7 @@ msgstr ""
 msgid "Proxy settings"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pods.tsx:80
+#: src/renderer/components/+workloads-pods/pods.tsx:77
 msgid "QoS"
 msgstr "QoS"
 
@@ -1976,27 +1985,28 @@ msgstr "QoS класс"
 msgid "Quotas"
 msgstr "Квоты"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:27
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:26
 msgid "Ranges (Min-Max)"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:114
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:113
 msgid "Read-only"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:78
 msgid "Read-only Root Filesystem"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:75
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:94
 msgid "Readiness"
 msgstr "Готовность"
 
-#: src/renderer/components/+events/event-details.tsx:33
+#: src/renderer/components/+events/event-details.tsx:32
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "Reason"
 msgstr "Причина"
 
-#: src/renderer/components/dock/pod-logs.store.ts:66
+#: src/renderer/components/dock/pod-logs.store.ts:57
 msgid "Reason: {0} ({1})"
 msgstr "Причина: {0} ({1})"
 
@@ -2004,8 +2014,8 @@ msgstr "Причина: {0} ({1})"
 msgid "Receive"
 msgstr "Получение"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:34
-#: src/renderer/components/+storage-classes/storage-classes.tsx:36
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:33
 #: src/renderer/components/+storage-volumes/volume-details.tsx:40
 msgid "Reclaim Policy"
 msgstr "Политика отката"
@@ -2015,7 +2025,7 @@ msgstr "Политика отката"
 #~ msgstr ""
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:70
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:76
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:75
 msgid "Reference"
 msgstr "Ссылка"
 
@@ -2040,10 +2050,10 @@ msgstr "Установка: {0}"
 msgid "Releases"
 msgstr "Релизы"
 
-#: src/renderer/components/+preferences/preferences.tsx:152
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:73
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:79
+#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:59
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:74
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:80
 #: src/renderer/components/item-object-list/item-list-layout.tsx:179
 #: src/renderer/components/menu/menu-actions.tsx:49
 #: src/renderer/components/menu/menu-actions.tsx:85
@@ -2066,11 +2076,11 @@ msgstr "Удалить поле"
 msgid "Remove item?"
 msgstr "Удалить объект?"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:61
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:60
 msgid "Remove selected bindings for <0>{0}</0>?"
 msgstr "Удалить выбранные связки <0>{0}</0>?"
 
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:112
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:111
 msgid "Remove selected bindings from ${name}"
 msgstr "Удалить выбранные связки из ${name}"
 
@@ -2078,11 +2088,11 @@ msgstr "Удалить выбранные связки из ${name}"
 msgid "Remove selected items ({0})"
 msgstr "Удалить выбранные элементы ({0})"
 
-#: src/renderer/components/kube-object/kube-object-menu.tsx:69
+#: src/renderer/components/kube-object/kube-object-menu.tsx:70
 msgid "Remove {resourceKind} <0>{resourceName}</0>?"
 msgstr "Удалить {resourceKind} <0>{resourceName}</0>?"
 
-#: src/renderer/components/+preferences/preferences.tsx:122
+#: src/renderer/components/+preferences/preferences.tsx:112
 msgid "Removing helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
@@ -2091,14 +2101,14 @@ msgstr ""
 #~ msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:62
-msgid "Renew Before"
-msgstr "Обновить до"
+#~ msgid "Renew Before"
+#~ msgstr "Обновить до"
 
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:84
-#: src/renderer/components/+config-autoscalers/hpa.tsx:50
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
-#: src/renderer/components/+workloads-deployments/deployments.tsx:61
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:80
+#: src/renderer/components/+config-autoscalers/hpa.tsx:47
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:62
+#: src/renderer/components/+workloads-deployments/deployments.tsx:59
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
 msgstr "Реплики"
 
@@ -2106,7 +2116,7 @@ msgstr "Реплики"
 msgid "Repo/Name"
 msgstr "Репозиторий/Имя"
 
-#: src/renderer/components/+preferences/preferences.tsx:146
+#: src/renderer/components/+preferences/preferences.tsx:132
 msgid "Repositories"
 msgstr ""
 
@@ -2133,7 +2143,7 @@ msgstr "Продолжительность запроса в секундах"
 msgid "Requests"
 msgstr "Запросы"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:87
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:86
 msgid "Required Drop Capabilities"
 msgstr ""
 
@@ -2162,18 +2172,18 @@ msgstr "Сбросить фильтры?"
 #~ msgid "Resetting kube-config to default: {kubeConfigDefaultPath}"
 #~ msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:44
-#: src/renderer/components/+custom-resources/crd-list.tsx:73
+#: src/renderer/components/+custom-resources/crd-details.tsx:43
+#: src/renderer/components/+custom-resources/crd-list.tsx:70
 msgid "Resource"
 msgstr ""
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:45
+#: src/renderer/components/+user-management-roles/role-details.tsx:44
 msgid "Resource Names"
 msgstr "Имена ресурсов"
 
 #: src/renderer/components/+config/config.tsx:47
-#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:33
-#: src/renderer/components/+namespaces/namespace-details.tsx:41
+#: src/renderer/components/+config-resource-quotas/resource-quotas.tsx:30
+#: src/renderer/components/+namespaces/namespace-details.tsx:40
 msgid "Resource Quotas"
 msgstr "Квоты ресурсов"
 
@@ -2181,7 +2191,7 @@ msgstr "Квоты ресурсов"
 msgid "Resource Version"
 msgstr ""
 
-#: src/renderer/components/kube-object/kube-object-details.tsx:46
+#: src/renderer/components/kube-object/kube-object-details.tsx:48
 msgid "Resource loading has failed: <0>{0}</0>"
 msgstr "Загрузка ресурса не удалась: <0>{0}</0>"
 
@@ -2194,7 +2204,7 @@ msgid "ResourceQuota name"
 msgstr "Имя квоты ресурса"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:198
-#: src/renderer/components/+user-management-roles/role-details.tsx:29
+#: src/renderer/components/+user-management-roles/role-details.tsx:28
 msgid "Resources"
 msgstr "Ресурсы"
 
@@ -2210,7 +2220,7 @@ msgstr "Продолжительность ответа в секундах"
 msgid "Restart session"
 msgstr "Перезагрузить сессию"
 
-#: src/renderer/components/+workloads-pods/pods.tsx:78
+#: src/renderer/components/+workloads-pods/pods.tsx:75
 msgid "Restarts"
 msgstr "Перезагрузки"
 
@@ -2223,27 +2233,27 @@ msgstr "Ревизия"
 msgid "Right click cluster icon to open cluster settings."
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:149
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:148
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:187
 msgid "Role"
 msgstr "Role"
 
 #: src/renderer/components/+user-management/user-management.tsx:31
-#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:34
+#: src/renderer/components/+user-management-roles-bindings/role-bindings.tsx:31
 msgid "Role Bindings"
 msgstr "Role Bindings"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:105
-msgid "Role ID"
-msgstr "Идентификатор роли"
+#~ msgid "Role ID"
+#~ msgstr "Идентификатор роли"
 
 #: src/renderer/components/+user-management-roles/add-role-dialog.tsx:74
 msgid "Role name"
 msgstr "Имя роли"
 
-#: src/renderer/components/+nodes/nodes.tsx:124
+#: src/renderer/components/+nodes/nodes.tsx:121
 #: src/renderer/components/+user-management/user-management.tsx:36
-#: src/renderer/components/+user-management-roles/roles.tsx:32
+#: src/renderer/components/+user-management-roles/roles.tsx:29
 msgid "Roles"
 msgstr "Roles"
 
@@ -2257,41 +2267,41 @@ msgstr "Откат"
 msgid "Rollback <0>{releaseName}</0>"
 msgstr "Откатить <0>{releaseName}</0>"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:24
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:142
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:23
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
 msgid "Rule"
 msgstr ""
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:105
-#: src/renderer/components/+network-ingresses/ingresses.tsx:34
-#: src/renderer/components/+user-management-roles/role-details.tsx:25
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:104
+#: src/renderer/components/+network-ingresses/ingresses.tsx:32
+#: src/renderer/components/+user-management-roles/role-details.tsx:24
 msgid "Rules"
 msgstr "Правила"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:125
 msgid "Run As Group"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:126
 msgid "Run As User"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:131
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:130
 msgid "Runtime Class"
 msgstr ""
 
 #: src/renderer/components/+apps-releases/release-details.tsx:114
-#: src/renderer/components/+config-maps/config-map-details.tsx:78
-#: src/renderer/components/+config-secrets/secret-details.tsx:97
-#: src/renderer/components/+workspaces/workspaces.tsx:132
+#: src/renderer/components/+config-maps/config-map-details.tsx:77
+#: src/renderer/components/+config-secrets/secret-details.tsx:96
+#: src/renderer/components/+workspaces/workspaces.tsx:137
 #: src/renderer/components/dock/edit-resource.tsx:87
-#: src/renderer/components/dock/pod-logs.tsx:161
+#: src/renderer/components/dock/pod-log-controls.tsx:74
 msgid "Save"
 msgstr "Сохранить"
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
-#: src/renderer/components/+workloads-deployments/deployments.tsx:86
-#: src/renderer/components/+workloads-deployments/deployments.tsx:87
+#: src/renderer/components/+workloads-deployments/deployments.tsx:83
+#: src/renderer/components/+workloads-deployments/deployments.tsx:84
 msgid "Scale"
 msgstr "Масштабировать"
 
@@ -2299,13 +2309,13 @@ msgstr "Масштабировать"
 msgid "Scale Deployment <0>{deploymentName}</0>"
 msgstr "Масштабировать Deployment <0>{deploymentName}</0>"
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:46
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:48
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:45
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:46
 msgid "Schedule"
 msgstr "Расписание"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:41
-#: src/renderer/components/+custom-resources/crd-list.tsx:76
+#: src/renderer/components/+custom-resources/crd-details.tsx:40
+#: src/renderer/components/+custom-resources/crd-list.tsx:73
 msgid "Scope"
 msgstr ""
 
@@ -2317,7 +2327,7 @@ msgstr "Селектор области"
 msgid "Scope name"
 msgstr "Имя области"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:141
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:140
 msgid "Se Linux"
 msgstr ""
 
@@ -2331,13 +2341,13 @@ msgstr "Поиск.."
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:65
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:108
-msgid "Secret"
-msgstr "Секрет"
+#~ msgid "Secret"
+#~ msgstr "Секрет"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:37
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:80
-msgid "Secret Name"
-msgstr "Название секрета"
+#~ msgid "Secret Name"
+#~ msgstr "Название секрета"
 
 #: src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx:72
 msgid "Secret is not found"
@@ -2347,7 +2357,7 @@ msgstr ""
 msgid "Secret name"
 msgstr "Имя секрета"
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:44
+#: src/renderer/components/+config-secrets/secret-details.tsx:43
 msgid "Secret successfully updated."
 msgstr "Секрет успешно обновлен."
 
@@ -2356,7 +2366,7 @@ msgid "Secret type"
 msgstr "Тип секрета"
 
 #: src/renderer/components/+config/config.tsx:39
-#: src/renderer/components/+config-secrets/secrets.tsx:40
+#: src/renderer/components/+config-secrets/secrets.tsx:37
 #: src/renderer/components/+workloads-pods/pod-details.tsx:113
 msgid "Secrets"
 msgstr "Secrets"
@@ -2443,35 +2453,35 @@ msgstr ""
 #~ msgid "Selected contexts: {0}"
 #~ msgstr ""
 
-#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:27
+#: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:26
 #: src/renderer/components/+network-services/service-details.tsx:37
-#: src/renderer/components/+network-services/services.tsx:50
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:69
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:75
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:57
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:69
-#: src/renderer/components/+workloads-jobs/job-details.tsx:56
-#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:69
-#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:56
+#: src/renderer/components/+network-services/services.tsx:47
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:68
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:74
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:56
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:68
+#: src/renderer/components/+workloads-jobs/job-details.tsx:55
+#: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:68
+#: src/renderer/components/+workloads-statefulsets/statefulset-details.tsx:55
 msgid "Selector"
 msgstr "Селектор"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:61
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:91
-msgid "Server"
-msgstr "Сервер"
+#~ msgid "Server"
+#~ msgstr "Сервер"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:102
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:101
 msgid "Service"
 msgstr "Service"
 
 #: src/renderer/components/+user-management/user-management.tsx:26
-#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:35
+#: src/renderer/components/+user-management-service-accounts/service-accounts.tsx:33
 msgid "Service Accounts"
 msgstr "Service Accounts"
 
 #: src/renderer/components/+network/network.tsx:27
-#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+network-services/services.tsx:40
 msgid "Services"
 msgstr "Services"
 
@@ -2487,18 +2497,18 @@ msgstr "Установлено"
 msgid "Set quota"
 msgstr "Установить квоту"
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:51
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:52
 msgid "Settings"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-menu.tsx:48
 #: src/renderer/components/+workloads-pods/pod-menu.tsx:78
-msgid "Shell"
-msgstr "Командная строка"
+#~ msgid "Shell"
+#~ msgstr "Командная строка"
 
-#: src/renderer/components/+config-secrets/secret-details.tsx:93
-#: src/renderer/components/+workloads-pods/pod-container-env.tsx:101
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/+config-secrets/secret-details.tsx:92
+#: src/renderer/components/+workloads-pods/pod-container-env.tsx:102
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 #: src/renderer/components/drawer/drawer-param-toggler.tsx:19
 msgid "Show"
 msgstr "Показать"
@@ -2507,11 +2517,11 @@ msgstr "Показать"
 msgid "Show Notes"
 msgstr "Показать логи"
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show current logs"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:160
+#: src/renderer/components/dock/pod-log-controls.tsx:73
 msgid "Show previous terminated container logs"
 msgstr ""
 
@@ -2519,12 +2529,12 @@ msgstr ""
 msgid "Show value"
 msgstr "Показать значение"
 
-#: src/renderer/components/dock/pod-logs.tsx:154
+#: src/renderer/components/dock/pod-log-controls.tsx:67
 msgid "Since"
 msgstr ""
 
 #: src/renderer/components/+nodes/node-charts.tsx:80
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:46
 msgid "Size"
 msgstr "Размер"
 
@@ -2533,10 +2543,10 @@ msgid "Size Limit"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:70
-msgid "Skip TLS Verify"
-msgstr "Skip TLS Verify"
+#~ msgid "Skip TLS Verify"
+#~ msgstr "Skip TLS Verify"
 
-#: src/renderer/components/+events/event-details.tsx:36
+#: src/renderer/components/+events/event-details.tsx:35
 #: src/renderer/components/+events/events.tsx:66
 #: src/renderer/components/+events/kube-event-details.tsx:48
 msgid "Source"
@@ -2546,7 +2556,11 @@ msgstr "Источник"
 msgid "Specified limits are higher than node capacity!"
 msgstr "Заданные лимиты выше вместимости ноды!"
 
-#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:39
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:26
+msgid "Started at"
+msgstr ""
+
+#: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:36
 msgid "Stateful Sets"
 msgstr ""
 
@@ -2557,59 +2571,55 @@ msgstr "StatefulSets"
 #: src/renderer/components/+apps-releases/release-details.tsx:192
 #: src/renderer/components/+apps-releases/releases.tsx:93
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:88
-#: src/renderer/components/+config-autoscalers/hpa.tsx:52
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:79
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:67
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:48
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:68
-#: src/renderer/components/+custom-resources/crd-resource-details.tsx:56
-#: src/renderer/components/+namespaces/namespace-details.tsx:37
-#: src/renderer/components/+namespaces/namespaces.tsx:34
-#: src/renderer/components/+network-services/services.tsx:52
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:65
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:52
+#: src/renderer/components/+config-autoscalers/hpa.tsx:49
+#: src/renderer/components/+custom-resources/crd-resource-details.tsx:49
+#: src/renderer/components/+namespaces/namespace-details.tsx:36
+#: src/renderer/components/+namespaces/namespaces.tsx:32
+#: src/renderer/components/+network-services/services.tsx:49
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:64
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:49
 #: src/renderer/components/+storage-volumes/volume-details.tsx:46
-#: src/renderer/components/+storage-volumes/volumes.tsx:45
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:39
+#: src/renderer/components/+storage-volumes/volumes.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:57
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:97
 #: src/renderer/components/+workloads-pods/pod-details.tsx:82
-#: src/renderer/components/+workloads-pods/pods.tsx:82
+#: src/renderer/components/+workloads-pods/pods.tsx:79
 msgid "Status"
 msgstr "Статус"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:64
-msgid "Status URI"
-msgstr "Адрес статуса"
+#~ msgid "Status URI"
+#~ msgstr "Адрес статуса"
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:57
-#: src/renderer/components/layout/sidebar.tsx:84
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
+#: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"
 msgstr "Storage"
 
-#: src/renderer/components/+storage-volumes/volumes.tsx:41
+#: src/renderer/components/+storage-volumes/volumes.tsx:38
 msgid "Storage Class"
 msgstr ""
 
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:54
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:53
 #: src/renderer/components/+storage-volumes/volume-details.tsx:43
 msgid "Storage Class Name"
 msgstr "Имя Storage Class"
 
 #: src/renderer/components/+storage/storage.tsx:40
-#: src/renderer/components/+storage-classes/storage-classes.tsx:33
+#: src/renderer/components/+storage-classes/storage-classes.tsx:30
 msgid "Storage Classes"
 msgstr "Storage Classes"
 
-#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:48
+#: src/renderer/components/+storage-volume-claims/volume-claims.tsx:45
 msgid "Storage class"
 msgstr "Класс хранилища"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:38
+#: src/renderer/components/+custom-resources/crd-details.tsx:37
 msgid "Stored versions"
 msgstr ""
 
-#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:68
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:76
+#: src/renderer/components/+workloads-daemonsets/daemonset-details.tsx:67
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:75
 msgid "Strategy Type"
 msgstr "Тип стратегии"
 
@@ -2626,7 +2636,7 @@ msgstr "Отправить"
 msgid "Submitting.."
 msgstr "Применение.."
 
-#: src/renderer/components/+network-endpoints/endpoint-details.tsx:24
+#: src/renderer/components/+network-endpoints/endpoint-details.tsx:23
 msgid "Subsets"
 msgstr ""
 
@@ -2634,31 +2644,31 @@ msgstr ""
 msgid "Successfully imported <0>{0}</0> cluster(s)"
 msgstr ""
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:128
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:127
 msgid "Supplemental Groups"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:54
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:49
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:53
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:47
 msgid "Suspend"
 msgstr "Заморозка"
 
-#: src/renderer/components/+network-ingresses/ingress-details.tsx:98
+#: src/renderer/components/+network-ingresses/ingress-details.tsx:97
 msgid "TLS"
 msgstr "TLS"
 
-#: src/renderer/components/+nodes/node-details.tsx:103
-#: src/renderer/components/+nodes/nodes.tsx:123
+#: src/renderer/components/+nodes/node-details.tsx:102
+#: src/renderer/components/+nodes/nodes.tsx:120
 msgid "Taints"
 msgstr "Метки блокировки"
 
 #: src/renderer/components/+preferences/preferences.tsx:171
-msgid "Telemetry & Usage Tracking"
-msgstr ""
+#~ msgid "Telemetry & Usage Tracking"
+#~ msgstr ""
 
 #: src/renderer/components/+preferences/preferences.tsx:174
-msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
-msgstr ""
+#~ msgid "Telemetry & usage data is collected to continuously improve the Lens experience."
+#~ msgstr ""
 
 #: src/renderer/components/dock/terminal.store.ts:28
 msgid "Terminal"
@@ -2672,7 +2682,7 @@ msgstr "Сессия терминала"
 msgid "The path to the kubectl binary on the system."
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:172
+#: src/renderer/components/dock/pod-logs.tsx:162
 msgid "There are no logs available for container."
 msgstr "Для контейнера нет логов."
 
@@ -2692,11 +2702,15 @@ msgstr ""
 msgid "This is the quick launch menu."
 msgstr ""
 
-#: src/renderer/components/+preferences/preferences.tsx:166
+#: src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx:22
+msgid "This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces."
+msgstr ""
+
+#: src/renderer/components/+preferences/preferences.tsx:152
 msgid "This will make Lens to trust ANY certificate authority without any validations."
 msgstr ""
 
-#: src/renderer/components/+network-policies/network-policy-details.tsx:59
+#: src/renderer/components/+network-policies/network-policy-details.tsx:58
 msgid "To"
 msgstr "Из"
 
@@ -2717,8 +2731,8 @@ msgid "Transmit"
 msgstr "Транзит"
 
 #: src/renderer/components/+workloads-cronjobs/cronjob-trigger-dialog.tsx:106
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:79
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:80
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:76
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:77
 msgid "Trigger"
 msgstr ""
 
@@ -2727,25 +2741,22 @@ msgid "Trigger CronJob <0>{cronjobName}</0>"
 msgstr ""
 
 #: src/renderer/components/+cluster/cluster-issues.tsx:102
-#: src/renderer/components/+config-secrets/secret-details.tsx:74
-#: src/renderer/components/+config-secrets/secrets.tsx:45
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificates.tsx:63
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuers.tsx:66
-#: src/renderer/components/+custom-resources/crd-details.tsx:82
-#: src/renderer/components/+events/event-details.tsx:48
+#: src/renderer/components/+config-secrets/secret-details.tsx:73
+#: src/renderer/components/+config-secrets/secrets.tsx:42
+#: src/renderer/components/+custom-resources/crd-details.tsx:81
+#: src/renderer/components/+events/event-details.tsx:47
 #: src/renderer/components/+events/events.tsx:64
 #: src/renderer/components/+network-services/service-details.tsx:41
-#: src/renderer/components/+network-services/services.tsx:46
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:152
+#: src/renderer/components/+network-services/services.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:151
 #: src/renderer/components/+storage-volumes/volume-details.tsx:69
-#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:95
+#: src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx:94
 #: src/renderer/components/+user-management-service-accounts/service-accounts-secret.tsx:43
 #: src/renderer/components/+workloads-pods/pod-details.tsx:140
 msgid "Type"
 msgstr "Тип"
 
-#: src/renderer/components/+preferences/preferences.tsx:138
+#: src/renderer/components/+preferences/preferences.tsx:124
 msgid "Type HTTP proxy url (example: http://proxy.acme.org:8080)"
 msgstr ""
 
@@ -2754,13 +2765,13 @@ msgid "UID"
 msgstr ""
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:126
-msgid "URL"
-msgstr "УРЛ"
+#~ msgid "URL"
+#~ msgstr "УРЛ"
 
 #: src/renderer/components/+nodes/node-menu.tsx:55
 #: src/renderer/components/+nodes/node-menu.tsx:56
-msgid "Uncordon"
-msgstr "Разблокировка"
+#~ msgid "Uncordon"
+#~ msgstr "Разблокировка"
 
 #: src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx:212
 msgid "Update"
@@ -2815,11 +2826,11 @@ msgstr "Использовать тоже имя для привязки рол�
 #~ msgid "Used"
 #~ msgstr "Использовано"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:155
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:154
 msgid "User"
 msgstr "Пользователь"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:99
+#: src/renderer/components/+custom-resources/crd-details.tsx:98
 msgid "Validation"
 msgstr ""
 
@@ -2832,11 +2843,11 @@ msgstr "Значение"
 #: src/renderer/components/+apps-releases/release-details.tsx:111
 #: src/renderer/components/+config-resource-quotas/add-quota-dialog.tsx:132
 #: src/renderer/components/+config-resource-quotas/resource-quota-details.tsx:62
-#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:79
+#: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:78
 msgid "Values"
 msgstr "Конфигурация"
 
-#: src/renderer/components/+user-management-roles/role-details.tsx:33
+#: src/renderer/components/+user-management-roles/role-details.tsx:32
 msgid "Verbs"
 msgstr "Определения"
 
@@ -2844,9 +2855,9 @@ msgstr "Определения"
 #: src/renderer/components/+apps-helm-charts/helm-charts.tsx:66
 #: src/renderer/components/+apps-releases/release-details.tsx:185
 #: src/renderer/components/+apps-releases/releases.tsx:91
-#: src/renderer/components/+custom-resources/crd-details.tsx:35
-#: src/renderer/components/+custom-resources/crd-list.tsx:75
-#: src/renderer/components/+nodes/nodes.tsx:125
+#: src/renderer/components/+custom-resources/crd-details.tsx:34
+#: src/renderer/components/+custom-resources/crd-list.tsx:72
+#: src/renderer/components/+nodes/nodes.tsx:122
 #: src/renderer/components/dock/install-chart.tsx:120
 #: src/renderer/components/dock/upgrade-chart.tsx:99
 msgid "Version"
@@ -2856,7 +2867,7 @@ msgstr "Версия"
 msgid "View Helm Release"
 msgstr "Показать Helm релиз"
 
-#: src/renderer/components/+storage-classes/storage-class-details.tsx:31
+#: src/renderer/components/+storage-classes/storage-class-details.tsx:30
 msgid "Volume Binding Mode"
 msgstr "Режим связи с Volume"
 
@@ -2868,8 +2879,8 @@ msgstr "Емкость диска Volume"
 msgid "Volume disk usage"
 msgstr "Использование диска Volume"
 
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:37
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:47
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:34
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:46
 #: src/renderer/components/+workloads-pods/pod-details.tsx:130
 msgid "Volumes"
 msgstr "Volumes"
@@ -2886,7 +2897,7 @@ msgstr "Предупреждения: {0}"
 msgid "Welcome!"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:88
+#: src/renderer/components/+workspaces/workspaces.tsx:92
 msgid "What is a Workspace?"
 msgstr ""
 
@@ -2894,16 +2905,16 @@ msgstr ""
 msgid "Worker"
 msgstr "Рабочие"
 
-#: src/renderer/components/layout/sidebar.tsx:81
+#: src/renderer/components/layout/sidebar.tsx:82
 msgid "Workloads"
 msgstr "Ресурсы"
 
 #: src/renderer/components/+workspaces/workspace-menu.tsx:39
-#: src/renderer/components/+workspaces/workspaces.tsx:100
+#: src/renderer/components/+workspaces/workspaces.tsx:104
 msgid "Workspaces"
 msgstr ""
 
-#: src/renderer/components/+workspaces/workspaces.tsx:90
+#: src/renderer/components/+workspaces/workspaces.tsx:94
 msgid "Workspaces are used to organize number of clusters into logical groups."
 msgstr ""
 
@@ -2916,27 +2927,25 @@ msgid "Wrong url format"
 msgstr "Неверный url формат"
 
 #: src/renderer/components/+cluster-settings/components/remove-cluster-button.tsx:28
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/certificate-details.tsx:44
-#: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:71
-#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:42
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:72
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:76
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:80
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:92
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:96
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:100
-#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:119
-#: src/renderer/components/+storage-classes/storage-classes.tsx:43
+#: src/renderer/components/+pod-security-policies/pod-security-policies.tsx:39
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:71
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:75
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:79
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:91
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:95
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:99
+#: src/renderer/components/+pod-security-policies/pod-security-policy-details.tsx:118
+#: src/renderer/components/+storage-classes/storage-classes.tsx:40
 msgid "Yes"
 msgstr "Да"
 
 #: src/renderer/components/+custom-resources/certmanager.k8s.io/issuer-details.tsx:118
-msgid "Zone"
-msgstr "Зона"
+#~ msgid "Zone"
+#~ msgstr "Зона"
 
 #: src/renderer/components/+apps-releases/release-details.tsx:180
-#: src/renderer/components/+events/event-details.tsx:40
-#: src/renderer/components/+events/event-details.tsx:43
+#: src/renderer/components/+events/event-details.tsx:39
+#: src/renderer/components/+events/event-details.tsx:42
 #: src/renderer/components/kube-object/kube-object-meta.tsx:18
 msgid "ago"
 msgstr "тому назад"
@@ -2949,36 +2958,37 @@ msgstr "и <0>{tailCount}</0> ещё"
 #~ msgid "applicable to all clusters"
 #~ msgstr ""
 
-#: src/renderer/components/+nodes/nodes.tsx:57
+#: src/renderer/components/+nodes/nodes.tsx:54
 msgid "cores:"
 msgstr "ядер:"
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:42
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:18
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:25
 msgid "exit code"
 msgstr "код выхода"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:66
+#: src/renderer/components/+custom-resources/crd-details.tsx:65
 msgid "kind"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:67
+#: src/renderer/components/+custom-resources/crd-details.tsx:66
 msgid "listKind"
 msgstr ""
 
-#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:48
-#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:61
+#: src/renderer/components/+workloads-cronjobs/cronjob-details.tsx:47
+#: src/renderer/components/+workloads-cronjobs/cronjobs.tsx:59
 msgid "never"
 msgstr ""
 
-#: src/renderer/components/cluster-manager/clusters-menu.tsx:130
+#: src/renderer/components/cluster-manager/clusters-menu.tsx:133
 msgid "new"
 msgstr ""
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:64
+#: src/renderer/components/+custom-resources/crd-details.tsx:63
 msgid "plural"
 msgstr ""
 
-#: src/renderer/components/+workloads-pods/pod-details-container.tsx:41
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:17
 msgid "ready"
 msgstr "готово"
 
@@ -2986,11 +2996,11 @@ msgstr "готово"
 msgid "sec"
 msgstr "сек"
 
-#: src/renderer/components/+custom-resources/crd-details.tsx:65
+#: src/renderer/components/+custom-resources/crd-details.tsx:64
 msgid "singular"
 msgstr ""
 
-#: src/renderer/components/dock/pod-logs.tsx:159
+#: src/renderer/components/dock/pod-log-controls.tsx:72
 msgid "timestamps"
 msgstr "временные метки"
 
@@ -2998,7 +3008,7 @@ msgstr "временные метки"
 msgid "{0, plural, one {Resource} other {Resources}}"
 msgstr "{0, plural, one {Ресурс} few {Ресурсы} many {Ресурсы} other {Ресурсы}}"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:63
 msgid "{0} desired, {1} updated"
 msgstr "{0} ожидаемые, {1} обновленные"
 
@@ -3014,11 +3024,11 @@ msgstr "{0} на Подах"
 msgid "{0} on {1}"
 msgstr "{0} на {1}"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:64
 msgid "{0} total, {1} available"
 msgstr "{0} всего, {1} доступно"
 
-#: src/renderer/components/+workloads-deployments/deployment-details.tsx:66
+#: src/renderer/components/+workloads-deployments/deployment-details.tsx:65
 msgid "{0} unavailable"
 msgstr "{0} недоступно"
 
@@ -3030,7 +3040,7 @@ msgstr "{accountName} конфигурация"
 msgid "{allItemsCount, plural, one {# item} other {# items}}"
 msgstr "{allItemsCount, plural, one {# элемент} few {# элемента} many {# элементов}  other {# элементов}}"
 
-#: src/renderer/components/+config-autoscalers/hpa.tsx:31
+#: src/renderer/components/+config-autoscalers/hpa.tsx:28
 msgid "{metricsRemainCount} more..."
 msgstr "{metricsRemainCount} еще…"
 

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -39,6 +39,7 @@ export interface ClusterModel {
   preferences?: ClusterPreferences;
   metadata?: ClusterMetadata;
   ownerRef?: string;
+  accessibleNamespaces?: string[];
 
   /** @deprecated */
   kubeConfig?: string; // yaml
@@ -179,8 +180,8 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
   }
 
   @action
-  addCluster(model: ClusterModel | Cluster ): Cluster {
-    appEventBus.emit({name: "cluster", action: "add"})
+  addCluster(model: ClusterModel | Cluster): Cluster {
+    appEventBus.emit({ name: "cluster", action: "add" })
     let cluster = model as Cluster;
     if (!(model instanceof Cluster)) {
       cluster = new Cluster(model)
@@ -195,7 +196,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
 
   @action
   async removeById(clusterId: ClusterId) {
-    appEventBus.emit({name: "cluster", action: "remove"})
+    appEventBus.emit({ name: "cluster", action: "remove" })
     const cluster = this.getById(clusterId);
     if (cluster) {
       this.clusters.delete(clusterId);

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -80,7 +80,7 @@ export class Cluster implements ClusterModel, ClusterState {
   @observable metadata: ClusterMetadata = {};
   @observable allowedNamespaces: string[] = [];
   @observable allowedResources: string[] = [];
-  @observable accessibleNamespaces?: string[];
+  @observable accessibleNamespaces: string[] = [];
 
   @computed get available() {
     return this.accessible && !this.disconnected;
@@ -427,7 +427,7 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   protected async getAllowedNamespaces() {
-    if (this.accessibleNamespaces?.length) {
+    if (this.accessibleNamespaces.length) {
       return this.accessibleNamespaces
     }
 

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -80,13 +80,14 @@ export class Cluster implements ClusterModel, ClusterState {
   @observable metadata: ClusterMetadata = {};
   @observable allowedNamespaces: string[] = [];
   @observable allowedResources: string[] = [];
+  @observable accessibleNamespaces?: string[];
 
   @computed get available() {
     return this.accessible && !this.disconnected;
   }
 
   get version(): string {
-    return String(this.metadata?.version) || ""
+    return String(this.metadata?.version) || ""
   }
 
   constructor(model: ClusterModel) {
@@ -149,7 +150,7 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   @action
-  async activate(force = false ) {
+  async activate(force = false) {
     if (this.activated && !force) {
       return this.pushState();
     }
@@ -340,7 +341,7 @@ export class Cluster implements ClusterModel, ClusterState {
       for (const w of warnings) {
         if (w.involvedObject.kind === 'Pod') {
           try {
-            const pod = (await client.readNamespacedPod(w.involvedObject.name, w.involvedObject.namespace)).body;
+            const { body: pod } = await client.readNamespacedPod(w.involvedObject.name, w.involvedObject.namespace);
             logger.debug(`checking pod ${w.involvedObject.namespace}/${w.involvedObject.name}`)
             if (podHasIssues(pod)) {
               uniqEventSources.add(w.involvedObject.uid);
@@ -351,11 +352,10 @@ export class Cluster implements ClusterModel, ClusterState {
           uniqEventSources.add(w.involvedObject.uid);
         }
       }
-      let nodeNotificationCount = 0;
       const nodes = (await client.listNode()).body.items;
-      nodes.map(n => {
-        nodeNotificationCount = nodeNotificationCount + getNodeWarningConditions(n).length
-      });
+      const nodeNotificationCount = nodes
+        .map(getNodeWarningConditions)
+        .reduce((sum, conditions) => sum + conditions.length, 0);
       return uniqEventSources.size + nodeNotificationCount;
     } catch (error) {
       logger.error("Failed to fetch event count: " + JSON.stringify(error))
@@ -371,7 +371,8 @@ export class Cluster implements ClusterModel, ClusterState {
       workspace: this.workspace,
       preferences: this.preferences,
       metadata: this.metadata,
-      ownerRef: this.ownerRef
+      ownerRef: this.ownerRef,
+      accessibleNamespaces: this.accessibleNamespaces,
     };
     return toJS(model, {
       recurseEverything: true
@@ -442,7 +443,7 @@ export class Cluster implements ClusterModel, ClusterState {
     } catch (error) {
       const ctx = this.getProxyKubeconfig().getContextObject(this.contextName)
       if (ctx.namespace) return [ctx.namespace]
-      return []
+      return this.accessibleNamespaces || [];
     }
   }
 

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -427,6 +427,10 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   protected async getAllowedNamespaces() {
+    if (this.accessibleNamespaces?.length) {
+      return this.accessibleNamespaces
+    }
+
     const api = this.getProxyKubeconfig().makeApiClient(CoreV1Api)
     try {
       const namespaceList = await api.listNamespace()
@@ -443,7 +447,7 @@ export class Cluster implements ClusterModel, ClusterState {
     } catch (error) {
       const ctx = this.getProxyKubeconfig().getContextObject(this.contextName)
       if (ctx.namespace) return [ctx.namespace]
-      return this.accessibleNamespaces || [];
+      return [];
     }
   }
 

--- a/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
+++ b/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
@@ -5,6 +5,7 @@ import { SubTitle } from "../../layout/sub-title";
 import { EditableList } from "../../editable-list";
 import { observable } from "mobx";
 import { _i18n } from "../../../i18n";
+import { Trans } from "@lingui/macro";
 
 interface Props {
   cluster: Cluster;
@@ -18,7 +19,7 @@ export class ClusterAccessibleNamespaces extends React.Component<Props> {
     return (
       <>
         <SubTitle title="Accessible Namespaces" />
-        <p>This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces.</p>
+        <p><Trans>This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces.</Trans></p>
         <EditableList
           placeholder={_i18n._("Add new namespace...")}
           add={(newNamespace) => {

--- a/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
+++ b/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
@@ -17,7 +17,7 @@ export class ClusterAccessibleNamespaces extends React.Component<Props> {
   render() {
     return (
       <>
-        <SubTitle title="Cluster's Accessible Namespaces" />
+        <SubTitle title="Accessible Namespaces" />
         <p>This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces.</p>
         <EditableList
           placeholder={_i18n._("Add new namespace...")}

--- a/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
+++ b/src/renderer/components/+cluster-settings/components/cluster-accessible-namespaces.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { Cluster } from "../../../../main/cluster";
+import { SubTitle } from "../../layout/sub-title";
+import { EditableList } from "../../editable-list";
+import { observable } from "mobx";
+import { _i18n } from "../../../i18n";
+
+interface Props {
+  cluster: Cluster;
+}
+
+@observer
+export class ClusterAccessibleNamespaces extends React.Component<Props> {
+  @observable namespaces = new Set(this.props.cluster.accessibleNamespaces);
+
+  render() {
+    return (
+      <>
+        <SubTitle title="Cluster's Accessible Namespaces" />
+        <p>This setting is useful for manually specifying which namespaces you have access to. This is useful when you don't have permissions to list namespaces.</p>
+        <EditableList
+          placeholder={_i18n._("Add new namespace...")}
+          add={(newNamespace) => {
+            this.namespaces.add(newNamespace);
+            this.props.cluster.accessibleNamespaces = Array.from(this.namespaces);
+          }}
+          items={Array.from(this.namespaces)}
+          remove={({ oldItem: oldNamesapce }) => {
+            this.namespaces.delete(oldNamesapce);
+            this.props.cluster.accessibleNamespaces = Array.from(this.namespaces);
+          }}
+        />
+      </>
+    );
+  }
+}

--- a/src/renderer/components/+cluster-settings/general.tsx
+++ b/src/renderer/components/+cluster-settings/general.tsx
@@ -6,6 +6,7 @@ import { ClusterIconSetting } from "./components/cluster-icon-setting";
 import { ClusterProxySetting } from "./components/cluster-proxy-setting";
 import { ClusterPrometheusSetting } from "./components/cluster-prometheus-setting";
 import { ClusterHomeDirSetting } from "./components/cluster-home-dir-setting";
+import { ClusterAccessibleNamespaces } from "./components/cluster-accessible-namespaces";
 
 interface Props {
   cluster: Cluster;
@@ -21,6 +22,7 @@ export class General extends React.Component<Props> {
       <ClusterProxySetting cluster={this.props.cluster} />
       <ClusterPrometheusSetting cluster={this.props.cluster} />
       <ClusterHomeDirSetting cluster={this.props.cluster} />
+      <ClusterAccessibleNamespaces cluster={this.props.cluster} />
     </div>;
   }
 }

--- a/src/renderer/components/editable-list/editable-list.scss
+++ b/src/renderer/components/editable-list/editable-list.scss
@@ -1,0 +1,12 @@
+.EditableList {
+  .EditableListContents {
+    display: grid;
+    grid-template-columns: 1fr auto;
+
+    .ValueRemove {
+      .Icon {
+        justify-content: unset;
+      }
+    }
+  }
+}

--- a/src/renderer/components/editable-list/editable-list.scss
+++ b/src/renderer/components/editable-list/editable-list.scss
@@ -1,11 +1,27 @@
 .EditableList {
   .el-contents {
-    display: grid;
-    grid-template-columns: 1fr auto;
+    display: flex;
+    flex-direction: column;
+    margin-top: $padding * 2;
 
     .el-value-remove {
       .Icon {
         justify-content: unset;
+      }
+    }
+
+    .el-item {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      padding: $padding $padding * 2;
+      margin-bottom: 1px;
+
+      :last-child {
+        margin-bottom: unset;
+      }
+
+      :first-child {
+        align-self: center;
       }
     }
   }

--- a/src/renderer/components/editable-list/editable-list.scss
+++ b/src/renderer/components/editable-list/editable-list.scss
@@ -1,9 +1,9 @@
 .EditableList {
-  .EditableListContents {
+  .el-contents {
     display: grid;
     grid-template-columns: 1fr auto;
 
-    .ValueRemove {
+    .el-value-remove {
       .Icon {
         justify-content: unset;
       }

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -1,6 +1,6 @@
 import "./editable-list.scss"
 
-import React from "React";
+import React from "react";
 import { Icon } from "../icon";
 import { Input } from "../input";
 import { observable } from "mobx";

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../icon";
 import { Input } from "../input";
 import { observable } from "mobx";
 import { observer } from "mobx-react";
+import { autobind } from "../../utils";
 
 export interface Props<T> {
   items: T[],
@@ -14,37 +15,48 @@ export interface Props<T> {
 
   // An optional prop used to convert T to a displayable string
   // defaults to `String`
-  display?: (item: T) => string,
+  renderItem?: (item: T, index: number) => React.ReactNode,
+}
+
+const defaultProps: Partial<Props<any>> = {
+  placeholder: "Add new item...",
+  renderItem: (item: any, index: number) => <React.Fragment key={index}>{item}</React.Fragment>
 }
 
 @observer
 export class EditableList<T> extends React.Component<Props<T>> {
+  static defaultProps = defaultProps as Props<any>;
   @observable currentNewItem = "";
 
+  @autobind()
+  onSubmit(val: string) {
+    const { add } = this.props
+
+    if (val) {
+      add(val)
+      this.currentNewItem = ""
+    }
+  }
+
   render() {
-    const { items, add, remove, display = String, placeholder = "Add new item..." } = this.props;
+    const { items, remove, renderItem, placeholder } = this.props;
 
     return (
       <div className="EditableList">
-        <div className="EditableListHeader">
+        <div className="el-header">
           <Input
             value={this.currentNewItem}
-            onSubmit={val => {
-              if (val) {
-                add(val);
-              }
-              this.currentNewItem = "";
-            }}
+            onSubmit={this.onSubmit}
             placeholder={placeholder}
             onChange={val => this.currentNewItem = val}
           />
         </div>
-        <div className="EditableListContents">
+        <div className="el-contents">
           {
             items
               .map((item, index) => [
-                <span key={`${item}-value`}>{display(item)}</span>,
-                <div key={`${item}-remove`} className="ValueRemove">
+                <span key={`${item}-value`}>{renderItem(item, index)}</span>,
+                <div key={`${item}-remove`} className="el-value-remove">
                   <Icon material="delete_outline" onClick={() => remove(({ index, oldItem: item }))} />
                 </div>
               ])

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -45,6 +45,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
       <div className="EditableList">
         <div className="el-header">
           <Input
+            theme="round-black"
             value={this.currentNewItem}
             onSubmit={this.onSubmit}
             placeholder={placeholder}
@@ -53,14 +54,14 @@ export class EditableList<T> extends React.Component<Props<T>> {
         </div>
         <div className="el-contents">
           {
-            items
-              .map((item, index) => [
-                <div key={`${index}-value`}>{renderItem(item, index)}</div>,
-                <div key={`${index}-remove`} className="el-value-remove">
+            items.map((item, index) => (
+              <div key={item + `${index}`} className="el-item Badge">
+                <div>{renderItem(item, index)}</div>
+                <div className="el-value-remove">
                   <Icon material="delete_outline" onClick={() => remove(({ index, oldItem: item }))} />
                 </div>
-              ])
-              .flat()
+              </div>
+            ))
           }
         </div>
       </div>

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -55,8 +55,8 @@ export class EditableList<T> extends React.Component<Props<T>> {
           {
             items
               .map((item, index) => [
-                <span key={`${item}-value`}>{renderItem(item, index)}</span>,
-                <div key={`${item}-remove`} className="el-value-remove">
+                <div key={`${index}-value`}>{renderItem(item, index)}</div>,
+                <div key={`${index}-remove`} className="el-value-remove">
                   <Icon material="delete_outline" onClick={() => remove(({ index, oldItem: item }))} />
                 </div>
               ])

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -1,0 +1,57 @@
+import "./editable-list.scss"
+
+import React from "React";
+import { Icon } from "../icon";
+import { Input } from "../input";
+import { observable } from "mobx";
+import { observer } from "mobx-react";
+
+export interface Props<T> {
+  items: T[],
+  add: (newItem: string) => void,
+  remove: (info: { oldItem: T, index: number }) => void,
+  placeholder?: string,
+
+  // An optional prop used to convert T to a displayable string
+  // defaults to `String`
+  display?: (item: T) => string,
+}
+
+@observer
+export class EditableList<T> extends React.Component<Props<T>> {
+  @observable currentNewItem = "";
+
+  render() {
+    const { items, add, remove, display = String, placeholder = "Add new item..." } = this.props;
+
+    return (
+      <div className="EditableList">
+        <div className="EditableListHeader">
+          <Input
+            value={this.currentNewItem}
+            onSubmit={val => {
+              if (val) {
+                add(val);
+              }
+              this.currentNewItem = "";
+            }}
+            placeholder={placeholder}
+            onChange={val => this.currentNewItem = val}
+          />
+        </div>
+        <div className="EditableListContents">
+          {
+            items
+              .map((item, index) => [
+                <span key={`${item}-value`}>{display(item)}</span>,
+                <div key={`${item}-remove`} className="ValueRemove">
+                  <Icon material="delete_outline" onClick={() => remove(({ index, oldItem: item }))} />
+                </div>
+              ])
+              .flat()
+          }
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -6,6 +6,7 @@ import { Input } from "../input";
 import { observable } from "mobx";
 import { observer } from "mobx-react";
 import { autobind } from "../../utils";
+import { _i18n } from "../../i18n";
 
 export interface Props<T> {
   items: T[],
@@ -19,7 +20,7 @@ export interface Props<T> {
 }
 
 const defaultProps: Partial<Props<any>> = {
-  placeholder: "Add new item...",
+  placeholder: _i18n._("Add new item..."),
   renderItem: (item: any, index: number) => <React.Fragment key={index}>{item}</React.Fragment>
 }
 

--- a/src/renderer/components/editable-list/index.ts
+++ b/src/renderer/components/editable-list/index.ts
@@ -1,0 +1,1 @@
+export * from "./editable-list"


### PR DESCRIPTION
The namespaces which are accessible to them. This is generally useful for when the user doesn't have permission to list the namespaces.

- Add new component "EditableList" which provides a simple way to
  display a list of items that can be added too.

- Add the ClusterAccessibleNamespaces to the GeneralClusterSettings

Signed-off-by: Sebastian Malton <smalton@mirantis.com>

closes #486 

~~This is a draft PR because it should be targeting `master` but `vue_react_migration` hasn't been merged to master yet.~~