### PR TITLE
Fix: allow to fetch kube-api objects with label & field selectors

### DIFF
--- a/src/renderer/api/kube-api-versioned.ts
+++ b/src/renderer/api/kube-api-versioned.ts
@@ -51,6 +51,6 @@ export class VersionedKubeApi<T extends KubeObject = any> extends KubeApi<T> {
       namespace: isNamespaced ? namespace : undefined,
       name: name,
     });
-    return resourcePath + (query ? `?` + stringify(query) : "");
+    return resourcePath + (query ? `?` + stringify(this.normalizeQuery(query)) : "");
   }
 }

--- a/src/renderer/api/kube-api.ts
+++ b/src/renderer/api/kube-api.ts
@@ -24,6 +24,8 @@ export interface IKubeApiQueryParams {
   timeoutSeconds?: number;
   limit?: number; // doesn't work with ?watch
   continue?: string; // might be used with ?limit from second request
+  labelSelector?: string | string[]; // restrict list of objects by their labels, e.g. labelSelector: ["label=value"]
+  fieldSelector?: string | string[]; // restrict list of objects by their fields, e.g. fieldSelector: "field=name"
 }
 
 export interface IKubeApiCluster {
@@ -114,7 +116,17 @@ export class KubeApi<T extends KubeObject = any> {
       namespace: this.isNamespaced ? namespace : undefined,
       name: name,
     });
-    return resourcePath + (query ? `?` + stringify(query) : "");
+    return resourcePath + (query ? `?` + stringify(this.normalizeQuery(query)) : "");
+  }
+
+  protected normalizeQuery(query: Partial<IKubeApiQueryParams> = {}) {
+    if (query.labelSelector) {
+      query.labelSelector = [query.labelSelector].flat().join(",")
+    }
+    if (query.fieldSelector) {
+      query.fieldSelector = [query.fieldSelector].flat().join(",")
+    }
+    return query;
   }
 
   protected parseResponse(data: KubeJsonApiData | KubeJsonApiData[] | KubeJsonApiDataList, namespace?: string): any {


### PR DESCRIPTION
_Example:_

```ts
  const pods = await podsApi.list({}, {
    labelSelector: [
      "k8s-app=kube-dns",
      "pod-template-hash=66bff467f8"
    ]
  });
```