### PR TITLE
Add posibility to add custom helm repository

### DIFF
--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -140,6 +140,43 @@ msgstr "Add field"
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr "Adding helm branch <0>{0}</0> has failed: {1}"
 
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:91
+msgid "Helm repository <0>{0}</0> has added"
+msgstr "Helm repository <0>{0}</0> has added"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Skip TLS certificate checks for the repository"
+msgstr "Skip TLS certificate checks for the repository"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Key file"
+msgstr "Key file"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:129
+msgid "Ca file"
+msgstr "Ca file"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:130
+msgid "Cerificate file"
+msgstr "Cerificate file"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:134
+msgid "Username"
+msgstr "Username"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:140
+msgid "Password"
+msgstr "Password"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "Helm repo name"
+msgstr "Helm repo name"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "More"
+msgstr "More"
+
 #: src/renderer/components/+preferences/preferences.tsx:108
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr "Adding repo <0>{0}</0> has failed: {1}"

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -140,6 +140,42 @@ msgstr ""
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:91
+msgid "Helm repository <0>{0}</0> has added"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Skip TLS certificate checks for the repository"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Key file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:129
+msgid "Ca file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:130
+msgid "Cerificate file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:134
+msgid "Username"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:140
+msgid "Password"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "Helm repo name"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "More"
+msgstr ""
+
 #: src/renderer/components/+preferences/preferences.tsx:108
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr ""

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -141,6 +141,42 @@ msgstr "Добавить поле"
 msgid "Adding helm branch <0>{0}</0> has failed: {1}"
 msgstr ""
 
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:91
+msgid "Helm repository <0>{0}</0> has added"
+msgstr "Helm репозиторий <0>{0}</0> добавлен"
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Skip TLS certificate checks for the repository"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:128
+msgid "Key file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:129
+msgid "Ca file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:130
+msgid "Cerificate file"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:134
+msgid "Username"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:140
+msgid "Password"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "Helm repo name"
+msgstr ""
+
+#: src/renderer/components/+preferences/add-helm-repo-dialog.tsx:163
+msgid "More"
+msgstr ""
+
 #: src/renderer/components/+preferences/preferences.tsx:108
 #~ msgid "Adding repo <0>{0}</0> has failed: {1}"
 #~ msgstr ""

