### PR TITLE
Fix cluster dashboard opening and state refreshing

### DIFF
--- a/src/common/cluster-ipc.ts
+++ b/src/common/cluster-ipc.ts
@@ -14,6 +14,17 @@ export const clusterIpc = {
     },
   }),
 
+  setFrameId: createIpcChannel({
+    channel: "cluster:set-frame-id",
+    handle: (clusterId: ClusterId, frameId?: number) => {
+      const cluster = clusterStore.getById(clusterId);
+      if (cluster) {
+        if (frameId) cluster.frameId = frameId; // save cluster's webFrame.routingId to be able to send push-updates
+        return cluster.pushState();
+      }
+    },
+  }),
+
   refresh: createIpcChannel({
     channel: "cluster:refresh",
     handle: (clusterId: ClusterId) => {

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -193,7 +193,6 @@ export class Cluster implements ClusterModel {
     const connectionStatus = await this.getConnectionStatus();
     this.online = connectionStatus > ClusterStatus.Offline;
     this.accessible = connectionStatus == ClusterStatus.AccessGranted;
-    this.pushState();
   }
 
   @action

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -59,6 +59,7 @@ export class Cluster implements ClusterModel {
   @observable online = false;
   @observable accessible = false;
   @observable ready = false;
+  @observable reconnecting = false;
   @observable disconnected = true;
   @observable failureReason: string;
   @observable nodes = 0;
@@ -110,7 +111,7 @@ export class Cluster implements ClusterModel {
 
   protected bindEvents() {
     logger.info(`[CLUSTER]: bind events`, this.getMeta());
-    const refreshTimer = setInterval(() => this.online && this.refresh(), 30000); // every 30s
+    const refreshTimer = setInterval(() => !this.disconnected && this.refresh(), 30000); // every 30s
 
     this.eventDisposers.push(
       reaction(this.getState, this.pushState),
@@ -192,6 +193,7 @@ export class Cluster implements ClusterModel {
     const connectionStatus = await this.getConnectionStatus();
     this.online = connectionStatus > ClusterStatus.Offline;
     this.accessible = connectionStatus == ClusterStatus.AccessGranted;
+    this.pushState();
   }
 
   @action

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -11,7 +11,7 @@ import { App } from "./components/app";
 import { LensApp } from "./lens-app";
 
 type AppComponent = React.ComponentType & {
-  init?(): void;
+  init?(): Promise<void>;
 }
 
 export async function bootstrap(App: AppComponent) {

--- a/src/renderer/components/+cluster/cluster.tsx
+++ b/src/renderer/components/+cluster/cluster.tsx
@@ -14,14 +14,15 @@ import { podsStore } from "../+workloads-pods/pods.store";
 import { clusterStore } from "./cluster.store";
 import { eventStore } from "../+events/event.store";
 import { isAllowedResource } from "../../../common/rbac";
+import { getHostedCluster } from "../../../common/cluster-store";
 
 @observer
 export class Cluster extends React.Component {
   private dependentStores = [nodesStore, podsStore];
 
   private watchers = [
-    interval(60, () => clusterStore.getMetrics()),
-    interval(20, () => eventStore.loadAll())
+    interval(60, () => { getHostedCluster().available && clusterStore.getMetrics()}),
+    interval(20, () => { getHostedCluster().available && eventStore.loadAll()})
   ];
 
   @computed get isLoaded() {

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -44,8 +44,8 @@ export class App extends React.Component {
     const clusterId = getHostedClusterId();
     logger.info(`[APP]: Init dashboard, clusterId=${clusterId}, frameId=${frameId}`)
     await Terminal.preloadFonts()
-    await clusterIpc.activate.invokeFromRenderer(clusterId, frameId);
-    await getHostedCluster().whenReady; // cluster.refresh() is done at this point
+    await clusterIpc.setFrameId.invokeFromRenderer(clusterId, frameId);
+    await getHostedCluster().whenReady; // cluster.activate() is done at this point
   }
 
   get startURL() {


### PR DESCRIPTION
This PR fixes cluster dashboard opening so that auth proxy is not opened multiple times. Also cluster state is refreshed now also when cluster is not accessible/online, to automatically get cluster dashboard back when the cluster connection comes back.

Cluster overview does not try to refresh events and metrics anymore if cluster is not available.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>