### PR TITLE
Move verbose log lines to silly level

### DIFF
--- a/src/common/base-store.ts
+++ b/src/common/base-store.ts
@@ -77,7 +77,7 @@ export class BaseStore<T = any> extends Singleton {
     );
     if (ipcMain) {
       const callback = (event: IpcMainEvent, model: T) => {
-        logger.debug(`[STORE]: SYNC ${this.name} from renderer`, { model });
+        logger.silly(`[STORE]: SYNC ${this.name} from renderer`, { model });
         this.onSync(model);
       };
       ipcMain.on(this.syncChannel, callback);
@@ -85,7 +85,7 @@ export class BaseStore<T = any> extends Singleton {
     }
     if (ipcRenderer) {
       const callback = (event: IpcRendererEvent, model: T) => {
-        logger.debug(`[STORE]: SYNC ${this.name} from main`, { model });
+        logger.silly(`[STORE]: SYNC ${this.name} from main`, { model });
         this.onSync(model);
       };
       ipcRenderer.on(this.syncChannel, callback);

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -76,7 +76,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     if (ipcRenderer) {
       ipcRenderer.on("cluster:state", (event, model: ClusterState) => {
         this.applyWithoutSync(() => {
-          logger.debug(`[CLUSTER-STORE]: received push-state at ${location.host}`, model);
+          logger.silly(`[CLUSTER-STORE]: received push-state at ${location.host}`, model);
           this.getById(model.id)?.updateModel(model);
         })
       })

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -68,7 +68,7 @@ export function broadcastIpc({ channel, frameId, frameOnly, webContentId, filter
   }
   views.forEach(webContent => {
     const type = webContent.getType();
-    logger.debug(`[IPC]: broadcasting "${channel}" to ${type}=${webContent.id}`, { args });
+    logger.silly(`[IPC]: broadcasting "${channel}" to ${type}=${webContent.id}`, { args });
     if (!frameOnly) {
       webContent.send(channel, ...args);
     }

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -396,7 +396,7 @@ export class Cluster implements ClusterModel {
   }
 
   pushState = (state = this.getState()): ClusterState => {
-    logger.debug(`[CLUSTER]: push-state`, state);
+    logger.silly(`[CLUSTER]: push-state`, state);
     broadcastIpc({
       channel: "cluster:state",
       frameId: this.frameId,

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -2,14 +2,16 @@ import { app, remote } from "electron";
 import winston from "winston"
 import { isDebugging } from "../common/vars";
 
+const logLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : isDebugging ? "debug" : "info"
+
 const consoleOptions: winston.transports.ConsoleTransportOptions = {
   handleExceptions: false,
-  level: isDebugging ? "debug" : "info",
+  level: logLevel,
 }
 
 const fileOptions: winston.transports.FileTransportOptions = {
   handleExceptions: false,
-  level: isDebugging ? "debug" : "info",
+  level: logLevel,
   filename: "lens.log",
   dirname: (app ?? remote?.app)?.getPath("logs"),
   maxsize: 16 * 1024,


### PR DESCRIPTION
This PR moves verbose log lines to `silly` log level. Logger reads now log level from env var `LOG_LEVEL` and defaults to `debug` or `info` depending on the present of `DEBUG` variable (to keep backward compatibility).

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>