### PR TITLE
Allow user to configure kubectl binary preferences

### DIFF
--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -1,4 +1,5 @@
 import type { ThemeId } from "../renderer/theme.store";
+import { app, remote } from 'electron';
 import semver from "semver"
 import { readFile } from "fs-extra"
 import { action, observable, reaction, toJS } from "mobx";
@@ -8,6 +9,7 @@ import { getAppVersion } from "./utils/app-version";
 import { kubeConfigDefaultPath, loadConfig } from "./kube-helpers";
 import { tracker } from "./tracker";
 import logger from "../main/logger";
+import path from 'path';
 
 export interface UserStoreModel {
   kubeConfigPath: string;
@@ -22,6 +24,9 @@ export interface UserPreferences {
   allowUntrustedCAs?: boolean;
   allowTelemetry?: boolean;
   downloadMirror?: string | "default";
+  downloadKubectlBinaries?: boolean;
+  downloadBinariesPath?: string;
+  kubectlBinariesPath?: string;
 }
 
 export class UserStore extends BaseStore<UserStoreModel> {
@@ -53,6 +58,9 @@ export class UserStore extends BaseStore<UserStoreModel> {
     allowUntrustedCAs: false,
     colorTheme: UserStore.defaultTheme,
     downloadMirror: "default",
+    downloadKubectlBinaries: true,  // Download kubectl binaries matching cluster version
+    downloadBinariesPath: "",
+    kubectlBinariesPath: "$PATH/kubectl"
   };
 
   get isNewVersion() {
@@ -96,6 +104,14 @@ export class UserStore extends BaseStore<UserStoreModel> {
     const { seenContexts, newContexts } = this;
     this.seenContexts.replace([...seenContexts, ...newContexts]);
     this.newContexts.clear();
+  }
+
+  /**
+   * Getting default directory to download kubectl binaries
+   * @returns string
+   */
+  getDefaultKubectlPath(): string {
+    return path.join((app || remote.app).getPath("userData"), "binaries")
   }
 
   @action

--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -59,8 +59,8 @@ export class UserStore extends BaseStore<UserStoreModel> {
     colorTheme: UserStore.defaultTheme,
     downloadMirror: "default",
     downloadKubectlBinaries: true,  // Download kubectl binaries matching cluster version
-    downloadBinariesPath: "",
-    kubectlBinariesPath: "$PATH/kubectl"
+    downloadBinariesPath: this.getDefaultKubectlPath(),
+    kubectlBinariesPath: ""
   };
 
   get isNewVersion() {

--- a/src/main/kubectl.ts
+++ b/src/main/kubectl.ts
@@ -261,22 +261,6 @@ export class Kubectl {
     })
   }
 
-  protected async scriptIsLatest(scriptPath: string) {
-    const scriptExists = await pathExists(scriptPath)
-    if (!scriptExists) return false
-
-    try {
-      const filehandle = await fs.promises.open(scriptPath, 'r')
-      const buffer = Buffer.alloc(40)
-      await filehandle.read(buffer, 0, 40, 0)
-      await filehandle.close()
-      return buffer.toString().startsWith(initScriptVersionString)
-    } catch (err) {
-      logger.error(err)
-      return false
-    }
-  }
-
   protected async writeInitScripts() {
     const kubectlPath = userStore.preferences?.downloadKubectlBinaries ? this.dirname : path.dirname(this.getPathFromPreferences())
     const helmPath = helmCli.getBinaryDir()

--- a/src/main/kubectl.ts
+++ b/src/main/kubectl.ts
@@ -97,7 +97,7 @@ export class Kubectl {
 
     this.url = `${this.getDownloadMirror()}/v${this.kubectlVersion}/bin/${platformName}/${arch}/${binaryName}`
 
-    this.dirname = path.normalize(path.join(Kubectl.kubectlDir, this.kubectlVersion))
+    this.dirname = path.normalize(path.join(this.getDownloadDir(), this.kubectlVersion))
     this.path = path.join(this.dirname, binaryName)
   }
 
@@ -105,7 +105,19 @@ export class Kubectl {
     return Kubectl.bundledKubectlPath
   }
 
+  public getPathFromPreferences() {
+    return userStore.preferences.kubectlBinariesPath || this.getBundledPath()
+  }
+
+  protected getDownloadDir() {
+    return userStore.preferences.downloadBinariesPath || Kubectl.kubectlDir
+  }
+
   public async getPath(bundled = false): Promise<string> {
+    if (!userStore.preferences.downloadKubectlBinaries) {
+      return this.getPathFromPreferences()
+    }
+
     // return binary name if bundled path is not functional
     if (!await this.checkBinary(this.getBundledPath(), false)) {
       Kubectl.invalidBundle = true
@@ -128,6 +140,7 @@ export class Kubectl {
   public async binDir() {
     try {
       await this.ensureKubectl()
+      await this.writeInitScripts()
       return this.dirname
     } catch (err) {
       logger.error(err)
@@ -180,6 +193,9 @@ export class Kubectl {
   }
 
   public async ensureKubectl(): Promise<boolean> {
+    if (!userStore.preferences.downloadKubectlBinaries) {
+      return true
+    }
     if (Kubectl.invalidBundle) {
       logger.error(`Detected invalid bundle binary, returning ...`)
       return false
@@ -203,10 +219,6 @@ export class Kubectl {
         release()
         return false
       }
-      await this.writeInitScripts().catch((error) => {
-        logger.error("Failed to write init scripts");
-        logger.error(error)
-      })
       logger.debug(`Releasing lock for ${this.kubectlVersion}`)
       release()
       return true
@@ -266,54 +278,51 @@ export class Kubectl {
   }
 
   protected async writeInitScripts() {
+    const kubectlPath = userStore.preferences.downloadKubectlBinaries ? this.dirname : path.dirname(this.getPathFromPreferences())
     const helmPath = helmCli.getBinaryDir()
     const fsPromises = fs.promises;
     const bashScriptPath = path.join(this.dirname, '.bash_set_path')
-    const bashScriptIsLatest = await this.scriptIsLatest(bashScriptPath)
-    if (!bashScriptIsLatest) {
-      let bashScript = "" + initScriptVersionString
-      bashScript += "tempkubeconfig=\"$KUBECONFIG\"\n"
-      bashScript += "test -f \"/etc/profile\" && . \"/etc/profile\"\n"
-      bashScript += "if test -f \"$HOME/.bash_profile\"; then\n"
-      bashScript += "  . \"$HOME/.bash_profile\"\n"
-      bashScript += "elif test -f \"$HOME/.bash_login\"; then\n"
-      bashScript += "  . \"$HOME/.bash_login\"\n"
-      bashScript += "elif test -f \"$HOME/.profile\"; then\n"
-      bashScript += "  . \"$HOME/.profile\"\n"
-      bashScript += "fi\n"
-      bashScript += `export PATH="${this.dirname}:${helmPath}:$PATH"\n`
-      bashScript += "export KUBECONFIG=\"$tempkubeconfig\"\n"
-      bashScript += "unset tempkubeconfig\n"
-      await fsPromises.writeFile(bashScriptPath, bashScript.toString(), { mode: 0o644 })
-    }
+
+    let bashScript = "" + initScriptVersionString
+    bashScript += "tempkubeconfig=\"$KUBECONFIG\"\n"
+    bashScript += "test -f \"/etc/profile\" && . \"/etc/profile\"\n"
+    bashScript += "if test -f \"$HOME/.bash_profile\"; then\n"
+    bashScript += "  . \"$HOME/.bash_profile\"\n"
+    bashScript += "elif test -f \"$HOME/.bash_login\"; then\n"
+    bashScript += "  . \"$HOME/.bash_login\"\n"
+    bashScript += "elif test -f \"$HOME/.profile\"; then\n"
+    bashScript += "  . \"$HOME/.profile\"\n"
+    bashScript += "fi\n"
+    bashScript += `export PATH="${helmPath}:${kubectlPath}:$PATH"\n`
+    bashScript += "export KUBECONFIG=\"$tempkubeconfig\"\n"
+    bashScript += "unset tempkubeconfig\n"
+    await fsPromises.writeFile(bashScriptPath, bashScript.toString(), { mode: 0o644 })
 
     const zshScriptPath = path.join(this.dirname, '.zlogin')
-    const zshScriptIsLatest = await this.scriptIsLatest(zshScriptPath)
-    if (!zshScriptIsLatest) {
-      let zshScript = "" + initScriptVersionString
 
-      zshScript += "tempkubeconfig=\"$KUBECONFIG\"\n"
-      // restore previous ZDOTDIR
-      zshScript += "export ZDOTDIR=\"$OLD_ZDOTDIR\"\n"
-      // source all the files
-      zshScript += "test -f \"$OLD_ZDOTDIR/.zshenv\" && . \"$OLD_ZDOTDIR/.zshenv\"\n"
-      zshScript += "test -f \"$OLD_ZDOTDIR/.zprofile\" && . \"$OLD_ZDOTDIR/.zprofile\"\n"
-      zshScript += "test -f \"$OLD_ZDOTDIR/.zlogin\" && . \"$OLD_ZDOTDIR/.zlogin\"\n"
-      zshScript += "test -f \"$OLD_ZDOTDIR/.zshrc\" && . \"$OLD_ZDOTDIR/.zshrc\"\n"
+    let zshScript = "" + initScriptVersionString
 
-      // voodoo to replace any previous occurrences of kubectl path in the PATH
-      zshScript += `kubectlpath=\"${this.dirname}"\n`
-      zshScript += `helmpath=\"${helmPath}"\n`
-      zshScript += "p=\":$kubectlpath:\"\n"
-      zshScript += "d=\":$PATH:\"\n"
-      zshScript += "d=${d//$p/:}\n"
-      zshScript += "d=${d/#:/}\n"
-      zshScript += "export PATH=\"$kubectlpath:$helmpath:${d/%:/}\"\n"
-      zshScript += "export KUBECONFIG=\"$tempkubeconfig\"\n"
-      zshScript += "unset tempkubeconfig\n"
-      zshScript += "unset OLD_ZDOTDIR\n"
-      await fsPromises.writeFile(zshScriptPath, zshScript.toString(), { mode: 0o644 })
-    }
+    zshScript += "tempkubeconfig=\"$KUBECONFIG\"\n"
+    // restore previous ZDOTDIR
+    zshScript += "export ZDOTDIR=\"$OLD_ZDOTDIR\"\n"
+    // source all the files
+    zshScript += "test -f \"$OLD_ZDOTDIR/.zshenv\" && . \"$OLD_ZDOTDIR/.zshenv\"\n"
+    zshScript += "test -f \"$OLD_ZDOTDIR/.zprofile\" && . \"$OLD_ZDOTDIR/.zprofile\"\n"
+    zshScript += "test -f \"$OLD_ZDOTDIR/.zlogin\" && . \"$OLD_ZDOTDIR/.zlogin\"\n"
+    zshScript += "test -f \"$OLD_ZDOTDIR/.zshrc\" && . \"$OLD_ZDOTDIR/.zshrc\"\n"
+
+    // voodoo to replace any previous occurrences of kubectl path in the PATH
+    zshScript += `kubectlpath=\"${kubectlPath}"\n`
+    zshScript += `helmpath=\"${helmPath}"\n`
+    zshScript += "p=\":$kubectlpath:\"\n"
+    zshScript += "d=\":$PATH:\"\n"
+    zshScript += "d=${d//$p/:}\n"
+    zshScript += "d=${d/#:/}\n"
+    zshScript += "export PATH=\"$helmpath:$kubectlpath:${d/%:/}\"\n"
+    zshScript += "export KUBECONFIG=\"$tempkubeconfig\"\n"
+    zshScript += "unset tempkubeconfig\n"
+    zshScript += "unset OLD_ZDOTDIR\n"
+    await fsPromises.writeFile(zshScriptPath, zshScript.toString(), { mode: 0o644 })
   }
 
   protected getDownloadMirror() {

--- a/src/main/kubectl.ts
+++ b/src/main/kubectl.ts
@@ -106,15 +106,15 @@ export class Kubectl {
   }
 
   public getPathFromPreferences() {
-    return userStore.preferences.kubectlBinariesPath || this.getBundledPath()
+    return userStore.preferences?.kubectlBinariesPath || this.getBundledPath()
   }
 
   protected getDownloadDir() {
-    return userStore.preferences.downloadBinariesPath || Kubectl.kubectlDir
+    return userStore.preferences?.downloadBinariesPath || Kubectl.kubectlDir
   }
 
   public async getPath(bundled = false): Promise<string> {
-    if (!userStore.preferences.downloadKubectlBinaries) {
+    if (userStore.preferences?.downloadKubectlBinaries === false) {
       return this.getPathFromPreferences()
     }
 
@@ -193,7 +193,7 @@ export class Kubectl {
   }
 
   public async ensureKubectl(): Promise<boolean> {
-    if (!userStore.preferences.downloadKubectlBinaries) {
+    if (userStore.preferences?.downloadKubectlBinaries === false) {
       return true
     }
     if (Kubectl.invalidBundle) {
@@ -278,7 +278,7 @@ export class Kubectl {
   }
 
   protected async writeInitScripts() {
-    const kubectlPath = userStore.preferences.downloadKubectlBinaries ? this.dirname : path.dirname(this.getPathFromPreferences())
+    const kubectlPath = userStore.preferences?.downloadKubectlBinaries ? this.dirname : path.dirname(this.getPathFromPreferences())
     const helmPath = helmCli.getBinaryDir()
     const fsPromises = fs.promises;
     const bashScriptPath = path.join(this.dirname, '.bash_set_path')

--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "events";
 import path from "path"
 import shellEnv from "shell-env"
 import { app } from "electron"
-import { Kubectl, bundledKubectl } from "./kubectl"
+import { Kubectl } from "./kubectl"
 import { Cluster } from "./cluster"
 import { ClusterPreferences } from "../common/cluster-store";
 import { helmCli } from "./helm/helm-cli"

--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -4,12 +4,13 @@ import { EventEmitter } from "events";
 import path from "path"
 import shellEnv from "shell-env"
 import { app } from "electron"
-import { Kubectl } from "./kubectl"
+import { Kubectl, bundledKubectl } from "./kubectl"
 import { Cluster } from "./cluster"
 import { ClusterPreferences } from "../common/cluster-store";
 import { helmCli } from "./helm/helm-cli"
 import { isWindows } from "../common/vars";
 import { tracker } from "../common/tracker";
+import { userStore } from "../common/user-store";
 
 export class ShellSession extends EventEmitter {
   static shellEnvs: Map<string, any> = new Map()
@@ -35,7 +36,8 @@ export class ShellSession extends EventEmitter {
   }
 
   public async open() {
-    this.kubectlBinDir = await this.kubectl.binDir()
+    const pathFromPreferences = userStore.preferences.kubectlBinariesPath || Kubectl.bundledKubectlPath
+    this.kubectlBinDir = userStore.preferences.downloadKubectlBinaries ? await this.kubectl.binDir() : path.dirname(pathFromPreferences)
     this.helmBinDir = helmCli.getBinaryDir()
     const env = await this.getCachedShellEnv()
     const shell = env.PTYSHELL
@@ -67,11 +69,11 @@ export class ShellSession extends EventEmitter {
   protected async getShellArgs(shell: string): Promise<Array<string>> {
     switch(path.basename(shell)) {
     case "powershell.exe":
-      return ["-NoExit", "-command", `& {Set-Location $Env:USERPROFILE; $Env:PATH="${this.kubectlBinDir};${this.helmBinDir};$Env:PATH"}`]
+      return ["-NoExit", "-command", `& {Set-Location $Env:USERPROFILE; $Env:PATH="${this.helmBinDir};${this.kubectlBinDir};$Env:PATH"}`]
     case "bash":
       return ["--init-file", path.join(this.kubectlBinDir, '.bash_set_path')]
     case "fish":
-      return ["--login", "--init-command", `export PATH="${this.kubectlBinDir}:${this.helmBinDir}:$PATH"; export KUBECONFIG="${this.kubeconfigPath}"`]
+      return ["--login", "--init-command", `export PATH="${this.helmBinDir}:${this.kubectlBinDir}:$PATH"; export KUBECONFIG="${this.kubeconfigPath}"`]
     case "zsh":
       return ["--login"]
     default:

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -7,10 +7,17 @@ import { SubTitle } from '../layout/sub-title';
 import { UserPreferences, userStore } from '../../../common/user-store';
 import { observer } from 'mobx-react';
 import { Kubectl } from '../../../main/kubectl';
+import { SelectOption, Select } from '../select';
 
 export const KubectlBinaries = observer(({ preferences }: { preferences: UserPreferences }) => {
   const [downloadPath, setDownloadPath] = useState(preferences.downloadBinariesPath || "");
   const [binariesPath, setBinariesPath] = useState(preferences.kubectlBinariesPath || "");
+
+  const downloadMirrorOptions: SelectOption<string>[] = [
+    { value: "default", label: "Default (Google)" },
+    { value: "china", label: "China (Azure)" },
+  ]
+
 
   const save = () => {
     preferences.downloadBinariesPath = downloadPath;
@@ -51,6 +58,15 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
           preferences.downloadKubectlBinaries = !preferences.downloadKubectlBinaries
         }
       />
+      <SubTitle title="Download mirror" />
+          <Select
+            placeholder={<Trans>Download mirror for kubectl</Trans>}
+            options={downloadMirrorOptions}
+            value={preferences.downloadMirror}
+            onChange={({ value }: SelectOption) => preferences.downloadMirror = value}
+            disabled={!preferences.downloadKubectlBinaries}
+          />
+      <SubTitle title="Directory for binaries"/>
       <Input
         theme="round-black"
         value={downloadPath}

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -59,13 +59,13 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
         }
       />
       <SubTitle title="Download mirror" />
-          <Select
-            placeholder={<Trans>Download mirror for kubectl</Trans>}
-            options={downloadMirrorOptions}
-            value={preferences.downloadMirror}
-            onChange={({ value }: SelectOption) => preferences.downloadMirror = value}
-            disabled={!preferences.downloadKubectlBinaries}
-          />
+      <Select
+        placeholder={<Trans>Download mirror for kubectl</Trans>}
+        options={downloadMirrorOptions}
+        value={preferences.downloadMirror}
+        onChange={({ value }: SelectOption) => preferences.downloadMirror = value}
+        disabled={!preferences.downloadKubectlBinaries}
+      />
       <SubTitle title="Directory for binaries"/>
       <Input
         theme="round-black"

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -54,8 +54,9 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
       <Checkbox
         label={<Trans>Download kubectl binaries</Trans>}
         value={preferences.downloadKubectlBinaries}
-        onChange={() =>
-          preferences.downloadKubectlBinaries = !preferences.downloadKubectlBinaries
+        onChange={downloadKubectlBinaries => {
+          preferences.downloadKubectlBinaries = downloadKubectlBinaries
+        }
         }
       />
       <SubTitle title="Download mirror" />

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Trans } from '@lingui/macro';
+import { isPath } from '../input/input.validators';
+import { Checkbox } from '../checkbox';
+import { Input } from '../input';
+import { SubTitle } from '../layout/sub-title';
+import { UserPreferences, userStore } from '../../../common/user-store';
+import { observer } from 'mobx-react';
+
+export const KubectlBinaries = observer(({ preferences }: { preferences: UserPreferences }) => {
+  const [downloadPath, setDownloadPath] = useState(preferences.downloadBinariesPath || "");
+  const [binariesPath, setBinariesPath] = useState(preferences.kubectlBinariesPath || "");
+
+  const save = () => {
+    preferences.downloadBinariesPath = downloadPath;
+    preferences.kubectlBinariesPath = binariesPath;
+  }
+
+  const renderPath = () => {
+    if (preferences.downloadKubectlBinaries) {
+      return null;
+    }
+    return (
+      <>
+        <SubTitle title="Path to Kubectl binary"/>
+        <Input
+          theme="round-black"
+          value={binariesPath}
+          validators={isPath}
+          onChange={setBinariesPath}
+          onBlur={save}
+        />
+        <small className="hint">
+          <Trans>Default: $PATH/kubectl</Trans>
+        </small>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2><Trans>Kubectl Binary</Trans></h2>
+      <small className="hint">
+        <Trans>Download kubectl binaries matching to Kubernetes cluster verison.</Trans>
+      </small>
+      <Checkbox
+        label={<Trans>Download kubectl binaries</Trans>}
+        value={preferences.downloadKubectlBinaries}
+        onChange={() =>
+          preferences.downloadKubectlBinaries = !preferences.downloadKubectlBinaries
+        }
+      />
+      <Input
+        theme="round-black"
+        value={downloadPath}
+        placeholder={`Directory to download binaries into`}
+        validators={isPath}
+        onChange={setDownloadPath}
+        onBlur={save}
+        disabled={!preferences.downloadKubectlBinaries}
+      />
+      <small>
+        Default: {userStore.getDefaultKubectlPath()}
+      </small>
+      {renderPath()}
+    </>
+  );
+});

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -54,10 +54,7 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
       <Checkbox
         label={<Trans>Download kubectl binaries</Trans>}
         value={preferences.downloadKubectlBinaries}
-        onChange={downloadKubectlBinaries => {
-          preferences.downloadKubectlBinaries = downloadKubectlBinaries
-        }
-        }
+        onChange={downloadKubectlBinaries => preferences.downloadKubectlBinaries = downloadKubectlBinaries}
       />
       <SubTitle title="Download mirror" />
       <Select

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -6,6 +6,7 @@ import { Input } from '../input';
 import { SubTitle } from '../layout/sub-title';
 import { UserPreferences, userStore } from '../../../common/user-store';
 import { observer } from 'mobx-react';
+import { Kubectl } from '../../../main/kubectl';
 
 export const KubectlBinaries = observer(({ preferences }: { preferences: UserPreferences }) => {
   const [downloadPath, setDownloadPath] = useState(preferences.downloadBinariesPath || "");
@@ -31,7 +32,7 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
           onBlur={save}
         />
         <small className="hint">
-          <Trans>Default: $PATH/kubectl</Trans>
+          <Trans>Default:</Trans>{" "}{Kubectl.bundledKubectlPath}
         </small>
       </>
     );

--- a/src/renderer/components/+preferences/preferences.scss
+++ b/src/renderer/components/+preferences/preferences.scss
@@ -19,6 +19,11 @@
         }
       }
 
+      .SubTitle {
+        text-transform: none;
+        margin: 0!important;
+      }
+
       .repos {
         position: relative;
 

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -140,7 +140,6 @@ export class Preferences extends React.Component {
           />
           <small className="hint">
             <Trans>Proxy is used only for non-cluster communication.</Trans>
-          </small>Proxy is used only for non-cluster communication.</Trans>
           </small>
 
           <KubectlBinaries preferences={preferences} />

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -16,6 +16,7 @@ import { Badge } from "../badge";
 import { themeStore } from "../../theme.store";
 import { history } from "../../navigation";
 import { Tooltip } from "../tooltip";
+import { KubectlBinaries } from "./kubectl-binaries";
 
 @observer
 export class Preferences extends React.Component {
@@ -168,6 +169,8 @@ export class Preferences extends React.Component {
           <small className="hint">
             <Trans>Proxy is used only for non-cluster communication.</Trans>
           </small>
+
+          <KubectlBinaries preferences={preferences} />
 
           <h2><Trans>Certificate Trust</Trans></h2>
           <Checkbox

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -24,11 +24,6 @@ export class Preferences extends React.Component {
   @observable helmRepos: HelmRepo[] = [];
   @observable helmAddedRepos = observable.map<string, HelmRepo>();
 
-  @observable downloadMirrorOptions: SelectOption<string>[] = [
-    { value: "default", label: "Default (Google)" },
-    { value: "china", label: "China (Azure)" },
-  ]
-
   @computed get themeOptions(): SelectOption<string>[] {
     return themeStore.themes.map(theme => ({
       label: theme.name,
@@ -122,13 +117,18 @@ export class Preferences extends React.Component {
             onChange={({ value }: SelectOption) => preferences.colorTheme = value}
           />
 
-          <h2><Trans>Download Mirror</Trans></h2>
-          <Select
-            placeholder={<Trans>Download mirror for kubectl</Trans>}
-            options={this.downloadMirrorOptions}
-            value={preferences.downloadMirror}
-            onChange={({ value }: SelectOption) => preferences.downloadMirror = value}
+          <h2><Trans>HTTP Proxy</Trans></h2>
+          <Input
+            theme="round-black"
+            placeholder={_i18n._(t`Type HTTP proxy url (example: http://proxy.acme.org:8080)`)}
+            value={preferences.httpsProxy || ""}
+            onChange={v => preferences.httpsProxy = v}
           />
+          <small className="hint">
+            <Trans>Proxy is used only for non-cluster communication.</Trans>
+          </small>
+
+          <KubectlBinaries preferences={preferences} />
 
           <h2><Trans>Helm</Trans></h2>
           <Select
@@ -158,19 +158,6 @@ export class Preferences extends React.Component {
               )
             })}
           </div>
-
-          <h2><Trans>HTTP Proxy</Trans></h2>
-          <Input
-            theme="round-black"
-            placeholder={_i18n._(t`Type HTTP proxy url (example: http://proxy.acme.org:8080)`)}
-            value={preferences.httpsProxy || ""}
-            onChange={v => preferences.httpsProxy = v}
-          />
-          <small className="hint">
-            <Trans>Proxy is used only for non-cluster communication.</Trans>
-          </small>
-
-          <KubectlBinaries preferences={preferences} />
 
           <h2><Trans>Certificate Trust</Trans></h2>
           <Checkbox

--- a/src/renderer/components/input/input.validators.ts
+++ b/src/renderer/components/input/input.validators.ts
@@ -2,6 +2,7 @@ import type { InputProps } from "./input";
 import { ReactNode } from "react";
 import { t } from "@lingui/macro";
 import { _i18n } from '../../i18n';
+import fse from "fs-extra";
 
 export interface Validator {
   debounce?: number; // debounce for async validators in ms
@@ -40,6 +41,12 @@ export const isUrl: Validator = {
   message: () => _i18n._(t`Wrong url format`),
   validate: value => !!value.match(/^http(s)?:\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]*)*$/),
 };
+
+export const isPath: Validator = {
+  condition: ({ type }) => type === "text",
+  message: () => _i18n._(t`This field must be a path to an existing file`),
+  validate: value => fse.pathExistsSync(value),
+}
 
 export const minLength: Validator = {
   condition: ({ minLength }) => !!minLength,

--- a/src/renderer/components/input/input.validators.ts
+++ b/src/renderer/components/input/input.validators.ts
@@ -45,7 +45,7 @@ export const isUrl: Validator = {
 export const isPath: Validator = {
   condition: ({ type }) => type === "text",
   message: () => _i18n._(t`This field must be a path to an existing file`),
-  validate: value => fse.pathExistsSync(value),
+  validate: value => !value || fse.pathExistsSync(value),
 }
 
 export const minLength: Validator = {


### PR DESCRIPTION
This PR adds two configuration options to global preferences:
- Option to define path where binaries will be downloaded
- Option to disable kubectl binary downloads. Instead, user can define path to kubectl. Then, that binary is used despite the version of Kubernetes cluster.

![image](https://user-images.githubusercontent.com/455844/92209621-fe2b2680-ee95-11ea-80ec-d8f6ac461029.png)


Fixes #679 