### PR TITLE
Allow to specify KubeObjectDetailRegistration priority

### DIFF
--- a/src/extensions/registries/kube-object-detail-registry.ts
+++ b/src/extensions/registries/kube-object-detail-registry.ts
@@ -9,13 +9,20 @@ export interface KubeObjectDetailRegistration {
   kind: string;
   apiVersions: string[];
   components: KubeObjectDetailComponents;
+  priority?: number;
 }
 
 export class KubeObjectDetailRegistry extends BaseRegistry<KubeObjectDetailRegistration> {
   getItemsForKind(kind: string, apiVersion: string) {
-    return this.items.filter((item) => {
+    const items = this.items.filter((item) => {
       return item.kind === kind && item.apiVersions.includes(apiVersion)
+    }).map((item) => {
+      if (item.priority === null) {
+        item.priority = 50
+      }
+      return item
     })
+    return items.sort((a, b) => b.priority - a.priority)
   }
 }
 

--- a/src/renderer/components/+config-autoscalers/hpa-details.tsx
+++ b/src/renderer/components/+config-autoscalers/hpa-details.tsx
@@ -137,7 +137,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "HorizontalPodAutoscaler",
   apiVersions: ["autoscaling/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+config-autoscalers/hpa-details.tsx
+++ b/src/renderer/components/+config-autoscalers/hpa-details.tsx
@@ -121,8 +121,6 @@ export class HpaDetails extends React.Component<Props> {
         <div className="metrics">
           {this.renderMetrics()}
         </div>
-
-        <KubeEventDetails object={hpa}/>
       </div>
     );
   }
@@ -133,5 +131,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["autoscaling/v1"],
   components: {
     Details: (props) => <HpaDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "HorizontalPodAutoscaler",
+  apiVersions: ["autoscaling/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+config-maps/config-map-details.tsx
+++ b/src/renderer/components/+config-maps/config-map-details.tsx
@@ -103,6 +103,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "ConfigMap",
   apiVersions: ["v1"],
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+config-maps/config-map-details.tsx
+++ b/src/renderer/components/+config-maps/config-map-details.tsx
@@ -87,8 +87,6 @@ export class ConfigMapDetails extends React.Component<Props> {
             </>
           )
         }
-
-        <KubeEventDetails object={configMap}/>
       </div>
     );
   }
@@ -101,3 +99,13 @@ kubeObjectDetailRegistry.add({
     Details: (props) => <ConfigMapDetails {...props} />
   }
 })
+
+kubeObjectDetailRegistry.add({
+  kind: "ConfigMap",
+  apiVersions: ["v1"],
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
+  }
+})
+
+

--- a/src/renderer/components/+events/kube-event-details.tsx
+++ b/src/renderer/components/+events/kube-event-details.tsx
@@ -29,7 +29,7 @@ export class KubeEventDetails extends React.Component<KubeEventDetailsProps> {
       )
     }
     return (
-      <>
+      <div>
         <DrawerTitle className="flex gaps align-center">
           <span><Trans>Events</Trans></span>
         </DrawerTitle>
@@ -57,7 +57,7 @@ export class KubeEventDetails extends React.Component<KubeEventDetailsProps> {
             )
           })}
         </div>
-      </>
+      </div>
     )
   }
 }

--- a/src/renderer/components/+network-endpoints/endpoint-details.tsx
+++ b/src/renderer/components/+network-endpoints/endpoint-details.tsx
@@ -31,8 +31,6 @@ export class EndpointDetails extends React.Component<Props> {
             )
           })
         }
-
-        <KubeEventDetails object={endpoint}/>
       </div>
     );
   }
@@ -43,5 +41,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <EndpointDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "Endpoints",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+network-endpoints/endpoint-details.tsx
+++ b/src/renderer/components/+network-endpoints/endpoint-details.tsx
@@ -46,7 +46,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Endpoints",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+network-ingresses/ingress-details.tsx
+++ b/src/renderer/components/+network-ingresses/ingress-details.tsx
@@ -127,8 +127,6 @@ export class IngressDetails extends React.Component<Props> {
 
         <DrawerTitle title={<Trans>Load-Balancer Ingress Points</Trans>}/>
         {this.renderIngressPoints(ingressPoints)}
-
-        <KubeEventDetails object={ingress}/>
       </div>
     )
   }
