### PR TITLE
fix cluster page integration test

### DIFF
--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -166,8 +166,8 @@ describe("Lens integration tests", () => {
         pages: [{
           name: "Cluster",
           href: "cluster",
-          expectedSelector: "div.ClusterNoMetrics p",
-          expectedText: "Metrics are not available due"
+          expectedSelector: "div.Cluster div.label",
+          expectedText: "Master"
         }]
       },
       {


### PR DESCRIPTION
Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

This makes the test independent of whether or not prometheus is installed on the minikube cluster