### PR TITLE
Fix: light theme terminal selection color

### DIFF
--- a/src/renderer/components/dock/terminal-window.scss
+++ b/src/renderer/components/dock/terminal-window.scss
@@ -18,11 +18,4 @@
   .xterm-viewport {
     @include custom-scrollbar;
   }
-
-  // fix: safari won't handle paste event for textarea with zero size block
-  .xterm-helper-textarea {
-    width: 10px !important;
-    height: 10px !important;
-    pointer-events: none;
-  }
 }

--- a/src/renderer/themes/lens-light.json
+++ b/src/renderer/themes/lens-light.json
@@ -67,7 +67,7 @@
     "terminalForeground": "#2d2d2d",
     "terminalCursor": "#2d2d2d",
     "terminalCursorAccent": "#ffffff",
-    "terminalSelection": "#bfbfbf",
+    "terminalSelection": "#bfbfbf66",
     "terminalBlack": "#2d2d2d",
     "terminalRed": "#cd3734 ",
     "terminalGreen": "#18cf12",


### PR DESCRIPTION
Making terminal text selection background color more transparent.

<img width="602" alt="terminal text selection" src="https://user-images.githubusercontent.com/9607060/99783713-d3af4800-2b2b-11eb-9d2f-374bfb3ec696.png">

Fixes #1430 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>