### PR TITLE
Setting new workspace name restrictions

### DIFF
--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -71,20 +71,17 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
   }
 
   @action
-  saveWorkspace(workspace: Workspace): { workspace?: Workspace, error?: string} {
+  saveWorkspace(workspace: Workspace) {
     const { id, name } = workspace;
     const existingWorkspace = this.getById(id);
-    if (!name) {
-      return { error: "Workspace should has a name." };
-    }
-    if (this.getByName(name)) {
-      return { error: `Workspace '${name}' already exist.` };
+    if (!name.trim() || this.getByName(name.trim())) {
+      return;
     }
     if (existingWorkspace) {
-      return { workspace: Object.assign(existingWorkspace, workspace) };
+      Object.assign(existingWorkspace, workspace);
     }
     this.workspaces.set(id, workspace);
-    return { workspace };
+    return workspace;
   }
 
   @action

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -51,6 +51,10 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     return this.workspaces.get(id);
   }
 
+  getByName(name: string): Workspace {
+    return this.workspacesList.find(workspace => workspace.name === name);
+  }
+
   @action
   setActive(id = WorkspaceStore.defaultId, { redirectToLanding = true, resetActiveCluster = true } = {}) {
     if (id === this.currentWorkspaceId) return;
@@ -67,14 +71,20 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
   }
 
   @action
-  saveWorkspace(workspace: Workspace) {
-    const id = workspace.id;
+  saveWorkspace(workspace: Workspace): { workspace?: Workspace, error?: string} {
+    const { id, name } = workspace;
     const existingWorkspace = this.getById(id);
-    if (existingWorkspace) {
-      Object.assign(existingWorkspace, workspace);
-    } else {
-      this.workspaces.set(id, workspace);
+    if (!name) {
+      return { error: "Workspace should has a name." };
     }
+    if (this.getByName(name)) {
+      return { error: `Workspace '${name}' already exist.` };
+    }
+    if (existingWorkspace) {
+      return { workspace: Object.assign(existingWorkspace, workspace) };
+    }
+    this.workspaces.set(id, workspace);
+    return { workspace };
   }
 
   @action

--- a/src/common/workspace-store_test.ts
+++ b/src/common/workspace-store_test.ts
@@ -93,7 +93,7 @@ describe("workspace store tests", () => {
       expect(ws.workspaces.size).toBe(2);
     })
 
-    it("cannot create namespace with existent name", () => {
+    it("cannot create workspace with existent name", () => {
       const ws = WorkspaceStore.getInstance<WorkspaceStore>();
 
       ws.saveWorkspace({
@@ -104,12 +104,34 @@ describe("workspace store tests", () => {
       expect(ws.workspacesList.length).toBe(1);  // default workspace only
     })
 
-    it("cannot create namespace with empty name", () => {
+    it("cannot create workspace with empty name", () => {
       const ws = WorkspaceStore.getInstance<WorkspaceStore>();
 
       ws.saveWorkspace({
         id: "random",
         name: "",
+      });
+
+      expect(ws.workspacesList.length).toBe(1);  // default workspace only
+    })
+
+    it("cannot create workspace with ' ' name", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      ws.saveWorkspace({
+        id: "random",
+        name: " ",
+      });
+
+      expect(ws.workspacesList.length).toBe(1);  // default workspace only
+    })
+
+    it("trim workspace name", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      ws.saveWorkspace({
+        id: "random",
+        name: "default ",
       });
 
       expect(ws.workspacesList.length).toBe(1);  // default workspace only

--- a/src/common/workspace-store_test.ts
+++ b/src/common/workspace-store_test.ts
@@ -92,6 +92,28 @@ describe("workspace store tests", () => {
 
       expect(ws.workspaces.size).toBe(2);
     })
+
+    it("cannot create namespace with existent name", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      ws.saveWorkspace({
+        id: "someid",
+        name: "default",
+      });
+
+      expect(ws.workspacesList.length).toBe(1);  // default workspace only
+    })
+
+    it("cannot create namespace with empty name", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      ws.saveWorkspace({
+        id: "random",
+        name: "",
+      });
+
+      expect(ws.workspacesList.length).toBe(1);  // default workspace only
+    })
   })
 
   describe("for a non-empty config", () => {

--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -93,6 +93,12 @@ export class Workspaces extends React.Component {
     })
   }
 
+  onInputKeypress = (evt: React.KeyboardEvent<any>, workspaceId: WorkspaceId) => {
+    if (evt.key == 'Enter') {
+      this.saveWorkspace(workspaceId);
+    }
+  }
+
   render() {
     return (
       <WizardLayout className="Workspaces" infoPanel={this.renderInfo()}>
@@ -142,6 +148,7 @@ export class Workspaces extends React.Component {
                       placeholder={_i18n._(t`Name`)}
                       value={editingWorkspace.name}
                       onChange={v => editingWorkspace.name = v}
+                      onKeyPress={(e) => this.onInputKeypress(e, workspaceId)}
                       autoFocus
                     />
                     <Input
@@ -149,16 +156,17 @@ export class Workspaces extends React.Component {
                       placeholder={_i18n._(t`Description`)}
                       value={editingWorkspace.description}
                       onChange={v => editingWorkspace.description = v}
-                    />
-                    <Icon
-                      material="cancel"
-                      tooltip={<Trans>Cancel</Trans>}
-                      onClick={() => this.clearEditing(workspaceId)}
+                      onKeyPress={(e) => this.onInputKeypress(e, workspaceId)}
                     />
                     <Icon
                       material="save"
                       tooltip={<Trans>Save</Trans>}
                       onClick={() => this.saveWorkspace(workspaceId)}
+                    />
+                    <Icon
+                      material="cancel"
+                      tooltip={<Trans>Cancel</Trans>}
+                      onClick={() => this.clearEditing(workspaceId)}
                     />
                   </Fragment>
                 )}

--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -142,6 +142,7 @@ export class Workspaces extends React.Component {
                       placeholder={_i18n._(t`Name`)}
                       value={editingWorkspace.name}
                       onChange={v => editingWorkspace.name = v}
+                      autoFocus
                     />
                     <Input
                       className="description"

--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -12,6 +12,7 @@ import { Icon } from "../icon";
 import { Input } from "../input";
 import { cssNames, prevDefault } from "../../utils";
 import { Button } from "../button";
+import { Notifications } from "../notifications";
 
 @observer
 export class Workspaces extends React.Component {
@@ -41,10 +42,12 @@ export class Workspaces extends React.Component {
 
   saveWorkspace = (id: WorkspaceId) => {
     const draft = toJS(this.editingWorkspaces.get(id));
-    if (draft) {
+    const { error } = workspaceStore.saveWorkspace(draft);
+    if (!error) {
       this.clearEditing(id);
-      workspaceStore.saveWorkspace(draft);
+      return;
     }
+    Notifications.error(error);
   }
 
   addWorkspace = () => {


### PR DESCRIPTION
* Preventing workspaces to have empty or existent name
* Swapped 'save' and 'clear' buttons
* Save workspace on hitting `Enter`.

![workspace errors](https://user-images.githubusercontent.com/9607060/92596113-f9a7a900-f2ad-11ea-8a11-ebbfbc52a986.gif)

Resolves #826 