### PR TITLE
Add CI step to run future extension tests.

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,6 +39,8 @@ jobs:
         displayName: Install dependencies
       - script: make integration-win
         displayName: Run integration tests
+      - script: make test-extensions
+        displayName: Run In-tree Extension tests
       - script: make build
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
         displayName: Build
@@ -78,6 +80,8 @@ jobs:
         displayName: Run tests
       - script: make integration-mac
         displayName: Run integration tests
+      - script: make test-extensions
+        displayName: Run In-tree Extension tests
       - script: make build
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
         displayName: Build
@@ -119,6 +123,8 @@ jobs:
         condition: eq(variables.CACHE_RESTORED, 'true')
       - script: make install-deps
         displayName: Install dependencies
+      - script: make test-extensions
+        displayName: Run In-tree Extension tests
       - script: make lint
         displayName: Lint
       - script: make test

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,15 @@ lint:
 test: download-bins
 	yarn test
 
-integration-linux:
+integration-linux: build-extension-types build-extensions
 	yarn build:linux
 	yarn integration
 
-integration-mac:
+integration-mac: build-extension-types build-extensions
 	yarn build:mac
 	yarn integration
 
-integration-win:
+integration-win: build-extension-types build-extensions
 	yarn build:win
 	yarn integration
 
@@ -58,9 +58,14 @@ endif
 build-extensions:
 	$(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(dir) build;)
 
-build-npm:
-	yarn compile:extension-types
+test-extensions:
+	$(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), $(MAKE) -C $(dir) test;)
+
+build-npm: build-extension-types
 	yarn npm:fix-package-version
+
+build-extension-types:
+	yarn compile:extension-types
 
 publish-npm: build-npm
 	npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"

--- a/build/set_npm_version.ts
+++ b/build/set_npm_version.ts
@@ -6,4 +6,4 @@ import appInfo from "../package.json"
 const packagePath = path.join(__dirname, "../src/extensions/npm/extensions/package.json")
 
 packageInfo.version = appInfo.version
-fs.writeFileSync(packagePath, JSON.stringify(packageInfo, null, 2))
+fs.writeFileSync(packagePath, JSON.stringify(packageInfo, null, 2) + "\n")

--- a/extensions/example-extension/Makefile
+++ b/extensions/example-extension/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/example-extension/package.json
+++ b/extensions/example-extension/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "npm run build --watch"
+    "dev": "npm run build --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {
     "react-open-doodles": "^1.0.5"

--- a/extensions/license-menu-item/Makefile
+++ b/extensions/license-menu-item/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/license-menu-item/package.json
+++ b/extensions/license-menu-item/package.json
@@ -5,7 +5,8 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "webpack -p",
-    "dev": "webpack --watch"
+    "dev": "webpack --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {},
   "devDependencies": {

--- a/extensions/metrics-cluster-feature/Makefile
+++ b/extensions/metrics-cluster-feature/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/metrics-cluster-feature/package.json
+++ b/extensions/metrics-cluster-feature/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "npm run build --watch"
+    "dev": "npm run build --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {
     "semver": "^7.3.2"

--- a/extensions/node-menu/Makefile
+++ b/extensions/node-menu/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/node-menu/package.json
+++ b/extensions/node-menu/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "npm run build --watch"
+    "dev": "npm run build --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {},
   "devDependencies": {

--- a/extensions/pod-menu/Makefile
+++ b/extensions/pod-menu/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/pod-menu/package.json
+++ b/extensions/pod-menu/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "npm run build --watch"
+    "dev": "npm run build --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {},
   "devDependencies": {

--- a/extensions/support-page/Makefile
+++ b/extensions/support-page/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/support-page/package.json
+++ b/extensions/support-page/package.json
@@ -6,7 +6,8 @@
   "renderer": "dist/renderer.js",
   "scripts": {
     "build": "webpack -p",
-    "dev": "webpack --watch"
+    "dev": "webpack --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {},
   "devDependencies": {

--- a/extensions/telemetry/Makefile
+++ b/extensions/telemetry/Makefile
@@ -1,5 +1,8 @@
 install-deps:
-	npm install
+	yarn install
 
 build: install-deps
-	npm run build
+	yarn run build
+
+test:
+	yarn run test

--- a/extensions/telemetry/package-lock.json
+++ b/extensions/telemetry/package-lock.json
@@ -8,12 +8,6 @@
       "version": "file:../../src/extensions/npm/extensions",
       "dev": true
     },
-    "@types/analytics-node": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.3.tgz",
-      "integrity": "sha512-Yk299LUqnyJ6fNYQkLFd0yTfUwIvgfxH3f5WEX3ib0PC5T+mZgqcOPMDhNZ4AOD/A9tXKJQeBIb6KvgzuXflaQ==",
-      "dev": true
-    },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -23,6 +17,12 @@
         "component-type": "^1.2.1",
         "join-component": "^1.1.0"
       }
+    },
+    "@types/analytics-node": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.3.tgz",
+      "integrity": "sha512-Yk299LUqnyJ6fNYQkLFd0yTfUwIvgfxH3f5WEX3ib0PC5T+mZgqcOPMDhNZ4AOD/A9tXKJQeBIb6KvgzuXflaQ==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/extensions/telemetry/package.json
+++ b/extensions/telemetry/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "webpack -p",
-    "dev": "webpack --watch"
+    "dev": "webpack --watch",
+    "test": "echo NO TESTS"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
- add calls to build-npm and build-extensions to intergration-* targets
- add testing calls to all extensions

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #1201 