### PR TITLE
Catch errors when fetching chart or chart values fails

### DIFF
--- a/src/main/routes/helm-route.ts
+++ b/src/main/routes/helm-route.ts
@@ -12,14 +12,22 @@ class HelmApiRoute extends LensApi {
 
   public async getChart(request: LensApiRequest) {
     const { params, query, response } = request;
-    const chart = await helmService.getChart(params.repo, params.chart, query.get("version"));
-    this.respondJson(response, chart);
+    try {
+      const chart = await helmService.getChart(params.repo, params.chart, query.get("version"));
+      this.respondJson(response, chart);
+    } catch (error) {
+      this.respondText(response, error, 422);
+    }
   }
 
   public async getChartValues(request: LensApiRequest) {
     const { params, query, response } = request;
-    const values = await helmService.getChartValues(params.repo, params.chart, query.get("version"));
-    this.respondJson(response, values);
+    try {
+      const values = await helmService.getChartValues(params.repo, params.chart, query.get("version"));
+      this.respondJson(response, values);
+    } catch (error) {
+      this.respondText(response, error, 422);
+    }
   }
 
   public async installChart(request: LensApiRequest) {


### PR DESCRIPTION
This PR will catch errors when fetching chart values fails, for example from deprecated `stable` repository and returns error response to client. 

<img width="1792" alt="Screenshot 2020-11-21 at 12 36 56" src="https://user-images.githubusercontent.com/455844/99875186-48e74f80-2bf6-11eb-9311-a6462423433a.png">

Fixes #1477 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>