### PR TITLE
Change order of init for fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 .PHONY: init dev build test clean
 
-init: download-bins install-deps compile-dev
+init: install-deps download-bins compile-dev
 	echo "Init done"
 
 download-bins:


### PR DESCRIPTION
I did a fresh clone and the `make init` failed. This was because the second step is to `yarn`, however the first step depends on some packages being installed, specifically `concurrently` and `ts-node`. It is fine if these are installed globally, however given `init` is supposed to bootstrap everything I feel this change is warranted.