### PR TITLE
Adding Extensions menu item for non-mac menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -127,6 +127,13 @@ export function buildMenu(windowManager: WindowManager) {
             navigate(preferencesURL())
           }
         },
+        {
+          label: 'Extensions',
+          accelerator: 'Ctrl+Shift+E',
+          click() {
+            navigate(extensionsURL())
+          }
+        },
         { type: 'separator' },
         { role: 'quit' }
       ]),


### PR DESCRIPTION
Fixed #1389 

![extensions menu](https://user-images.githubusercontent.com/9607060/99239459-262af480-280c-11eb-9a24-5623c2efe0ad.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>