### PR TITLE
Fix PR auto-labler failure on fork

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 ---
 name: "Pull Request Labeler"
 
-'on':
+on:
   - pull_request
 
 jobs:
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v2
+        if: github.repository == 'lensapp/lens'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler-config.yml


### PR DESCRIPTION
Auto labler doesn't seems to have permission to write (READ-only) to lenapp/lens repo, if it runs on a fork, see https://github.com/actions/labeler/issues/36 

And, there seems no workaround. (there is one, but it's a cron job... https://github.com/marketplace/actions/periodic-labeler)

So to avoid confusion, just disable it, if the action is not on lensapp/lens.