### PR TITLE
Fix integration test teardown

### DIFF
--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -21,10 +21,11 @@ export function setup(): Application {
 }
 
 export async function tearDown(app: Application) {
-  const pid = app.mainProcess.pid
+  let mpid: any = app.mainProcess.pid
+  let pid = await mpid()
   await app.stop()
   try {
-    process.kill(pid, 0);
+    process.kill(pid, "SIGKILL");
   } catch (e) {
     return
   }


### PR DESCRIPTION
This PR will fix tearDown function in integration tests. Despite the type declaration, `mainProcess.id` is a function that returns a promise.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>