### PR TITLE
Release v4.0.0-alpha.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-extensions:
 	$(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(dir) build;)
 
 build-npm:
-	yarn compile:extension-rollup
+	yarn compile:extension-types
 	yarn npm:fix-package-version
 
 publish-npm: build-npm

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-npm:
 	yarn npm:fix-package-version
 
 publish-npm: build-npm
-	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+	npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
 	cd src/extensions/npm/extensions && npm publish --access=public
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ build-npm:
 	yarn npm:fix-package-version
 
 publish-npm: build-npm
+	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 	cd src/extensions/npm/extensions && npm publish --access=public
 
 clean:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.6",
+  "version": "4.0.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.6 (current version)
+## 4.0.0-alpha.1 (current version)
+
+- Extension API
+- Improved pod logs
+- Tray icon
+- Add last-status information for container
+- Add LoadBalancer information to Ingress view
+- Move tracker to an extension
+- Add support page (as an extension)
+
+## 3.6.6
 - Fix labels' word boundary to cover only drawer badges
 - Fix cluster dashboard opening not to start authentication proxy twice
 - Fix: Refresh cluster connection status also when connection is disconnected


### PR DESCRIPTION
## Changes since v3.6.7

- Extension API (#1131)
- Improved pod logs (#1043, #1074)
- Tray icon (#1005)
- Add last-status information for container (#1041)
- Add LoadBalancer information to Ingress view (#1064)
- Move tracker to an extension (#1092)
- Add support page (as an extension) (#1112)

### Known issues

- Missing Windows build