### PR TITLE
Fix: check for location bevore navigate

### DIFF
--- a/src/renderer/navigation.ts
+++ b/src/renderer/navigation.ts
@@ -18,8 +18,11 @@ if (ipcRenderer) {
 }
 
 export function navigate(location: LocationDescriptor) {
-  if (history.location.pathname === location) return;
+  const currentLocation = navigation.getPath();
   navigation.push(location);
+  if (currentLocation === navigation.getPath()) {
+    navigation.goBack(); // prevent sequences of same url in history
+  }
 }
 
 export interface IURLParams<P = {}, Q = {}> {

--- a/src/renderer/navigation.ts
+++ b/src/renderer/navigation.ts
@@ -18,6 +18,7 @@ if (ipcRenderer) {
 }
 
 export function navigate(location: LocationDescriptor) {
+  if (history.location.pathname === location) return;
   navigation.push(location);
 }
 


### PR DESCRIPTION
When we're using `navigation.push(location);` it won't check for current location url before adding new item to history stack. This causes issues with `history.back()` (which is triggered at closing Preferences). In other words, if you hit `Cmd+,` few times repeatedly, you'll need same amount of `✕` clicks to close Preferences page.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>