### PR TITLE
Fixing minor light theme issues

### DIFF
--- a/src/renderer/components/+landing-page/landing-page.scss
+++ b/src/renderer/components/+landing-page/landing-page.scss
@@ -1,8 +1,24 @@
 .LandingPage {
   height: 100%;
-  background: #282b2f url(../../components/icon/crane.svg) no-repeat;
-  background-position: 0 35%;
-  background-size: 85%;
-  background-clip: content-box;
   text-align: center;
+  z-index: 0;
+
+  &::after {
+    content: "";
+    background: url(../../components/icon/crane.svg) no-repeat;
+    background-position: 0 35%;
+    background-size: 85%;
+    background-clip: content-box;
+    opacity: 1;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    position: absolute;
+    z-index: -1;
+
+    .theme-light & {
+      opacity: 0.2;
+    }
+  }
 }

--- a/src/renderer/components/+workloads-cronjobs/cronjob-trigger-dialog.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjob-trigger-dialog.tsx
@@ -97,7 +97,6 @@ export class CronJobTriggerDialog extends Component<Props> {
   render() {
     const { className, ...dialogProps } = this.props;
     const cronjobName = this.cronjob ? this.cronjob.getName() : "";
-    console.log(cronjobName);
     const header = (
       <h5>
         <Trans>Trigger CronJob <span>{cronjobName}</span></Trans>

--- a/src/renderer/components/chart/chart.tsx
+++ b/src/renderer/components/chart/chart.tsx
@@ -63,14 +63,14 @@ export class Chart extends React.Component<ChartProps> {
     this.renderChart()
   }
 
-  componentDidUpdate(prevProps: ChartProps) {
-    const { data, showChart, redraw } = this.props
+  componentDidUpdate() {
+    const { showChart, redraw } = this.props
     if (redraw) {
       this.chart.destroy()
       this.renderChart()
       return
     }
-    if (!isEqual(prevProps.data, data) && showChart) {
+    if (showChart) {
       if (!this.chart) this.renderChart()
       else this.updateChart()
     }

--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -1,5 +1,4 @@
 .ClustersMenu {
-  @include hidden-scrollbar;
   $spacing: $padding * 2;
 
   position: relative;
@@ -23,8 +22,7 @@
     padding: $spacing;
     width: 320px;
     background: $bgc;
-    z-index: 100;
-    color: white;
+    color: $textColorAccent;
     filter: drop-shadow(0 0px 2px #ffffff33);
     pointer-events: none;
 
@@ -38,6 +36,19 @@
       border-right: $arrowSize solid $bgc;
       right: 100%;
     }
+
+    .theme-light & {
+      filter: drop-shadow(0 0px 2px #777);
+      background: white;
+
+      &:before {
+        border-right-color: white;
+      }
+    }
+  }
+
+  .clusters {
+    @include hidden-scrollbar;
   }
 
   > .add-cluster {

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -110,18 +110,20 @@ export class ClustersMenu extends React.Component<Props> {
             </p>
           </div>
         )}
-        {clusters.map(cluster => {
-          return (
-            <ClusterIcon
-              key={cluster.id}
-              showErrors={true}
-              cluster={cluster}
-              isActive={cluster.id === getMatchedClusterId()}
-              onClick={() => this.showCluster(cluster.id)}
-              onContextMenu={() => this.showContextMenu(cluster)}
-            />
-          )
-        })}
+        <div className="clusters flex column gaps">
+          {clusters.map(cluster => {
+            return (
+              <ClusterIcon
+                key={cluster.id}
+                showErrors={true}
+                cluster={cluster}
+                isActive={cluster.id === getMatchedClusterId()}
+                onClick={() => this.showCluster(cluster.id)}
+                onContextMenu={() => this.showContextMenu(cluster)}
+              />
+            )
+          })}
+        </div>
         <div className="add-cluster" onClick={this.addCluster}>
           <Tooltip targetId="add-cluster-icon">
             <Trans>Add Cluster</Trans>


### PR DESCRIPTION
* Fixing light theme appearance at Landing page
* Updating chart options when passing new one
* Fixing Cluster Menu scroll behavior and tooltip

Moved cluster icons to their own block while keeping `Add Cluster` button always visible.
Before:
![Aug-25-2020 16-35-40](https://user-images.githubusercontent.com/9607060/91182042-54f46b80-e6f2-11ea-9330-7d77d3f3ec9c.gif)

After:
![Aug-25-2020 16-35-52](https://user-images.githubusercontent.com/9607060/91182054-5887f280-e6f2-11ea-8bd2-705bc3856916.gif)

Switching theme in `Landing Page`
![Aug-25-2020 16-36-00](https://user-images.githubusercontent.com/9607060/91182018-4c9c3080-e6f2-11ea-86ff-6c52443cfa3d.gif)
