### PR TITLE
display last-applied-configuration annotation in detail-view

### DIFF
--- a/src/renderer/api/kube-object.ts
+++ b/src/renderer/api/kube-object.ts
@@ -115,12 +115,12 @@ export class KubeObject implements ItemObject {
     return KubeObject.stringifyLabels(this.metadata.labels);
   }
 
-  getAnnotations(): string[] {
+  getAnnotations(filter = false): string[] {
     const labels = KubeObject.stringifyLabels(this.metadata.annotations);
-    return labels.filter(label => {
+    return filter ? labels.filter(label => {
       const skip = resourceApplierApi.annotations.some(key => label.startsWith(key));
       return !skip;
-    })
+    }) : labels;
   }
 
   getOwnerRefs() {
@@ -138,7 +138,7 @@ export class KubeObject implements ItemObject {
       getNs(),
       getId(),
       ...getLabels(),
-      ...getAnnotations(),
+      ...getAnnotations(true),
     ]
   }
 


### PR DESCRIPTION
fix #719 display last-applied-configuration annotation in detail-view , but still filter it in search fields

Signed-off-by: Yangjun Wang <yangjun.wang@wartsila.com>