### PR TITLE
Optimise cluster activate and refresh

### DIFF
--- a/src/common/cluster-ipc.ts
+++ b/src/common/cluster-ipc.ts
@@ -14,6 +14,14 @@ export const clusterIpc = {
     },
   }),
 
+  refresh: createIpcChannel({
+    channel: "cluster:refresh",
+    handle: (clusterId: ClusterId) => {
+      const cluster = clusterStore.getById(clusterId);
+      if (cluster) return cluster.refresh();
+    },
+  }),
+
   disconnect: createIpcChannel({
     channel: "cluster:disconnect",
     handle: (clusterId: ClusterId) => {

--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -39,7 +39,7 @@ export class ShellSession extends EventEmitter {
   public async open() {
     this.kubectlBinDir = await this.kubectl.binDir()
     const pathFromPreferences = userStore.preferences.kubectlBinariesPath || Kubectl.bundledKubectlPath
-    this.kubectlPathDir = userStore.preferences.downloadKubectlBinaries ? await this.kubectl.binDir() : path.dirname(pathFromPreferences)
+    this.kubectlPathDir = userStore.preferences.downloadKubectlBinaries ? this.kubectlBinDir : path.dirname(pathFromPreferences)
     this.helmBinDir = helmCli.getBinaryDir()
     const env = await this.getCachedShellEnv()
     const shell = env.PTYSHELL

--- a/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -39,7 +39,7 @@ export class ClusterStatus extends React.Component<Props> {
       });
     })
     if (this.cluster.disconnected) {
-      await this.refreshCluster();
+      await this.activateCluster();
     }
   }
 
@@ -47,13 +47,13 @@ export class ClusterStatus extends React.Component<Props> {
     ipcRenderer.removeAllListeners(`kube-auth:${this.props.clusterId}`);
   }
 
-  refreshCluster = async () => {
+  activateCluster = async () => {
     await clusterIpc.activate.invokeFromRenderer(this.props.clusterId);
   }
 
   reconnect = async () => {
     this.isReconnecting = true;
-    await this.refreshCluster();
+    await this.activateCluster();
     this.isReconnecting = false;
   }
 


### PR DESCRIPTION
This PR will optimise cluster dashboard opening. `cluster.activate()` will fetch only those data that is required for the dashboard. Also kubectl downloading is not blocking operation anymore (fixes #933). Full cluster information refresh is done periodically and when opening cluster settings.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>