### PR TITLE
FIX: get back to webview  / empty cluster-view bug

### DIFF
--- a/integration/specs/app_spec.ts
+++ b/integration/specs/app_spec.ts
@@ -26,9 +26,12 @@ describe("app start", () => {
 
   const waitForMinikubeDashboard = async (app: Application) => {
     await app.client.waitUntilTextExists("pre.kube-auth-out", "Authentication proxy started")
-    await app.client.getWindowCount()
-    await app.client.waitForExist(`iframe[name="minikube"]`)
-    await app.client.frame("minikube")
+    let windowCount = await app.client.getWindowCount()
+    // wait for webview to appear on window count
+    while (windowCount == 1) {
+      windowCount = await app.client.getWindowCount()
+    }
+    await app.client.windowByIndex(windowCount - 1)
     await app.client.waitUntilTextExists("span.link-text", "Cluster")
   }
 

--- a/src/common/cluster-ipc.ts
+++ b/src/common/cluster-ipc.ts
@@ -5,12 +5,8 @@ import { tracker } from "./tracker";
 export const clusterIpc = {
   activate: createIpcChannel({
     channel: "cluster:activate",
-    handle: (clusterId: ClusterId, frameId?: number) => {
-      const cluster = clusterStore.getById(clusterId);
-      if (cluster) {
-        if (frameId) cluster.frameId = frameId; // save cluster's webFrame.routingId to be able to send push-updates
-        return cluster.activate(true);
-      }
+    handle: async (clusterId: ClusterId) => {
+      return clusterStore.getById(clusterId)?.activate({ init: true });
     },
   }),
 

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -75,10 +75,13 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     });
     if (ipcRenderer) {
       ipcRenderer.on("cluster:state", (event, model: ClusterState) => {
-        this.applyWithoutSync(() => {
-          logger.silly(`[CLUSTER-STORE]: received push-state at ${location.host}`, model);
-          this.getById(model.id)?.updateModel(model);
-        })
+        const cluster = this.getById(model.id);
+        if (cluster) {
+          this.applyWithoutSync(() => {
+            logger.silly(`[CLUSTER-STORE]: received push-state at ${location.host}`, model);
+            cluster.updateModel(model);
+          })
+        }
       })
     }
   }
@@ -210,14 +213,14 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
 export const clusterStore = ClusterStore.getInstance<ClusterStore>();
 
 export function isClusterView(): boolean {
-  return !!getHostedClusterId(); // note: process.isMainFrame cannot be used here since it's "true" for webview-tags
+  return !!getHostedClusterId(); // note: process.isMainFrame cannot be used with "webview"-tags since they have own renderer process
 }
 
 export function getClusterIdFromHost(hostname: string): ClusterId {
   return hostname.match(/^(.*?)\.localhost/)?.[1]
 }
 
-export function getClusterFrameUrl(clusterId: ClusterId) {
+export function getClusterViewUrl(clusterId: ClusterId) {
   const { protocol, host } = location
   return `${protocol}//${clusterId}.${host}`
 }

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -209,13 +209,17 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
 
 export const clusterStore = ClusterStore.getInstance<ClusterStore>();
 
+export function isClusterView(): boolean {
+  return !!getHostedClusterId(); // note: process.isMainFrame cannot be used here since it's "true" for webview-tags
+}
+
 export function getClusterIdFromHost(hostname: string): ClusterId {
-  const subDomains = hostname.split(":")[0].split(".");
-  return subDomains.slice(-2)[0]; // e.g host == "%clusterId.localhost:45345"
+  return hostname.match(/^(.*?)\.localhost/)?.[1]
 }
 
 export function getClusterFrameUrl(clusterId: ClusterId) {
-  return `//${clusterId}.${location.host}`;
+  const { protocol, host } = location
+  return `${protocol}//${clusterId}.${host}`
 }
 
 export function getHostedClusterId() {

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -56,7 +56,6 @@ export interface IpcBroadcastParams<A extends any[] = any> {
   frameId?: number; // send to inner frame of webContents
   frameOnly?: boolean; // send message only to view with provided `frameId`
   filter?: (webContent: WebContents) => boolean
-  timeout?: number; // todo: add support
   args?: A;
 }
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -31,6 +31,7 @@ export class WindowManager {
         nodeIntegration: true,
         nodeIntegrationInSubFrames: true,
         enableRemoteModule: true,
+        webviewTag: true,
       },
     });
     this.windowState.manage(this.mainView);

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -4,7 +4,7 @@ import { render } from "react-dom";
 import { isMac } from "../common/vars";
 import { userStore } from "../common/user-store";
 import { workspaceStore } from "../common/workspace-store";
-import { clusterStore } from "../common/cluster-store";
+import { clusterStore, isClusterView } from "../common/cluster-store";
 import { i18nStore } from "./i18n";
 import { themeStore } from "./theme.store";
 import { App } from "./components/app";
@@ -35,4 +35,4 @@ export async function bootstrap(App: AppComponent) {
 }
 
 // run
-bootstrap(process.isMainFrame ? LensApp : App);
+bootstrap(isClusterView() ? App : LensApp);

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -34,17 +34,15 @@ import { Terminal } from "./dock/terminal";
 import { getHostedCluster, getHostedClusterId } from "../../common/cluster-store";
 import logger from "../../main/logger";
 import { clusterIpc } from "../../common/cluster-ipc";
-import { webFrame } from "electron";
 import { MainLayout } from "./layout/main-layout";
 
 @observer
 export class App extends React.Component {
   static async init() {
-    const frameId = webFrame.routingId;
     const clusterId = getHostedClusterId();
-    logger.info(`[APP]: Init dashboard, clusterId=${clusterId}, frameId=${frameId}`)
+    logger.info(`[APP]: Init dashboard, clusterId=${clusterId}`)
     await Terminal.preloadFonts()
-    await clusterIpc.activate.invokeFromRenderer(clusterId, frameId);
+    await clusterIpc.activate.invokeFromRenderer(clusterId);
     await getHostedCluster().whenReady; // cluster.refresh() is done at this point
   }
 

--- a/src/renderer/components/cluster-manager/cluster-view.route.ts
+++ b/src/renderer/components/cluster-manager/cluster-view.route.ts
@@ -2,7 +2,7 @@ import { reaction } from "mobx";
 import { ipcRenderer } from "electron";
 import { matchPath, RouteProps } from "react-router";
 import { buildURL, navigation } from "../../navigation";
-import { clusterStore } from "../../../common/cluster-store";
+import { clusterStore, isClusterView } from "../../../common/cluster-store";
 
 export interface IClusterViewRouteParams {
   clusterId: string;
@@ -30,7 +30,7 @@ export function getMatchedCluster() {
 }
 
 if (ipcRenderer) {
-  if (process.isMainFrame) {
+  if (isClusterView()) {
     // Keep track of active cluster-id for handling IPC/menus/etc.
     reaction(() => getMatchedClusterId(), clusterId => {
       ipcRenderer.send("cluster-view:current-id", clusterId);

--- a/src/renderer/components/cluster-manager/cluster-view.route.ts
+++ b/src/renderer/components/cluster-manager/cluster-view.route.ts
@@ -30,7 +30,7 @@ export function getMatchedCluster() {
 }
 
 if (ipcRenderer) {
-  if (isClusterView()) {
+  if (!isClusterView()) {
     // Keep track of active cluster-id for handling IPC/menus/etc.
     reaction(() => getMatchedClusterId(), clusterId => {
       ipcRenderer.send("cluster-view:current-id", clusterId);

--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -1,16 +1,13 @@
 import { WebviewTag } from "electron";
 import { observable, when } from "mobx";
-import { ClusterId, clusterStore, getClusterFrameUrl } from "../../../common/cluster-store";
+import { ClusterId, clusterStore, getClusterViewUrl } from "../../../common/cluster-store";
 import logger from "../../../main/logger";
-import { isDebugging, isDevelopment, isProduction } from "../../../common/vars";
 import { getMatchedCluster } from "./cluster-view.route";
-
-export type LensViewElem = HTMLIFrameElement | WebviewTag;
 
 export interface LensView {
   isLoaded?: boolean
   clusterId: ClusterId;
-  view: LensViewElem;
+  view: WebviewTag;
 }
 
 export const lensViews = observable.map<ClusterId, LensView>();
@@ -24,31 +21,22 @@ export async function initView(clusterId: ClusterId) {
     return;
   }
   logger.info(`[LENS-VIEW]: init dashboard, clusterId=${clusterId}`)
-  let view: LensViewElem;
-  const cluster = clusterStore.getById(clusterId);
   const parentElem = document.getElementById("lens-views");
-  const frameUrl = getClusterFrameUrl(clusterId);
   const onLoad = () => {
     logger.info(`[LENS-VIEW]: loaded from ${view.src}`)
     lensViews.get(clusterId).isLoaded = true;
   };
-  if (isDevelopment || isDebugging) {
-    view = document.createElement("iframe");
-    view.addEventListener("load", onLoad);
-    view.name = cluster.contextName;
-  } else if (isProduction) {
-    view = document.createElement("webview");
-    view.addEventListener("did-frame-finish-load", onLoad);
-    view.setAttribute("nodeintegration", "true");
-    view.setAttribute("enableremotemodule", "true");
-  }
-  view.setAttribute("src", frameUrl);
+  const view = document.createElement("webview");
+  view.addEventListener("did-frame-finish-load", onLoad);
+  view.setAttribute("nodeintegration", "true");
+  view.setAttribute("enableremotemodule", "true");
+  view.setAttribute("src", getClusterViewUrl(clusterId));
   parentElem.appendChild(view);
   lensViews.set(clusterId, { clusterId, view });
   await autoCleanOnRemove(clusterId, view);
 }
 
-export async function autoCleanOnRemove(clusterId: ClusterId, view: LensViewElem) {
+export async function autoCleanOnRemove(clusterId: ClusterId, view: WebviewTag) {
   await when(() => !clusterStore.getById(clusterId));
   logger.info(`[LENS-VIEW]: remove dashboard, clusterId=${clusterId}`)
   lensViews.delete(clusterId);


### PR DESCRIPTION
Switching back to `webview` since `iframe` not reliable and might start missing IPC-events for some reasons.
This could be reproduced by multiple attempts to add/remove same cluster, which might leads to empty cluster-view screen.