### PR TITLE
Allowing to disable hardware acceleration from Preferences

### DIFF
--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -27,6 +27,7 @@ export interface UserPreferences {
   downloadKubectlBinaries?: boolean;
   downloadBinariesPath?: string;
   kubectlBinariesPath?: string;
+  disableHardwareAcceleration?: boolean;
 }
 
 export class UserStore extends BaseStore<UserStoreModel> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,7 +56,6 @@ async function main() {
 
   // preload configuration from stores
   await Promise.all([
-    userStore.load(),
     clusterStore.load(),
     workspaceStore.load(),
   ]);
@@ -75,6 +74,12 @@ async function main() {
 
   // create window manager and open app
   windowManager = new WindowManager(proxyPort);
+}
+
+// Disable hardware acceleration if flag is checked in Preferences
+userStore.load();
+if (userStore.preferences.disableHardwareAcceleration) {
+  app.disableHardwareAcceleration();
 }
 
 app.on("ready", main);

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -17,6 +17,7 @@ import { themeStore } from "../../theme.store";
 import { history } from "../../navigation";
 import { Tooltip } from "../tooltip";
 import { KubectlBinaries } from "./kubectl-binaries";
+import { isMac } from "../../../common/vars";
 
 @observer
 export class Preferences extends React.Component {
@@ -194,6 +195,21 @@ export class Preferences extends React.Component {
           <small className="hint">
             <Trans>Telemetry & usage data is collected to continuously improve the Lens experience.</Trans>
           </small>
+
+          {isMac && (
+            <>
+              <h2><Trans>Hardware Acceleration</Trans></h2>
+              <Checkbox
+                label={<Trans>Disable hardware acceleration</Trans>}
+                value={preferences.disableHardwareAcceleration}
+                onChange={v => preferences.disableHardwareAcceleration = v}
+              />
+              <small className="hint">
+                <Trans>Enabled hardware acceleration can cause rendering issues on some devices with the MacOS.</Trans><br />
+                <Trans>You need to restart the app to activate the changes.</Trans>
+              </small>
+            </>
+          )}
         </WizardLayout>
       </div>
     );


### PR DESCRIPTION
Adding one more checkbox in Preferences page which disables hardware accelereation on app reload.

Result of `app.getGPUFeatureStatus()` (https://www.electronjs.org/docs/all#appgetgpufeaturestatus) with/without flag checked:
```
'2d_canvas': 'unavailable_software',
flash_3d: 'disabled_software',
flash_stage3d: 'disabled_software',
flash_stage3d_baseline: 'disabled_software',
gpu_compositing: 'disabled_software',
metal: 'disabled_off',
multiple_raster_threads: 'enabled_on',
oop_rasterization: 'disabled_off',
opengl: 'disabled_off',
protected_video_decode: 'disabled_off',
rasterization: 'disabled_software',
skia_renderer: 'disabled_off_ok',
video_decode: 'disabled_software',
webgl: 'unavailable_software',
webgl2: 'unavailable_software'
```

```
'2d_canvas': 'enabled',
flash_3d: 'enabled',
flash_stage3d: 'enabled',
flash_stage3d_baseline: 'enabled',
gpu_compositing: 'enabled',
metal: 'disabled_off',
multiple_raster_threads: 'enabled_on',
oop_rasterization: 'enabled',
opengl: 'enabled_on',
protected_video_decode: 'unavailable_off',
rasterization: 'enabled',
skia_renderer: 'disabled_off_ok',
video_decode: 'enabled',
webgl: 'enabled',
webgl2: 'enabled'
```

![hardware acceleration flag](https://user-images.githubusercontent.com/9607060/97005306-ee9b9600-1546-11eb-81ad-a45777d3445c.png)

Fixes #462 
Fixes #222 
Fixes #562 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>