### PR TITLE
Make BaseStore abstract

### DIFF
--- a/extensions/telemetry/src/telemetry-preferences-store.ts
+++ b/extensions/telemetry/src/telemetry-preferences-store.ts
@@ -1,11 +1,13 @@
 import { Store } from "@k8slens/extensions";
 import { toJS } from "mobx"
 
-export type TelemetryPreferencesModel = {
+export type TelemetryPreferencesModel = {
   enabled: boolean;
 }
 
 export class TelemetryPreferencesStore extends Store.ExtensionStore<TelemetryPreferencesModel> {
+  enabled = true;
+
   private constructor() {
     super({
       configName: "preferences-store",
@@ -15,17 +17,13 @@ export class TelemetryPreferencesStore extends Store.ExtensionStore<TelemetryPre
     })
   }
 
-  get enabled() {
-    return this.data.enabled
-  }
-
-  set enabled(v: boolean) {
-    this.data.enabled = v
+  protected fromStore({ enabled }: TelemetryPreferencesModel): void {
+    this.enabled = enabled
   }
 
   toJSON(): TelemetryPreferencesModel {
     return toJS({
-      enabled: this.data.enabled
+      enabled: this.enabled
     }, {
       recurseEverything: true
     })

--- a/src/common/base-store.ts
+++ b/src/common/base-store.ts
@@ -15,7 +15,10 @@ export interface BaseStoreParams<T = any> extends ConfOptions<T> {
   syncOptions?: IReactionOptions;
 }
 
-export class BaseStore<T = any> extends Singleton {
+/**
+ * Note: T should only contain base JSON serializable types.
+ */
+export abstract class BaseStore<T = any> extends Singleton {
   protected storeConfig: Config<T>;
   protected syncDisposers: Function[] = [];
 
@@ -146,16 +149,19 @@ export class BaseStore<T = any> extends Singleton {
     }
   }
 
-  @action
-  protected fromStore(data: T) {
-    if (!data) return;
-    this.data = data;
-  }
+  /**
+   * fromStore is called internally when a child class syncs with the file
+   * system.
+   * @param data the parsed information read from the stored JSON file
+   */
+  protected abstract fromStore(data: T): void;
 
-  // todo: use "serializr" ?
-  toJSON(): T {
-    return toJS(this.data, {
-      recurseEverything: true,
-    })
-  }
+  /**
+   * toJSON is called when syncing the store to the filesystem. It should
+   * produce a JSON serializable object representaion of the current state.
+   *
+   * It is recommended that a round trip is valid. Namely, calling
+   * `this.fromStore(this.toJSON())` shouldn't change the state.
+   */
+  abstract toJSON(): T;
 }

--- a/src/extensions/extension-store.ts
+++ b/src/extensions/extension-store.ts
@@ -2,17 +2,17 @@ import { BaseStore } from "../common/base-store"
 import * as path from "path"
 import { LensExtension } from "./lens-extension"
 
-export class ExtensionStore<T = any> extends BaseStore<T> {
+export abstract class ExtensionStore<T> extends BaseStore<T> {
   protected extension: LensExtension
 
   async loadExtension(extension: LensExtension) {
     this.extension = extension
-    await super.load()
+    return super.load()
   }
 
   async load() {
     if (!this.extension) { return }
-    await super.load()
+    return super.load()
   }
 
   protected cwd() {


### PR DESCRIPTION
I believe that this should be the type signature for `BaseStore`, it is rather confusing that these methods are almost always overloaded (and in the single case where it wasn't it really should have been). 

I believe that this is a better structure for our code. This also raises the question as to if `LensExtension` should be `abstract` as well, so that developers know that they should and need to use/implement `onActivate` and `onDeactivate`. That would be a very good afforance in the design.