### PR TITLE
Increase timeout when doing port-forward through tcpPortUsed.waitUntilUsed

### DIFF
--- a/src/main/routes/port-forward-route.ts
+++ b/src/main/routes/port-forward-route.ts
@@ -57,7 +57,7 @@ class PortForward {
       }
     })
     try {
-      await tcpPortUsed.waitUntilUsed(this.localPort, 500, 3000)
+      await tcpPortUsed.waitUntilUsed(this.localPort, 500, 15000)
       return true
     } catch (error) {
       this.process.kill()


### PR DESCRIPTION
Fix for  #634
set max timeout to 15 seconds to prevent failed opening of local port
This is an issue on mac binaries, simple solution is to bump up to 15 seconds.
Otherwise you have to click port forward again.