### PR TITLE
make targets running npm .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ endif
 binaries/client:
 	yarn download-bins
 
+.PHONY: node_modules
 node_modules:
-	yarn install --frozen-lockfile --verbose
+	yarn install --frozen-lockfile
 	yarn check --verify-tree --integrity
 
 static/build/LensDev.html:
@@ -63,9 +64,11 @@ else
 	yarn dist
 endif
 
+.PHONY: $(extension_node_modules)
 $(extension_node_modules):
 	cd $(@:/node_modules=) && npm install --no-audit --no-fund
 
+.PHONY: $(extension_dists)
 $(extension_dists): src/extensions/npm/extensions/dist
 	cd $(@:/dist=) && npm run build
 

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,8 @@ endif
 
 .PHONY: $(extension_node_modules)
 $(extension_node_modules):
-	cd $(@:/node_modules=) && npm install --no-audit --no-fund
+	cd $(@:/node_modules=) && yarn import && yarn install && rm yarn.lock
 
-.PHONY: $(extension_dists)
 $(extension_dists): src/extensions/npm/extensions/dist
 	cd $(@:/dist=) && npm run build
 

--- a/docs/extensions/get-started/anatomy.md
+++ b/docs/extensions/get-started/anatomy.md
@@ -51,7 +51,7 @@ Each Lens extension must have a `package.json` file. It contains a mix of Node.j
   "main": "dist/main.js",
   "renderer": "dist/renderer.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch"
   },
   "dependencies": {
@@ -94,4 +94,4 @@ export default class ExampleExtension extends LensRendererExtension {
 }
 ```
 
-The Hello World sample extension uses the `Cluster Page` capability, which is just one of the Lens extension API's capabilities. The [Common Capabilities](../capabilities/common-capabilities.md) page will help you home in on the right capabilities to use with your own extensions. 
+The Hello World sample extension uses the `Cluster Page` capability, which is just one of the Lens extension API's capabilities. The [Common Capabilities](../capabilities/common-capabilities.md) page will help you home in on the right capabilities to use with your own extensions.

--- a/extensions/example-extension/package.json
+++ b/extensions/example-extension/package.json
@@ -9,7 +9,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/kube-object-event-status/package.json
+++ b/extensions/kube-object-event-status/package.json
@@ -8,7 +8,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch",
     "test": "echo NO TESTS"
   },

--- a/extensions/license-menu-item/package.json
+++ b/extensions/license-menu-item/package.json
@@ -4,7 +4,7 @@
   "description": "License menu item",
   "main": "dist/main.js",
   "scripts": {
-    "build": "webpack -p",
+    "build": "npm run webpack -p",
     "dev": "webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/license-menu-item/package.json
+++ b/extensions/license-menu-item/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "npm run webpack -p",
-    "dev": "webpack --watch",
+    "dev": "npm run webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },
   "dependencies": {},

--- a/extensions/metrics-cluster-feature/package.json
+++ b/extensions/metrics-cluster-feature/package.json
@@ -8,7 +8,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/node-menu/package.json
+++ b/extensions/node-menu/package.json
@@ -8,7 +8,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/pod-menu/package.json
+++ b/extensions/pod-menu/package.json
@@ -8,7 +8,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "npm run webpack --config webpack.config.js",
     "dev": "npm run build --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/support-page/package.json
+++ b/extensions/support-page/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "renderer": "dist/renderer.js",
   "scripts": {
-    "build": "webpack -p",
+    "build": "npm run webpack -p",
     "dev": "webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/support-page/package.json
+++ b/extensions/support-page/package.json
@@ -6,7 +6,7 @@
   "renderer": "dist/renderer.js",
   "scripts": {
     "build": "npm run webpack -p",
-    "dev": "webpack --watch",
+    "dev": "npm run webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },
   "dependencies": {},

--- a/extensions/telemetry/package.json
+++ b/extensions/telemetry/package.json
@@ -9,7 +9,7 @@
     "styles": []
   },
   "scripts": {
-    "build": "webpack -p",
+    "build": "npm run webpack -p",
     "dev": "webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },

--- a/extensions/telemetry/package.json
+++ b/extensions/telemetry/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "npm run webpack -p",
-    "dev": "webpack --watch",
+    "dev": "npm run webpack --watch",
     "test": "jest --passWithNoTests --env=jsdom src $@"
   },
   "dependencies": {},


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

I have found that locally `make dev` was no longer working for me (due to missing packages). I noticed that `make` wasn't running some of the dependencies on the `dev` make target and I saw that those targets should rightly be marked as `.PHONY` since they don't updated their names in the filesystem.