--- a/src/main/helm/helm-repo-manager.ts
+++ b/src/main/helm/helm-repo-manager.ts
@@ -22,7 +22,7 @@ export interface HelmRepo {
   cacheFilePath?: string
   caFile?: string,
   certFile?: string,
-  insecure_skip_tls_verify?: boolean,
+  insecureSkipTlsVerify?: boolean,
   keyFile?: string,
   username?: string,
   password?: string,
@@ -125,6 +125,25 @@ export class HelmRepoManager extends Singleton {
     logger.info(`[HELM]: adding repo "${name}" from ${url}`);
     const helm = await helmCli.binaryPath();
     const { stdout } = await promiseExec(`"${helm}" repo add ${name} ${url}`).catch((error) => {
+      throw(error.stderr);
+    });
+
+    return stdout;
+  }
+
+  public async addСustomRepo(repoAttributes : HelmRepo) {
+    logger.info(`[HELM]: adding repo "${repoAttributes.name}" from ${repoAttributes.url}`);
+    const helm = await helmCli.binaryPath();
+
+    const insecureSkipTlsVerify = repoAttributes.insecureSkipTlsVerify ? " --insecure-skip-tls-verify" : "";
+    const username = repoAttributes.username ? ` --username "${repoAttributes.username}"` : "";
+    const password = repoAttributes.password ? ` --password "${repoAttributes.password}"` : "";
+    const caFile = repoAttributes.caFile ? ` --ca-file "${repoAttributes.caFile}"` : "";
+    const keyFile = repoAttributes.keyFile ? ` --key-file "${repoAttributes.keyFile}"` : "";
+    const certFile = repoAttributes.certFile ? ` --cert-file "${repoAttributes.certFile}"` : "";
+
+    const addRepoCommand = `"${helm}" repo add ${repoAttributes.name} ${repoAttributes.url}${insecureSkipTlsVerify}${username}${password}${caFile}${keyFile}${certFile}`;
+    const { stdout } = await promiseExec(addRepoCommand).catch((error) => {
       throw(error.stderr);
     });
 

--- a/src/renderer/components/+preferences/add-helm-repo-dialog.scss
+++ b/src/renderer/components/+preferences/add-helm-repo-dialog.scss
@@ -1,0 +1,22 @@
+.AddHelmRepoDialog {
+  --flex-gap: #{$margin * 1.5};
+
+  .accordion {
+    font-weight: bold;
+    align-self: flex-start;
+    padding: 0;
+    &:focus:not(:active) {
+      box-shadow: none;
+    }
+  }
+  .Icon {
+    --color-active: black;
+  }
+
+  .fields-title {
+    display: grid;
+    grid-template-columns: min-content auto;
+    align-items: center;
+    gap: $margin / 2;
+  }
+}

--- a/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
+++ b/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
@@ -1,0 +1,178 @@
+import "./add-helm-repo-dialog.scss";
+
+import React from "react";
+import { remote, FileFilter } from "electron";
+import { observable } from "mobx";
+import { observer } from "mobx-react";
+import { t, Trans } from "@lingui/macro";
+import { _i18n } from "../../i18n";
+import { Dialog, DialogProps } from "../dialog";
+import { Wizard, WizardStep } from "../wizard";
+import { Input } from "../input";
+import { Checkbox } from "../checkbox";
+import { Button } from "../button";
+import { systemName, isUrl, isPath } from "../input/input_validators";
+import { SubTitle } from "../layout/sub-title";
+import { Icon } from "../icon";
+import { Notifications } from "../notifications";
+import { HelmRepo, repoManager } from "../../../main/helm/helm-repo-manager";
+
+interface Props extends Partial<DialogProps> {
+  onAddRepo: Function
+}
+
+enum FileType {
+  CaFile = "caFile",
+  KeyFile = "keyFile",
+  CertFile = "certFile",
+}
+
+@observer
+export class AddHelmRepoDialog extends React.Component<Props> {
+  private emptyRepo = {name: "", url: "", username: "", password: "", insecureSkipTlsVerify: false, caFile:"", keyFile: "", certFile: ""};
+
+  private static keyExtensions = ["key", "keystore", "jks", "p12", "pfx", "pem"];
+  private static certExtensions = ["crt", "cer", "ca-bundle", "p7b", "p7c" , "p7s", "p12", "pfx", "pem"];
+
+  @observable static isOpen = false;
+
+  static open() {
+    AddHelmRepoDialog.isOpen = true;
+  }
+
+  static close() {
+    AddHelmRepoDialog.isOpen = false;
+  }
+
+  @observable helmRepo : HelmRepo = this.emptyRepo;
+  @observable showOptions = false;
+
+  close = () => {
+    AddHelmRepoDialog.close();
+    this.helmRepo = this.emptyRepo;
+    this.showOptions = false;
+  };
+
+  setFilepath(type: FileType, value: string) {
+    this.helmRepo[type] = value;
+  }
+
+  getFilePath(type: FileType) : string {
+    return this.helmRepo[type];
+  }
+
+  async selectFileDialog(type: FileType, fileFilter: FileFilter) {
+    const { dialog, BrowserWindow } = remote;
+    const { canceled, filePaths } = await dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), {
+      defaultPath: this.getFilePath(type),
+      properties: ["openFile", "showHiddenFiles"],
+      message: _i18n._(t`Select file`),
+      buttonLabel: _i18n._(t`Use file`),
+      filters: [
+        fileFilter,
+        { name: "Any", extensions: ["*"]}
+      ]
+    });
+
+    if (!canceled && filePaths.length) {
+      this.setFilepath(type, filePaths[0]);
+    }
+  }
+
+  async addCustomRepo() {
+    try {
+      await repoManager.addСustomRepo(this.helmRepo);
+      Notifications.ok(<Trans>Helm repository <b>{this.helmRepo.name}</b> has added</Trans>);
+      this.props.onAddRepo();
+      this.close();
+    } catch (err) {
+      Notifications.error(<Trans>Adding helm branch <b>{this.helmRepo.name}</b> has failed: {String(err)}</Trans>);
+    }
+  }
+
+  renderFileInput(placeholder:string, fileType:FileType ,fileExtensions:string[]){
+    return(
+      <div className="flex gaps align-center">
+        <Input
+          placeholder={placeholder}
+          validators = {isPath}
+          className="box grow"
+          value={this.getFilePath(fileType)}
+          onChange={v => this.setFilepath(fileType, v)}
+        />
+        <Icon
+          material="folder"
+          onClick={() => this.selectFileDialog(fileType, {name: placeholder, extensions: fileExtensions})}
+          tooltip={<Trans>Browse</Trans>}
+        />
+      </div>);
+  }
+
+  renderOptions() {
+    return (
+      <>
+        <SubTitle title={<Trans>Security settings</Trans>} />
+        <Checkbox
+          label={_i18n._(t`Skip TLS certificate checks for the repository`)}
+          value={this.helmRepo.insecureSkipTlsVerify}
+          onChange={v => this.helmRepo.insecureSkipTlsVerify = v}
+        />
+        {this.renderFileInput(_i18n._(t`Key file`), FileType.KeyFile, AddHelmRepoDialog.keyExtensions)}
+        {this.renderFileInput(_i18n._(t`Ca file`), FileType.CaFile, AddHelmRepoDialog.certExtensions)}
+        {this.renderFileInput(_i18n._(t`Cerificate file`), FileType.CertFile, AddHelmRepoDialog.certExtensions)}
+        <SubTitle title={<Trans>Chart Repository Credentials</Trans>} />
+        <Input
+          placeholder={_i18n._(t`Username`)}
+          value={this.helmRepo.username} onChange= {v => this.helmRepo.username = v}
+        />
+        <Input
+          type="password"
+          placeholder={_i18n._(t`Password`)}
+          value={this.helmRepo.password} onChange={v => this.helmRepo.password = v}
+        />
+      </>);
+  }
+
+  render() {
+    const { ...dialogProps } = this.props;
+
+    const header = <h5><Trans>Add custom Helm Repo</Trans></h5>;
+
+    return (
+      <Dialog
+        {...dialogProps}
+        className="AddHelmRepoDialog"
+        isOpen={AddHelmRepoDialog.isOpen}
+        close={this.close}
+      >
+        <Wizard header={header} done={this.close}>
+          <WizardStep contentClass="flow column" nextLabel={<Trans>Add</Trans>} next={()=>{this.addCustomRepo();}}>
+            <div className="flex column gaps">
+              <Input
+                autoFocus required
+                placeholder={_i18n._(t`Helm repo name`)}
+                validators={systemName}
+                value={this.helmRepo.name} onChange={v => this.helmRepo.name = v}
+              />
+              <Input
+                required
+                placeholder={_i18n._(t`URL`)}
+                validators={isUrl}
+                value={this.helmRepo.url} onChange={v => this.helmRepo.url = v}
+              />
+              <Button plain className="accordion" onClick={() => this.showOptions = !this.showOptions} >
+                <Trans>More</Trans>
+                <Icon
+                  small
+                  tooltip={_i18n._(t`More`)}
+                  material={this.showOptions ? "remove" : "add"}
+                />
+              </Button>
+              {this.showOptions && this.renderOptions()}
+            </div>
+          </WizardStep>
+        </Wizard>
+      </Dialog>
+    );
+  }
+}

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -13,11 +13,13 @@ import { Input } from "../input";
 import { Checkbox } from "../checkbox";
 import { Notifications } from "../notifications";
 import { Badge } from "../badge";
