### PR TITLE
Preloading previous logs on scroll

### DIFF
--- a/src/renderer/components/+workloads-pods/pod-menu.tsx
+++ b/src/renderer/components/+workloads-pods/pod-menu.tsx
@@ -51,7 +51,6 @@ export class PodMenu extends React.Component<Props> {
       selectedContainer: container,
       showTimestamps: false,
       previous: false,
-      tailLines: 1000
     });
   }
 

--- a/src/renderer/components/dock/pod-log-controls.tsx
+++ b/src/renderer/components/dock/pod-log-controls.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { IPodLogsData, podLogsStore } from "./pod-logs.store";
+import { t, Trans } from "@lingui/macro";
+import { Select, SelectOption } from "../select";
+import { Badge } from "../badge";
+import { Icon } from "../icon";
+import { _i18n } from "../../i18n";
+import { cssNames, downloadFile } from "../../utils";
+import { Pod } from "../../api/endpoints";
+
+interface Props {
+  ready: boolean
+  tabId: string
+  tabData: IPodLogsData
+  logs: string[][]
+  save: (data: Partial<IPodLogsData>) => void
+  reload: () => void
+}
+
+export const PodLogControls = observer((props: Props) => {
+  if (!props.ready) return null;
+  const { tabData, tabId, save, reload, logs } = props;
+  const { selectedContainer, showTimestamps, previous } = tabData;
+  const since = podLogsStore.getTimestamps(podLogsStore.logs.get(tabId)[0]);
+  const pod = new Pod(tabData.pod);
+  const toggleTimestamps = () => {
+    save({ showTimestamps: !showTimestamps });
+  }
+
+  const togglePrevious = () => {
+    save({ previous: !previous });
+    reload();
+  }
+
+  const downloadLogs = () => {
+    const fileName = selectedContainer ? selectedContainer.name : pod.getName();
+    const [oldLogs, newLogs] = logs;
+    downloadFile(fileName + ".log", [...oldLogs, ...newLogs].join("\n"), "text/plain");
+  }
+
+  const onContainerChange = (option: SelectOption) => {
+    const { containers, initContainers } = tabData;
+    save({
+      selectedContainer: containers
+        .concat(initContainers)
+        .find(container => container.name === option.value)
+    })
+    reload();
+  }
+
+  const containerSelectOptions = () => {
+    const { containers, initContainers } = tabData;
+    return [
+      {
+        label: _i18n._(t`Containers`),
+        options: containers.map(container => {
+          return { value: container.name }
+        }),
+      },
+      {
+        label: _i18n._(t`Init Containers`),
+        options: initContainers.map(container => {
+          return { value: container.name }
+        }),
+      }
+    ];
+  }
+
+  const formatOptionLabel = (option: SelectOption) => {
+    const { value, label } = option;
+    return label || <><Icon small material="view_carousel"/> {value}</>;
+  }
+
+  return (
+    <div className="PodLogControls flex gaps align-center">
+      <span><Trans>Pod</Trans>:</span> <Badge label={pod.getName()}/>
+      <span><Trans>Namespace</Trans>:</span> <Badge label={pod.getNs()}/>
+      <span><Trans>Container</Trans></span>
+      <Select
+        options={containerSelectOptions()}
+        value={{ value: selectedContainer.name }}
+        formatOptionLabel={formatOptionLabel}
+        onChange={onContainerChange}
+        autoConvertOptions={false}
+      />
+      <div className="time-range">
+        {since && (
+          <>
+            <Trans>Since</Trans>{" "}
+            <b>{new Date(since[0]).toLocaleString()}</b>
+          </>
+        )}
+      </div>
+      <div className="flex gaps">
+        <Icon
+          material="av_timer"
+          onClick={toggleTimestamps}
+          className={cssNames("timestamps-icon", { active: showTimestamps })}
+          tooltip={(showTimestamps ? _i18n._(t`Hide`) : _i18n._(t`Show`)) + " " + _i18n._(t`timestamps`)}
+        />
+        <Icon
+          material="history"
+          onClick={togglePrevious}
+          className={cssNames("undo-icon", { active: previous })}
+          tooltip={(previous ? _i18n._(t`Show current logs`) : _i18n._(t`Show previous terminated container logs`))}
+        />
+        <Icon
+          material="get_app"
+          onClick={downloadLogs}
+          tooltip={_i18n._(t`Save`)}
+        />
+      </div>
+    </div>
+  );
+});

