### PR TITLE
Release v3.6.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-beta.1",
+  "version": "3.6.0-beta.2",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,12 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0-beta.1 (current version)
+## 3.6.0-beta.2 (current version)
+- Fix: too narrow sidebar without clusters
+- Fix app crash when iterating Events without 'kind' property defined
+- Detect non-functional bundled kubectl
+
+## 3.6.0-beta.1
 - Allow user to select Kubeconfig from filesystem
 - Store reference to added Kubeconfig files
 - Show the path of the cluster's Kubeconfig in cluster settings


### PR DESCRIPTION
## Changes since v3.6.0-beta.1

- Fix: cluster-menu spacing, incorrect cluster-view after switching workspace (#765)
- Fix integration tests (#767)
- Change owner of minikube config files to $USER (#681)
- Fixing app crash when iterating Events without 'kind' prop defined (#743)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>