### PR TITLE
Fix CRD conditions rendering

### DIFF
--- a/src/renderer/api/endpoints/crd.api.ts
+++ b/src/renderer/api/endpoints/crd.api.ts
@@ -50,7 +50,7 @@ export class CustomResourceDefinition extends KubeObject {
       message: string;
       reason: string;
       status: string;
-      type: string;
+      type?: string;
     }[];
     acceptedNames: {
       plural: string;

--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -74,7 +74,7 @@ export class CrdResourceDetails extends React.Component<Props> {
               return (
                 <Badge
                   key={kind + index} label={kind}
-                  className={cssNames({ disabled: status === "False" }, kind)}
+                  className={cssNames({ disabled: status === "False" }, kind.toLowerCase())}
                   tooltip={message}
                 />
               );

--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -13,8 +13,9 @@ import { apiManager } from "../../api/api-manager";
 import { crdStore } from "./crd.store";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { Input } from "../input";
+import { CustomResourceDefinition } from "../../api/endpoints/crd.api";
 
-interface Props extends KubeObjectDetailsProps {
+interface Props extends KubeObjectDetailsProps<CustomResourceDefinition> {
 }
 
 function CrdColumnValue({ value }: { value: any[] | {} | string }) {
@@ -66,12 +67,14 @@ export class CrdResourceDetails extends React.Component<Props> {
         })}
         {showStatus && (
           <DrawerItem name={<Trans>Status</Trans>} className="status" labelsOnly>
-            {object.status.conditions.map((condition: { type: string; message: string; status: string }) => {
-              const { type, message, status } = condition;
+            {object.status.conditions.map((condition, index) => {
+              const { type, reason, message, status } = condition;
+              const kind = type || reason;
+              if (!kind) return null;
               return (
                 <Badge
-                  key={type} label={type}
-                  className={cssNames({ disabled: status === "False" }, type.toLowerCase())}
+                  key={kind + index} label={kind}
+                  className={cssNames({ disabled: status === "False" }, kind)}
                   tooltip={message}
                 />
               );


### PR DESCRIPTION
Using `reason` field for CRD status badges if no `type` provided.

Resolves #977 

![crd badges](https://user-images.githubusercontent.com/9607060/94524819-cf596380-023b-11eb-9e87-4e60bb830e74.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>