### PR TITLE
Remove extra refreshEvents polling

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -111,12 +111,10 @@ export class Cluster implements ClusterModel {
   protected bindEvents() {
     logger.info(`[CLUSTER]: bind events`, this.getMeta());
     const refreshTimer = setInterval(() => this.online && this.refresh(), 30000); // every 30s
-    const refreshEventsTimer = setInterval(() => this.online && this.refreshEvents(), 3000); // every 3s
 
     this.eventDisposers.push(
       reaction(this.getState, this.pushState),
       () => clearInterval(refreshTimer),
-      () => clearInterval(refreshEventsTimer),
     );
   }
 


### PR DESCRIPTION
This PR removes extra timer for `cluster.refreshEvents`. `cluster.refresh` fetches also events and that is executed every 30 seconds, which is enough.


Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>