### PR TITLE
Try to reconnect non-accessible clusters on activate

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -130,7 +130,7 @@ export class Cluster implements ClusterModel {
     if (!this.eventDisposers.length) {
       this.bindEvents();
     }
-    if (this.disconnected) {
+    if (this.disconnected || !this.accessible) {
       await this.reconnect();
     }
     await this.refresh();


### PR DESCRIPTION
This PR will do reconnect the cluster on activate when user does not have access to the cluster, for example token is not valid anymore. 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>