### PR TITLE
Fix service account's imagePullSecrets rendering if secret is not found

### DIFF
--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -41,7 +41,7 @@ export class ServiceAccountsDetails extends React.Component<Props> {
     const imagePullSecrets = serviceAccount.getImagePullSecrets().map(async({ name }) => {
       return secretsStore.load({ name, namespace }).catch(_err => { return this.generateDummySecretObject(name) });
     });
-    this.imagePullSecrets = (await Promise.all(imagePullSecrets))
+    this.imagePullSecrets = await Promise.all(imagePullSecrets)
   })
 
   renderSecrets() {

--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -39,9 +39,9 @@ export class ServiceAccountsDetails extends React.Component<Props> {
     });
     this.secrets = await Promise.all(secrets);
     const imagePullSecrets = serviceAccount.getImagePullSecrets().map(async({ name }) => {
-      return secretsStore.load({ name, namespace }).catch(_err => { return null });
+      return secretsStore.load({ name, namespace }).catch(_err => { return this.generateDummySecretObject(name) });
     });
-    this.imagePullSecrets = (await Promise.all(imagePullSecrets)).filter(secret => !!secret)
+    this.imagePullSecrets = (await Promise.all(imagePullSecrets))
   })
 
   renderSecrets() {
@@ -54,20 +54,12 @@ export class ServiceAccountsDetails extends React.Component<Props> {
     )
   }
 
