### PR TITLE
Fix background of What's New page with white theme

### DIFF
--- a/src/renderer/components/+whats-new/whats-new.scss
+++ b/src/renderer/components/+whats-new/whats-new.scss
@@ -1,10 +1,24 @@
 .WhatsNew {
   $spacing: $padding * 2;
 
-  background: $mainBackground url(../../components/icon/crane.svg) no-repeat;
-  background-position: 0 35%;
-  background-size: 85%;
-  background-clip: content-box;
+  &::after {
+    content: "";
+    background: url(../../components/icon/crane.svg) no-repeat;
+    background-position: 0 35%;
+    background-size: 85%;
+    background-clip: content-box;
+    opacity: .75;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    position: absolute;
+    z-index: -1;
+
+    .theme-light & {
+      opacity: 0.2;
+    }
+  }
 
   .logo {
     width: 200px;


### PR DESCRIPTION

<img width="1662" src="https://user-images.githubusercontent.com/455844/93763387-06b38900-fc1a-11ea-9644-b35fca9e6766.png">

Fixes #907 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>