--- a/src/renderer/components/dock/pod-logs.scss
+++ b/src/renderer/components/dock/pod-logs.scss
@@ -27,7 +27,7 @@
     display: block;
     height: 0;
     border-top: 1px solid $primary;
-    margin: $margin * 2;
+    margin: $margin * 2 0;
 
     &:after {
       position: absolute;
@@ -44,11 +44,10 @@
   .jump-to-bottom {
     position: absolute;
     font-size: small;
-    left: 50%;
+    right: 30px;
     padding: $unit / 2 $unit * 1.5;
     border-radius: $unit * 2;
     opacity: 0;
-    transform: translateX(-50%);
     transition: opacity 0.2s;
 
     &.active {

--- a/src/renderer/components/dock/pod-logs.scss
+++ b/src/renderer/components/dock/pod-logs.scss
@@ -43,7 +43,6 @@
 
   .jump-to-bottom {
     position: absolute;
-    font-size: small;
     right: 30px;
     padding: $unit / 2 $unit * 1.5;
     border-radius: $unit * 2;

--- a/src/renderer/components/dock/pod-logs.scss
+++ b/src/renderer/components/dock/pod-logs.scss
@@ -40,4 +40,23 @@
       border-radius: $radius;
     }
   }
+
+  .jump-to-bottom {
+    position: absolute;
+    font-size: small;
+    left: 50%;
+    padding: $unit / 2 $unit * 1.5;
+    border-radius: $unit * 2;
+    opacity: 0;
+    transform: translateX(-50%);
+    transition: opacity 0.2s;
+
+    &.active {
+      opacity: 1;
+    }
+
+    .Icon {
+      --size: $unit * 2;
+    }
+  }
 }

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -142,12 +142,10 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
    * @param tabId
    */
   getLastSinceTime(tabId: TabId) {
-    const timestamps = this.getTimestamps(this.logs.get(tabId).join("\n"));
-    let stamp = new Date(0);
-    if (timestamps) {
-      stamp = new Date(timestamps.slice(-1)[0]);
-      stamp.setSeconds(stamp.getSeconds() + 1); // avoid duplicates from last second
-    }
+    const logs = this.logs.get(tabId);
+    const timestamps = this.getTimestamps(logs[logs.length - 1]);
+    const stamp = new Date(timestamps[0]);
+    stamp.setSeconds(stamp.getSeconds() + 1); // avoid duplicates from last second
     return stamp.toISOString();
   }
 

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -181,7 +181,7 @@ export function createPodLogsTab(data: IPodLogsData, tabParams: Partial<IDockTab
   tab = dockStore.createTab({
     id: podId,
     kind: TabKind.POD_LOGS,
-    title: `Logs: ${data.pod.getName()}`,
+    title: data.pod.getName(),
     ...tabParams
   }, false);
   podLogsStore.setData(tab.id, data);

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -81,14 +81,8 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
    */
   loadMore = async (tabId: TabId) => {
     const oldLogs = this.logs.get(tabId);
-    const timestamps = this.getTimestamps(oldLogs);
-    let sinceTime = new Date(0);
-    if (timestamps) {
-      sinceTime = new Date(timestamps.slice(-1)[0]);
-      sinceTime.setSeconds(sinceTime.getSeconds() + 1); // avoid duplicates from last second
-    }
     const logs = await this.loadLogs(tabId, {
-      sinceTime: sinceTime.toISOString()
+      sinceTime: this.getLastSinceTime(tabId)
     });
     // Add newly received logs to bottom
     // TODO: set a new log separator here
@@ -125,6 +119,21 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
     const id = dockStore.selectedTabId;
     const logs = this.logs.get(id);
     return logs ? logs.split("\n").length : 0;
+  }
+
+  /**
+   * It gets timestamps from all logs then returns last one + 1 second
+   * (this allows to avoid getting the last stamp in the selection)
+   * @param tabId
+   */
+  getLastSinceTime(tabId: TabId) {
+    const timestamps = this.getTimestamps(this.logs.get(tabId));
+    let stamp = new Date(0);
+    if (timestamps) {
+      stamp = new Date(timestamps.slice(-1)[0]);
+      stamp.setSeconds(stamp.getSeconds() + 1); // avoid duplicates from last second
+    }
+    return stamp.toISOString();
   }
 
   getTimestamps(logs: string) {

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -144,7 +144,7 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
   getLastSinceTime(tabId: TabId) {
     const logs = this.logs.get(tabId);
     const timestamps = this.getTimestamps(logs[logs.length - 1]);
-    const stamp = new Date(timestamps[0]);
+    const stamp = new Date(timestamps ? timestamps[0] : null);
     stamp.setSeconds(stamp.getSeconds() + 1); // avoid duplicates from last second
     return stamp.toISOString();
   }

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -72,7 +72,6 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
         _i18n._(t`Reason: ${error.reason} (${error.code})`)
       ].join("\n");
       this.refresher.stop();
-      Notifications.error(message);
       this.logs.set(tabId, message);
     }
   }

