### PR TITLE
Release v3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,16 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.0 (current version)
+## 3.6.1 (current version)
+- Inject Host header to k8s client requests
+- Remove extra refreshEvents polling
+- Fix windows installer when app directory removed manually
+
+**Known issues**
+
+- Kubectl exec command does not work in terminal against clusters that are behind a load balancer and require Host header in request, for example Rancher clusters.
+
+## 3.6.0
 - Allow user to configure directory where Kubectl binaries are downloaded
 - Allow user to configure path to Kubectl binary, instead of using bundled Kubectl
 - Allow user to select Kubeconfig from filesystem
@@ -64,7 +73,7 @@ Here you can find description of changes we've built into each release. While we
 ## 3.5.2
 - Fix application not opening properly in some cases by catching and logging error from shell sync.
 
-## 3.5.1 (current version)
+## 3.5.1
 - Fix kubernetes api requests to work with non-"namespaces" pathnames
 - Fix: Handle invalid metrics responses properly
 - Fix: Display namespace defined in kubeconfig always in the namespace selector


### PR DESCRIPTION
## Changes since v3.6.0

- Inject Host header to k8s client requests (#887 )
- Remove extra refreshEvents polling (#892)
- Fix windows installer when app directory removed manually (#893)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>