### PR TITLE
Adding space after drawer badges only

### DIFF
--- a/src/renderer/components/badge/badge.tsx
+++ b/src/renderer/components/badge/badge.tsx
@@ -18,13 +18,6 @@ export class Badge extends React.Component<Props> {
         {label}
         {children}
       </span>
-      { /**
-          * This is a zero-width-space. It makes there be a word seperation
-          * between adjacent Badge's because <span>'s are ignored for browers'
-          * word detection algorithmns use for determining the extent of the
-          * text to highlight on multi-click sequences.
-          */}
-      &#8203;
     </>
   }
 }

--- a/src/renderer/components/drawer/drawer-item.scss
+++ b/src/renderer/components/drawer/drawer-item.scss
@@ -48,6 +48,11 @@
         float: left;
         margin: $spacing;
 
+        &:after {
+          content: " ";
+          display: block;
+        }
+
         &.disabled {
           opacity: 0.5;
         }


### PR DESCRIPTION
Removing extra spaces from all `Badge` elements which will fix cluster overview metrics padding issue illustrated here:
<img width="804" alt="big paddings" src="https://user-images.githubusercontent.com/9607060/94901622-96b9c400-049f-11eb-9d51-96b4d4b6286b.png">

This relates to https://github.com/lensapp/lens/issues/869

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>