### PR TITLE
Bump versions of bundled binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "rebuild-pty": "yarn run electron-rebuild -f -w node-pty"
   },
   "config": {
-    "bundledKubectlVersion": "1.17.4",
-    "bundledHelmVersion": "3.2.4"
+    "bundledKubectlVersion": "1.17.11",
+    "bundledHelmVersion": "3.3.1"
   },
   "engines": {
     "node": ">=12.0 <13.0"


### PR DESCRIPTION
This PR bumps bundled `kubectl` version to `1.17.11` and `helm` to `3.3.1`.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>