### PR TITLE
Fix UI staleness after network issues

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -67,12 +67,12 @@ export class Cluster implements ClusterModel, ClusterState {
   @observable kubeConfigPath: string;
   @observable apiUrl: string; // cluster server url
   @observable kubeProxyUrl: string; // lens-proxy to kube-api url
-  @observable enabled = false;
-  @observable online = false;
-  @observable accessible = false;
-  @observable ready = false;
+  @observable enabled = false; // only enabled clusters are visible to users
+  @observable online = false; // describes if we can detect that cluster is online
+  @observable accessible = false; // if user is able to access cluster resources
+  @observable ready = false; // cluster is in usable state
   @observable reconnecting = false;
-  @observable disconnected = true;
+  @observable disconnected = true; // false if user has selected to connect
   @observable failureReason: string;
   @observable isAdmin = false;
   @observable eventCount = 0;
@@ -127,19 +127,20 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   protected bindEvents() {
-    logger.info(`[CLUSTER]: bind events`, this.getMeta());
-    const refreshTimer = setInterval(() => !this.disconnected && this.refresh(), 30000); // every 30s
-    const refreshMetadataTimer = setInterval(() => !this.disconnected && this.refreshMetadata(), 900000); // every 15 minutes
-
-    if (ipcMain) {
-      this.eventDisposers.push(
-        reaction(() => this.getState(), () => this.pushState()),
-        () => {
-          clearInterval(refreshTimer);
-          clearInterval(refreshMetadataTimer);
-        },
-      );
+    if (!ipcMain) {
+      return
     }
+    logger.info(`[CLUSTER]: bind events`, this.getMeta())
+    const refreshTimer = setInterval(() => !this.disconnected && this.refresh(), 30000) // every 30s
+    const refreshMetadataTimer = setInterval(() => !this.disconnected && this.refreshMetadata(), 900000) // every 15 minutes
+
+    this.eventDisposers.push(
+      reaction(() => this.getState(), () => this.pushState()),
+      () => {
+        clearInterval(refreshTimer)
+        clearInterval(refreshMetadataTimer)
+      },
+    );
   }
 
   protected unbindEvents() {

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -127,20 +127,19 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   protected bindEvents() {
-    if (!ipcMain) {
-      return
-    }
     logger.info(`[CLUSTER]: bind events`, this.getMeta())
     const refreshTimer = setInterval(() => !this.disconnected && this.refresh(), 30000) // every 30s
     const refreshMetadataTimer = setInterval(() => !this.disconnected && this.refreshMetadata(), 900000) // every 15 minutes
 
-    this.eventDisposers.push(
-      reaction(() => this.getState(), () => this.pushState()),
-      () => {
-        clearInterval(refreshTimer)
-        clearInterval(refreshMetadataTimer)
-      },
-    );
+    if (ipcMain) {
+      this.eventDisposers.push(
+        reaction(() => this.getState(), () => this.pushState()),
+        () => {
+          clearInterval(refreshTimer)
+          clearInterval(refreshMetadataTimer)
+        },
+      );
+    }
   }
 
   protected unbindEvents() {

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -111,7 +111,6 @@ export class KubeWatchApi {
 
   protected async onRouteEvent(event: IKubeWatchRouteEvent) {
     if (event.type === "STREAM_END") {
-      console.log("stream end")
       this.disconnect();
       const { apiBase, namespace } = KubeApi.parseApi(event.url);
       const api = apiManager.getApi(apiBase);

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -109,17 +109,23 @@ export class KubeWatchApi {
     }
   }
 
-  protected async onRouteEvent({ type, url }: IKubeWatchRouteEvent) {
-    if (type === "STREAM_END") {
+  protected async onRouteEvent(event: IKubeWatchRouteEvent) {
+    if (event.type === "STREAM_END") {
+      console.log("stream end")
       this.disconnect();
-      const { apiBase, namespace } = KubeApi.parseApi(url);
+      const { apiBase, namespace } = KubeApi.parseApi(event.url);
       const api = apiManager.getApi(apiBase);
       if (api) {
         try {
           await api.refreshResourceVersion({ namespace });
           this.reconnect();
         } catch (error) {
-          console.debug("failed to refresh resource version", error)
+          console.error("failed to refresh resource version", error)
+          if (this.subscribers.size > 0) {
+            setTimeout(() => {
+              this.onRouteEvent(event)
+            }, 1000)
+          }
         }
       }
     }

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -54,6 +54,9 @@ export class App extends React.Component {
     appEventBus.emit({name: "cluster", action: "open", params: {
       clusterId: clusterId
     }})
+    window.addEventListener("online", () => {
+      window.location.reload()
+    })
   }
 
   get startURL() {

--- a/src/renderer/lens-app.tsx
+++ b/src/renderer/lens-app.tsx
@@ -1,5 +1,6 @@
 import "../common/system-ca"
 import React from "react";
+import { ipcRenderer } from "electron";
 import { Route, Router, Switch } from "react-router";
 import { observer } from "mobx-react";
 import { userStore } from "../common/user-store";
@@ -17,6 +18,12 @@ import { extensionLoader } from "../extensions/extension-loader";
 export class LensApp extends React.Component {
   static async init() {
     extensionLoader.loadOnClusterManagerRenderer();
+    window.addEventListener("offline", () => {
+      ipcRenderer.send("network:offline")
+    })
+    window.addEventListener("online", () => {
+      ipcRenderer.send("network:online")
+    })
   }
 
   render() {


### PR DESCRIPTION
- adds network online/offline events
- connected cluster is automatically set to offline when network goes offline.. Lens still tries to check if cluster is accessible because minikube and other local clusters are connectable even if network is offline
- forces recheck when network comes back
- fixes a bug in watch api where error during STREAM_END did stop retries

Might fix #1110 