### PR TITLE
Fix bundled kubectl path on dev env

### DIFF
--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -2,7 +2,7 @@ import { ChildProcess, spawn } from "child_process"
 import { waitUntilUsed } from "tcp-port-used";
 import { broadcastIpc } from "../common/ipc";
 import type { Cluster } from "./cluster"
-import { bundledKubectl, Kubectl } from "./kubectl"
+import { Kubectl } from "./kubectl"
 import logger from "./logger"
 
 export interface KubeAuthProxyLog {
@@ -23,7 +23,7 @@ export class KubeAuthProxy {
     this.env = env
     this.port = port
     this.cluster = cluster
-    this.kubectl = bundledKubectl
+    this.kubectl = Kubectl.bundled()
   }
 
   public async run(): Promise<void> {

--- a/src/main/kubectl.ts
+++ b/src/main/kubectl.ts
@@ -36,15 +36,21 @@ const packageMirrors: Map<string, string> = new Map([
 let bundledPath: string
 const initScriptVersionString = "# lens-initscript v3\n"
 
-if (isDevelopment || isTestEnv) {
-  const platformName = isWindows ? "windows" : process.platform
-  bundledPath = path.join(process.cwd(), "binaries", "client", platformName, process.arch, "kubectl")
-} else {
-  bundledPath = path.join(process.resourcesPath, process.arch, "kubectl")
-}
+export function bundledKubectlPath(): string {
+  if (bundledPath) { return bundledPath }
 
-if (isWindows) {
-  bundledPath = `${bundledPath}.exe`
+  if (isDevelopment || isTestEnv) {
+    const platformName = isWindows ? "windows" : process.platform
+    bundledPath = path.join(process.cwd(), "binaries", "client", platformName, process.arch, "kubectl")
+  } else {
+    bundledPath = path.join(process.resourcesPath, process.arch, "kubectl")
+  }
+
+  if (isWindows) {
+    bundledPath = `${bundledPath}.exe`
+  }
+
+  return bundledPath
 }
 
 export class Kubectl {
@@ -58,7 +64,6 @@ export class Kubectl {
     return path.join((app || remote.app).getPath("userData"), "binaries", "kubectl")
   }
 
-  public static readonly bundledKubectlPath = bundledPath
   public static readonly bundledKubectlVersion: string = bundledVersion
   public static invalidBundle = false
   private static bundledInstance: Kubectl;
@@ -102,7 +107,7 @@ export class Kubectl {
   }
 
   public getBundledPath() {
-    return Kubectl.bundledKubectlPath
+    return bundledKubectlPath()
   }
 
   public getPathFromPreferences() {
@@ -125,19 +130,19 @@ export class Kubectl {
     // return binary name if bundled path is not functional
     if (!await this.checkBinary(this.getBundledPath(), false)) {
       Kubectl.invalidBundle = true
-      return path.basename(bundledPath)
+      return path.basename(this.getBundledPath())
     }
 
     try {
       if (!await this.ensureKubectl()) {
         logger.error("Failed to ensure kubectl, fallback to the bundled version")
-        return Kubectl.bundledKubectlPath
+        return this.getBundledPath()
       }
       return this.path
     } catch (err) {
       logger.error("Failed to ensure kubectl, fallback to the bundled version")
       logger.error(err)
-      return Kubectl.bundledKubectlPath
+      return this.getBundledPath()
     }
   }
 
@@ -183,7 +188,7 @@ export class Kubectl {
       try {
         const exist = await pathExists(this.path)
         if (!exist) {
-          await fs.promises.copyFile(Kubectl.bundledKubectlPath, this.path)
+          await fs.promises.copyFile(this.getBundledPath(), this.path)
           await fs.promises.chmod(this.path, 0o755)
         }
         return true
@@ -321,6 +326,3 @@ export class Kubectl {
     return packageMirrors.get("default") // MacOS packages are only available from default
   }
 }
-
-const bundledKubectl = Kubectl.bundled()
-export { bundledKubectl }

--- a/src/main/kubectl_spec.ts
+++ b/src/main/kubectl_spec.ts
@@ -1,20 +1,20 @@
 import packageInfo from "../../package.json"
 import path from "path"
-import { bundledKubectl, Kubectl } from "../../src/main/kubectl";
+import { Kubectl } from "../../src/main/kubectl";
 import { isWindows } from "../common/vars";
 
 jest.mock("../common/user-store");
 
 describe("kubectlVersion", () => {
   it("returns bundled version if exactly same version used", async () => {
-    const kubectl = new Kubectl(bundledKubectl.kubectlVersion)
-    expect(kubectl.kubectlVersion).toBe(bundledKubectl.kubectlVersion)
+    const kubectl = new Kubectl(Kubectl.bundled().kubectlVersion)
+    expect(kubectl.kubectlVersion).toBe(Kubectl.bundled().kubectlVersion)
   })
 
   it("returns bundled version if same major.minor version is used", async () => {
     const { bundledKubectlVersion } = packageInfo.config;
     const kubectl = new Kubectl(bundledKubectlVersion);
-    expect(kubectl.kubectlVersion).toBe(bundledKubectl.kubectlVersion)
+    expect(kubectl.kubectlVersion).toBe(Kubectl.bundled().kubectlVersion)
   })
 })
 

--- a/src/main/routes/port-forward-route.ts
+++ b/src/main/routes/port-forward-route.ts
@@ -1,7 +1,7 @@
 import { LensApiRequest } from "../router"
 import { LensApi } from "../lens-api"
 import { spawn, ChildProcessWithoutNullStreams } from "child_process"
-import { bundledKubectl } from "../kubectl"
+import { Kubectl } from "../kubectl"
 import { getFreePort } from "../port"
 import { shell } from "electron"
 import * as tcpPortUsed from "tcp-port-used"
@@ -37,7 +37,7 @@ class PortForward {
 
   public async start() {
     this.localPort = await getFreePort()
-    const kubectlBin = await bundledKubectl.getPath()
+    const kubectlBin = await Kubectl.bundled().getPath()
     const args = [
       "--kubeconfig", this.kubeConfig,
       "port-forward",

--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -38,7 +38,7 @@ export class ShellSession extends EventEmitter {
 
   public async open() {
     this.kubectlBinDir = await this.kubectl.binDir()
-    const pathFromPreferences = userStore.preferences.kubectlBinariesPath || Kubectl.bundledKubectlPath
+    const pathFromPreferences = userStore.preferences.kubectlBinariesPath || this.kubectl.getBundledPath()
     this.kubectlPathDir = userStore.preferences.downloadKubectlBinaries ? this.kubectlBinDir : path.dirname(pathFromPreferences)
     this.helmBinDir = helmCli.getBinaryDir()
     const env = await this.getCachedShellEnv()

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -6,7 +6,7 @@ import { Input } from '../input';
 import { SubTitle } from '../layout/sub-title';
 import { UserPreferences, userStore } from '../../../common/user-store';
 import { observer } from 'mobx-react';
-import { Kubectl } from '../../../main/kubectl';
+import { bundledKubectlPath } from '../../../main/kubectl';
 import { SelectOption, Select } from '../select';
 
 export const KubectlBinaries = observer(({ preferences }: { preferences: UserPreferences }) => {
@@ -58,7 +58,7 @@ export const KubectlBinaries = observer(({ preferences }: { preferences: UserPre
       <SubTitle title="Path to Kubectl binary" />
       <Input
         theme="round-black"
-        placeholder={Kubectl.bundledKubectlPath}
+        placeholder={bundledKubectlPath()}
         value={binariesPath}
         validators={isPath}
         onChange={setBinariesPath}


### PR DESCRIPTION
Bundled kubectl on dev environment was pointing to "production" path. Debugging this revealed multiple issues caused by global state (which was modified during import).

Fixes #980