### PR TITLE
Release v3.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.5-rc.1",
+  "version": "3.6.5",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,12 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.5-rc.1 (current version)
+## 3.6.5 (current version)
+- Fix app crash when CRD conditions were not present
+- Add support for Stacklight prometheus metrics
+- Terminal: set NO_PROXY env for localhost communication
+- Fix CPU/Memory usage metrics when using prometheus operator
+- Display last-applied-configuration annotation
 - Fix Notifications not to block items not visually under them from being interacted with
 - Fix side bar not to scroll after clicking on lower menu item
 - Auto-select context if only one context is present in pasted Kubeconfig

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
 ## 3.6.5 (current version)
+- Prevent drawer close when revealing secret value
 - Fix app crash when CRD conditions were not present
 - Add support for Stacklight prometheus metrics
 - Terminal: set NO_PROXY env for localhost communication


### PR DESCRIPTION
## Changes since 3.6.4

- fix Notifications blocking items not visually under them from being interacted with (#915)
- fix side bar scrolls after clicking on lower item (#928)
- Auto select one and only cluster from pasted config (#888)
- reduce height on draggable-top and only render it on macos (#942) 
- Make download dir option consistent with other settings (#875) 
- Allow to add the same cluster to multiple workspaces (#961)
- Convert bytes in memory BarChart properly (#947)
- Fix iframe ipc flakyness after cluster is removed (#954)
- dropdowns should have 'cursor: pointer;' (#956) 
- Fix spdy proxy (#962)
- Helm components should always use version information (#949) 
- cleanup proxy upgrade handler (#963)
- Do not filter contexts when adding new clusters (#969)
- Fix reading CRD conditions (#967) 
- Helm 3.3.4 (#964)
- Fix kubeconfig fetching for service account (#966)
- Add migration to fix kubeconfig paths that point to snap config dir (#972)
- Removing pre-defined input type (#984) 
- adding more integration tests (#890)
- display last-applied-configuration annotation in detail-view (#943)
- make namespace filter multi select and change onChange (#987)
- Fix CRD conditions rendering (#994) 
- refactor overview statuses to be more DRY (#912) 
- Add support for Docker Enterprise Container Cloud metrics (#998)
- Terminal: set NO_PROXY env for localhost communication (#982)
- Fix CPU/Memory usage metrics when using prometheus operator. (#632) 
- Prevent drawer close on secret's click (#1003)

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>