### PR TITLE
Expose more apis for KubeObjectListLayout usage

### DIFF
--- a/src/extensions/renderer-api/k8s-api.ts
+++ b/src/extensions/renderer-api/k8s-api.ts
@@ -1,4 +1,6 @@
+export { isAllowedResource } from "../../common/rbac"
 export { apiManager } from "../../renderer/api/api-manager";
+export { KubeObjectStore } from "../../renderer/kube-object.store"
 export { KubeApi, forCluster, IKubeApiCluster } from "../../renderer/api/kube-api";
 export { KubeObject } from "../../renderer/api/kube-object";
 export { Pod, podsApi, IPodContainer, IPodContainerStatus } from "../../renderer/api/endpoints";

--- a/src/extensions/renderer-api/navigation.ts
+++ b/src/extensions/renderer-api/navigation.ts
@@ -1,1 +1,3 @@
-export { navigate, hideDetails, showDetails } from "../../renderer/navigation"
+export { navigate, hideDetails, showDetails, getDetailsUrl } from "../../renderer/navigation"
+export { RouteProps } from "react-router"
+export { IURLParams } from "../../common/utils/buildUrl";


### PR DESCRIPTION
Usage example:

```typescript
import { LensRendererExtension, Component, K8sApi } from "@k8slens/extensions";

export class PodsStore extends K8sApi.KubeObjectStore<K8sApi.Pod> {
  api = K8sApi.podsApi;
}

enum sortBy {
  name = "name"
}

export const podsStore = new PodsStore();
K8sApi.apiManager.registerStore(K8sApi.podsApi, podsStore);

export class ExamplePage extends React.Component<{ extension: LensRendererExtension }> {

  async componentDidMount() {
    await podsStore.loadAll()
  }

  render() {
    return (
      <Component.KubeObjectListLayout
        className="Pods" store={podsStore}
        sortingCallbacks={{
          [sortBy.name]: (pod: K8sApi.Pod) => pod.getName()
        }}
        searchFilters={[
          (pod: K8sApi.Pod) => pod.getSearchFields(),
          (pod: K8sApi.Pod) => pod.getStatusMessage(),
        ]}
        renderHeaderTitle="Pods"
        renderTableHeader={[
          { title: "Name", className: "name", sortBy: sortBy.name },
        ]}
        renderTableContents={(pod: K8sApi.Pod) => [
          pod.getName()
        ]}
      />
    )
  }
}

```