### PR TITLE
Adding menu accelerators for basic actions

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -67,6 +67,7 @@ export function buildMenu(windowManager: WindowManager) {
       { type: 'separator' },
       {
         label: 'Preferences',
+        accelerator: 'Cmd+,',
         click() {
           navigate(preferencesURL())
         }
@@ -91,6 +92,7 @@ export function buildMenu(windowManager: WindowManager) {
     submenu: [
       {
         label: 'Add Cluster',
+        accelerator: 'CmdOrCtrl+Shift+A',
         click() {
           navigate(addClusterURL())
         }
@@ -98,6 +100,7 @@ export function buildMenu(windowManager: WindowManager) {
       ...activeClusterOnly([
         {
           label: 'Cluster Settings',
+          accelerator: 'CmdOrCtrl+Shift+S',
           click() {
             navigate(clusterSettingsURL({
               params: {
@@ -111,6 +114,7 @@ export function buildMenu(windowManager: WindowManager) {
         { type: 'separator' },
         {
           label: 'Preferences',
+          accelerator: 'Ctrl+,',
           click() {
             navigate(preferencesURL())
           }


### PR DESCRIPTION
Adding keyboard menu accelerators for Preferences (`CmdOrCtrl+,`), Cluster Settings (`CmdOrCtrl+Shift+S`) and Add Cluster (`CmdOrCtrl+Shift+A`) pages.

![file menu](https://user-images.githubusercontent.com/9607060/90893945-886c8880-e3c8-11ea-8818-30431093d6b5.png)
![mac menu](https://user-images.githubusercontent.com/9607060/90893952-8acee280-e3c8-11ea-8f53-d19775bd946e.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>