### PR TITLE
Fix Ctrl+Q bug

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -93,10 +93,9 @@ app.on("activate", (event, hasVisibleWindows) => {
   }
 });
 
-// Quit app on Cmd+Q (MacOS)
-app.on("will-quit", (event) => {
-  logger.info('APP:QUIT');
-  event.preventDefault(); // prevent app's default shutdown (e.g. required for telemetry, etc.)
+// Prevent app.exit() on closing all windows
+app.on("window-all-closed", () => {
+  logger.info('APP:CLOSE');
   clusterManager?.stop(); // close cluster connections
   return; // skip exit to make tray work, to quit go to app's global menu or tray's menu
 })


### PR DESCRIPTION
Hi, I found some issues related to not-working Ctrl+Q/File->Quit flows:
Lens just closes the window but still works, however the same button in the tray fully closes the app

So, IMHO the deal in the wrong event, where the system prevents app.exit() call on windows closing.

The fix has tested on Ubuntu, in theory, it should not affect Mac users because of app.exit() calling on Ctrl+Q
