### PR TITLE
refactor registering extensions

### DIFF
--- a/extensions/example-extension/renderer.tsx
+++ b/extensions/example-extension/renderer.tsx
@@ -1,4 +1,4 @@
-import { LensRendererExtension, Registry } from "@k8slens/extensions";
+import { LensRendererExtension } from "@k8slens/extensions";
 import { ExamplePage, ExampleIcon } from "./page"
 import React from "react"
 
@@ -7,17 +7,17 @@ export default class ExampleExtension extends LensRendererExtension {
     console.log('EXAMPLE EXTENSION RENDERER: ACTIVATED', this.getMeta());
   }
 
-  registerClusterPage(registry: Registry.ClusterPageRegistry) {
-    this.disposers.push(
-      registry.add({
+  clusterPages() {
+    return [
+      {
         path: "/extension-example",
         title: "Example Extension",
         components: {
           Page: () => <ExamplePage extension={this} />,
           MenuIcon: ExampleIcon,
         }
-      })
-    )
+      }
+    ]
   }
 
   onDeactivate() {

--- a/extensions/metrics-cluster-feature/renderer.tsx
+++ b/extensions/metrics-cluster-feature/renderer.tsx
@@ -1,11 +1,11 @@
-import { Registry, LensRendererExtension } from "@k8slens/extensions"
+import { LensRendererExtension } from "@k8slens/extensions"
 import { MetricsFeature } from "./src/metrics-feature"
 import React from "react"
 
 export default class ClusterMetricsFeatureExtension extends LensRendererExtension {
-  registerClusterFeatures(registry: Registry.ClusterFeatureRegistry) {
-    this.disposers.push(
-      registry.add({
+  clusterFeatures() {
+    return [
+      {
         title: "Metrics Stack",
         components: {
           Description: () => {
@@ -19,7 +19,7 @@ export default class ClusterMetricsFeatureExtension extends LensRendererExtensio
           }
         },
         feature: new MetricsFeature()
-      })
-    )
+      }
+    ]
   }
 }

--- a/extensions/node-menu/renderer.tsx
+++ b/extensions/node-menu/renderer.tsx
@@ -1,4 +1,4 @@
-import { Registry, LensRendererExtension } from "@k8slens/extensions";
+import { LensRendererExtension } from "@k8slens/extensions";
 import React from "react"
 import { NodeMenu } from "./src/node-menu"
 
@@ -7,15 +7,15 @@ export default class NodeMenuRendererExtension extends LensRendererExtension {
     console.log("node-menu extension activated")
   }
 
-  registerKubeObjectMenus(registry: Registry.KubeObjectMenuRegistry) {
-    this.disposers.push(
-      registry.add({
+  kubeObjectMenus() {
+    return [
+      {
         kind: "Node",
         apiVersions: ["v1"],
         components: {
           MenuItem: (props) => <NodeMenu {...props} />
         }
-      })
-    )
+      }
+    ]
   }
 }

--- a/extensions/pod-menu/renderer.tsx
+++ b/extensions/pod-menu/renderer.tsx
@@ -1,4 +1,4 @@
-import { Registry, LensRendererExtension } from "@k8slens/extensions";
+import { LensRendererExtension } from "@k8slens/extensions";
 import { PodShellMenu } from "./src/shell-menu"
 import { PodLogsMenu } from "./src/logs-menu"
 import React from "react"
@@ -8,24 +8,22 @@ export default class PodMenuRendererExtension extends LensRendererExtension {
     console.log("pod-menu extension activated")
   }
 
-  registerKubeObjectMenus(registry: Registry.KubeObjectMenuRegistry) {
-    this.disposers.push(
-      registry.add({
+  kubeObjectMenus() {
+    return [
+      {
         kind: "Pod",
         apiVersions: ["v1"],
         components: {
           MenuItem: (props) => <PodShellMenu {...props} />
         }
-      })
-    )
-    this.disposers.push(
-      registry.add({
+      },
+      {
         kind: "Pod",
         apiVersions: ["v1"],
         components: {
           MenuItem: (props) => <PodLogsMenu {...props} />
         }
-      })
-    )
+      }
+    ]
   }
 }

--- a/extensions/support-page/renderer.tsx
+++ b/extensions/support-page/renderer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Component, LensRendererExtension, Navigation, Registry } from "@k8slens/extensions";
+import { Component, LensRendererExtension, Navigation } from "@k8slens/extensions";
 import { supportPageRoute, supportPageURL } from "./src/support.route";
 import { Support } from "./src/support";
 
@@ -8,22 +8,22 @@ export default class SupportPageRendererExtension extends LensRendererExtension 
     console.log("support page extension activated")
   }
 
-  registerGlobalPage(registry: Registry.GlobalPageRegistry) {
-    this.disposers.push(
-      registry.add({
+  globalPages() {
+    return [
+      {
         ...supportPageRoute,
         url: supportPageURL(),
         hideInMenu: true,
         components: {
           Page: Support,
         }
-      })
-    )
+      }
+    ]
   }
 
-  registerStatusBarItem(registry: Registry.StatusBarRegistry) {
-    this.disposers.push(
-      registry.add({
+  statusBarItems() {
+    return [
+      {
         item: (
           <div
             className="flex align-center gaps hover-highlight"
@@ -33,7 +33,7 @@ export default class SupportPageRendererExtension extends LensRendererExtension 
             <span>Support</span>
           </div>
         )
-      })
-    )
+      }
+    ]
   }
 }

--- a/extensions/telemetry/renderer.tsx
+++ b/extensions/telemetry/renderer.tsx
@@ -1,4 +1,4 @@
-import { LensRendererExtension, Registry } from "@k8slens/extensions";
+import { LensRendererExtension } from "@k8slens/extensions";
 import { telemetryPreferencesStore } from "./src/telemetry-preferences-store"
 import { TelemetryPreferenceHint, TelemetryPreferenceInput } from "./src/telemetry-preference"
 import { tracker } from "./src/tracker"
@@ -11,16 +11,16 @@ export default class TelemetryRendererExtension extends LensRendererExtension {
     await telemetryPreferencesStore.loadExtension(this)
   }
 
-  registerAppPreferences(registry: Registry.AppPreferenceRegistry) {
-    this.disposers.push(
-      registry.add({
+  appPreferences() {
+    return [
+      {
         title: "Telemetry & Usage Tracking",
         components: {
           Hint: () => <TelemetryPreferenceHint />,
           Input: () => <TelemetryPreferenceInput telemetry={telemetryPreferencesStore} />
         }
-      })
-    )
+      }
+    ]
   }
 
   onDeactivate() {

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -1,28 +1,72 @@
 import { LensExtension } from "./lens-extension"
-import type { GlobalPageRegistry, ClusterPageRegistry, AppPreferenceRegistry, StatusBarRegistry, KubeObjectMenuRegistry, ClusterFeatureRegistry } from "./registries"
+import type { GlobalPageRegistry, ClusterPageRegistry, AppPreferenceRegistry, StatusBarRegistry, KubeObjectMenuRegistry, ClusterFeatureRegistry,
+  PageRegistration, AppPreferenceRegistration, StatusBarRegistration, KubeObjectMenuRegistration, ClusterFeatureRegistration } from "./registries"
 
 export class LensRendererExtension extends LensExtension {
+  /*
+   * Extensions must implement these
+   */
+
+  globalPages(): PageRegistration[] {
+    return []
+  }
+
+  clusterPages(): PageRegistration[] {
+    return []
+  }
+
+  appPreferences(): AppPreferenceRegistration[] {
+    return []
+  }
+
+  clusterFeatures(): ClusterFeatureRegistration[] {
+    return []
+  }
+
+  statusBarItems(): StatusBarRegistration[] {
+    return []
+  }
+
+  kubeObjectMenus(): KubeObjectMenuRegistration[] {
+    return []
+  }
+
+  /*
+   * these don't need to be exposed to extension developers (can we hide them?)
+   */
   registerGlobalPage(registry: GlobalPageRegistry) {
-    return
+    for (let page of this.globalPages()) {
+      this.disposers.push(registry.add(page))
+    }
   }
 
   registerClusterPage(registry: ClusterPageRegistry) {
-    return
+    for (let page of this.clusterPages()) {
+      this.disposers.push(registry.add(page))
+    }
   }
 
   registerAppPreferences(registry: AppPreferenceRegistry) {
-    return
+    for (let preference of this.appPreferences()) {
+      this.disposers.push(registry.add(preference))
+    }
   }
 
   registerClusterFeatures(registry: ClusterFeatureRegistry) {
-    return
+    for (let feature of this.clusterFeatures()) {
+      this.disposers.push(registry.add(feature))
+    }
   }
 
   registerStatusBarItem(registry: StatusBarRegistry) {
-    return
+    for (let item of this.statusBarItems()) {
+      this.disposers.push(registry.add(item))
+    }
   }
 
   registerKubeObjectMenus(registry: KubeObjectMenuRegistry) {
-    return
+    for (let menu of this.kubeObjectMenus()) {
+      this.disposers.push(registry.add(menu))
+    }
   }
 }


### PR DESCRIPTION
extension implementors do not need to be aware of disposer and registry internals

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

This is a very simple modification where the existing functionality remains the same but the important thing is it's less complicated for the extension implementor.