### PR TITLE
Force revision type to number for sort

### DIFF
--- a/src/renderer/api/endpoints/helm-releases.api.ts
+++ b/src/renderer/api/endpoints/helm-releases.api.ts
@@ -141,7 +141,7 @@ export class HelmRelease implements ItemObject {
   chart: string
   status: string
   updated: string
-  revision: number
+  revision: string
 
   getId() {
     return this.namespace + this.name;
@@ -165,7 +165,7 @@ export class HelmRelease implements ItemObject {
   }
 
   getRevision() {
-    return this.revision;
+    return parseInt(this.revision, 10);
   }
 
   getStatus() {


### PR DESCRIPTION
Fix #1020 

I didn't fully understand Lens's internal. 
When I checked the [HelmRelease data here](https://github.com/lensapp/lens/blob/master/src/renderer/api/endpoints/helm-releases.api.ts#L74), `revision` field is already `string`. So, `getRevision` return `string` typed revision. 

I'm not sure why [`revision: number`](https://github.com/lensapp/lens/blob/master/src/renderer/api/endpoints/helm-releases.api.ts#L144) doesn't force to number type. Because I'm not TS expert.

So, I set `revision` type to string and then `parseInt` in `getRevision()`. 
It works now.

<img width="83" alt="스크린샷 2020-10-18 오후 9 13 05" src="https://user-images.githubusercontent.com/390146/96367291-eaa6f700-1187-11eb-97ef-5297d78a2567.png">
<img width="75" alt="스크린샷 2020-10-18 오후 9 13 10" src="https://user-images.githubusercontent.com/390146/96367292-ed095100-1187-11eb-8b69-b391368221c6.png">