### PR TITLE
Fix: path checks in custom extension loader

### DIFF
--- a/src/extensions/extension-manager.ts
+++ b/src/extensions/extension-manager.ts
@@ -61,6 +61,7 @@ export class ExtensionManager {
   async getExtensionByManifest(manifestPath: string): Promise<InstalledExtension> {
     let manifestJson: ExtensionManifest;
     try {
+      fs.accessSync(manifestPath, fs.constants.F_OK); // check manifest file for existence
       manifestJson = __non_webpack_require__(manifestPath)
       this.packagesJson.dependencies[manifestJson.name] = path.dirname(manifestPath)
 
@@ -110,7 +111,6 @@ export class ExtensionManager {
       }
       const absPath = path.resolve(folderPath, fileName);
       const manifestPath = path.resolve(absPath, "package.json");
-      await fs.access(manifestPath, fs.constants.F_OK)
       const ext = await this.getExtensionByManifest(manifestPath).catch(() => null)
       if (ext) {
         extensions.push(ext)
@@ -131,11 +131,10 @@ export class ExtensionManager {
         continue
       }
       const absPath = path.resolve(folderPath, fileName);
-      if (!fs.existsSync(absPath) || !fs.lstatSync(absPath).isDirectory()) {
+      if (!fs.existsSync(absPath) || !fs.lstatSync(absPath).isDirectory()) { // skip non-directories
         continue;
       }
       const manifestPath = path.resolve(absPath, "package.json");
-      await fs.access(manifestPath, fs.constants.F_OK)
       const ext = await this.getExtensionByManifest(manifestPath).catch(() => null)
       if (ext) {
         extensions.push(ext)

--- a/src/extensions/extension-manager.ts
+++ b/src/extensions/extension-manager.ts
@@ -131,6 +131,9 @@ export class ExtensionManager {
         continue
       }
       const absPath = path.resolve(folderPath, fileName);
+      if (!fs.existsSync(absPath) || !fs.lstatSync(absPath).isDirectory()) {
+        continue;
+      }
       const manifestPath = path.resolve(absPath, "package.json");
       await fs.access(manifestPath, fs.constants.F_OK)
       const ext = await this.getExtensionByManifest(manifestPath).catch(() => null)


### PR DESCRIPTION
Accepting only directories and checking for `package.json` availability while loading an extension from home folder.

It allows to avoid parsing `.DS_Store` file which can be created automatically in any folder by macOS. And skips directories without manifest `package.json`.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>