### PR TITLE
Test is user cluster admin on cluster activate

### DIFF
--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -38,6 +38,7 @@ import { getFreePort } from "../port";
 import { V1ResourceAttributes } from "@kubernetes/client-node";
 import { apiResources } from "../../common/rbac";
 import request from "request-promise-native"
+import { Kubectl } from "../kubectl";
 
 const mockedRequest = request as jest.MockedFunction<typeof request>
 
@@ -73,6 +74,7 @@ describe("create clusters", () => {
       })
     }
     mockFs(mockOpts)
+    jest.spyOn(Kubectl.prototype, "ensureKubectl").mockReturnValue(Promise.resolve(true))
   })
 
   afterEach(() => {
@@ -117,6 +119,7 @@ describe("create clusters", () => {
       }
     }
 
+    jest.spyOn(Cluster.prototype, "isClusterAdmin").mockReturnValue(Promise.resolve(true))
     jest.spyOn(Cluster.prototype, "canI")
       .mockImplementationOnce((attr: V1ResourceAttributes): Promise<boolean> => {
         expect(attr.namespace).toBe("default")
@@ -160,6 +163,7 @@ describe("create clusters", () => {
     expect(c.allowedNamespaces.length).toBe(1)
     expect(c.allowedResources.length).toBe(apiResources.length)
 
+    c.disconnect()
     jest.resetAllMocks()
   })
 })

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -142,6 +142,7 @@ export class Cluster implements ClusterModel {
     await this.refreshConnectionStatus()
     if (this.accessible) {
       await this.refreshAllowedResources()
+      this.isAdmin = await this.isClusterAdmin()
       this.ready = true
       this.kubeCtl = new Kubectl(this.version)
       this.kubeCtl.ensureKubectl() // download kubectl in background, so it's not blocking dashboard


### PR DESCRIPTION
This PR will add `isClusterAdmin()` check back to cluster activate phase. Cluster dashboard is using that information for example when establishing watch requests. This might fix #1100, but it indicates that something is wrong with the logic when re-connecting watch requests if not cluster-admin and, thus, requires further investigation.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>