### PR TITLE
Release v3.6.5-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.4",
+  "version": "3.6.5-rc.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,26 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.4 (current version)
+## 3.6.5-rc.1 (current version)
+- Fix Notifications not to block items not visually under them from being interacted with
+- Fix side bar not to scroll after clicking on lower menu item
+- Auto-select context if only one context is present in pasted Kubeconfig
+- Fix background image of What's New page on white theme
+- Reduce height on draggable-top and only render it on macos
+- Download dir option is now consistent with other settings
+- Allow to add the same cluster multiple times
+- Convert bytes in memory chart properly
+- Fix empty dashboard screen after cluster is removed and added multiple times in a row to application
+- Dropdowns have pointer cursor now
+- Proxy kubectl exec requests properly
+- Pass always chart version information when dealing with helm commands
+- Fix app crash when conditions are not yet present in CRD objects
+- Fix kubeconfig generating for service account
+- Update bundled Helm binary to version 3.3.4
+- Fix clusters' kubeconfig paths that point to snap config dir to use current snap config path
+
+
+## 3.6.4
 - Fix: deleted namespace does not get auto unselected
 - Get focus to dock tab (terminal & resource editor) content after resize
 - Downloading kubectl binary does not block dashboard opening anymore


### PR DESCRIPTION
## Changes since 3.6.4

- fix Notifications blocking items not visually under them from being interacted with (#915)
- fix side bar scrolls after clicking on lower item (#928)
- Auto select one and only cluster from pasted config (#888)
- reduce height on draggable-top and only render it on macos (#942) 
- Make download dir option consistent with other settings (#875) 
- Allow to add the same cluster to multiple workspaces (#961)
- Convert bytes in memory BarChart properly (#947)
- Fix iframe ipc flakyness after cluster is removed (#954)
- dropdowns should have 'cursor: pointer;' (#956) 
- Fix spdy proxy (#962)
- Helm components should always use version information (#949) 
- cleanup proxy upgrade handler (#963)
- Do not filter contexts when adding new clusters (#969)
- Fix reading CRD conditions (#967) 
- Helm 3.3.4 (#964)
- Fix kubeconfig fetching for service account (#966)
- Add migration to fix kubeconfig paths that point to snap config dir (#972)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>