### PR TITLE
Display path to cluster's kubeconfig file in cluster settings

### DIFF
--- a/src/renderer/components/+cluster-settings/cluster-settings.scss
+++ b/src/renderer/components/+cluster-settings/cluster-settings.scss
@@ -66,6 +66,10 @@
             word-break: break-word;
             color: var(--textColorSecondary);
           }
+
+          .link {
+            @include pseudo-link;
+          }
         }
       }
     }

--- a/src/renderer/components/+cluster-settings/status.tsx
+++ b/src/renderer/components/+cluster-settings/status.tsx
@@ -36,9 +36,9 @@ export class Status extends React.Component<Props> {
             </TableRow>
           );
         })}
-        <TableRow key="kubeconfig">
+        <TableRow>
           <TableCell>Kubeconfig</TableCell>
-          <TableCell className="value" onClick={this.openKubeconfig}><a>{cluster.kubeConfigPath}</a></TableCell>
+          <TableCell className="link value" onClick={this.openKubeconfig}>{cluster.kubeConfigPath}</TableCell>
         </TableRow>
       </Table>
     );

--- a/src/renderer/components/+cluster-settings/status.tsx
+++ b/src/renderer/components/+cluster-settings/status.tsx
@@ -2,12 +2,21 @@ import React from "react";
 import { Cluster } from "../../../main/cluster";
 import { SubTitle } from "../layout/sub-title";
 import { Table, TableCell, TableRow } from "../table";
+import { autobind } from "../../utils";
+import { shell } from "electron";
 
 interface Props {
   cluster: Cluster;
 }
 
 export class Status extends React.Component<Props> {
+
+  @autobind()
+  openKubeconfig() {
+    const { cluster } = this.props;
+    shell.showItemInFolder(cluster.kubeConfigPath)
+  }
+
   renderStatusRows() {
     const { cluster } = this.props;
     const rows = [
@@ -27,6 +36,10 @@ export class Status extends React.Component<Props> {
             </TableRow>
           );
         })}
+        <TableRow key="kubeconfig">
+          <TableCell>Kubeconfig</TableCell>
+          <TableCell className="value" onClick={this.openKubeconfig}><a>{cluster.kubeConfigPath}</a></TableCell>
+        </TableRow>
       </Table>
     );
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/455844/91411629-45d7ff80-e851-11ea-8ff1-04808b3b27ba.png)

When clicking Kubeconfig link, file explorer will be opened.

Fixes #741 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>