### PR TITLE
Add migration to fix kubeconfig paths that point to snap config dir

### DIFF
--- a/src/migrations/cluster-store/index.ts
+++ b/src/migrations/cluster-store/index.ts
@@ -7,6 +7,7 @@ import version260Beta3 from "./2.6.0-beta.3"
 import version270Beta0 from "./2.7.0-beta.0"
 import version270Beta1 from "./2.7.0-beta.1"
 import version360Beta1 from "./3.6.0-beta.1"
+import snap from "./snap"
 
 export default {
   ...version200Beta2,
@@ -16,4 +17,5 @@ export default {
   ...version270Beta0,
   ...version270Beta1,
   ...version360Beta1,
+  ...snap
 }

--- a/src/migrations/cluster-store/snap.ts
+++ b/src/migrations/cluster-store/snap.ts
@@ -3,6 +3,7 @@
 import { migration } from "../migration-wrapper";
 import { ClusterModel, ClusterStore } from "../../common/cluster-store";
 import { getAppVersion } from "../../common/utils/app-version";
+import fs from "fs"
 
 export default migration({
   version: getAppVersion(), // Run always after upgrade
@@ -19,8 +20,10 @@ export default migration({
         /**
          * replace snap version with 'current' in kubeconfig path
          */
-        const kubeconfigPath = cluster.kubeConfigPath.replace(/\/snap\/kontena-lens\/[0-9]*\//, "/snap/kontena-lens/current/")
-        cluster.kubeConfigPath = kubeconfigPath
+        if (!fs.existsSync(cluster.kubeConfigPath)) {
+          const kubeconfigPath = cluster.kubeConfigPath.replace(/\/snap\/kontena-lens\/[0-9]*\//, "/snap/kontena-lens/current/")
+          cluster.kubeConfigPath = kubeconfigPath
+        }
         return cluster;
       })
 

--- a/src/migrations/cluster-store/snap.ts
+++ b/src/migrations/cluster-store/snap.ts
@@ -1,0 +1,30 @@
+// Fix embedded kubeconfig paths under snap config
+
+import { migration } from "../migration-wrapper";
+import { ClusterModel, ClusterStore } from "../../common/cluster-store";
+import { getAppVersion } from "../../common/utils/app-version";
+
+export default migration({
+  version: getAppVersion(), // Run always after upgrade
+  run(store, printLog) {
+    if (!process.env["SNAP"]) return;
+
+    printLog("Migrating embedded kubeconfig paths")
+    const storedClusters: ClusterModel[] = store.get("clusters") || [];
+    if (!storedClusters.length) return;
+
+    printLog("Number of clusters to migrate: ", storedClusters.length)
+    const migratedClusters = storedClusters
+      .map(cluster => {
+        /**
+         * replace snap version with 'current' in kubeconfig path
+         */
+        const kubeconfigPath = cluster.kubeConfigPath.replace(/\/snap\/kontena-lens\/[0-9]*\//, "/snap/kontena-lens/current/")
+        cluster.kubeConfigPath = kubeconfigPath
+        return cluster;
+      })
+
+
+    store.set("clusters", migratedClusters)
+  }
+})


### PR DESCRIPTION
This PR adds cluster store migration that is executed every time the snap version of the app is upgraded. The migration will replace `/snap/kontena-lens/[0-9]*/` in kubeconfig path with `/snap/kontena-lens/current/`.

Fixes #951 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>