### PR TITLE
Expose registration and related component interfaces to extensions

### DIFF
--- a/src/extensions/core-api/index.ts
+++ b/src/extensions/core-api/index.ts
@@ -10,6 +10,7 @@ import * as EventBus from "./event-bus"
 import * as Store from "./stores"
 import * as Util from "./utils"
 import * as ClusterFeature from "./cluster-feature"
+import * as Interface from "../interfaces"
 
 // TODO: allow to expose windowManager.navigate() as Navigation.navigate() in runtime
 export let windowManager: WindowManager;
@@ -18,6 +19,7 @@ export {
   App,
   EventBus,
   ClusterFeature,
+  Interface,
   Store,
   Util,
 }

--- a/src/extensions/interfaces/index.ts
+++ b/src/extensions/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from "./registrations"

--- a/src/extensions/interfaces/registrations.ts
+++ b/src/extensions/interfaces/registrations.ts
@@ -1,0 +1,7 @@
+export type { AppPreferenceRegistration, AppPreferenceComponents } from "../registries/app-preference-registry"
+export type { ClusterFeatureRegistration, ClusterFeatureComponents } from "../registries/cluster-feature-registry"
+export type { KubeObjectDetailRegistration, KubeObjectDetailComponents } from "../registries/kube-object-detail-registry"
+export type { KubeObjectMenuRegistration, KubeObjectMenuComponents } from "../registries/kube-object-menu-registry"
+export type { KubeObjectStatusRegistration } from "../registries/kube-object-status-registry"
+export type { PageRegistration, PageComponents } from "../registries/page-registry"
+export type { StatusBarRegistration } from "../registries/status-bar-registry"


### PR DESCRIPTION
This PR will expose registration and related component interfaces to extensions. This is mainly needed for generated api reference.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>