### PR TITLE
Release v4.0.0-alpha.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,15 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0-alpha.4 (current version)
+## 4.0.0-alpha.5 (current version)
 
 - Extension API
 - Improved pod logs
+- Mechanism for users to specify accessible namespaces
 - Tray icon
 - Add last-status information for container
 - Add LoadBalancer information to Ingress view
 - Move tracker to an extension
 - Add support page (as an extension)
+- Ability to restart deployment
 - Status bar visual fixes
 - Fix proxy upgrade socket timeouts
 - Fix UI staleness after network issues


### PR DESCRIPTION
## Changes since v4.0.0-alpha.4

- Fix rendering of boolean values in CRDs (#1087)
- Removing !important statements from theme variables (#1303)
- Do not expose registries to extensions (#1304)
- Remove hard-source-webpack-plugin (#1305)
- Keeping Icon focus state only for keyboard (#1234)
- Generate API Reference documentation using typedocs and gh-actions
- Fix KubeObjectDetails example in common capabilities (#1299)
- Expose CRD api to extensions (#1297)
- Implemented app menu testing support (#1105)
- Docs: extension styling and theming (#1267)
- Add some overview documentation to the getting started page (#1269)
- Add mechanism for users to specify accessible namespaces (#702)
- Log search (#1114)
- Export more UI components via extensions-api (#1285)
- Hot-reload/cache plugins to improve Lens DX (#1250)
- Fix Documentation: Contributing (#1273)
- ApiManager.registerStore should be simplified #1275 (#1278)
- Remove PR auto labler (#1272)
- Extensions api fixes (#1233)
- Docs: extension common capabilities (#1259)
- Docs: Extension Anatomy (#1265)
- Docs: extension testing (#1264)
- New Documentation: Contributing section (#1266)
- Renaming theme .json files (#1256)
- Docs: enable syntax highlight for code blocks (#1254)
- Restructure docs menu (#1235)
- Documentation (MKDOCS) (#1230)
- Restart deployment (#1175)
- UI for enabling/disabling extensions (#1208)
