### PR TITLE
Release v3.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,12 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.8 (current version)
+## 3.6.9 (current version)
+- Use Alpine 3.12 for node shell sessions
+- Fix errors on app quit
+- Fix kube-auth-proxy to accept only target cluster hostname
+
+## 3.6.8
 - Fix cluster connection issue when opening cluster settings for disconnected clusters
 - Fetch available Helm repositories from Artifact HUB
 - Check if user is cluster admin before opening cluster dashboard


### PR DESCRIPTION
## Changes since v3.6.8
- Catch errors when responding from proxy error (#1465)
- Fix TypeError: Cannot read property 'stopServer' of undefined (#1467)
- Add app focus event tracking (#1464)
- kube-auth-proxy: accept only target cluster hostname (#1466)
- Use latest alpine version (3.12) for shell sessions (#1468)