### PR TITLE
Release v3.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,14 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.7 (current version)
+## 3.6.8 (current version)
+- Fix cluster connection issue when opening cluster settings for disconnected clusters
+- Fetch available Helm repositories from Artifact HUB
+- Check if user is cluster admin before opening cluster dashboard
+- Fix issue when application is disconnecting too fast from pod shell
+- Fix UI staleness after network issues
+
+## 3.6.7
 - Fix cluster dashboard opening when cluster is initially offline
 
 ## 3.6.6


### PR DESCRIPTION
## Changes since v3.6.7

- Start authentication proxy when opening cluster settings (#1120)
- Fetch available Helm repositories from Artifact HUB cache (#1121)
- Test is user cluster admin on cluster activate (#1122)
- Fix proxy upgrade socket timeouts (#1249)
- Fix UI staleness after network issues (#1306)