### PR TITLE
Download binaries before building the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ integration-win:
 test-app:
 	yarn test
 
-build: install-deps
+build: install-deps download-bins
 	yarn install
 ifeq "$(DETECTED_OS)" "Windows"
 	yarn dist:win


### PR DESCRIPTION
Downloading binaries got lost during the refactoring. This PR will add it back.


Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>