### PR TITLE
Fix: Unhandled exception for <DropFileInput disabled={true}/>

### DIFF
--- a/src/renderer/components/input/drop-file-input.tsx
+++ b/src/renderer/components/input/drop-file-input.tsx
@@ -51,13 +51,13 @@ export class DropFileInput<T extends HTMLElement = any> extends React.Component<
   }
 
   render() {
-    const { disabled, className } = this.props;
     const { onDragEnter, onDragLeave, onDragOver, onDrop } = this;
-    const contentElem = React.Children.only(this.props.children) as React.ReactElement<React.HTMLProps<HTMLElement>>;
-    if (disabled) {
-      return contentElem;
-    }
+    const { disabled, className } = this.props;
     try {
+      const contentElem = React.Children.only(this.props.children) as React.ReactElement<React.HTMLProps<HTMLElement>>;
+      if (disabled) {
+        return contentElem;
+      }
       const isValidContentElem = React.isValidElement(contentElem);
       if (isValidContentElem) {
         const contentElemProps: React.HTMLProps<HTMLElement> = {
@@ -72,8 +72,8 @@ export class DropFileInput<T extends HTMLElement = any> extends React.Component<
         return React.cloneElement(contentElem, contentElemProps);
       }
     } catch (err) {
-      logger.error("Invalid root content-element for DropFileInput", { err: String(err) });
-      return contentElem;
+      logger.error(`Error: <DropFileInput/> must contain only single child element`);
+      return this.props.children;
     }
   }
 }

--- a/src/renderer/components/input/drop-file-input.tsx
+++ b/src/renderer/components/input/drop-file-input.tsx
@@ -53,10 +53,13 @@ export class DropFileInput<T extends HTMLElement = any> extends React.Component<
   render() {
     const { disabled, className } = this.props;
     const { onDragEnter, onDragLeave, onDragOver, onDrop } = this;
+    const contentElem = React.Children.only(this.props.children) as React.ReactElement<React.HTMLProps<HTMLElement>>;
+    if (disabled) {
+      return contentElem;
+    }
     try {
-      const contentElem = React.Children.only(this.props.children) as React.ReactElement<React.HTMLProps<HTMLElement>>;
       const isValidContentElem = React.isValidElement(contentElem);
-      if (!disabled && isValidContentElem) {
+      if (isValidContentElem) {
         const contentElemProps: React.HTMLProps<HTMLElement> = {
           className: cssNames("DropFileInput", className, {
             droppable: this.dropAreaActive,
@@ -70,7 +73,7 @@ export class DropFileInput<T extends HTMLElement = any> extends React.Component<
       }
     } catch (err) {
       logger.error("Invalid root content-element for DropFileInput", { err: String(err) });
-      return this.props.children;
+      return contentElem;
     }
   }
 }


### PR DESCRIPTION
Which is causing component/app crash (but should return provided `props.children` as is).

Signed-off-by: Roman <ixrock@gmail.com>