### PR TITLE
Release v3.6.0-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-rc.2",
+  "version": "3.6.0-rc.3",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
 ## 3.6.0-rc.3 (current version)
-- Fix Dialog Escape keypress behavior
+- Fix Dialog Esc keypress behavior
 - Set new workspace name restrictions
 - Fix cluster's apiUrl
 - Fix: Cluster dashboard not rendered

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0-rc.2 (current version)
+## 3.6.0-rc.3 (current version)
+- Fix Dialog Escape keypress behavior
+- Set new workspace name restrictions
+- Fix cluster's apiUrl
+- Fix: Cluster dashboard not rendered
+- Fix proxy kubeconfig file permissions
+- Move verbose log lines to silly level
+- Add path to auth proxy url if present in cluster url
+- Fix path validation message
+
+## 3.6.0-rc.2
 - Refresh input values on cluster change
 - Update logo
 - Fix margins in cluster menu


### PR DESCRIPTION
## Changes since v3.6.0-rc.2

- remove make-syncronous and file-type calls from migration (#844)
- Fixing Dialog Escape keypress behavior (#831)
- Setting new workspace name restrictions (#832) 
- Fix cluster's apiUrl (#846) 
- [FIX]: Cluster dashboard not rendered (#848)
- Fix proxy kubeconfig file permissions (#857)
- Move verbose log lines to silly level (#859) 
- Add path to auth proxy url if present in cluster url (#856)
- fix isPath message (#860)