### PR TITLE
Use webpack instead of tsc to output extension-api.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "compile:main": "yarn run webpack --config webpack.main.ts",
     "compile:renderer": "yarn run webpack --config webpack.renderer.ts",
     "compile:i18n": "yarn run lingui compile",
-    "compile:extension-types": "yarn run tsc -p ./tsconfig.extensions.json --outDir src/extensions/npm/extensions/dist",
+    "compile:extension-types": "yarn run webpack --config webpack.extensions.ts",
     "npm:fix-package-version": "yarn run ts-node build/set_npm_version.ts",
     "build:linux": "yarn run compile && electron-builder --linux --dir -c.productName=Lens",
     "build:mac": "yarn run compile && electron-builder --mac --dir -c.productName=Lens",

--- a/tsconfig.extensions.json
+++ b/tsconfig.extensions.json
@@ -1,11 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "files": [
-    "src/extensions/extension-api.ts",
-  ],
   "compilerOptions": {
     "module": "CommonJS",
-    "sourceMap": false,
-    "declaration": true
+    "declaration": true, // should output .d.ts
+    "sourceMap": true, // for use with webpack's devtool: 'inline-source-map'
+    "outDir": "./src/extensions/npm/extensions/dist" // where .d.ts output
   }
 }

--- a/tsconfig.extensions.json
+++ b/tsconfig.extensions.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "declaration": true, // should output .d.ts
-    "sourceMap": true, // for use with webpack's devtool: 'inline-source-map'
-    "outDir": "./src/extensions/npm/extensions/dist" // where .d.ts output
+    "declaration": true,
+    "sourceMap": false,
+    "outDir": "./src/extensions/npm/extensions/dist"
   }
 }

--- a/tsconfig.extensions.json
+++ b/tsconfig.extensions.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "CommonJS",
-    "declaration": true,
-    "sourceMap": false,
-    "outDir": "./src/extensions/npm/extensions/dist"
-  }
-}

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -1,0 +1,93 @@
+
+import path from 'path';
+import webpack from "webpack";
+import nodeExternals from "webpack-node-externals";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
+
+import { sassCommonVars } from "./src/common/vars";
+
+export default function (): webpack.Configuration {
+    return {
+        // Compile for Electron for renderer process
+        // see <https://webpack.js.org/configuration/target/>
+        target: "electron-renderer",
+        externals: [
+             // in order to ignore all modules in node_modules folder
+             // <https://www.npmjs.com/package/webpack-node-externals>
+             nodeExternals()
+        ],
+        devtool: 'inline-source-map',
+        entry: './src/extensions/extension-api.ts',
+        output: {
+            filename: 'extension-api.js',
+            // need to be an absolute path
+            path: path.resolve(__dirname, 'src/extensions/npm/extensions/dist/src/extensions'),
+            libraryTarget: "commonjs"
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.tsx?$/,
+                    loader: 'ts-loader',
+                    options: {
+                        configFile: 'tsconfig.extensions.json',
+                    }
+                },
+                // for src/renderer/components/fonts/roboto-mono-nerd.ttf
+                // in src/renderer/components/dock/terminal.ts 95:25-65
+                {
+                    test: /\.(ttf|eot|woff2?)$/,
+                    use: {
+                        loader: "url-loader",
+                        options: {
+                            name: "fonts/[name].[ext]"
+                        }
+                    }
+                },
+                // for import scss files
+                {
+                    test: /\.s?css$/,
+                    use: [
+                        // https://webpack.js.org/plugins/mini-css-extract-plugin/
+                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: "css-loader",
+                            options: {
+                                sourceMap: true
+                            },
+                        },
+                        {
+                            loader: "sass-loader",
+                            options: {
+                                sourceMap: true,
+                                prependData: `@import "${path.basename(sassCommonVars)}";`,
+                                sassOptions: {
+                                    includePaths: [
+                                        path.dirname(sassCommonVars)
+                                    ]
+                                },
+                            }
+                        },
+                    ]
+                }
+            ]
+        },
+        resolve: {
+            extensions: ['.ts', '.tsx']
+        },
+        plugins: [
+            // In ts-loader's README they said to output a built .d.ts file, 
+            // you can set "declaration": true in tsconfig.extensions.json,
+            // and use the DeclarationBundlerPlugin in your webpack config... but
+            // !! the DeclarationBundlerPlugin doesn't work anymore, author archived it.
+            // https://www.npmjs.com/package/declaration-bundler-webpack-plugin
+            // new DeclarationBundlerPlugin({
+            //   moduleName: '@k8slens/extensions',
+            //    out: 'extension-api.d.ts',
+            // }),
+            new MiniCssExtractPlugin({
+                filename: "[name].css",
+            }),
+        ]
+    };
+}

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -1,7 +1,6 @@
 
 import path from 'path';
 import webpack from "webpack";
-import nodeExternals from "webpack-node-externals";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 
 import { sassCommonVars } from "./src/common/vars";
