### PR TITLE
Wait until cluster is ready before initializing cluster dashboard

### DIFF
--- a/integration/specs/app_spec.ts
+++ b/integration/specs/app_spec.ts
@@ -1,7 +1,6 @@
 import { Application } from "spectron"
 import * as util from "../helpers/utils"
 import { spawnSync } from "child_process"
-import logger from "../../src/main/logger"
 
 jest.setTimeout(20000)
 
@@ -27,7 +26,6 @@ describe("app start", () => {
   const waitForMinikubeDashboard = async (app: Application) => {
     await app.client.waitUntilTextExists("pre.kube-auth-out", "Authentication proxy started")
     let windowCount = await app.client.getWindowCount()
-    logger.info("Window count: "+windowCount)
     await app.client.waitForExist(`iframe[name="minikube"]`)
     await app.client.frame("minikube")
     await app.client.waitUntilTextExists("span.link-text", "Cluster")

--- a/integration/specs/app_spec.ts
+++ b/integration/specs/app_spec.ts
@@ -69,7 +69,6 @@ describe("app start", () => {
     await clickWhatsNew(app)
     await addMinikubeCluster(app)
     await waitForMinikubeDashboard(app)
-    await app.client.click('a[href="/nodes"]')
     await app.client.click(".sidebar-nav #workloads span.link-text")
     await app.client.waitUntilTextExists('a[href="/pods"]', "Pods")
     await app.client.click('a[href="/pods"]')

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -27,6 +27,7 @@ export interface ClusterState extends ClusterModel {
   online: boolean;
   disconnected: boolean;
   accessible: boolean;
+  ready: boolean;
   failureReason: string;
   nodes: number;
   eventCount: number;
@@ -47,6 +48,7 @@ export class Cluster implements ClusterModel {
   protected eventDisposers: Function[] = [];
 
   whenInitialized = when(() => this.initialized);
+  whenReady = when(() => this.ready);
 
   @observable initialized = false;
   @observable contextName: string;
@@ -56,6 +58,7 @@ export class Cluster implements ClusterModel {
   @observable kubeProxyUrl: string; // lens-proxy to kube-api url
   @observable online: boolean;
   @observable accessible: boolean;
+  @observable ready: boolean;
   @observable disconnected: boolean;
   @observable failureReason: string;
   @observable nodes = 0;
@@ -149,6 +152,7 @@ export class Cluster implements ClusterModel {
     this.disconnected = true;
     this.online = false;
     this.accessible = false;
+    this.ready = false;
     this.pushState();
   }
 
@@ -172,6 +176,7 @@ export class Cluster implements ClusterModel {
         this.refreshEvents(),
         this.refreshAllowedResources(),
       ]);
+      this.ready = true
     }
   }
 
@@ -370,6 +375,7 @@ export class Cluster implements ClusterModel {
       initialized: this.initialized,
       apiUrl: this.apiUrl,
       online: this.online,
+      ready: this.ready,
       disconnected: this.disconnected,
       accessible: this.accessible,
       failureReason: this.failureReason,

--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -21,10 +21,10 @@ export async function initView(clusterId: ClusterId) {
   }
   logger.info(`[LENS-VIEW]: init dashboard, clusterId=${clusterId}`)
   const cluster = clusterStore.getById(clusterId);
-  await cluster.whenInitialized;
+  await cluster.whenReady;
   const parentElem = document.getElementById("lens-views");
   const iframe = document.createElement("iframe");
-  iframe.name = cluster.preferences.clusterName;
+  iframe.name = cluster.contextName;
   iframe.setAttribute("src", `//${clusterId}.${location.host}`)
   iframe.addEventListener("load", async () => {
     logger.info(`[LENS-VIEW]: loaded from ${iframe.src}`)


### PR DESCRIPTION
Previously cluster dashboard was opened right after the state was received first time. This PR will wait until cluster is ready after the first refresh.