### PR TITLE
Add LoadBalancer information to the Ingress view

### DIFF
--- a/src/renderer/api/endpoints/ingress.api.ts
+++ b/src/renderer/api/endpoints/ingress.api.ts
@@ -2,7 +2,6 @@ import { KubeObject } from "../kube-object";
 import { autobind } from "../../utils";
 import { IMetrics, metricsApi } from "./metrics.api";
 import { KubeApi } from "../kube-api";
-import { hostname } from "os";
 
 export class IngressApi extends KubeApi<Ingress> {
   getMetrics(ingress: string, namespace: string): Promise<IIngressMetrics> {
@@ -110,17 +109,11 @@ export class Ingress extends KubeObject {
   }
 
   getLoadBalancers() {
-    const ingressAddresses: string[] = [];
-    const { status: { loadBalancer } } = this;
-
-    if (!loadBalancer) return [];
-
-    loadBalancer.ingress.forEach(address => {
-      const entry = address.hostname ? address.hostname : address.ip;
-      ingressAddresses.push(entry); 
-    })
-
-    return ingressAddresses;
+    const { status: { loadBalancer = { ingress: [] } } } = this;
+    
+    return (loadBalancer.ingress ?? []).map(address => (
+      address.hostname || address.ip
+    ))
   }
 }
 

--- a/src/renderer/api/endpoints/ingress.api.ts
+++ b/src/renderer/api/endpoints/ingress.api.ts
@@ -2,6 +2,7 @@ import { KubeObject } from "../kube-object";
 import { autobind } from "../../utils";
 import { IMetrics, metricsApi } from "./metrics.api";
 import { KubeApi } from "../kube-api";
+import { hostname } from "os";
 
 export class IngressApi extends KubeApi<Ingress> {
   getMetrics(ingress: string, namespace: string): Promise<IIngressMetrics> {
@@ -106,6 +107,20 @@ export class Ingress extends KubeObject {
       ports.push(tlsPort)
     }
     return ports.join(", ")
+  }
+
+  getLoadBalancers() {
+    const ingressAddresses: string[] = [];
+    const { status: { loadBalancer } } = this;
+
+    if (!loadBalancer) return [];
+
+    loadBalancer.ingress.forEach(address => {
+      const entry = address.hostname ? address.hostname : address.ip;
+      ingressAddresses.push(entry); 
+    })
+
+    return ingressAddresses;
   }
 }
 

--- a/src/renderer/components/+network-ingresses/ingresses.tsx
+++ b/src/renderer/components/+network-ingresses/ingresses.tsx
@@ -39,12 +39,14 @@ export class Ingresses extends React.Component<Props> {
         renderTableHeader={[
           { title: <Trans>Name</Trans>, className: "name", sortBy: sortBy.name },
           { title: <Trans>Namespace</Trans>, className: "namespace", sortBy: sortBy.namespace },
+          { title: <Trans>LoadBalancers</Trans>, className: "loadbalancers" },
           { title: <Trans>Rules</Trans>, className: "rules" },
           { title: <Trans>Age</Trans>, className: "age", sortBy: sortBy.age },
         ]}
         renderTableContents={(ingress: Ingress) => [
           ingress.getName(),
           ingress.getNs(),
+          ingress.getLoadBalancers().map(lb => <p key={lb}>{lb}</p>),
           ingress.getRoutes().map(route => <p key={route}>{route}</p>),
           ingress.getAge(),
         ]}


### PR DESCRIPTION
Add a new LoadBalancer column in the Ingress view so that users can see the hostname or IP of the Ingress Controller to be used.

Fixes #772 

Signed-off-by: Steve Richards <srichards@mirantis.com>