### PR TITLE
add a zero width space to Badges to fix double click highlighting issue

### DIFF
--- a/src/renderer/components/badge/badge.tsx
+++ b/src/renderer/components/badge/badge.tsx
@@ -13,11 +13,12 @@ interface Props extends React.HTMLAttributes<any>, TooltipDecoratorProps {
 export class Badge extends React.Component<Props> {
   render() {
     const { className, label, small, children, ...elemProps } = this.props;
-    return (
+    return <>
       <span className={cssNames("Badge", { small }, className)} {...elemProps}>
         {label}
         {children}
       </span>
-    );
+      &#8203;
+    </>
   }
 }

--- a/src/renderer/components/badge/badge.tsx
+++ b/src/renderer/components/badge/badge.tsx
@@ -18,6 +18,12 @@ export class Badge extends React.Component<Props> {
         {label}
         {children}
       </span>
+      { /**
+          * This is a zero-width-space. It makes there be a word seperation
+          * between adjacent Badge's because <span>'s are ignored for browers'
+          * word detection algorithmns use for determining the extent of the
+          * text to highlight on multi-click sequences.
+          */}
       &#8203;
     </>
   }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #869 