+import { Button } from "../button";
 import { themeStore } from "../../theme.store";
 import { Tooltip } from "../tooltip";
 import { KubectlBinaries } from "./kubectl-binaries";
 import { appPreferenceRegistry } from "../../../extensions/registries/app-preference-registry";
 import { PageLayout } from "../layout/page-layout";
+import { AddHelmRepoDialog } from "./add-helm-repo-dialog";
 
 @observer
 export class Preferences extends React.Component {
@@ -134,16 +136,25 @@ export class Preferences extends React.Component {
         <KubectlBinaries preferences={preferences}/>
 
         <h2><Trans>Helm</Trans></h2>
-        <Select id="HelmRepoSelect"
-          placeholder={<Trans>Repositories</Trans>}
-          isLoading={this.helmLoading}
-          isDisabled={this.helmLoading}
-          options={this.helmOptions}
-          onChange={this.onRepoSelect}
-          formatOptionLabel={this.formatHelmOptionLabel}
-          controlShouldRenderValue={false}
-        />
-        <div className="repos flex column">
+        <div className="flex gaps">
+          <Select id="HelmRepoSelect"
+            placeholder={<Trans>Repositories</Trans>}
+            isLoading={this.helmLoading}
+            isDisabled={this.helmLoading}
+            options={this.helmOptions}
+            onChange={this.onRepoSelect}
+            formatOptionLabel={this.formatHelmOptionLabel}
+            controlShouldRenderValue={false}
+            className="box grow"
+          />
+          <Button
+            primary
+            label={<Trans>Add Custom Helm Repo</Trans>}
+            onClick={AddHelmRepoDialog.open}
+          />
+        </div>
+        <AddHelmRepoDialog onAddRepo={()=>this.loadHelmRepos()}/>
+        <div className="repos flex gaps column">
           {Array.from(this.helmAddedRepos).map(([name, repo]) => {
             const tooltipId = `message-${name}`;
 


### PR DESCRIPTION
The commit adds the possibility to add a custom helm repository instead of selecting prepared ones
The commit adds new button in preferences - helm section
![image](https://user-images.githubusercontent.com/53330707/99059203-ae648c00-25b7-11eb-96ee-e5ed846e1d8f.png)


Warning! Implementation is ugly, need your comments on how to improve it.