### PR TITLE
Release v3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0-rc.3",
+  "version": "3.6.0",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,47 +2,15 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0-rc.3 (current version)
-- Fix Dialog Esc keypress behavior
-- Set new workspace name restrictions
-- Fix cluster's apiUrl
-- Fix: Cluster dashboard not rendered
-- Fix proxy kubeconfig file permissions
-- Move verbose log lines to silly level
-- Add path to auth proxy url if present in cluster url
-- Fix path validation message
-
-## 3.6.0-rc.2
-- Refresh input values on cluster change
-- Update logo
-- Fix margins in cluster menu
-
-## 3.6.0-rc.1
+## 3.6.0 (current version)
 - Allow user to configure directory where Kubectl binaries are downloaded
 - Allow user to configure path to Kubectl binary, instead of using bundled Kubectl
-- Log application logs also to log file
-- Restrict file permissions to only the user for pasted kubeconfigs
-- Close Preferences and Cluster Setting on Esc keypress
+- Allow user to select Kubeconfig from filesystem
+- Show the path of the cluster's Kubeconfig in cluster settings
+- Store reference to added Kubeconfig files
+- Update logo
 - Update Kubectl versions used with Lens
 - Update Helm binary version
-- Fix: Update CRD api to use preferred version and implement v1 differences
-- Fix: Allow to drag and drop cluster icons
-- Fix: Wider version select box for Helm chart installation
-- Fix: Reload only active dashboard view, not the whole app window
-- Fix cluster icon margins
-- Fix: Reconnect non-accessible clusters on reconnect
-- Fix: Bundle Kubectl and Helm binaries
-- Fix: Remove double copyright
-
-## 3.6.0-beta.2
-- Fix: too narrow sidebar without clusters
-- Fix app crash when iterating Events without 'kind' property defined
-- Detect non-functional bundled kubectl
-
-## 3.6.0-beta.1
-- Allow user to select Kubeconfig from filesystem
-- Store reference to added Kubeconfig files
-- Show the path of the cluster's Kubeconfig in cluster settings
 - Add support for PodDisruptionBudgets
 - Add port-forwarding for containers in pod
 - Add shortcut keys to menu items
@@ -52,6 +20,30 @@ Here you can find description of changes we've built into each release. While we
 - Allow to trigger cronjobs
 - Show devtools in menu
 - Open last active cluster as default
+- Log application logs also to log file
+- Fix Dialog Esc keypress behavior
+- Set new workspace name restrictions
+- Fix cluster's apiUrl
+- Fix: Cluster dashboard not rendered
+- Fix app reload in cluster settings
+- Fix proxy kubeconfig file permissions
+- Move verbose log lines to silly level
+- Add path to auth proxy url if present in cluster url
+- Fix path validation message
+- Fix: Refresh input values on cluster change
+- Fix margins in cluster menu
+- Restrict file permissions to only the user for pasted kubeconfigs
+- Close Preferences and Cluster Setting on Esc keypress
+- Fix: Update CRD api to use preferred version and implement v1 differences
+- Fix: Allow to drag and drop cluster icons
+- Fix: Wider version select box for Helm chart installation
+- Fix: Reload only active dashboard view, not the whole app window
+- Fix cluster icon margins
+- Fix: Reconnect non-accessible clusters on reconnect
+- Fix: Remove double copyright
+- Fix: too narrow sidebar without clusters
+- Fix app crash when iterating Events without 'kind' property defined
+- Detect non-functional bundled kubectl
 - Fix format duration rounding days error
 - Handle unsupported resources properly after they've been created from editor
 - Fix CRD api parsing


### PR DESCRIPTION
## Changes since v3.5.3

- Add support for PodDisruptionBudgets (#452)
- Kubeconfigs as file references (#466)
- Remove redundant applyHeaders method (#469)
- adding port-forward for containers in pods (#528)
- Lens restructure (#540)
- Use LensDev on development environment (557)
- Show devtools always in menu (#559)
- fix format duration rounding days error (#582)
- Handle unknown resources properly after they've been created in editor (#617)
- Fix CRD api parsing (#622)
- Fix Resource Quota Rendering (#624)
- Use the Kubernetes regex for matching system names (#659)
- fix: 🐛 Change kind to "Endpoints" in renderer (#672)
- add cluster icon migration code (#673)
- Added load-balancer hostname/IP to ingress details (#675)
- Handle status values that contains an object (#693)
- Add cronjob trigger (#694)
- Fix: incorrect path to install/uninstall feature (#723)
- Fix: sync in sub-frames for common-stores are broken (#724)
- Adding menu accelerators for basic actions (#729)
- Increase timeout when doing port-forward through tcpPortUsed.waitUntilUsed (#732)
- Allow user to select Kubeconfig from filesystem (#740)
- Fixing minor light theme issues (#744)
- Fix manifests order for Metrics feature(#752)
- Use proxy kubeconfig for shell and resource applier (#754)
- Remove cluster view on cluster remove (#758)
- Fix: cluster-menu spacing, incorrect cluster-view after switching workspace (#765)
- Fix integration tests (#767)
- Change owner of minikube config files to $USER (#681)
- Fixing app crash when iterating Events without 'kind' prop defined (#743)
- Allow for users to enabled release mode debugging (#481)
- Upgrade eslint typescript parser (#773)
- Allow to override logger for LensBinary (#776)
- Update Kubectl version map (#780)
- Bump versions of bundled binaries (#781)
- Do not set app to dev mode if debugging flag is passed (#774)
- Adding margin to last cluster icon (#788)
- Reload active dashboard view (#783)
- Update help texts for Add cluster (#785)
- Try to reconnect non-accessible clusters on activate (#789)
- Using import type statement (#793)
- Download binaries before building the app (#799)
- Some Grammatical Fixes ❤️ (#641) 
- Remove double copyright (#802)
- Change order of init for fresh clone (#797)
- Update CRD api to use preferred version and implement v1 differences (#718)
- Wider Select box for Helm chart installation (#803)
- Close Preferences and Cluster Setting on Esc keypress (#804)
- Restrict file permissions to only the user for pasted kubeconfigs that are kept in App dir (#805)
- Add drag and drop capabilities for the order of cluster icons (#623)
- Allow user to configure kubectl binary preferences (#800)
- Removing DEBUG env from package.json commands (#810) 
- More cluster menu fixes (#815) 
- Update logo (#819) 
- Refresh input values on cluster change (#814)
- Add progress bar for webpack compilation (#794) 
- Remove explicit yarn install call from make build task (#835) 
- remove make-syncronous and file-type calls from migration (#844)
- Fixing Dialog Escape keypress behavior (#831)
- Setting new workspace name restrictions (#832) 
- Fix cluster's apiUrl (#846) 
- [FIX]: Cluster dashboard not rendered (#848)
- Fix proxy kubeconfig file permissions (#857)
- Move verbose log lines to silly level (#859) 
- Add path to auth proxy url if present in cluster url (#856)
- fix isPath message (#860)
- App reload in cluster settings (#858)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>