### PR TITLE
implemented app menu testing support

### DIFF
--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -48,16 +48,15 @@ describe("Lens integration tests", () => {
     })
 
     // Todo figure out how to access main menu to get these to work
-    it.skip('shows "add cluster"', async () => {
-      await app.client.keys(['Shift', 'Meta', 'A'])
+    it('shows "add cluster"', async () => {
+      await app.electron.ipcRenderer.send('test-menu-item-click', "File", "Add Cluster")
       await app.client.waitUntilTextExists("h2", "Add Cluster")
-      await app.client.keys(['Shift', 'Meta'])
     })
 
-    it.skip('shows "preferences"', async () => {
-      await app.client.keys(['Meta', ','])
+    it('shows "preferences"', async () => {
+      let appName: string = process.platform === "darwin" ? "Lens" : "File"
+      await app.electron.ipcRenderer.send('test-menu-item-click', appName, "Preferences")
       await app.client.waitUntilTextExists("h2", "Preferences")
-      await app.client.keys('Meta')
     })
 
     it.skip('quits Lens"', async () => {

--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -47,16 +47,23 @@ describe("Lens integration tests", () => {
       await clickWhatsNew(app)
     })
 
-    // Todo figure out how to access main menu to get these to work
     it('shows "add cluster"', async () => {
       await app.electron.ipcRenderer.send('test-menu-item-click', "File", "Add Cluster")
       await app.client.waitUntilTextExists("h2", "Add Cluster")
     })
 
-    it('shows "preferences"', async () => {
+    describe("preferences page", () => {
+      it('shows "preferences"', async () => {
       let appName: string = process.platform === "darwin" ? "Lens" : "File"
       await app.electron.ipcRenderer.send('test-menu-item-click', appName, "Preferences")
       await app.client.waitUntilTextExists("h2", "Preferences")
+      })
+
+      it('ensures helm repos', async () => {
+        await app.client.waitUntilTextExists("div.repos #message-stable", "stable") // wait for the helm-cli to fetch the stable repo
+        await app.client.click("#HelmRepoSelect") // click the repo select to activate the drop-down
+        await app.client.waitUntilTextExists("div.Select__option", "")  // wait for at least one option to appear (any text)
+      })
     })
 
     it.skip('quits Lens"', async () => {

--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -54,9 +54,9 @@ describe("Lens integration tests", () => {
 
     describe("preferences page", () => {
       it('shows "preferences"', async () => {
-      let appName: string = process.platform === "darwin" ? "Lens" : "File"
-      await app.electron.ipcRenderer.send('test-menu-item-click', appName, "Preferences")
-      await app.client.waitUntilTextExists("h2", "Preferences")
+        let appName: string = process.platform === "darwin" ? "Lens" : "File"
+        await app.electron.ipcRenderer.send('test-menu-item-click', appName, "Preferences")
+        await app.client.waitUntilTextExists("h2", "Preferences")
       })
 
       it('ensures helm repos', async () => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -242,7 +242,7 @@ export function buildMenu(windowManager: WindowManager) {
       const parentLabels: string[] = [];
       let menuItem: MenuItem
 
-      for (let name of names) {
+      for (const name of names) {
         parentLabels.push(name);
         menuItem = menu?.items?.find(item => item.label === name);
         if (!menuItem) {
@@ -256,7 +256,7 @@ export function buildMenu(windowManager: WindowManager) {
         return;
       }
 
-      let { enabled, visible, click } = menuItem;
+      const { enabled, visible, click } = menuItem;
       if (enabled === false || visible === false || typeof click !== 'function') {
         logger.info(`[MENU:test-menu-item-click] Menu item ${parentLabels.join(" -> ")} not clickable`);
         return;

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, Menu, MenuItem, MenuItemConstructorOptions, webContents, shell } from "electron"
+import { app, BrowserWindow, dialog, ipcMain, IpcMainEvent, Menu, MenuItem, MenuItemConstructorOptions, webContents, shell } from "electron"
 import { autorun } from "mobx";
 import { WindowManager } from "./window-manager";
 import { appName, isMac, isWindows } from "../common/vars";
@@ -235,4 +235,35 @@ export function buildMenu(windowManager: WindowManager) {
 
   const menu = Menu.buildFromTemplate(Object.values(appMenu));
   Menu.setApplicationMenu(menu);
+
+  if (!!process.env.JEST_WORKER_ID) {
+    ipcMain.on('test-menu-item-click', (event: IpcMainEvent, ...names: string[]) => {
+      let menu: Menu = Menu.getApplicationMenu()
+      const parentLabels: string[] = [];
+      let menuItem: MenuItem
+
+      for (let name of names) {
+        parentLabels.push(name);
+        menuItem = menu?.items?.find(item => item.label === name);
+        if (!menuItem) {
+          break;
+        }
+        menu = menuItem.submenu;
+      }
+    
+      if (!menuItem) {
+        logger.info(`[MENU:test-menu-item-click] Cannot find menu item ${parentLabels.join(" -> ")}`);
+        return;
+      }
+
+      let { enabled, visible, click } = menuItem;
+      if (enabled === false || visible === false || typeof click !== 'function') {
+        logger.info(`[MENU:test-menu-item-click] Menu item ${parentLabels.join(" -> ")} not clickable`);
+        return;
+      }
+
+      logger.info(`[MENU:test-menu-item-click] Menu item ${parentLabels.join(" -> ")} click!`);
+      menuItem.click();
+    });
+  }
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -253,7 +253,7 @@ export function buildMenu(windowManager: WindowManager) {
         menu = menuItem.submenu;
       }
     
-      let menuPath: string = parentLabels.join(" -> ")
+      const menuPath: string = parentLabels.join(" -> ")
       if (!menuItem) {
         logger.info(`[MENU:test-menu-item-click] Cannot find menu item ${menuPath}`);
         return;

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -128,7 +128,7 @@ export class Preferences extends React.Component {
         <KubectlBinaries preferences={preferences}/>
 
         <h2><Trans>Helm</Trans></h2>
-        <Select
+        <Select id="HelmRepoSelect"
           placeholder={<Trans>Repositories</Trans>}
           isLoading={this.helmLoading}
           isDisabled={this.helmLoading}


### PR DESCRIPTION
Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

- adds an ipc channel for simulating a menu item click in the Lens code (only if the app is built for test purposes)
- initiate menu item selection from the test code using this ipc channel

This does work but it is intrusive (adds test functionality directly in the app code)

solution comes from [here](https://github.com/electron-userland/spectron/issues/21#issuecomment-219057770), and [here](https://github.com/electron-userland/spectron/issues/21#issuecomment-222287739)

Also added test for Helm repos properly loaded on the Preferences page

closes #524 