@@ -11,12 +10,6 @@ export default function (): webpack.Configuration {
         // Compile for Electron for renderer process
         // see <https://webpack.js.org/configuration/target/>
         target: "electron-renderer",
-        externals: [
-             // in order to ignore all modules in node_modules folder
-             // <https://www.npmjs.com/package/webpack-node-externals>
-             nodeExternals()
-        ],
-        devtool: 'inline-source-map',
         entry: './src/extensions/extension-api.ts',
         output: {
             filename: 'extension-api.js',
@@ -73,7 +66,7 @@ export default function (): webpack.Configuration {
             ]
         },
         resolve: {
-            extensions: ['.ts', '.tsx']
+            extensions: ['.ts', '.tsx', '.js']
         },
         plugins: [
             // In ts-loader's README they said to output a built .d.ts file, 

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -1,8 +1,6 @@
 
 import path from 'path';
 import webpack from "webpack";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
-
 import { sassCommonVars } from "./src/common/vars";
 
 export default function (): webpack.Configuration {
@@ -15,6 +13,8 @@ export default function (): webpack.Configuration {
             filename: 'extension-api.js',
             // need to be an absolute path
             path: path.resolve(__dirname, 'src/extensions/npm/extensions/dist/src/extensions'),
+            // can be use in commonjs environments
+            // e.g. require('@k8slens/extensions')
             libraryTarget: "commonjs"
         },
         module: {
@@ -41,18 +41,13 @@ export default function (): webpack.Configuration {
                 {
                     test: /\.s?css$/,
                     use: [
-                        // https://webpack.js.org/plugins/mini-css-extract-plugin/
-                        MiniCssExtractPlugin.loader,
-                        {
-                            loader: "css-loader",
-                            options: {
-                                sourceMap: true
-                            },
-                        },
+                        // Creates `style` nodes from JS strings
+                        "style-loader",
+                        // Translates CSS into CommonJS
+                        "css-loader",
                         {
                             loader: "sass-loader",
                             options: {
-                                sourceMap: true,
                                 prependData: `@import "${path.basename(sassCommonVars)}";`,
                                 sassOptions: {
                                     includePaths: [
@@ -77,10 +72,7 @@ export default function (): webpack.Configuration {
             // new DeclarationBundlerPlugin({
             //   moduleName: '@k8slens/extensions',
             //    out: 'extension-api.d.ts',
-            // }),
-            new MiniCssExtractPlugin({
-                filename: "[name].css",
-            }),
+            // })
         ]
     };
 }

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -4,15 +4,17 @@ import webpack from "webpack";
 import { sassCommonVars } from "./src/common/vars";
 
 export default function (): webpack.Configuration {
+    const entry = "./src/extensions/extension-api.ts"
+    const outDir = "./src/extensions/npm/extensions/dist";
     return {
         // Compile for Electron for renderer process
         // see <https://webpack.js.org/configuration/target/>
         target: "electron-renderer",
-        entry: './src/extensions/extension-api.ts',
+        entry,
         output: {
             filename: 'extension-api.js',
             // need to be an absolute path
-            path: path.resolve(__dirname, 'src/extensions/npm/extensions/dist/src/extensions'),
+            path: path.resolve(__dirname, `${outDir}/src/extensions`),
             // can be use in commonjs environments
             // e.g. require('@k8slens/extensions')
             libraryTarget: "commonjs"
@@ -23,7 +25,14 @@ export default function (): webpack.Configuration {
                     test: /\.tsx?$/,
                     loader: 'ts-loader',
                     options: {
-                        configFile: 'tsconfig.extensions.json',
+                        // !! ts-loader will use tsconfig.json at folder root
+                        // !! changes in tsconfig.json may have side effects
+                        // !! on '@k8slens/extensions' module
+                        compilerOptions: {
+                            declaration: true, // output .d.ts
+                            sourceMap: false, // to override sourceMap: true in tsconfig.json
+                            outDir // where the .d.ts should be located
+                        }
                     }
                 },
                 // for src/renderer/components/fonts/roboto-mono-nerd.ttf
@@ -41,9 +50,9 @@ export default function (): webpack.Configuration {
                 {
                     test: /\.s?css$/,
                     use: [
-                        // Creates `style` nodes from JS strings
+                        // creates `style` nodes from JS strings
                         "style-loader",
-                        // Translates CSS into CommonJS
+                        // translates CSS into CommonJS
                         "css-loader",
                         {
                             loader: "sass-loader",


### PR DESCRIPTION
The original script `compile:extension-types` (introduced in https://github.com/lensapp/lens/pull/1387) which uses `tsc` to output `.d.ts` didn't (completely) resolve issue https://github.com/lensapp/lens/issues/1262, because `tsc` only transpile `.ts/tsx` to `.js`

The `require('module')/import` in `ts/tsx` are the same after transpilation. Keeping `require/import` causes https://github.com/lensapp/generator-lens-ext/pull/13 (see comments) for extension developers, when they try to import modules from `@k8slens/extensions`

The PR aims to use WebPack to solve the problem. I added a new `webpack.extensions.ts`, and used `webpack` + `ts-loader` to pack `@k8slens/extensions` as one file `extension-api.js` and output `.d.ts` just the same original `tsc`.

I tried to keep `webpack.extensions.ts` as simple as possible, so remove unnecessary settings which are in other more complicated settings such as `webpack.renderer.ts` or `webpack.main.ts`

Closes https://github.com/lensapp/lens/issues/1262

Signed-off-by: Hung-Han (Henry) Chen <1474479+chenhunghan@users.noreply.github.com>