### PR TITLE
Allow to override logger for LensBinary

### DIFF
--- a/src/main/helm/helm-repo-manager.ts
+++ b/src/main/helm/helm-repo-manager.ts
@@ -46,6 +46,7 @@ export class HelmRepoManager extends Singleton {
   }
 
   async init() {
+    helmCli.setLogger(logger)
     await helmCli.ensureBinary();
     if (!this.initialized) {
       this.helmEnv = await this.parseHelmEnv()


### PR DESCRIPTION
Noticed while testing #481 that `LensBinary` uses `logger` instance when running `yarn download:helm`. That will cause issues since `Electron.app` is undefined at that point. This PR will change to use `console` by default, but it can be overridden if needed.


Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>