### PR TITLE
Removing webpack warnings on build

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,8 +1,9 @@
-import { ClusterId, clusterStore } from "../common/cluster-store";
+import { clusterStore } from "../common/cluster-store";
 import { BrowserWindow, dialog, ipcMain, shell, webContents } from "electron"
 import windowStateKeeper from "electron-window-state"
 import { observable } from "mobx";
 import { initMenu } from "./menu";
+import type { ClusterId } from "../common/cluster-store";
 
 export class WindowManager {
   protected mainView: BrowserWindow;


### PR DESCRIPTION
Removing annoying build warnings by using typescript 3.8 `import type` statement.

Reference https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html

![Screenshot 2020-09-02 at 16 19 17](https://user-images.githubusercontent.com/9607060/91988550-0ff6b780-ed38-11ea-8dea-c1940598a8a2.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>