### PR TITLE
Restrict pasted kubeconfig file permissions to only the user

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -60,7 +60,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
   static embedCustomKubeConfig(clusterId: ClusterId, kubeConfig: KubeConfig | string): string {
     const filePath = ClusterStore.getCustomKubeConfigPath(clusterId);
     const fileContents = typeof kubeConfig == "string" ? kubeConfig : dumpConfigYaml(kubeConfig);
-    saveToAppFiles(filePath, fileContents);
+    saveToAppFiles(filePath, fileContents, { mode: 0o600});
     return filePath;
   }
 

--- a/src/common/utils/saveToAppFiles.ts
+++ b/src/common/utils/saveToAppFiles.ts
@@ -1,11 +1,11 @@
 // Save file to electron app directory (e.g. "/Users/$USER/Library/Application Support/Lens" for MacOS)
 import path from "path";
 import { app, remote } from "electron";
-import { ensureDirSync, writeFileSync } from "fs-extra";
+import { ensureDirSync, writeFileSync, WriteFileOptions } from "fs-extra";
 
-export function saveToAppFiles(filePath: string, contents: any): string {
+export function saveToAppFiles(filePath: string, contents: any, options?: WriteFileOptions): string {
   const absPath = path.resolve((app || remote.app).getPath("userData"), filePath);
   ensureDirSync(path.dirname(absPath));
-  writeFileSync(absPath, contents);
+  writeFileSync(absPath, contents, options);
   return absPath;
 }


### PR DESCRIPTION


Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

Fixes permissions considerations of #655 