### PR TITLE
set "allowJs" to false in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
-    "allowJs": true,
+    "allowJs": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "traceResolution": false,


### PR DESCRIPTION
- None of the .ts files include any of the .js files

- All .js files are either passed to electron-builder or used as config
  files for other programs.

Signed-off-by: Sebastian Malton <sebastian@malton.name>