### PR TITLE
Workspace layout minor fixes

### DIFF
--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -117,7 +117,7 @@ export class Workspaces extends React.Component {
             const isEditing = this.editingWorkspaces.has(workspaceId);
             const editingWorkspace = this.editingWorkspaces.get(workspaceId);
             const managed = !!ownerRef
-            const className = cssNames("workspace flex gaps", {
+            const className = cssNames("workspace flex gaps align-center", {
               active: isActive,
               editing: isEditing,
               default: isDefault,

--- a/src/renderer/components/layout/wizard-layout.scss
+++ b/src/renderer/components/layout/wizard-layout.scss
@@ -3,6 +3,7 @@
 
   position: relative;
   padding: $padding * 2;
+  width: 100%;
   height: 100%;
   display: grid;
   grid-template-columns: 1fr 40%;


### PR DESCRIPTION
Fixing workspaces width and description alignment.

<img width="1440" alt="workspaces" src="https://user-images.githubusercontent.com/9607060/99146686-7c245e80-268b-11eb-9c61-3f3abfcdef4b.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>