-  renderImagePullSecrets(imagePullSecretNames: { name: string; }[]) {
+  renderImagePullSecrets() {
     const { imagePullSecrets } = this;
     if (!imagePullSecrets) {
       return <Spinner center/>
     }
-    const secrets = imagePullSecretNames.map(({name}) => {
-      let secret = imagePullSecrets.find((secret) => secret.getName() === name)
-      if (!secret) {
-        secret = this.generateDummySecretObject(name)
-      }
-      return secret
-    })
-
-    return this.renderSecretLinks(secrets)
+    return this.renderSecretLinks(imagePullSecrets)
   }
 
   renderSecretLinks(secrets: Secret[]) {
@@ -125,7 +117,7 @@ export class ServiceAccountsDetails extends React.Component<Props> {
         }
         {imagePullSecrets.length > 0 &&
         <DrawerItem name={<Trans>ImagePullSecrets</Trans>} className="links">
-          {this.renderImagePullSecrets(imagePullSecrets)}
+          {this.renderImagePullSecrets()}
         </DrawerItem>
         }
 

--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -55,15 +55,14 @@ export class ServiceAccountsDetails extends React.Component<Props> {
   }
 
   renderImagePullSecrets(imagePullSecretNames: { name: string; }[]) {
-    const { object: serviceAccount } = this.props;
     const { imagePullSecrets } = this;
     if (!imagePullSecrets) {
       return <Spinner center/>
     }
     const secrets = imagePullSecretNames.map(({name}) => {
-      let secret = imagePullSecrets.find((secret) => secret.getName() === name && secret.getNs() === serviceAccount.getNs())
+      let secret = imagePullSecrets.find((secret) => secret.getName() === name)
       if (!secret) {
-        secret = this.generateDummySecretObject(name, serviceAccount.getNs())
+        secret = this.generateDummySecretObject(name)
       }
       return secret
     })
@@ -81,7 +80,7 @@ export class ServiceAccountsDetails extends React.Component<Props> {
               small material="warning"
               tooltip={<Trans>Secret is not found</Trans>}
             />
-         </div>
+          </div>
         )
       }
       return (
@@ -92,12 +91,11 @@ export class ServiceAccountsDetails extends React.Component<Props> {
     })
   }
 
-  generateDummySecretObject(name: string, namespace: string) {
+  generateDummySecretObject(name: string) {
     return new Secret({
       apiVersion: "v1",
       kind: "Secret",
       metadata: {
-        namespace: namespace,
         name: name,
         uid: null,
         selfLink: null,

--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -15,6 +15,7 @@ import { getDetailsUrl } from "../../navigation";
 import { KubeObjectDetailsProps } from "../kube-object";
 import { apiManager } from "../../api/api-manager";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
+import { Icon } from "../icon";
 
 interface Props extends KubeObjectDetailsProps<ServiceAccount> {
 }
@@ -22,21 +23,25 @@ interface Props extends KubeObjectDetailsProps<ServiceAccount> {
 @observer
 export class ServiceAccountsDetails extends React.Component<Props> {
   @observable secrets: Secret[];
+  @observable imagePullSecrets: Secret[];
 
   @disposeOnUnmount
   loadSecrets = autorun(async () => {
     this.secrets = null;
+    this.imagePullSecrets = null;
     const { object: serviceAccount } = this.props;
     if (!serviceAccount) {
       return;
     }
     const namespace = serviceAccount.getNs();
     const secrets = serviceAccount.getSecrets().map(({ name }) => {
-      const secret = secretsStore.getByName(name, namespace);
-      if (!secret) return secretsStore.load({ name, namespace });
-      return secret;
+      return secretsStore.load({ name, namespace });
     });
     this.secrets = await Promise.all(secrets);
+    const imagePullSecrets = serviceAccount.getImagePullSecrets().map(async({ name }) => {
+      return secretsStore.load({ name, namespace }).catch(_err => { return null });
+    });
+    this.imagePullSecrets = (await Promise.all(imagePullSecrets)).filter(secret => !!secret)
   })
 
   renderSecrets() {
@@ -49,15 +54,56 @@ export class ServiceAccountsDetails extends React.Component<Props> {
     )
   }
 
+  renderImagePullSecrets(imagePullSecretNames: { name: string; }[]) {
+    const { object: serviceAccount } = this.props;
+    const { imagePullSecrets } = this;
+    if (!imagePullSecrets) {
+      return <Spinner center/>
+    }
+    const secrets = imagePullSecretNames.map(({name}) => {
+      let secret = imagePullSecrets.find((secret) => secret.getName() === name && secret.getNs() === serviceAccount.getNs())
+      if (!secret) {
+        secret = this.generateDummySecretObject(name, serviceAccount.getNs())
+      }
+      return secret
+    })
+
+    return this.renderSecretLinks(secrets)
+  }
+
   renderSecretLinks(secrets: Secret[]) {
-    return secrets.map(secret => {
+    return secrets.map((secret) => {
+      if (secret.getId() === null) {
+        return (
+          <div key={secret.getName()}>
+            {secret.getName()}
+            <Icon
+              small material="warning"
+              tooltip={<Trans>Secret is not found</Trans>}
+            />
+         </div>
+        )
+      }
       return (
         <Link key={secret.getId()} to={getDetailsUrl(secret.selfLink)}>
           {secret.getName()}
         </Link>
       )
-    }
-    )
+    })
+  }
+
+  generateDummySecretObject(name: string, namespace: string) {
+    return new Secret({
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        namespace: namespace,
+        name: name,
+        uid: null,
+        selfLink: null,
+        resourceVersion: null
+      }
+    })
   }
 
   render() {
@@ -69,9 +115,7 @@ export class ServiceAccountsDetails extends React.Component<Props> {
       secret.getNs() == serviceAccount.getNs() &&
       secret.getAnnotations().some(annot => annot == `kubernetes.io/service-account.name: ${serviceAccount.getName()}`)
     )
-    const imagePullSecrets = serviceAccount.getImagePullSecrets().map(({ name }) =>
-      secretsStore.getByName(name, serviceAccount.getNs())
-    )
+    const imagePullSecrets = serviceAccount.getImagePullSecrets()
     return (
       <div className="ServiceAccountsDetails">
         <KubeObjectMeta object={serviceAccount}/>
@@ -83,7 +127,7 @@ export class ServiceAccountsDetails extends React.Component<Props> {
         }
         {imagePullSecrets.length > 0 &&
         <DrawerItem name={<Trans>ImagePullSecrets</Trans>} className="links">
-          {this.renderSecretLinks(imagePullSecrets)}
+          {this.renderImagePullSecrets(imagePullSecrets)}
         </DrawerItem>
         }
 


### PR DESCRIPTION
This PR fixes service account's imagePullSecrets rendering if the secret does not exist. Now if the imagePullSecret is not found, app will display warning icon with `Secret is not found` as tooltip text beside the value of imagePullSecret.

<img width="738" src="https://user-images.githubusercontent.com/455844/93469923-d8703980-f8f9-11ea-87aa-71cd78dcbae9.png">

If the secret is found, app will render link to the secret like before.

Fixes #823
Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>