### PR TITLE
remove make-syncronous and file-type calls from migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
     "jsonpath": "^1.0.2",
     "lodash": "^4.17.15",
     "mac-ca": "^1.0.4",
-    "make-synchronous": "^0.1.1",
     "marked": "^1.1.0",
     "md5-file": "^5.0.0",
     "mobx": "^5.15.5",

--- a/src/common/cluster-store_test.ts
+++ b/src/common/cluster-store_test.ts
@@ -33,7 +33,7 @@ describe("empty config", () => {
       id: "foo",
       preferences: {
         terminalCWD: "/tmp",
-        icon: "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAA1wAAAKoCAYAAABjkf5",
+        icon: "data:;base64,iVBORw0KGgoAAAANSUhEUgAAA1wAAAKoCAYAAABjkf5",
         clusterName: "minikube"
       },
       kubeConfigPath: ClusterStore.embedCustomKubeConfig("foo", "fancy foo config"),
@@ -285,7 +285,7 @@ describe("pre 2.6.0 config with a cluster icon", () => {
     const storedClusterData = clusterStore.clustersList[0];
     expect(storedClusterData.hasOwnProperty('icon')).toBe(false);
     expect(storedClusterData.preferences.hasOwnProperty('icon')).toBe(true);
-    expect(storedClusterData.preferences.icon.startsWith("data:image/jpeg;base64,")).toBe(true);
+    expect(storedClusterData.preferences.icon.startsWith("data:;base64,")).toBe(true);
   })
 })
 
@@ -364,6 +364,6 @@ describe("pre 3.6.0-beta.1 config with an existing cluster", () => {
 
   it("migrates to modern format with icon not in file", async () => {
     const { icon } = clusterStore.clustersList[0].preferences;
-    expect(icon.startsWith("data:image/jpeg;base64,")).toBe(true);
+    expect(icon.startsWith("data:;base64,")).toBe(true);
   })
 })

--- a/src/common/cluster-store_test.ts
+++ b/src/common/cluster-store_test.ts
@@ -33,7 +33,7 @@ describe("empty config", () => {
       id: "foo",
       preferences: {
         terminalCWD: "/tmp",
-        icon: "data:image/jpeg;base64, iVBORw0KGgoAAAANSUhEUgAAA1wAAAKoCAYAAABjkf5",
+        icon: "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAA1wAAAKoCAYAAABjkf5",
         clusterName: "minikube"
       },
       kubeConfigPath: ClusterStore.embedCustomKubeConfig("foo", "fancy foo config"),
@@ -364,6 +364,6 @@ describe("pre 3.6.0-beta.1 config with an existing cluster", () => {
 
   it("migrates to modern format with icon not in file", async () => {
     const { icon } = clusterStore.clustersList[0].preferences;
-    expect(icon.startsWith("data:image/jpeg;base64, ")).toBe(true);
+    expect(icon.startsWith("data:image/jpeg;base64,")).toBe(true);
   })
 })

--- a/src/migrations/cluster-store/3.6.0-beta.1.ts
+++ b/src/migrations/cluster-store/3.6.0-beta.1.ts
@@ -7,11 +7,6 @@ import { migration } from "../migration-wrapper";
 import fse from "fs-extra"
 import { ClusterModel, ClusterStore } from "../../common/cluster-store";
 import { loadConfig } from "../../common/kube-helpers";
-import makeSynchronous from "make-synchronous"
-
-const AsyncFunction = Object.getPrototypeOf(async function () { return }).constructor;
-const getFileTypeFnString = `return require("file-type").fromBuffer(fileData)`;
-const getFileType = new AsyncFunction("fileData", getFileTypeFnString);
 
 export default migration({
   version: "3.6.0-beta.1",
@@ -48,13 +43,8 @@ export default migration({
             printLog(`migrating ${cluster.preferences.icon} for ${cluster.preferences.clusterName}`)
             const iconPath = cluster.preferences.icon.replace("store://", "")
             const fileData = fse.readFileSync(path.join(userDataPath, iconPath));
-            const { mime = "" } = makeSynchronous(getFileType)(fileData);
 
-            if (!mime) {
-              printLog(`mime type not detected for ${cluster.preferences.clusterName}'s icon: ${iconPath}`)
-            }
-
-            cluster.preferences.icon = `data:${mime};base64, ${fileData.toString('base64')}`;
+            cluster.preferences.icon = `data:;base64,${fileData.toString('base64')}`;
           } else {
             delete cluster.preferences?.icon;
           }

--- a/src/renderer/components/+cluster-settings/components/cluster-icon-setting.tsx
+++ b/src/renderer/components/+cluster-settings/components/cluster-icon-setting.tsx
@@ -28,7 +28,7 @@ export class ClusterIconSetting extends React.Component<Props> {
     try {
       if (file) {
         const buf = Buffer.from(await file.arrayBuffer());
-        cluster.preferences.icon = `data:${file.type};base64, ${buf.toString('base64')}`;
+        cluster.preferences.icon = `data:${file.type};base64,${buf.toString('base64')}`;
       } else {
         // this has to be done as a seperate branch (and not always) because `cluster`
         // is observable and triggers an update loop.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7811,14 +7811,6 @@ make-plural@^6.2.1:
   resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-6.2.1.tgz#2790af1d05fb2fc35a111ce759ffdb0aca1339a3"
   integrity sha512-AmkruwJ9EjvyTv6AM8MBMK3TAeOJvhgTv5YQXzF0EP2qawhpvMjDpHvsdOIIT0Vn+BB0+IogmYZ1z+Ulm/m0Fg==
 
-make-synchronous@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/make-synchronous/-/make-synchronous-0.1.1.tgz#0169f6ec769c3cf8948d66790da262740c1209e7"
-  integrity sha512-Y4SxxqhaoyMDokJQ0AZz0E+bLhRkOSR7Z/IQoTKPdS6HYi3aobal2kMHoHHoqBadPWjf07P4K1FQLXOx3wf9Yw==
-  dependencies:
-    subsume "^3.0.0"
-    type-fest "^0.16.0"
-
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -10929,14 +10921,6 @@ style-loader@^1.2.1:
     loader-utils "^2.0.0"
     schema-utils "^2.6.6"
 
-subsume@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/subsume/-/subsume-3.0.0.tgz#22c92730f441ad72ee9af4bdad42dc4ff830cfaf"
-  integrity sha512-6n/UfV8UWKwJNO8OAOiKntwEMihuBeeoJfzpL542C+OuvT4iWG9SwjrXkOmsxjb4SteHUsos9SvrdqZ9+ICwTQ==
-  dependencies:
-    escape-string-regexp "^2.0.0"
-    unique-string "^2.0.0"
-
 sumchecker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"
@@ -11444,11 +11428,6 @@ type-fest@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
-
-type-fest@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
-  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
 
 type-fest@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <smalton@mirantis.com>

This PR fixes the issue with the subsume package not being included in production webpack builds. It is achieved by removing the dependency on said package.