### PR TITLE
Add missing kubeObjectDetailItems observable to LensRendererExtension

### DIFF
--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -6,7 +6,10 @@ import { broadcastIpc } from "../common/ipc"
 import { observable, reaction, toJS, } from "mobx"
 import logger from "../main/logger"
 import { app, ipcRenderer, remote } from "electron"
-import { appPreferenceRegistry, clusterFeatureRegistry, clusterPageRegistry, globalPageRegistry, kubeObjectMenuRegistry, menuRegistry, statusBarRegistry } from "./registries";
+import {
+  appPreferenceRegistry, clusterFeatureRegistry, clusterPageRegistry, globalPageRegistry,
+  kubeObjectDetailRegistry, kubeObjectMenuRegistry, menuRegistry, statusBarRegistry
+} from "./registries";
 
 export interface InstalledExtension extends ExtensionModel {
   manifestPath: string;
@@ -56,6 +59,7 @@ export class ExtensionLoader {
     this.autoloadExtensions((extension: LensRendererExtension) => {
       extension.registerTo(clusterPageRegistry, extension.clusterPages)
       extension.registerTo(kubeObjectMenuRegistry, extension.kubeObjectMenuItems)
+      extension.registerTo(kubeObjectDetailRegistry, extension.kubeObjectDetailItems)
     })
   }
 

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -1,4 +1,8 @@
-import type { AppPreferenceRegistration, ClusterFeatureRegistration, KubeObjectMenuRegistration, PageRegistration, StatusBarRegistration } from "./registries"
+import type {
+  AppPreferenceRegistration, ClusterFeatureRegistration,
+  KubeObjectMenuRegistration, KubeObjectDetailRegistration,
+  PageRegistration, StatusBarRegistration
+} from "./registries"
 import { observable } from "mobx";
 import { LensExtension } from "./lens-extension"
 
@@ -8,5 +12,6 @@ export class LensRendererExtension extends LensExtension {
   @observable.shallow appPreferences: AppPreferenceRegistration[] = []
   @observable.shallow clusterFeatures: ClusterFeatureRegistration[] = []
   @observable.shallow statusBarItems: StatusBarRegistration[] = []
+  @observable.shallow kubeObjectDetailItems: KubeObjectDetailRegistration[] = []
   @observable.shallow kubeObjectMenuItems: KubeObjectMenuRegistration[] = []
 }


### PR DESCRIPTION
This was missing in #1185 