### PR TITLE
Remove extension when folder is removed during runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,6 +362,7 @@
     "nodemon": "^2.0.4",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0",
+    "prettier": "^2.2.0",
     "progress-bar-webpack-plugin": "^2.1.0",
     "raw-loader": "^4.0.1",
     "react": "^16.14.0",

--- a/src/common/utils/rectify-array.ts
+++ b/src/common/utils/rectify-array.ts
@@ -3,6 +3,6 @@
  * @param items either one item or an array of items
  * @returns a list of items
  */
-export function recitfy<T>(items: T | T[]): T[] {
+export function rectify<T>(items: T | T[]): T[] {
   return Array.isArray(items) ? items : [items];
 }

--- a/src/extensions/__tests__/extension-loader.test.ts
+++ b/src/extensions/__tests__/extension-loader.test.ts
@@ -1,0 +1,120 @@
+import { ExtensionLoader } from "../extension-loader";
+
+const manifestPath = "manifest/path";
+const manifestPath2 = "manifest/path2";
+const manifestPath3 = "manifest/path3";
+
+jest.mock(
+  "electron",
+  () => ({
+    ipcRenderer: {
+      invoke: jest.fn(async (channel: string, ...args: any[]) => {
+        if (channel === "extensions:loaded") {
+          return [
+            [
+              manifestPath,
+              {
+                manifest: {
+                  name: "TestExtension",
+                  version: "1.0.0",
+                },
+                manifestPath,
+                isBundled: false,
+                isEnabled: true,
+              },
+            ],
+            [
+              manifestPath2,
+              {
+                manifest: {
+                  name: "TestExtension2",
+                  version: "2.0.0",
+                },
+                manifestPath: manifestPath2,
+                isBundled: false,
+                isEnabled: true,
+              },
+            ],
+          ];
+        }
+      }),
+      on: jest.fn(
+        (channel: string, listener: (event: any, ...args: any[]) => void) => {
+          if (channel === "extensions:loaded") {
+            // First initialize with extensions 1 and 2
+            // and then broadcast event to remove extensioin 2 and add extension number 3
+            setTimeout(() => {
+              listener({}, [
+                [
+                  manifestPath,
+                  {
+                    manifest: {
+                      name: "TestExtension",
+                      version: "1.0.0",
+                    },
+                    manifestPath,
+                    isBundled: false,
+                    isEnabled: true,
+                  },
+                ],
+                [
+                  manifestPath3,
+                  {
+                    manifest: {
+                      name: "TestExtension3",
+                      version: "3.0.0",
+                    },
+                    manifestPath3,
+                    isBundled: false,
+                    isEnabled: true,
+                  },
+                ],
+              ]);
+            }, 10);
+          }
+        }
+      ),
+    },
+  }),
+  {
+    virtual: true,
+  }
+);
+
+describe("ExtensionLoader", () => {
+  it("renderer updates extension after ipc broadcast", async (done) => {
+    const extensionLoader = new ExtensionLoader();
+
+    expect(extensionLoader.userExtensions).toMatchInlineSnapshot(`Map {}`);
+
+    await extensionLoader.init();
+
+    setTimeout(() => {
+      // Assert the extensions after the extension broadcast event
+      expect(extensionLoader.userExtensions).toMatchInlineSnapshot(`
+        Map {
+          "manifest/path" => Object {
+            "isBundled": false,
+            "isEnabled": true,
+            "manifest": Object {
+              "name": "TestExtension",
+              "version": "1.0.0",
+            },
+            "manifestPath": "manifest/path",
+          },
+          "manifest/path3" => Object {
+            "isBundled": false,
+            "isEnabled": true,
+            "manifest": Object {
+              "name": "TestExtension3",
+              "version": "3.0.0",
+            },
+            "manifestPath3": "manifest/path3",
+          },
+        }
+      `);
+
+      done();
+    }, 10);
+  });
+});

--- a/src/extensions/registries/base-registry.ts
+++ b/src/extensions/registries/base-registry.ts
@@ -1,7 +1,7 @@
 // Base class for extensions-api registries
 import { action, observable } from "mobx";
 import { LensExtension } from "../lens-extension";
-import { recitfy } from "../../common/utils";
+import { rectify } from "../../common/utils";
 
 export class BaseRegistry<T> {
   private items = observable<T>([], { deep: false });
@@ -13,7 +13,7 @@ export class BaseRegistry<T> {
   add(items: T | T[], ext?: LensExtension): () => void; // allow method overloading with required "ext"
   @action
   add(items: T | T[]) {
-    const itemArray = recitfy(items);
+    const itemArray = rectify(items);
     this.items.push(...itemArray);
     return () => this.remove(...itemArray);
   }

--- a/src/extensions/registries/page-registry.ts
+++ b/src/extensions/registries/page-registry.ts
@@ -7,7 +7,7 @@ import { compile } from "path-to-regexp";
 import { BaseRegistry } from "./base-registry";
 import { LensExtension, sanitizeExtensionName } from "../lens-extension";
 import logger from "../../main/logger";
-import { recitfy } from "../../common/utils";
+import { rectify } from "../../common/utils";
 
 export interface PageRegistration {
   /**
@@ -54,7 +54,7 @@ export function getExtensionPageUrl<P extends object>({ extensionId, pageId = ""
 export class PageRegistry extends BaseRegistry<RegisteredPage> {
   @action
   add(items: PageRegistration | PageRegistration[], ext: LensExtension) {
-    const itemArray = recitfy(items);
+    const itemArray = rectify(items);
     let registeredPages: RegisteredPage[] = [];
     try {
       registeredPages = itemArray.map(page => ({

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -303,6 +303,7 @@ export class Extensions extends React.Component {
 
   renderExtensions() {
     const { extensions, extensionsPath, search } = this;
+
     if (!extensions.length) {
       return (
         <div className="flex align-center box grow justify-center gaps">
@@ -311,6 +312,7 @@ export class Extensions extends React.Component {
         </div>
       );
     }
+
     return extensions.map(ext => {
       const { manifestPath: extId, isEnabled, manifest } = ext;
       const { name, description } = manifest;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11480,6 +11480,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
+  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
- prettier is added only to support inline snapshots
- If user has extension page open and the extension folder is deleted, "Page not found" 'error' will be displayed. We could redirect to a working page. I'll add issue for this.

Fixes #1461