### PR TITLE
Align NamespaceSelect and SearchField with each other

### DIFF
--- a/src/renderer/components/input/search-input.scss
+++ b/src/renderer/components/input/search-input.scss
@@ -7,7 +7,11 @@
   > label {
     color: inherit;
     border-radius: $radius;
-    padding: $padding / 1.33 $padding * 1.25;
+    padding: 6px 6px 6px 10px;
+
+    .Icon {
+      height: $margin * 2;
+    }
   }
 
   &.compact {

--- a/src/renderer/components/item-object-list/item-list-layout.scss
+++ b/src/renderer/components/item-object-list/item-list-layout.scss
@@ -15,6 +15,14 @@
       white-space: nowrap;
     }
 
+    .NamespaceSelect {
+      .Select {
+        &__value-container {
+          margin-bottom: 0;
+        }
+      }
+    }
+
     .SearchInput {
       label {
         background: none;


### PR DESCRIPTION
Fine-tuning namespace and search field styles for having equal heights.
Before:
<img width="584" alt="different heights" src="https://user-images.githubusercontent.com/9607060/95684305-61c51400-0bf9-11eb-884b-a7f058fa456b.png">
After:
<img width="572" alt="equal heights" src="https://user-images.githubusercontent.com/9607060/95684311-6ab5e580-0bf9-11eb-8610-48eb2f555c3f.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>