### PR TITLE
Ability to show previous terminated container logs

### DIFF
--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -42,12 +42,14 @@ export interface IPodMetrics<T = IMetrics> {
   networkTransmit: T;
 }
 
+// Reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#read-log-pod-v1-core
 export interface IPodLogsQuery {
   container?: string;
   tailLines?: number;
   timestamps?: boolean;
   sinceTime?: string; // Date.toISOString()-format
   follow?: boolean;
+  previous?: boolean;
 }
 
 export enum PodStatus {

--- a/src/renderer/components/+workloads-pods/pod-menu.tsx
+++ b/src/renderer/components/+workloads-pods/pod-menu.tsx
@@ -50,6 +50,7 @@ export class PodMenu extends React.Component<Props> {
       initContainers: pod.getInitContainers(),
       selectedContainer: container,
       showTimestamps: false,
+      previous: false,
       tailLines: 1000
     });
   }

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -73,7 +73,7 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
       } else {
         this.logs.set(tabId, { oldLogs, newLogs: loadedLogs });
       }
-    } catch (error) {
+    } catch ({error}) {
       this.logs.set(tabId, {
         oldLogs: [
           _i18n._(t`Failed to load logs: ${error.message}`),

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -13,6 +13,7 @@ export interface IPodLogsData {
   initContainers: IPodContainer[]
   showTimestamps: boolean
   tailLines: number
+  previous: boolean
 }
 
 type TabId = string;
@@ -48,7 +49,7 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
     }
     const data = this.getData(tabId);
     const { oldLogs, newLogs } = this.logs.get(tabId);
-    const { selectedContainer, tailLines } = data;
+    const { selectedContainer, tailLines, previous } = data;
     const pod = new Pod(data.pod);
     try {
       // if logs already loaded, check the latest timestamp for getting updates only from this point
@@ -64,7 +65,8 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
         sinceTime: lastLogDate.toISOString(),
         timestamps: true,  // Always setting timestampt to separate old logs from new ones
         container: selectedContainer.name,
-        tailLines: tailLines,
+        tailLines,
+        previous
       });
       if (!oldLogs) {
         this.logs.set(tabId, { oldLogs: loadedLogs, newLogs });

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -183,13 +183,13 @@ export class PodLogs extends React.Component<Props> {
           <Icon
             material="av_timer"
             onClick={this.toggleTimestamps}
-            className={cssNames({ active: showTimestamps })}
+            className={cssNames("timestamps-icon", { active: showTimestamps })}
             tooltip={(showTimestamps ? _i18n._(t`Hide`) : _i18n._(t`Show`)) + " " + _i18n._(t`timestamps`)}
           />
           <Icon
             material="undo"
             onClick={this.togglePrevious}
-            className={cssNames({ active: previous })}
+            className={cssNames("undo-icon", { active: previous })}
             tooltip={(previous ? _i18n._(t`Show current logs`) : _i18n._(t`Show previous terminated container logs`))}
           />
           <Icon

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -94,6 +94,11 @@ export class PodLogs extends React.Component<Props> {
     this.save({ showTimestamps: !this.tabData.showTimestamps });
   }
 
+  togglePrevious = () => {
+    this.save({ previous: !this.tabData.previous });
+    this.reload();
+  }
+
   onScroll = (evt: React.UIEvent<HTMLDivElement>) => {
     const logsArea = evt.currentTarget;
     const { scrollHeight, clientHeight, scrollTop } = logsArea;
@@ -148,7 +153,7 @@ export class PodLogs extends React.Component<Props> {
 
   renderControls() {
     if (!this.ready) return null;
-    const { selectedContainer, showTimestamps, tailLines } = this.tabData;
+    const { selectedContainer, showTimestamps, tailLines, previous } = this.tabData;
     const timestamps = podLogsStore.getTimestamps(podLogsStore.logs.get(this.tabId).oldLogs);
     return (
       <div className="controls flex gaps align-center">
@@ -178,8 +183,14 @@ export class PodLogs extends React.Component<Props> {
           <Icon
             material="av_timer"
             onClick={this.toggleTimestamps}
-            className={cssNames("timestamps-icon", { active: showTimestamps })}
+            className={cssNames({ active: showTimestamps })}
             tooltip={(showTimestamps ? _i18n._(t`Hide`) : _i18n._(t`Show`)) + " " + _i18n._(t`timestamps`)}
+          />
+          <Icon
+            material="undo"
+            onClick={this.togglePrevious}
+            className={cssNames({ active: previous })}
+            tooltip={(previous ? _i18n._(t`Show current logs`) : _i18n._(t`Show previous terminated container logs`))}
           />
           <Icon
             material="get_app"


### PR DESCRIPTION
Based on @Nox-404 PR (https://github.com/lensapp/lens/pull/746) which adds control to show logs for previous containers. Emulates `kubectl get logs --previous` behavior.

![previous container logs](https://user-images.githubusercontent.com/9607060/95715902-44349080-0c73-11eb-8572-268c6e490663.gif)

Fixes #497 
Fixes #602 