### PR TITLE
Fixing Cluster Icon margins

### DIFF
--- a/src/renderer/components/cluster-icon/cluster-icon.scss
+++ b/src/renderer/components/cluster-icon/cluster-icon.scss
@@ -4,7 +4,6 @@
   position: relative;
   border-radius: $radius;
   padding: $radius;
-  margin-bottom: $padding * 2;
   user-select: none;
   cursor: pointer;
 

--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -16,10 +16,10 @@
   .clusters {
     @include hidden-scrollbar;
     padding: 0 $spacing; // extra spacing for cluster-icon's badge
-    margin-bottom: $spacing;
+    margin-bottom: $margin;
 
-    > :last-child {
-      margin-bottom: $margin;
+    .ClusterIcon {
+      margin-bottom: $margin * 1.5;
     }
 
     &:empty {


### PR DESCRIPTION
Fixing cluster icon positioning inside cluster settings.

![Screenshot 2020-09-07 at 13 24 55](https://user-images.githubusercontent.com/9607060/92378281-3e94d980-f10e-11ea-9924-9f39e9926bcd.png)
![Screenshot 2020-09-07 at 13 24 26](https://user-images.githubusercontent.com/9607060/92378285-3fc60680-f10e-11ea-96c1-8e197ce096e2.png)
![Screenshot 2020-09-07 at 13 24 06](https://user-images.githubusercontent.com/9607060/92378290-405e9d00-f10e-11ea-81b6-e91de46dd60d.png)
![Screenshot 2020-09-07 at 13 09 41](https://user-images.githubusercontent.com/9607060/92378292-40f73380-f10e-11ea-8e65-669ff3001621.png)

Fixes #813 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>