### PR TITLE
Fixing return statements in Pod menus extension

### DIFF
--- a/extensions/pod-menu/src/logs-menu.tsx
+++ b/extensions/pod-menu/src/logs-menu.tsx
@@ -22,7 +22,7 @@ export class PodLogsMenu extends React.Component<PodLogsMenuProps> {
     const { object: pod, toolbar } = this.props
     const containers = pod.getAllContainers();
     const statuses = pod.getContainerStatuses();
-    if (!containers.length) return;
+    if (!containers.length) return null;
     return (
       <Component.MenuItem onClick={Util.prevDefault(() => this.showLogs(containers[0]))}>
         <Component.Icon material="subject" title="Logs" interactive={toolbar}/>

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -34,7 +34,7 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
   render() {
     const { object, toolbar } = this.props
     const containers = object.getRunningContainers();
-    if (!containers.length) return;
+    if (!containers.length) return null;
     return (
       <Component.MenuItem onClick={Util.prevDefault(() => this.execShell(containers[0].name))}>
         <Component.Icon svg="ssh" interactive={toolbar} title="Pod shell"/>

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -65,7 +65,6 @@ export class PodDetails extends React.Component<Props> {
     const { nodeName } = spec;
     const nodeSelector = pod.getNodeSelectors();
     const volumes = pod.getVolumes();
-    const labels = pod.getLabels();
     const metrics = podsStore.metrics;
     return (
       <div className="PodDetails">


### PR DESCRIPTION
Fixing return statements in Pod menus.
Something but `undefined` should be returned from React `render()` method.

Resolved #1209 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>