### PR TITLE
Npm package publish preparations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,13 @@ else
 endif
 
 build-extensions:
-	$(foreach file, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(file) build;)
+	$(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(dir) build;)
+
+build-npm:
+	yarn npm:fix-package-version
+
+publish-npm: build-npm
+	cd src/extensions/npm/extensions && npm publish
 
 clean:
 ifeq "$(DETECTED_OS)" "Windows"

--- a/build/set_npm_version.ts
+++ b/build/set_npm_version.ts
@@ -1,0 +1,9 @@
+import * as fs from "fs"
+import * as path from "path"
+import packageInfo from "../src/extensions/npm/extensions/package.json"
+import appInfo from "../package.json"
+
+const packagePath = path.join(__dirname, "../src/extensions/npm/extensions/package.json")
+
+packageInfo.version = appInfo.version
+fs.writeFileSync(packagePath, JSON.stringify(packageInfo, null, 2))

--- a/extensions/example-extension/package-lock.json
+++ b/extensions/example-extension/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/extensions/example-extension/package.json
+++ b/extensions/example-extension/package.json
@@ -16,6 +16,7 @@
     "react-open-doodles": "^1.0.5"
   },
   "devDependencies": {
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions",
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
     "webpack": "^4.44.2"

--- a/extensions/example-extension/tsconfig.json
+++ b/extensions/example-extension/tsconfig.json
@@ -16,7 +16,6 @@
     "jsx": "react"
   },
   "include": [
-    "../../src/extensions/npm/**/*.d.ts",
     "./*.ts",
     "./*.tsx"
   ],

--- a/extensions/metrics-cluster-feature/package-lock.json
+++ b/extensions/metrics-cluster-feature/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/extensions/metrics-cluster-feature/package.json
+++ b/extensions/metrics-cluster-feature/package.json
@@ -15,6 +15,7 @@
     "semver": "^7.3.2"
   },
   "devDependencies": {
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions",
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
     "webpack": "^4.44.2",

--- a/extensions/metrics-cluster-feature/tsconfig.json
+++ b/extensions/metrics-cluster-feature/tsconfig.json
@@ -16,7 +16,6 @@
     "jsx": "react"
   },
   "include": [
-    "../../src/extensions/npm/**/*.d.ts",
     "./*.ts",
     "./*.tsx"
   ],

--- a/extensions/node-menu/package-lock.json
+++ b/extensions/node-menu/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/extensions/node-menu/package.json
+++ b/extensions/node-menu/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions",
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
     "webpack": "^4.44.2",

--- a/extensions/node-menu/tsconfig.json
+++ b/extensions/node-menu/tsconfig.json
@@ -16,7 +16,6 @@
     "jsx": "react"
   },
   "include": [
-    "../../src/extensions/npm/**/*.d.ts",
     "./*.ts",
     "./*.tsx"
   ],

--- a/extensions/pod-menu/package-lock.json
+++ b/extensions/pod-menu/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/extensions/pod-menu/package.json
+++ b/extensions/pod-menu/package.json
@@ -17,6 +17,7 @@
     "typescript": "^4.0.3",
     "webpack": "^4.44.2",
     "mobx": "^5.15.5",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions"
   }
 }

--- a/extensions/pod-menu/tsconfig.json
+++ b/extensions/pod-menu/tsconfig.json
@@ -16,7 +16,6 @@
     "jsx": "react"
   },
   "include": [
-    "../../src/extensions/npm/**/*.d.ts",
     "./*.ts",
     "./*.tsx"
   ],

--- a/extensions/support-page/package-lock.json
+++ b/extensions/support-page/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/extensions/support-page/package.json
+++ b/extensions/support-page/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.9.53",
     "@types/react-router": "^5.1.8",
     "@types/webpack": "^4.41.17",
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions",
     "mobx": "^5.15.5",
     "react": "^16.13.1",
     "ts-loader": "^8.0.4",

--- a/extensions/support-page/tsconfig.json
+++ b/extensions/support-page/tsconfig.json
@@ -24,7 +24,6 @@
   },
   "include": [
     "renderer.tsx",
-    "../../src/extensions/npm/**/*.d.ts",
     "src/**/*"
   ]
 }

--- a/extensions/telemetry/package-lock.json
+++ b/extensions/telemetry/package-lock.json
@@ -4,6 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@k8slens/extensions": {
+      "version": "file:../../src/extensions/npm/extensions",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/extensions/telemetry/package.json
+++ b/extensions/telemetry/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@k8slens/extensions": "file:../../src/extensions/npm/extensions",
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
     "webpack": "^4.44.2",

--- a/extensions/telemetry/tsconfig.json
+++ b/extensions/telemetry/tsconfig.json
@@ -24,7 +24,6 @@
   },
   "include": [
     "renderer.ts",
-    "../../src/extensions/npm/**/*.d.ts",
     "src/**/*"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compile:renderer": "webpack --config webpack.renderer.ts",
     "compile:i18n": "lingui compile",
     "compile:extension-rollup": "rollup --config src/extensions/rollup.config.js",
+    "npm:fix-package-version": "ts-node build/set_npm_version.ts",
     "build:linux": "yarn compile && electron-builder --linux --dir -c.productName=Lens",
     "build:mac": "yarn compile && electron-builder --mac --dir -c.productName=Lens",
     "build:win": "yarn compile && electron-builder --win --dir -c.productName=Lens",

--- a/src/extensions/npm/extensions/package.json
+++ b/src/extensions/npm/extensions/package.json
@@ -5,9 +5,7 @@
   "version": "0.0.0",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",
-  "files": [
-    "api.d.ts"
-  ],
+  "types": "api.d.ts",
   "author": {
     "name": "Mirantis, Inc.",
     "email": "info@k8slens.dev"


### PR DESCRIPTION
- in-tree extensions to consume the npm package via `file:/..`
- make targets for build/publish
- automation that sets npm package to match app version

Fixes #1142 