@@ -139,5 +137,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["extensions/v1beta1"],
   components: {
     Details: (props) => <IngressDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "Ingress",
+  apiVersions: ["extensions/v1beta1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+network-ingresses/ingress-details.tsx
+++ b/src/renderer/components/+network-ingresses/ingress-details.tsx
@@ -142,7 +142,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Ingress",
   apiVersions: ["extensions/v1beta1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+network-policies/network-policy-details.tsx
+++ b/src/renderer/components/+network-policies/network-policy-details.tsx
@@ -153,7 +153,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "NetworkPolicy",
   apiVersions: ["networking.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+network-policies/network-policy-details.tsx
+++ b/src/renderer/components/+network-policies/network-policy-details.tsx
@@ -137,8 +137,6 @@ export class NetworkPolicyDetails extends React.Component<Props> {
             })}
           </>
         )}
-
-        <KubeEventDetails object={policy}/>
       </div>
     );
   }
@@ -149,5 +147,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["networking.k8s.io/v1"],
   components: {
     Details: (props) => <NetworkPolicyDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "NetworkPolicy",
+  apiVersions: ["networking.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+network-services/service-details.tsx
+++ b/src/renderer/components/+network-services/service-details.tsx
@@ -78,8 +78,6 @@ export class ServiceDetails extends React.Component<Props> {
         <DrawerTitle title={_i18n._(t`Endpoint`)}/>
 
         <ServiceDetailsEndpoint endpoint={endpoint} />
-
-        <KubeEventDetails object={service}/>
       </div>
     );
   }
@@ -90,5 +88,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <ServiceDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "Service",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+network-services/service-details.tsx
+++ b/src/renderer/components/+network-services/service-details.tsx
@@ -94,7 +94,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Service",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -149,7 +149,6 @@ export class NodeDetails extends React.Component<Props> {
           maxCpu={node.getCpuCapacity()}
           maxMemory={node.getMemoryCapacity()}
         />
-        <KubeEventDetails object={node}/>
       </div>
     )
   }
@@ -160,5 +159,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <NodeDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "Node",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -165,7 +165,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Node",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+storage-classes/storage-class-details.tsx
+++ b/src/renderer/components/+storage-classes/storage-class-details.tsx
@@ -71,7 +71,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "StorageClass",
   apiVersions: ["storage.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+storage-classes/storage-class-details.tsx
+++ b/src/renderer/components/+storage-classes/storage-class-details.tsx
@@ -55,8 +55,6 @@ export class StorageClassDetails extends React.Component<Props> {
             }
           </>
         )}
-
-        <KubeEventDetails object={storageClass}/>
       </div>
     );
   }
@@ -67,5 +65,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["storage.k8s.io/v1"],
   components: {
     Details: (props) => <StorageClassDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "StorageClass",
+  apiVersions: ["storage.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
+++ b/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
@@ -104,7 +104,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "PersistentVolumeClaim",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
+++ b/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
@@ -88,8 +88,6 @@ export class PersistentVolumeClaimDetails extends React.Component<Props> {
             </Fragment>
           ))}
         </DrawerItem>
-
-        <KubeEventDetails object={volumeClaim}/>
       </div>
     );
   }
@@ -100,5 +98,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <PersistentVolumeClaimDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "PersistentVolumeClaim",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+storage-volumes/volume-details.tsx
+++ b/src/renderer/components/+storage-volumes/volume-details.tsx
@@ -112,7 +112,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "PersistentVolume",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+storage-volumes/volume-details.tsx
+++ b/src/renderer/components/+storage-volumes/volume-details.tsx
@@ -96,8 +96,6 @@ export class PersistentVolumeDetails extends React.Component<Props> {
             </DrawerItem>
           </>
         )}
-
-        <KubeEventDetails object={volume}/>
       </div>
     );
   }
@@ -108,5 +106,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <PersistentVolumeDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "PersistentVolume",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx
+++ b/src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx
@@ -112,8 +112,6 @@ export class RoleBindingDetails extends React.Component<Props> {
           </Table>
         )}
 
