### PR TITLE
Fix: removing pre-defined Input type

### DIFF
--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -282,7 +282,6 @@ export class Input extends React.Component<InputProps, State> {
       onKeyDown: this.onKeyDown,
       rows: multiLine ? (rows || 1) : null,
       ref: this.bindRef,
-      type: "text",
       spellCheck: "false",
     });
 


### PR DESCRIPTION
Allowing an `Input` component to respect any `type` property other than `text`, for example to make password fields.
There's nothing wrong if no type passed to html `<input />`, because default one is `text` anyway https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>