### PR TITLE
Update CRD api to use preferred version and implement v1 differences

### DIFF
--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -11,7 +11,7 @@ const fileOptions: winston.transports.FileTransportOptions = {
   handleExceptions: false,
   level: isDebugging ? "debug" : "info",
   filename: "lens.log",
-  dirname: (app || remote.app).getPath("logs"),
+  dirname: (app ?? remote?.app)?.getPath("logs"),
   maxsize: 16 * 1024,
   maxFiles: 16,
   tailable: true,

--- a/src/renderer/api/kube-api-versioned.ts
+++ b/src/renderer/api/kube-api-versioned.ts
@@ -1,0 +1,37 @@
+import { stringify } from "querystring";
+import { KubeObject } from "./kube-object";
+import { createKubeApiURL } from "./kube-api-parse";
+import { KubeApi, IKubeApiQueryParams } from "./kube-api";
+
+export class VersionedKubeApi<T extends KubeObject = any> extends KubeApi<T> {
+  private preferredVersion?: string;
+
+  async getPreferredVersion() {
+    if (this.preferredVersion) return;
+
+    const apiGroupVersion = await this.request.get<{ preferredVersion: { version: string; }; }>(`${this.apiPrefix}/${this.apiGroup}`);
+    this.preferredVersion = apiGroupVersion.preferredVersion.version;
+  }
+
+  async list({ namespace = "" } = {}, query?: IKubeApiQueryParams): Promise<T[]> {
+    await this.getPreferredVersion();
+    return await super.list({namespace}, query);
+  }
+  async get({ name = "", namespace = "default" } = {}, query?: IKubeApiQueryParams): Promise<T> {
+    await this.getPreferredVersion();
+    return super.get({ name, namespace }, query);
+  }
+
+  getUrl({ name = "", namespace = "" } = {}, query?: Partial<IKubeApiQueryParams>) {
+    const { apiPrefix, apiGroup, apiVersion, apiResource, preferredVersion, isNamespaced } = this;
+
+    const resourcePath = createKubeApiURL({
+      apiPrefix: apiPrefix,
+      apiVersion: `${apiGroup}/${preferredVersion ?? apiVersion}`,
+      resource: apiResource,
+      namespace: isNamespaced ? namespace : undefined,
+      name: name,
+    });
+    return resourcePath + (query ? `?` + stringify(query) : "");
+  }
+}

--- a/src/renderer/api/kube-api-versioned.ts
+++ b/src/renderer/api/kube-api-versioned.ts
@@ -1,16 +1,35 @@
 import { stringify } from "querystring";
 import { KubeObject } from "./kube-object";
 import { createKubeApiURL } from "./kube-api-parse";
-import { KubeApi, IKubeApiQueryParams } from "./kube-api";
+import { KubeApi, IKubeApiQueryParams, IKubeApiOptions } from "./kube-api";
+import { apiManager } from "./api-manager";
 
 export class VersionedKubeApi<T extends KubeObject = any> extends KubeApi<T> {
   private preferredVersion?: string;
 
+  constructor(opts: IKubeApiOptions<T>) {
+    super(opts);
+
+    this.getPreferredVersion().then(() => {
+      if (this.apiBase != opts.apiBase)
+        apiManager.registerApi(this.apiBase, this);
+    });
+  }
+
+  // override this property to make read-write
+  apiBase: string
+
   async getPreferredVersion() {
     if (this.preferredVersion) return;
 
-    const apiGroupVersion = await this.request.get<{ preferredVersion: { version: string; }; }>(`${this.apiPrefix}/${this.apiGroup}`);
+    const apiGroupVersion = await this.request.get<{ preferredVersion?: { version: string; }; }>(`${this.apiPrefix}/${this.apiGroup}`);
+    
+    if (!apiGroupVersion?.preferredVersion) return;
+
     this.preferredVersion = apiGroupVersion.preferredVersion.version;
+
+    // update apiBase
+    this.apiBase = this.getUrl();
   }
 
   async list({ namespace = "" } = {}, query?: IKubeApiQueryParams): Promise<T[]> {

--- a/src/renderer/components/+custom-resources/crd-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-details.tsx
@@ -102,13 +102,13 @@ export class CRDDetails extends React.Component<Props> {
             </TableHead>
             {
               printerColumns.map((column, index) => {
-                const { name, type, JSONPath } = column;
+                const { name, type, jsonPath } = column;
                 return (
                   <TableRow key={index}>
                     <TableCell className="name">{name}</TableCell>
                     <TableCell className="type">{type}</TableCell>
                     <TableCell className="json-path">
-                      <Badge label={JSONPath}/>
+                      <Badge label={jsonPath}/>
                     </TableCell>
                   </TableRow>
                 )

--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -57,7 +57,7 @@ export class CrdResourceDetails extends React.Component<Props> {
         <KubeObjectMeta object={object}/>
         {extraColumns.map(column => {
           const { name } = column;
-          const value = jsonPath.query(object, column.JSONPath.slice(1));
+          const value = jsonPath.query(object, (column.jsonPath).slice(1));
           return (
             <DrawerItem key={name} name={name}>
               <CrdColumnValue value={value} />

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -57,7 +57,7 @@ export class CrdResources extends React.Component<Props> {
       [sortBy.age]: (item: KubeObject) => item.metadata.creationTimestamp,
     }
     extraColumns.forEach(column => {
-      sortingCallbacks[column.name] = (item: KubeObject) => jsonPath.query(item, column.JSONPath.slice(1))
+      sortingCallbacks[column.name] = (item: KubeObject) => jsonPath.query(item, column.jsonPath.slice(1))
     })
     // todo: merge extra columns and other params to predefined view
     const { List } = apiManager.getViews(crd.getResourceApiBase());
@@ -88,9 +88,9 @@ export class CrdResources extends React.Component<Props> {
         renderTableContents={(crdInstance: KubeObject) => [
           crdInstance.getName(),
           isNamespaced && crdInstance.getNs(),
-          ...extraColumns.map(column =>
-            jsonPath.query(crdInstance, column.JSONPath.slice(1))
-          ),
+          ...extraColumns.map(column => {
+            return jsonPath.query(crdInstance, (column.jsonPath).slice(1))
+          }),
           crdInstance.getAge(),
         ]}
         renderItemMenu={(item: KubeObject) => {


### PR DESCRIPTION
While attempting to test #693 on master I was not getting any results for the CRD list. According to this doc the version property is now deprecated and optional, therefore we need to search in the versions array to get a version. I'm not sure if we should pick the `served` version or the first of the array.

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#specify-multiple-versions

Note this did have my CRD appear but when I clicked on it the popup was blank. I am assuming this is because of ongoing refactoring work. Also on an older cluster that didn't support the v1 CRD's yet, got 404's.

The additional printer column definition also has changed

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#additional-printer-columns

The key difference is it is now in the version object and the case of the property changed from `JSONPath` to `jsonPath`

Fixes #726 