-        <KubeEventDetails object={roleBinding}/>
-
         <AddRemoveButtons
           onAdd={() => AddRoleBindingDialog.open(roleBinding)}
           onRemove={selectedSubjects.length ? this.removeSelectedSubjects : null}
@@ -133,9 +131,27 @@ kubeObjectDetailRegistry.add({
   }
 })
 kubeObjectDetailRegistry.add({
+  kind: "RoleBinding",
+  apiVersions: ["rbac.authorization.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
+  }
+})
+
+
+kubeObjectDetailRegistry.add({
   kind: "ClusterRoleBinding",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
   components: {
     Details: (props) => <RoleBindingDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "ClusterRoleBinding",
+  apiVersions: ["rbac.authorization.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx
+++ b/src/renderer/components/+user-management-roles-bindings/role-binding-details.tsx
@@ -133,7 +133,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "RoleBinding",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }
@@ -150,7 +150,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "ClusterRoleBinding",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+user-management-roles/role-details.tsx
+++ b/src/renderer/components/+user-management-roles/role-details.tsx
@@ -59,8 +59,6 @@ export class RoleDetails extends React.Component<Props> {
             </div>
           )
         })}
-
-        <KubeEventDetails object={role}/>
       </div>
     )
   }
@@ -73,11 +71,27 @@ kubeObjectDetailRegistry.add({
     Details: (props) => <RoleDetails {...props}/>
   }
 })
+kubeObjectDetailRegistry.add({
+  kind: "Role",
+  apiVersions: ["rbac.authorization.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
+  }
+})
 
 kubeObjectDetailRegistry.add({
   kind: "ClusterRole",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
   components: {
     Details: (props) => <RoleDetails {...props}/>
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "ClusterRole",
+  apiVersions: ["rbac.authorization.k8s.io/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props}/>
   }
 })

--- a/src/renderer/components/+user-management-roles/role-details.tsx
+++ b/src/renderer/components/+user-management-roles/role-details.tsx
@@ -74,7 +74,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Role",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }
@@ -90,7 +90,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "ClusterRole",
   apiVersions: ["rbac.authorization.k8s.io/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props}/>
   }

--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -140,7 +140,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "ServiceAccount",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
+++ b/src/renderer/components/+user-management-service-accounts/service-accounts-details.tsx
@@ -125,8 +125,6 @@ export class ServiceAccountsDetails extends React.Component<Props> {
         <div className="secrets">
           {this.renderSecrets()}
         </div>
-
-        <KubeEventDetails object={serviceAccount}/>
       </div>
     )
   }
@@ -137,5 +135,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["v1"],
   components: {
     Details: (props) => <ServiceAccountsDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "ServiceAccount",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
@@ -96,7 +96,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "CronJob",
   apiVersions: ["batch/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
@@ -81,7 +81,6 @@ export class CronJobDetails extends React.Component<Props> {
             }
           </>
         }
-        <KubeEventDetails object={cronJob}/>
       </div>
     )
   }
