### PR TITLE
Fix extension cluster menu highlight/routing issues

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -100,7 +100,7 @@ export class App extends React.Component {
       const tabRoutes = this.getTabLayoutRoutes(menu);
       if (tabRoutes.length > 0) {
         const pageComponent = () => <TabLayout tabs={tabRoutes} />;
-        return <Route key={"extension-tab-layout-route-" + index} component={pageComponent}/>;
+        return <Route key={"extension-tab-layout-route-" + index} component={pageComponent} path={tabRoutes.map((tab) => tab.routePath)} />;
       } else {
         const page = clusterPageRegistry.getByPageMenuTarget(menu.target);
         if (page) {

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -98,23 +98,30 @@ export class Sidebar extends React.Component<Props> {
   }
 
   renderRegisteredMenus() {
-    return clusterPageMenuRegistry.getRootItems().map((menuItem) => {
+    return clusterPageMenuRegistry.getRootItems().map((menuItem, index) => {
       const registeredPage = clusterPageRegistry.getByPageMenuTarget(menuItem.target);
+      const tabRoutes = this.getTabLayoutRoutes(menuItem);
       let pageUrl: string;
+      let routePath: string;
       let isActive = false;
       if (registeredPage) {
         const { extensionId, id: pageId } = registeredPage;
         pageUrl = getExtensionPageUrl({ extensionId, pageId, params: menuItem.target.params });
-        isActive = pageUrl === navigation.location.pathname;
-      }
-      const tabRoutes = this.getTabLayoutRoutes(menuItem);
-      if (!registeredPage && tabRoutes.length == 0) {
+        routePath = registeredPage.routePath;
+        isActive = isActiveRoute(registeredPage.routePath);
+      } else if (tabRoutes.length > 0) {
+        pageUrl = tabRoutes[0].url;
+        routePath = tabRoutes[0].routePath;
+        isActive = isActiveRoute(tabRoutes.map((tab) => tab.routePath));
+      } else {
         return;
       }
       return (
         <SidebarNavItem
-          key={pageUrl} url={pageUrl}
-          text={menuItem.title} icon={<menuItem.components.Icon/>}
+          key={"registered-item-" + index}
+          url={pageUrl}
+          text={menuItem.title}
+          icon={<menuItem.components.Icon/>}
           isActive={isActive}
           subMenus={tabRoutes}
         />


### PR DESCRIPTION
Fixes multiple issues with cluster menus that are registered via extensions:

- Sidebar `isActive` needs to match all sub-items, not just one
- Each top-level menu item needs to setup routes for all sub-items while registering TabLayout


Now it seems to work with multiple extensions/sub-menus:

![image](https://user-images.githubusercontent.com/1446224/99766896-b3bb5c80-2b0a-11eb-84a0-6900a948bf86.png)


Fixes #1458 