### PR TITLE
Release v3.6.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-dev",
+  "version": "3.6.0-beta.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ Here you can find description of changes we've built into each release. While we
 - Allow to remove clusters from right click
 - Allow to trigger cronjobs
 - Show devtools in menu
-- Open last opened workspace as default
+- Open last active cluster as default
 - Fix format duration rounding days error
 - Handle unsupported resources properly after they've been created from editor
 - Fix CRD api parsing

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,34 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.5.3 (current version)
+## 3.6.0-beta.1 (current version)
+- Allow user to select Kubeconfig from filesystem
+- Handle Kubeconfig file as file references
+- Show the path of the cluster's Kubeconfig in cluster settings
+- Add support for PodDisruptionBudgets
+- Add port-forwarding for containers in pod
+- Add shortcut keys to menu items
+- Improve light theme support
+- Show GKE ingress IP
+- Allow to remove clusters from right click
+- Allow to trigger cronjobs
+- Show devtools in menu
+- Open last opened workspace as default
+- Fix format duration rounding days error
+- Handle unsupported resources properly after they've been created from editor
+- Fix CRD api parsing
+- Fix: allow to edit Endpoint resources
+- Fix: handle status values that contains an object
+- Fix: incorrect path to install/uninstall feature
+- Fix: increase timeout when doing port-forward
+- Fix: change manifests order for Metrics feature
+- Fix: Master donut graph for memory usage only appears to show one master
+- Fix: Error during creation of Kubernetes secret
+- Fix: Show age of resource in seconds
+- Fix: Node shell pods are pending
+- Fix: Wrong created time in resource details
+
+## 3.5.3
 - Updated [EULA](https://k8slens.dev/licenses/eula.md)
 
 ## 3.5.2

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ Here you can find description of changes we've built into each release. While we
 
 ## 3.6.0-beta.1 (current version)
 - Allow user to select Kubeconfig from filesystem
-- Handle Kubeconfig file as file references
+- Store reference to added Kubeconfig files
 - Show the path of the cluster's Kubeconfig in cluster settings
 - Add support for PodDisruptionBudgets
 - Add port-forwarding for containers in pod


### PR DESCRIPTION
## Changes since v3.5.3

- Add support for PodDisruptionBudgets (#452)
- Kubeconfigs as file references (#466)
- Remove redundant applyHeaders method (#469)
- adding port-forward for containers in pods (#528)
- Lens restructure (#540)
- Use LensDev on development environment (557)
- Show devtools always in menu (#559)
- fix format duration rounding days error (#582)
- Handle unknown resources properly after they've been created in editor (#617)
- Fix CRD api parsing (#622)
- Fix Resource Quota Rendering (#624)
- Use the Kubernetes regex for matching system names (#659)
- fix: 🐛 Change kind to "Endpoints" in renderer (#672)
- add cluster icon migration code (#673)
- Added load-balancer hostname/IP to ingress details (#675)
- Handle status values that contains an object (#693)
- Add cronjob trigger (#694)
- Fix: incorrect path to install/uninstall feature (#723)
- Fix: sync in sub-frames for common-stores are broken (#724)
- Adding menu accelerators for basic actions (#729)
- Increase timeout when doing port-forward through tcpPortUsed.waitUntilUsed (#732)
- Allow user to select Kubeconfig from filesystem (#740)
- Fixing minor light theme issues (#744)
- Fix manifests order for Metrics feature(#752)
- Use proxy kubeconfig for shell and resource applier (#754)
- Remove cluster view on cluster remove (#758)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>