@@ -92,5 +91,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["batch/v1"],
   components: {
     Details: (props) => <CronJobDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "CronJob",
+  apiVersions: ["batch/v1"],
+  priority: 0,
+  components: {
+    Details: (props) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -91,7 +91,6 @@ export class DaemonSetDetails extends React.Component<Props> {
         </DrawerItem>
         <ResourceMetricsText metrics={metrics}/>
         <PodDetailsList pods={childPods} owner={daemonSet}/>
-        <KubeEventDetails object={daemonSet}/>
       </div>
     )
   }
@@ -102,5 +101,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["apps/v1"],
   components: {
     Details: (props: any) => <DaemonSetDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "DaemonSet",
+  apiVersions: ["apps/v1"],
+  priority: 0,
+  components: {
+    Details: (props: any) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -106,7 +106,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "DaemonSet",
   apiVersions: ["apps/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: any) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -116,7 +116,6 @@ export class DeploymentDetails extends React.Component<Props> {
         <ResourceMetricsText metrics={metrics}/>
         <ReplicaSets replicaSets={replicaSets}/>
         <PodDetailsList pods={childPods} owner={deployment}/>
-        <KubeEventDetails object={deployment}/>
       </div>
     )
   }
@@ -127,5 +126,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["apps/v1"],
   components: {
     Details: (props: any) => <DeploymentDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "Deployment",
+  apiVersions: ["apps/v1"],
+  priority: 0,
+  components: {
+    Details: (props: any) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -131,7 +131,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Deployment",
   apiVersions: ["apps/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: any) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -101,7 +101,6 @@ export class JobDetails extends React.Component<Props> {
           <PodDetailsStatuses pods={childPods}/>
         </DrawerItem>
         <PodDetailsList pods={childPods} owner={job}/>
-        <KubeEventDetails object={job}/>
       </div>
     )
   }
@@ -112,5 +111,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["batch/v1"],
   components: {
     Details: (props: any) => <JobDetails {...props}/>
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "Job",
+  apiVersions: ["batch/v1"],
+  priority: 0,
+  components: {
+    Details: (props: any) => <KubeEventDetails {...props}/>
   }
 })

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -116,7 +116,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Job",
   apiVersions: ["batch/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: any) => <KubeEventDetails {...props}/>
   }

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -231,7 +231,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "Pod",
   apiVersions: ["v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: KubeObjectDetailsProps<Pod>) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -215,7 +215,6 @@ export class PodDetails extends React.Component<Props> {
             })}
           </>
         )}
-        <KubeEventDetails object={pod}/>
       </div>
     )
   }
@@ -225,6 +224,15 @@ kubeObjectDetailRegistry.add({
   kind: "Pod",
   apiVersions: ["v1"],
   components: {
-    Details: (props: any) => <PodDetails {...props} />
+    Details: (props: KubeObjectDetailsProps<Pod>) => <PodDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "Pod",
+  apiVersions: ["v1"],
+  priority: 0,
+  components: {
+    Details: (props: KubeObjectDetailsProps<Pod>) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -106,7 +106,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "ReplicaSet",
   apiVersions: ["apps/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: any) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -91,7 +91,6 @@ export class ReplicaSetDetails extends React.Component<Props> {
         </DrawerItem>
         <ResourceMetricsText metrics={metrics}/>
         <PodDetailsList pods={childPods} owner={replicaSet}/>
-        <KubeEventDetails object={replicaSet}/>
       </div>
     )
   }
@@ -102,5 +101,13 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["apps/v1"],
   components: {
     Details: (props: any) => <ReplicaSetDetails {...props} />
+  }
+})
+kubeObjectDetailRegistry.add({
+  kind: "ReplicaSet",
+  apiVersions: ["apps/v1"],
+  priority: 0,
+  components: {
+    Details: (props: any) => <KubeEventDetails {...props} />
   }
 })

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -106,7 +106,7 @@ kubeObjectDetailRegistry.add({
 kubeObjectDetailRegistry.add({
   kind: "StatefulSet",
   apiVersions: ["apps/v1"],
-  priority: 0,
+  priority: 5,
   components: {
     Details: (props: any) => <KubeEventDetails {...props} />
   }

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -89,7 +89,6 @@ export class StatefulSetDetails extends React.Component<Props> {
         </DrawerItem>
         <ResourceMetricsText metrics={metrics}/>
         <PodDetailsList pods={childPods} owner={statefulSet}/>
-        <KubeEventDetails object={statefulSet}/>
       </div>
     )
   }
@@ -101,5 +100,14 @@ kubeObjectDetailRegistry.add({
   apiVersions: ["apps/v1"],
   components: {
     Details: (props: any) => <StatefulSetDetails {...props} />
+  }
+})
+
+kubeObjectDetailRegistry.add({
+  kind: "StatefulSet",
+  apiVersions: ["apps/v1"],
+  priority: 0,
+  components: {
+    Details: (props: any) => <KubeEventDetails {...props} />
   }
 })


### PR DESCRIPTION
Allows extensions (or core) to specify placement of object details. For example:

```ts
  kubeObjectDetailItems = [
    {
      kind: "Pod",
      apiVersions: ["v1"],
      priority: 10,
      components: {
        Details: (props: any) => <CustomPodDetails pod={props.object} />
      }
    }
  ]
```
Would be shown above Pod events.