### PR TITLE
Fixing Dialog Escape keypress behavior

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -1,4 +1,3 @@
-import { WorkspaceId, workspaceStore } from "./workspace-store";
 import path from "path";
 import { app, ipcRenderer, remote } from "electron";
 import { unlink } from "fs-extra";
@@ -13,7 +12,7 @@ import { saveToAppFiles } from "./utils/saveToAppFiles";
 import { KubeConfig } from "@kubernetes/client-node";
 import _ from "lodash";
 import move from "array-move";
-import { is } from "immer/dist/internal";
+import type { WorkspaceId } from "./workspace-store";
 
 export interface ClusterIconUpload {
   clusterId: string;

--- a/src/renderer/components/dialog/dialog.tsx
+++ b/src/renderer/components/dialog/dialog.tsx
@@ -92,6 +92,7 @@ export class Dialog extends React.PureComponent<DialogProps, DialogState> {
     this.props.onOpen();
     if (!this.props.pinned) {
       if (this.elem) this.elem.addEventListener('click', this.onClickOutside);
+      // Using document.body target to handle keydown event before Drawer does
       document.body.addEventListener('keydown', this.onEscapeKey);
     }
   }

--- a/src/renderer/components/dialog/dialog.tsx
+++ b/src/renderer/components/dialog/dialog.tsx
@@ -92,7 +92,7 @@ export class Dialog extends React.PureComponent<DialogProps, DialogState> {
     this.props.onOpen();
     if (!this.props.pinned) {
       if (this.elem) this.elem.addEventListener('click', this.onClickOutside);
-      window.addEventListener('keydown', this.onEscapeKey);
+      document.body.addEventListener('keydown', this.onEscapeKey);
     }
   }
 
@@ -100,7 +100,7 @@ export class Dialog extends React.PureComponent<DialogProps, DialogState> {
     this.props.onClose();
     if (!this.props.pinned) {
       if (this.elem) this.elem.removeEventListener('click', this.onClickOutside);
-      window.removeEventListener('keydown', this.onEscapeKey);
+      document.body.removeEventListener('keydown', this.onEscapeKey);
     }
   }
 

--- a/src/renderer/components/drawer/drawer.tsx
+++ b/src/renderer/components/drawer/drawer.tsx
@@ -40,6 +40,7 @@ export class Drawer extends React.Component<DrawerProps> {
   });
 
   componentDidMount() {
+    // Using window target for events to make sure they will be catched after other places (e.g. Dialog)
     window.addEventListener("mousedown", this.onMouseDown)
     window.addEventListener("click", this.onClickOutside)
     window.addEventListener("keydown", this.onEscapeKey)

--- a/src/renderer/components/layout/sidebar.scss
+++ b/src/renderer/components/layout/sidebar.scss
@@ -40,7 +40,7 @@
     div.logo-text {
       position: absolute;
       left: 42px;
-      top: 11.5px;
+      top: 11px;
     }
 
     .logo-icon {


### PR DESCRIPTION
Allowing to close Dialog only (not along with opened Drawer) after hitting Esc key. Made by changed `keypress` target - `document.body` is located 'lower' in event bubbling stairs so it will fire event earlier than Drawer.

![esc closes dialog](https://user-images.githubusercontent.com/9607060/92576141-d1aa4c80-f291-11ea-8738-b239c2fe3c44.gif)

Fixes #757 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>