### PR TITLE
Open last active cluster view when switching between workspaces

### DIFF
--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -3,7 +3,6 @@ import { BaseStore } from "./base-store";
 import { clusterStore } from "./cluster-store"
 import { landingURL } from "../renderer/components/+landing-page/landing-page.route";
 import { navigate } from "../renderer/navigation";
-import { clusterViewURL } from "../renderer/components/cluster-manager/cluster-view.route";
 
 export type WorkspaceId = string;
 export type ClusterId = string;
@@ -82,7 +81,6 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     if (resetActiveCluster) {
       if (clusterId) {
         clusterStore.setActive(clusterId)
-        navigate(clusterViewURL({ params: { clusterId } }));
       } else {
         clusterStore.setActive(null) 
         if (redirectToLanding) {

--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -146,7 +146,9 @@ export class AddCluster extends React.Component {
         clusterStore.addCluster(...newClusters);
         if (newClusters.length === 1) {
           const clusterId = newClusters[0].id;
+          const wsId = workspaceStore.currentWorkspace.id;
           clusterStore.setActive(clusterId);
+          workspaceStore.setLastActiveClusterId(wsId, clusterStore.activeClusterId);
           navigate(clusterViewURL({ params: { clusterId } }));
         } else {
           Notifications.ok(

--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -146,9 +146,8 @@ export class AddCluster extends React.Component {
         clusterStore.addCluster(...newClusters);
         if (newClusters.length === 1) {
           const clusterId = newClusters[0].id;
-          const wsId = workspaceStore.currentWorkspace.id;
           clusterStore.setActive(clusterId);
-          workspaceStore.setLastActiveClusterId(wsId, clusterStore.activeClusterId);
+          workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, clusterStore.activeClusterId);
           navigate(clusterViewURL({ params: { clusterId } }));
         } else {
           Notifications.ok(

--- a/src/renderer/components/+workspaces/workspace-menu.tsx
+++ b/src/renderer/components/+workspaces/workspace-menu.tsx
@@ -10,6 +10,8 @@ import { observable } from "mobx";
 import { workspaceStore, WorkspaceId } from "../../../common/workspace-store";
 import { cssNames } from "../../utils";
 import { clusterStore } from "../../../common/cluster-store";
+import { navigate } from "../../navigation";
+import { clusterViewURL } from "../cluster-manager/cluster-view.route";
 
 interface Props extends Partial<MenuProps> {
 }
@@ -23,6 +25,8 @@ export class WorkspaceMenu extends React.Component<Props> {
       workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, clusterStore.activeClusterId);
     }
     workspaceStore.setActive(id);
+    const clusterId = workspaceStore.currentWorkspace.lastActiveClusterId;
+    navigate(clusterViewURL({ params: { clusterId } }));
   }
 
   render() {

--- a/src/renderer/components/+workspaces/workspace-menu.tsx
+++ b/src/renderer/components/+workspaces/workspace-menu.tsx
@@ -20,7 +20,7 @@ export class WorkspaceMenu extends React.Component<Props> {
 
   activateWorkspace = (id: WorkspaceId) => {
     if (clusterStore.activeClusterId) {
-      workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspace.id, clusterStore.activeClusterId);
+      workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, clusterStore.activeClusterId);
     }
     workspaceStore.setActive(id);
   }

--- a/src/renderer/components/+workspaces/workspace-menu.tsx
+++ b/src/renderer/components/+workspaces/workspace-menu.tsx
@@ -7,8 +7,9 @@ import { Trans } from "@lingui/macro";
 import { Menu, MenuItem, MenuProps } from "../menu";
 import { Icon } from "../icon";
 import { observable } from "mobx";
-import { workspaceStore } from "../../../common/workspace-store";
+import { workspaceStore, WorkspaceId } from "../../../common/workspace-store";
 import { cssNames } from "../../utils";
+import { clusterStore } from "../../../common/cluster-store";
 
 interface Props extends Partial<MenuProps> {
 }
@@ -16,6 +17,13 @@ interface Props extends Partial<MenuProps> {
 @observer
 export class WorkspaceMenu extends React.Component<Props> {
   @observable menuVisible = false;
+
+  activateWorkspace = (id: WorkspaceId) => {
+    if (clusterStore.activeClusterId) {
+      workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspace.id, clusterStore.activeClusterId);
+    }
+    workspaceStore.setActive(id);
+  }
 
   render() {
     const { className, ...menuProps } = this.props;
@@ -38,7 +46,7 @@ export class WorkspaceMenu extends React.Component<Props> {
               key={workspaceId}
               title={description}
               active={workspaceId === currentWorkspace.id}
-              onClick={() => workspaceStore.setActive(workspaceId)}
+              onClick={() => this.activateWorkspace(workspaceId)}
             >
               <Icon small material="layers"/>
               <span className="workspace">{name}</span>

--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -54,6 +54,7 @@ export class Workspaces extends React.Component {
       id: workspaceId,
       name: "",
       description: "",
+      lastActiveClusterId: ""
     })
   }
 

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -29,6 +29,10 @@ interface Props {
 @observer
 export class ClustersMenu extends React.Component<Props> {
   showCluster = (clusterId: ClusterId) => {
+    const wsId = workspaceStore.currentWorkspace.id;
+    if(clusterId) { 
+      workspaceStore.setLastActiveClusterId(wsId, clusterId);
+    }
     clusterStore.setActive(clusterId);
     navigate(clusterViewURL({ params: { clusterId } }));
   }
@@ -57,7 +61,12 @@ export class ClustersMenu extends React.Component<Props> {
       menu.append(new MenuItem({
         label: _i18n._(t`Disconnect`),
         click: async () => {
+          const wsId = workspaceStore.currentWorkspace.id;
+          const wsLastActiveClusterId = workspaceStore.currentWorkspace.lastActiveClusterId
           if (clusterStore.isActive(cluster.id)) {
+            if (wsLastActiveClusterId === cluster.id) {
+              workspaceStore.setLastActiveClusterId(wsId, "");
+            }            
             navigate(landingURL());
             clusterStore.setActive(null);
           }
@@ -75,6 +84,12 @@ export class ClustersMenu extends React.Component<Props> {
             label: _i18n._(t`Remove`),
           },
           ok: () => {
+            const wsId = workspaceStore.currentWorkspace.id;
+            const wsLastActiveClusterId = workspaceStore.currentWorkspace.lastActiveClusterId 
+            
+            if (wsLastActiveClusterId === cluster.id) {
+              workspaceStore.setLastActiveClusterId(wsId, "");
+            }
             if (clusterStore.activeClusterId === cluster.id) {
               navigate(landingURL());
             }

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -29,9 +29,8 @@ interface Props {
 @observer
 export class ClustersMenu extends React.Component<Props> {
   showCluster = (clusterId: ClusterId) => {
-    const wsId = workspaceStore.currentWorkspace.id;
     if(clusterId) { 
-      workspaceStore.setLastActiveClusterId(wsId, clusterId);
+      workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, clusterId);
     }
     clusterStore.setActive(clusterId);
     navigate(clusterViewURL({ params: { clusterId } }));
@@ -61,11 +60,10 @@ export class ClustersMenu extends React.Component<Props> {
       menu.append(new MenuItem({
         label: _i18n._(t`Disconnect`),
         click: async () => {
-          const wsId = workspaceStore.currentWorkspace.id;
           const wsLastActiveClusterId = workspaceStore.currentWorkspace.lastActiveClusterId
           if (clusterStore.isActive(cluster.id)) {
             if (wsLastActiveClusterId === cluster.id) {
-              workspaceStore.setLastActiveClusterId(wsId, "");
+              workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, "");
             }            
             navigate(landingURL());
             clusterStore.setActive(null);
@@ -84,11 +82,10 @@ export class ClustersMenu extends React.Component<Props> {
             label: _i18n._(t`Remove`),
           },
           ok: () => {
-            const wsId = workspaceStore.currentWorkspace.id;
             const wsLastActiveClusterId = workspaceStore.currentWorkspace.lastActiveClusterId 
             
             if (wsLastActiveClusterId === cluster.id) {
-              workspaceStore.setLastActiveClusterId(wsId, "");
+              workspaceStore.setLastActiveClusterId(workspaceStore.currentWorkspaceId, "");
             }
             if (clusterStore.activeClusterId === cluster.id) {
               navigate(landingURL());


### PR DESCRIPTION
This enhancement will store the last active cluster used in a workspace. If you then switch to a different
workspace and switch back the cluster view will be restored.

If a cluster is disconnected then it will not become active after switching back to the workspace - only an active cluster in the workspace will be "re-activated" when switching back to the workspace.

Signed-off-by: Steve Richards <srichards@mirantis.com>

fixes #827 