### PR TITLE
Fix PR autolabler on PR forks 

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@
 name: "Pull Request Labeler"
 
 'on':
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
Use event pull_request_target > disable autolabler on forks

Signed-off-by: Hung-Han (Henry) Chen <1474479+chenhunghan@users.noreply.github.com>