### PR TITLE
make LensExtension abstract as an affordence to extension devs

### DIFF
--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -3,7 +3,7 @@ import { action, observable, reaction } from "mobx";
 import logger from "../main/logger";
 
 export type LensExtensionId = string; // path to manifest (package.json)
-export type LensExtensionConstructor = new (...args: ConstructorParameters<typeof LensExtension>) => LensExtension;
+export type LensExtensionConstructor = new (ext: InstalledExtension) => LensExtension;
 
 export interface LensExtensionManifest {
   name: string;
@@ -13,7 +13,13 @@ export interface LensExtensionManifest {
   renderer?: string; // path to %ext/dist/renderer.js
 }
 
-export class LensExtension {
+/**
+ * LensExtension is an abstract class representing a loaded extensions.
+ *
+ * To make an extension, a new class that extends this class must be made and
+ * must not have a different constructor type.
+ */
+export abstract class LensExtension {
   readonly manifest: LensExtensionManifest;
   readonly manifestPath: string;
   readonly isBundled: boolean;
@@ -46,7 +52,7 @@ export class LensExtension {
   async enable() {
     if (this.isEnabled) return;
     this.isEnabled = true;
-    this.onActivate();
+    await this.onActivate();
     logger.info(`[EXTENSION]: enabled ${this.name}@${this.version}`);
   }
 
@@ -54,7 +60,7 @@ export class LensExtension {
   async disable() {
     if (!this.isEnabled) return;
     this.isEnabled = false;
-    this.onDeactivate();
+    await this.onDeactivate();
     logger.info(`[EXTENSION]: disabled ${this.name}@${this.version}`);
   }
 
@@ -87,11 +93,7 @@ export class LensExtension {
     };
   }
 
-  protected onActivate() {
-    // mock
-  }
+  protected abstract onActivate(): void | Promise<void>;
 
-  protected onDeactivate() {
-    // mock
-  }
+  protected abstract onDeactivate(): void | Promise<void>;
 }

--- a/src/extensions/lens-main-extension.ts
+++ b/src/extensions/lens-main-extension.ts
@@ -4,7 +4,7 @@ import { LensExtension } from "./lens-extension";
 import { WindowManager } from "../main/window-manager";
 import { getExtensionPageUrl } from "./registries/page-registry";
 
-export class LensMainExtension extends LensExtension {
+export abstract class LensMainExtension extends LensExtension {
   @observable.shallow appMenus: MenuRegistration[] = [];
 
   async navigate<P extends object>(pageId?: string, params?: P, frameId?: number) {

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -3,7 +3,7 @@ import { observable } from "mobx";
 import { LensExtension } from "./lens-extension";
 import { getExtensionPageUrl } from "./registries/page-registry";
 
-export class LensRendererExtension extends LensExtension {
+export abstract class LensRendererExtension extends LensExtension {
   @observable.shallow globalPages: PageRegistration[] = [];
   @observable.shallow clusterPages: PageRegistration[] = [];
   @observable.shallow globalPageMenus: PageMenuRegistration[] = [];


### PR DESCRIPTION
I believe that LensExtension should be `abstract` as the two methods (`onActivate` and `onDeactivate`) both really should be implemented (even for simple extensions).

This would also be a very good affordance to extension developers to remind them that these two methods exist and initializing items that are used only for the duration of the extension's lifetime should be created and deleted within these (instead of in the constructor).

Signed-off-by: Sebastian Malton <sebastian@malton.name>