### PR TITLE
Release v3.6.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-beta.2",
+  "version": "3.6.0-rc.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,24 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0-beta.2 (current version)
+## 3.6.0-rc.1 (current version)
+- Allow user to configure directory where Kubectl binaries are downloaded
+- Allow user to configure path to Kubectl binary, instead of using bundled Kubectl
+- Log application logs also to log file
+- Restrict file permissions to only the user for pasted kubeconfigs
+- Close Preferences and Cluster Setting on Esc keypress
+- Update Kubectl versions used with Lens
+- Update Helm binary version
+- Fix: Update CRD api to use preferred version and implement v1 differences
+- Fix: Allow to drag and drop cluster icons
+- Fix: Wider version select box for Helm chart installation
+- Fix: Reload only active dashboard view, not the whole app window
+- Fix cluster icon margins
+- Fix: Reconnect non-accessible clusters on reconnect
+- Fix: Bundle Kubectl and Helm binaries
+- Fix: Remove double copyright
+
+## 3.6.0-beta.2
 - Fix: too narrow sidebar without clusters
 - Fix app crash when iterating Events without 'kind' property defined
 - Detect non-functional bundled kubectl


### PR DESCRIPTION
## Changes since v3.6.0-beta.2

- Allow for users to enabled release mode debugging (#481)
- Upgrade eslint typescript parser (#773)
- Allow to override logger for LensBinary (#776)
- Update Kubectl version map (#780)
- Bump versions of bundled binaries (#781)
- Do not set app to dev mode if debugging flag is passed (#774)
- Adding margin to last cluster icon (#788)
- Reload active dashboard view (#783)
- Update help texts for Add cluster (#785)
- Try to reconnect non-accessible clusters on activate (#789)
- Using import type statement (#793)
- Download binaries before building the app (#799)
- Some Grammatical Fixes ❤️ (#641) 
- Remove double copyright (#802)
- Change order of init for fresh clone (#797)
- Update CRD api to use preferred version and implement v1 differences (#718)
- Wider Select box for Helm chart installation (#803)
- Close Preferences and Cluster Setting on Esc keypress (#804)
- Restrict file permissions to only the user for pasted kubeconfigs that are kept in App dir (#805)
- Add drag and drop capabilities for the order of cluster icons (#623)
- Allow user to configure kubectl binary preferences (#800)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>