### PR TITLE
FIX: invalid command in Makefile for compiling extensions-api types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build-extensions:
 	$(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(dir) build;)
 
 build-npm:
-	yarn compile:extension-rollup
+	yarn compile:extension-types
 	yarn npm:fix-package-version
 
 publish-npm: build-npm

--- a/src/extensions/extension-manager.ts
+++ b/src/extensions/extension-manager.ts
@@ -80,8 +80,8 @@ export class ExtensionManager {
 
   async loadExtensions() {
     const bundledExtensions = await this.loadBundledExtensions()
-    const localExtendions = await this.loadFromFolder(this.localFolderPath)
-    const extensions = bundledExtensions.concat(localExtendions)
+    const localExtensions = await this.loadFromFolder(this.localFolderPath)
+    const extensions = bundledExtensions.concat(localExtensions)
     return new Map(extensions.map(ext => [ext.id, ext]));
   }
 


### PR DESCRIPTION
Minor fixes:

- invalid command in `Makefile` for compiling `extension-api` types
- variable name typo fix
