### PR TITLE
Fix: navigating to extension page

### DIFF
--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -44,13 +44,9 @@ export class LensExtension {
     return this.manifest.description
   }
 
-  getPageUrl(baseUrl = "") {
+  getPageRoute(suffixPathOrUrl = "") {
     const validUrlName = this.name.replace("@", "").replace("/", "-");
-    return compile(this.routePrefix)({ name: validUrlName }) + baseUrl;
-  }
-
-  getPageRoute(baseRoute = "") {
-    return this.getPageUrl() + baseRoute;
+    return compile(this.routePrefix)({ name: validUrlName }) + suffixPathOrUrl;
   }
 
   @action

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -49,7 +49,7 @@ export class LensExtension {
   }
 
   getPageRoute(baseRoute = "") {
-    return this.routePrefix + baseRoute;
+    return this.getPageUrl() + baseRoute;
   }
 
   @action

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -45,7 +45,8 @@ export class LensExtension {
   }
 
   getPageUrl(baseUrl = "") {
-    return compile(this.routePrefix)({ name: this.name }) + baseUrl;
+    const validUrlName = this.name.replace("@", "").replace("/", "-");
+    return compile(this.routePrefix)({ name: validUrlName }) + baseUrl;
   }
 
   getPageRoute(baseRoute = "") {

--- a/src/extensions/lens-main-extension.ts
+++ b/src/extensions/lens-main-extension.ts
@@ -8,7 +8,7 @@ export class LensMainExtension extends LensExtension {
 
   async navigate(location?: string, frameId?: number) {
     const windowManager = WindowManager.getInstance<WindowManager>();
-    const url = this.getPageUrl(location); // get full path to extension's page
+    const url = this.getPageRoute(location); // get full path to extension's page
     await windowManager.navigate(url, frameId);
   }
 }

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -16,6 +16,6 @@ export class LensRendererExtension extends LensExtension {
 
   async navigate(location?: string) {
     const { navigate } = await import("../renderer/navigation");
-    navigate(this.getPageUrl(location));
+    navigate(this.getPageRoute(location));
   }
 }

--- a/src/extensions/registries/page-menu-registry.ts
+++ b/src/extensions/registries/page-menu-registry.ts
@@ -23,10 +23,17 @@ export interface PageMenuComponents {
 
 export class PageMenuRegistry<T extends PageMenuRegistration> extends BaseRegistry<T> {
   getItems() {
-    return super.getItems().map(menuItem => ({
-      ...menuItem,
-      url: menuItem.extension.getPageRoute(menuItem.url),
-    }));
+    return super.getItems().map(menuItem => {
+      const menuItemUrl = menuItem.extension.getPageRoute(menuItem.url);
+      return {
+        ...menuItem,
+        url: menuItemUrl,
+        subMenus: menuItem?.subMenus?.map(subMenuItem => ({
+          ...subMenuItem,
+          url: menuItemUrl + subMenuItem.url,
+        }))
+      }
+    });
   }
 }
 

--- a/src/extensions/registries/page-menu-registry.ts
+++ b/src/extensions/registries/page-menu-registry.ts
@@ -23,10 +23,10 @@ export interface PageMenuComponents {
 
 export class PageMenuRegistry<T extends PageMenuRegistration> extends BaseRegistry<T> {
   getItems() {
-    return super.getItems().map(item => {
-      item.url = item.extension.getPageUrl(item.url)
-      return item
-    });
+    return super.getItems().map(menuItem => ({
+      ...menuItem,
+      url: menuItem.extension.getPageRoute(menuItem.url),
+    }));
   }
 }
 

--- a/src/extensions/registries/page-registry.ts
+++ b/src/extensions/registries/page-registry.ts
@@ -22,9 +22,16 @@ export interface PageComponents {
 
 export class PageRegistry<T extends PageRegistration> extends BaseRegistry<T> {
   getItems() {
-    return super.getItems().map(item => {
-      item.routePath = item.extension.getPageRoute(item.routePath)
-      return item
+    return super.getItems().map(page => {
+      const pageRoute = page.extension.getPageRoute(page.routePath);
+      return {
+        ...page,
+        routePath: pageRoute,
+        subPages: page?.subPages?.map(subPage => ({
+          ...subPage,
+          routePath: pageRoute + subPage.routePath
+        }))
+      }
     });
   }
 }

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -5,7 +5,6 @@ import { remote } from "electron"
 import type { Cluster } from "../../../main/cluster";
 import { DragDropContext, Draggable, DraggableProvided, Droppable, DroppableProvided, DropResult } from "react-beautiful-dnd";
 import { observer } from "mobx-react";
-import { matchPath } from "react-router";
 import { _i18n } from "../../i18n";
 import { t, Trans } from "@lingui/macro";
 import { userStore } from "../../../common/user-store";
@@ -15,7 +14,7 @@ import { ClusterIcon } from "../cluster-icon";
 import { Icon } from "../icon";
 import { autobind, cssNames, IClassName } from "../../utils";
 import { Badge } from "../badge";
-import { navigate, navigation } from "../../navigation";
+import { isActiveRoute, navigate } from "../../navigation";
 import { addClusterURL } from "../+add-cluster";
 import { clusterSettingsURL } from "../+cluster-settings";
 import { landingURL } from "../+landing-page";
@@ -153,12 +152,11 @@ export class ClustersMenu extends React.Component<Props> {
             const registeredPage = globalPageRegistry.getById(menuItemId);
             if (!registeredPage) return;
             const { routePath, exact } = registeredPage;
-            const isActive = !!matchPath(navigation.location.pathname, { path: routePath, exact });
             return (
               <Icon
                 key={routePath}
                 tooltip={title}
-                active={isActive}
+                active={isActiveRoute({ path: routePath, exact })}
                 onClick={() => navigate(url)}
               />
             )


### PR DESCRIPTION
Proper handling extension page base route.

_Fixes:_
- extension page route matches to actual extension name, e.g. `/extension/lens-hello-world`
- extension name updated in accordance to be supported in URL (`@` removed, `/` => `-`)

Signed-off-by: Roman <ixrock@gmail.com>