### PR TITLE
Catch errors when responding from proxy error

### DIFF
--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -131,7 +131,11 @@ export class LensProxy {
           }
         }
       }
-      res.writeHead(500).end("Oops, something went wrong.")
+      try {
+        res.writeHead(500).end("Oops, something went wrong.")
+      } catch (e) {
+        // Can't send headers. Probably app is closing.
+      }
     })
 
     return proxy;

--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -134,7 +134,7 @@ export class LensProxy {
       try {
         res.writeHead(500).end("Oops, something went wrong.")
       } catch (e) {
-        // Can't send headers. Probably app is closing.
+        logger.error(`[LENS-PROXY]: Failed to write headers: `, e)
       }
     })
 


### PR DESCRIPTION
This PR will catch errors when responding from proxy error. Most of the proxy errors are happening when closing the app and it's not possible to respond anymore from proxy server.

Fixes #1356 . Also before this fix saw this error #191, but not anymore after the fix.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>