### PR TITLE
Release v4.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0-beta.3 (current version)
+## 4.0.0-beta.4 (current version)
 
 - Extension API
 - Improved pod logs
@@ -10,6 +10,7 @@ Here you can find description of changes we've built into each release. While we
 - Tray icon
 - Add last-status information for container
 - Add LoadBalancer information to Ingress view
+- Add search by ip to Pod view
 - Move tracker to an extension
 - Add support page (as an extension)
 - Ability to restart deployment
@@ -19,6 +20,8 @@ Here you can find description of changes we've built into each release. While we
 - Add +/- buttons in scale deployment popup screen
 - Update chart details when selecting another chart
 - Use latest alpine version (3.12) for shell sessions
+- Fix errors on app quit
+- Fix kube-auth-proxy to accept only target cluster hostname
 
 ## 3.6.8
 - Fix cluster connection issue when opening cluster settings for disconnected clusters


### PR DESCRIPTION
## Changes since v4.0.0-beta.3

- Fix extension cluster menu highlight/routing issues (#1459)
- fix SwitchCase indent rule in eslint (#1454)
- Allow extension cluster menus to have a parent (#1452)
- Enforce semicolons in eslint (#1450)
- Make BaseStore abstract (#1431)
- Add Search by Ip to Pod View (#1445)
- Fix extensionLoader error on dev environments where renderer might start early (#1447)
- Fix TypeError: Cannot read property 'stopServer' of undefined (#1440)
- Refactor ipc module (#1225)
- kube-auth-proxy: accept only target cluster hostname (#1433)
- Catch errors when responding from proxy error (#1416)
- Reorder File menu (#1420)
- Add computed name property to cluster (#1428)
- Extension Guides documentation (#1427)
- Track service start and stop events (#1414)
- Showing colors in logs (#1419)
- Fixing workspaces adding/editing (#1405)
- Remove make init from the readme (#1417)
- Cache make build-extensions (#1407)
- Documentation: add new gh-action to manually update the default version of the docs (#1413)
- Documentation Update: Properly create tags and aliases, add workflow to delete unwanted / old versions (#1355)
- Reworked remaining docs (#1402)