### PR TITLE
Adding margin to last cluster menu icon

### DIFF
--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -18,6 +18,10 @@
     padding: 0 $spacing; // extra spacing for cluster-icon's badge
     margin-bottom: $spacing;
 
+    > :last-child {
+      margin-bottom: $margin;
+    }
+
     &:empty {
       display: none;
     }


### PR DESCRIPTION
Before:
<img width="551" alt="Screenshot 2020-09-02 at 09 25 36" src="https://user-images.githubusercontent.com/9607060/91940075-8fb46000-ecff-11ea-916c-e707b6962c05.png">
After:
<img width="489" alt="Screenshot 2020-09-02 at 09 30 34" src="https://user-images.githubusercontent.com/9607060/91940099-9b078b80-ecff-11ea-9bc8-4950d352d046.png">
<img width="493" alt="Screenshot 2020-09-02 at 09 29 03" src="https://user-images.githubusercontent.com/9607060/91940102-9ba02200-ecff-11ea-8c87-e77d607f7cca.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>