### PR TITLE
Documentation Update: Properly create tags and aliases, add workflow …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
       - master
-
+  release:
+    types: 
+      - published
 jobs:
   build:
     name: Deploy docs
@@ -27,13 +29,12 @@ jobs:
       - name: Checkout Release from lens
         uses: actions/checkout@v2
         with:
-          repository: lensapp/lens
+          fetch-depth: 0
 
       - name: git config
         run: |
            git config --local user.email "action@github.com"
            git config --local user.name "GitHub Action"
-           git pull
 
       - name: Using Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -45,17 +46,19 @@ jobs:
            yarn install
            yarn typedocs-extensions-api
 
-      - name: mkdocs deploy latest
+      - name: mkdocs deploy master
+        if: contains(github.ref, 'refs/heads/master')
         run: |
-           mike deploy --push latest
+           mike deploy --push master
 
-
-      - name: mkdocs deploy new release / tag
-        if: contains(github.ref, 'refs/tags/v')
+      - name: Get the release version
+        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+  
+      - name: mkdocs deploy new release
+        if: contains(github.ref, 'refs/tags/v') # && !github.event.release.prerelease (generate pre-release docs until Lens 4.0.0 is GA, see #1408)
         run: |
-           mike deploy --push--update-aliases ${{ github.ref }} latest
-           mike set-default --push ${{ github.ref }}
-
-
-
-
+           mike deploy --push --update-aliases ${{ steps.get_version.outputs.VERSION }} latest
+           mike set-default --push ${{ steps.get_version.outputs.VERSION }}
+           

--- a/.github/workflows/mkdocs-delete-version.yml
+++ b/.github/workflows/mkdocs-delete-version.yml
@@ -1,0 +1,38 @@
+name: Delete Documentation Version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version string to be deleted (e.g."v0.0.1")'
+        required: true
+jobs:
+  build:
+    name: Delete docs Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://${{ secrets.GH_TOKEN }}@github.com/lensapp/mkdocs-material-insiders.git
+          pip install mike
+          
+      - name: Checkout Release from lens
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: git config
+        run: |
+           git config --local user.email "action@github.com"
+           git config --local user.name "GitHub Action"
+
+
+      - name: mkdocs delete version
+        run: |
+           mike delete --push ${{ github.event.inputs.version }}
+           


### PR DESCRIPTION
Documentation Update: 
- Properly create tags and aliases
  - create new tag and update alias "latest" on release publish (for release and pre-release until Lens 4.0.0 is GA, see #1408)
  - master contains always the docs generated from last master branch commit
- add workflow to delete old unwanted versions from gh-pages branch using mkdocs delete

![Documentation delete Version GH-Action](https://user-images.githubusercontent.com/26629812/98966615-c4b50e00-250b-11eb-9ee1-e26229fda1fd.png)

Signed-off-by: Mario Sarcher <msarcher@mirantis.com>