--- a/src/renderer/components/dock/pod-logs.store.ts
+++ b/src/renderer/components/dock/pod-logs.store.ts
@@ -15,7 +15,6 @@ export interface IPodLogsData {
   initContainers: IPodContainer[]
   showTimestamps: boolean
   previous: boolean
-  newLogsSince?: string // Timestamp after which all logs are considered to be new
 }
 
 type TabId = string;
@@ -33,6 +32,7 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
   });
 
   @observable logs = observable.map<TabId, PodLogs>();
+  @observable newLogSince = observable.map<TabId, string>(); // Timestamp after which all logs are considered to be new
 
   constructor() {
     super({
@@ -118,13 +118,9 @@ export class PodLogsStore extends DockTabStore<IPodLogsData> {
    * @param tabId
    */
   setNewLogSince(tabId: TabId) {
-    const data = this.data.get(tabId);
-    if (data.newLogsSince || !this.logs.has(tabId)) return;
-    const timestamp = podLogsStore.getLastSinceTime(tabId);
-    this.setData(tabId, {
-      ...data,
-      newLogsSince: timestamp.split(".")[0] // Removing milliseconds from string
-    })
+    if (!this.logs.has(tabId) || this.newLogSince.has(tabId)) return;
+    const timestamp = this.getLastSinceTime(tabId);
+    this.newLogSince.set(tabId, timestamp.split(".")[0]); // Removing milliseconds from string
   }
 
   /**

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -99,13 +99,13 @@ export class PodLogs extends React.Component<Props> {
   get logs() {
     if (!podLogsStore.logs.has(this.tabId)) return [];
     const logs = podLogsStore.logs.get(this.tabId);
-    const { getData, removeTimestamps } = podLogsStore;
-    const { showTimestamps, newLogsSince } = getData(this.tabId);
+    const { getData, removeTimestamps, newLogSince } = podLogsStore;
+    const { showTimestamps } = getData(this.tabId);
     let oldLogs = logs;
     let newLogs = "";
-    if (newLogsSince) {
+    if (newLogSince.has(this.tabId)) {
       // Finding separator timestamp in logs
-      const index = logs.indexOf(newLogsSince);
+      const index = logs.indexOf(newLogSince.get(this.tabId));
       if (index !== -1) {
         // Splitting logs to old and new ones
         oldLogs = logs.substring(0, index);

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -6,14 +6,14 @@ import { t, Trans } from "@lingui/macro";
 import { computed, observable, reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { _i18n } from "../../i18n";
-import { autobind, cssNames, downloadFile } from "../../utils";
+import { autobind, cssNames } from "../../utils";
 import { Icon } from "../icon";
-import { Select, SelectOption } from "../select";
 import { Spinner } from "../spinner";
 import { IDockTab } from "./dock.store";
 import { InfoPanel } from "./info-panel";
 import { IPodLogsData, logRange, podLogsStore } from "./pod-logs.store";
 import { Button } from "../button";
+import { PodLogControls } from "./pod-log-controls";
 
 interface Props {
   className?: string
@@ -93,7 +93,7 @@ export class PodLogs extends React.Component<Props> {
   /**
    * Computed prop which returns logs with or without timestamps added to each line and
    * does separation between new and old logs
-   * @returns {Array} An array with 2 string items - [oldLogs, newLogs]
+   * @returns {Array} An array with 2 items - [oldLogs, newLogs]
    */
   @computed
   get logs() {
@@ -118,18 +118,6 @@ export class PodLogs extends React.Component<Props> {
     return [oldLogs, newLogs];
   }
 
-  toggleTimestamps = () => {
-    this.save({ showTimestamps: !this.tabData.showTimestamps });
-  }
-
-  /**
-   * Setting 'previous' param to load API request fetching logs from previous container
-   */
-  togglePrevious = () => {
-    this.save({ previous: !this.tabData.previous });
-    this.reload();
-  }
-
   onScroll = (evt: React.UIEvent<HTMLDivElement>) => {
     const logsArea = evt.currentTarget;
     const toBottomOffset = 100 * 16; // 100 lines * 16px (height of each line)
@@ -144,46 +132,6 @@ export class PodLogs extends React.Component<Props> {
     }
     this.lastLineIsShown = clientHeight + scrollTop === scrollHeight;
   };
-
-  downloadLogs = () => {
-    const { pod, selectedContainer } = this.tabData;
-    const fileName = selectedContainer ? selectedContainer.name : pod.getName();
-    const [oldLogs, newLogs] = this.logs;
-    downloadFile(fileName + ".log", [...oldLogs, ...newLogs].join("\n"), "text/plain");
-  }
-
-  onContainerChange = (option: SelectOption) => {
-    const { containers, initContainers } = this.tabData;
-    this.save({
-      selectedContainer: containers
-        .concat(initContainers)
-        .find(container => container.name === option.value)
-    })
-    this.reload();
-  }
-
-  get containerSelectOptions() {
-    const { containers, initContainers } = this.tabData;
-    return [
-      {
-        label: _i18n._(t`Containers`),
-        options: containers.map(container => {
-          return { value: container.name }
-        }),
-      },
-      {
-        label: _i18n._(t`Init Containers`),
-        options: initContainers.map(container => {
-          return { value: container.name }
-        }),
-      }
-    ];
-  }
-
-  formatOptionLabel = (option: SelectOption) => {
-    const { value, label } = option;
-    return label || <><Icon small material="view_carousel"/> {value}</>;
-  }
 
   renderJumpToBottom() {
     if (!this.logsElement) return null;
@@ -202,51 +150,6 @@ export class PodLogs extends React.Component<Props> {
         <Trans>Jump to bottom</Trans>
         <Icon material="expand_more" />
       </Button>
-    );
-  }
-
-  renderControls() {
-    if (!this.ready) return null;
-    const { selectedContainer, showTimestamps, previous } = this.tabData;
-    const since = podLogsStore.getTimestamps(podLogsStore.logs.get(this.tabId)[0]);
-    return (
-      <div className="controls flex gaps align-center">
-        <span><Trans>Container</Trans></span>
-        <Select
-          options={this.containerSelectOptions}
-          value={{ value: selectedContainer.name }}
-          formatOptionLabel={this.formatOptionLabel}
-          onChange={this.onContainerChange}
-          autoConvertOptions={false}
-        />
-        <div className="time-range">
-          {since && (
-            <>
-              <Trans>Since</Trans>{" "}
-              <b>{new Date(since[0]).toLocaleString()}</b>
-            </>
-          )}
-        </div>
-        <div className="flex gaps">
-          <Icon
-            material="av_timer"
-            onClick={this.toggleTimestamps}
-            className={cssNames("timestamps-icon", { active: showTimestamps })}
-            tooltip={(showTimestamps ? _i18n._(t`Hide`) : _i18n._(t`Show`)) + " " + _i18n._(t`timestamps`)}
-          />
-          <Icon
-            material="undo"
-            onClick={this.togglePrevious}
-            className={cssNames("undo-icon", { active: previous })}
-            tooltip={(previous ? _i18n._(t`Show current logs`) : _i18n._(t`Show previous terminated container logs`))}
-          />
-          <Icon
-            material="get_app"
-            onClick={this.downloadLogs}
-            tooltip={_i18n._(t`Save`)}
-          />
-        </div>
-      </div>
     );
   }
 
@@ -282,11 +185,21 @@ export class PodLogs extends React.Component<Props> {
 
   render() {
     const { className } = this.props;
+    const controls = (
+      <PodLogControls
+        ready={this.ready}
+        tabId={this.tabId}
+        tabData={this.tabData}
+        logs={this.logs}
+        save={this.save}
+        reload={this.reload}
+      />
+    )
     return (
       <div className={cssNames("PodLogs flex column", className)}>
         <InfoPanel
           tabId={this.props.tab.id}
-          controls={this.renderControls()}
+          controls={controls}
           showSubmitClose={false}
           showButtons={false}
         />

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -38,7 +38,15 @@ export class PodLogs extends React.Component<Props> {
           return;
         }
         await this.load();
-      }, { fireImmediately: true })
+      }, { fireImmediately: true }),
+
+      // Check if need to show JumpToBottom if new log amount is less than previous one
+      reaction(() => podLogsStore.logs.get(this.tabId), () => {
+        const { tabId } = this;
+        if (podLogsStore.logs.has(tabId) && podLogsStore.logs.get(tabId).length < logRange) {
+          this.showJumpToBottom = false;
+        }
+      })
     ]);
   }
 

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -208,7 +208,7 @@ export class PodLogs extends React.Component<Props> {
   renderControls() {
     if (!this.ready) return null;
     const { selectedContainer, showTimestamps, previous } = this.tabData;
-    const timestamps = podLogsStore.getTimestamps(podLogsStore.logs.get(this.tabId).join("\n"));
+    const since = podLogsStore.getTimestamps(podLogsStore.logs.get(this.tabId)[0]);
     return (
       <div className="controls flex gaps align-center">
         <span><Trans>Container</Trans></span>
@@ -220,10 +220,10 @@ export class PodLogs extends React.Component<Props> {
           autoConvertOptions={false}
         />
         <div className="time-range">
-          {timestamps && (
+          {since && (
             <>
               <Trans>Since</Trans>{" "}
-              <b>{new Date(timestamps[0]).toLocaleString()}</b>
+              <b>{new Date(since[0]).toLocaleString()}</b>
             </>
           )}
         </div>

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -110,8 +110,6 @@ export class PodLogs extends React.Component<Props> {
         // Splitting logs to old and new ones
         oldLogs = logs.slice(0, index);
         newLogs = logs.slice(index);
-
-
       }
     }
     if (!showTimestamps) {

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -183,7 +183,7 @@ export class PodLogs extends React.Component<Props> {
         <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(this.colorConverter.ansi_to_html(oldLogs.join("\n"))) }} />
         {newLogs.length > 0 && (
           <>
-            <p className="new-logs-sep" title={_i18n._(t`New logs since opening the dialog`)}/>
+            <p className="new-logs-sep" title={_i18n._(t`New logs since opening logs tab`)}/>
             <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(this.colorConverter.ansi_to_html(newLogs.join("\n"))) }} />
           </>
         )}

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -25,7 +25,6 @@ export class PodLogs extends React.Component<Props> {
   @observable ready = false;
   @observable preloading = false; // Indicator for setting Spinner (loader) at the top of the logs
   @observable showJumpToBottom = false;
-  @observable newLogsSince = ""; // The time after which the logs are considered to be new
 
   private logsElement: HTMLDivElement;
   private lastLineIsShown = true; // used for proper auto-scroll content after refresh
@@ -39,13 +38,7 @@ export class PodLogs extends React.Component<Props> {
           return;
         }
         await this.load();
-      }, { fireImmediately: true }),
-      // Setting newLogSince separator timestamp to split old logs from new ones
-      reaction(() => podLogsStore.logs.get(this.tabId), () => {
-        if (this.newLogsSince) return;
-        const timestamp = podLogsStore.getLastSinceTime(this.tabId);
-        this.newLogsSince = timestamp.split(".")[0]; // Removing milliseconds from string
-      })
+      }, { fireImmediately: true })
     ]);
   }
 
@@ -107,12 +100,12 @@ export class PodLogs extends React.Component<Props> {
     if (!podLogsStore.logs.has(this.tabId)) return [];
     const logs = podLogsStore.logs.get(this.tabId);
     const { getData, removeTimestamps } = podLogsStore;
-    const { showTimestamps } = getData(this.tabId);
+    const { showTimestamps, newLogsSince } = getData(this.tabId);
     let oldLogs = logs;
     let newLogs = "";
-    if (this.newLogsSince) {
+    if (newLogsSince) {
       // Finding separator timestamp in logs
-      const index = logs.indexOf(this.newLogsSince);
+      const index = logs.indexOf(newLogsSince);
       if (index !== -1) {
         // Splitting logs to old and new ones
         oldLogs = logs.substring(0, index);


### PR DESCRIPTION
Part of #430 
* Loading previous logs when scrolled to top of the log area
* Showing `Jump to bottom` button when scrolled up a few lines
* Returned new/old logs separator
* Store refactorings
![preloading on scroll](https://user-images.githubusercontent.com/9607060/95855993-04000b80-0d62-11eb-9595-c765b582561c.gif)

