### PR TITLE
Release v3.6.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-rc.1",
+  "version": "3.6.0-rc.2",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,12 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0-rc.1 (current version)
+## 3.6.0-rc.2 (current version)
+- Refresh input values on cluster change
+- Update logo
+- Fix margins in cluster menu
+
+## 3.6.0-rc.1
 - Allow user to configure directory where Kubectl binaries are downloaded
 - Allow user to configure path to Kubectl binary, instead of using bundled Kubectl
 - Log application logs also to log file


### PR DESCRIPTION
## Changes since v3.6.0-beta.2

- Removing DEBUG env from package.json commands (#810) 
- More cluster menu fixes (#815) 
- Update logo (#819) 
- Refresh input values on cluster change (#814)
- Add progress bar for webpack compilation (#794) 
- Remove explicit yarn install call from make build task (#835) 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>