### PR TITLE
get focus to dock tab content after resize

### DIFF
--- a/src/renderer/components/dock/editor-panel.tsx
+++ b/src/renderer/components/dock/editor-panel.tsx
@@ -48,6 +48,7 @@ export class EditorPanel extends React.Component<Props> {
 
   onResize = () => {
     this.editor.resize();
+    this.editor.focus();
   }
 
   onCursorPosChange = (pos: Ace.Point) => {

--- a/src/renderer/components/dock/terminal.ts
+++ b/src/renderer/components/dock/terminal.ts
@@ -152,6 +152,7 @@ export class Terminal {
   onResize = () => {
     if (!this.isActive) return;
     this.fitLazy();
+    this.focus();
   }
 
   onActivate = () => {


### PR DESCRIPTION
fix #830, besides terminal get focus for other dock tab contents(with `EditorPanel`) as well.