### PR TITLE
Release v4.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0-rc.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0-beta.4 (current version)
+## 4.0.0-rc.1 (current version)
 
 - Extension API
 - Improved pod logs
@@ -12,14 +12,19 @@ Here you can find description of changes we've built into each release. While we
 - Add LoadBalancer information to Ingress view
 - Add search by ip to Pod view
 - Move tracker to an extension
-- Add support page (as an extension)
 - Ability to restart deployment
+- Add stateful set scale slider
 - Status bar visual fixes
-- Fix proxy upgrade socket timeouts
-- Fix UI staleness after network issues
 - Add +/- buttons in scale deployment popup screen
 - Update chart details when selecting another chart
 - Use latest alpine version (3.12) for shell sessions
+- Open last active cluster after switching workspaces
+- Replace deprecated stable helm repository with bitnami
+- Catch errors return error response when fetching chart or chart values fails
+- Update EULA url
+- Change add-cluster to single column layout
+- Fix proxy upgrade socket timeouts
+- Fix UI staleness after network issues
 - Fix errors on app quit
 - Fix kube-auth-proxy to accept only target cluster hostname
 

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -23,6 +23,8 @@ Here you can find description of changes we've built into each release. While we
 - Catch errors return error response when fetching chart or chart values fails
 - Update EULA url
 - Change add-cluster to single column layout
+- Replace cluster warning event polling with watches
+- Fix pod usage metrics on Kubernetes >=1.19
 - Fix proxy upgrade socket timeouts
 - Fix UI staleness after network issues
 - Fix errors on app quit


### PR DESCRIPTION
## Changes since v4.0.0-beta.4

- Pod logs refactoring (#1516)
- Add extension uninstall (#1524)
- Use webpack instead of tsc to output extension-api.ts (#1499)
- Store prometheus cluster metadata based on metrics request responses (#1438)
- Remove extension when folder is removed during runtime (#1518)
- Replace cluster warning event polling with watches (#1521)
- Add starting point for mobx related documentaion (#1422)
- Documentation: remove feature navigation.instant as it conflicts with mkdocs versions (#1526)
- Installing extensions UI improvements (#1522)
- [BREAKING]: refine and document cluster feature api (#1507)
- Fix workspace flaky tests (#1520)
- Fix pod usage metrics on Kubernetes >=1.19 (#1514)
- Change add-cluster to single column layout (#1515)
- Add stateful set scale slider (#1406)
- [BREAKING]: remove deprecated routePath before GA (#1505)
- Fix: Unhandled exception for <DropFileInput disabled={true}/> (#1512)
- Tweak install extension ux (#1510)
- Allow to install packed extensions from URL or local file (#1456)
- Set scrollbar colors as global styles (#1484)
- Resolve extension enabled status when loading it (#1485)
- Remove @observable.shallow from Lens(M|R)Extension (#1504)
- Add designated folder for extensions (#1245)
- Add documentation on how to use Lens Extension Generator (#1411)
- Fix Documentation: Support (#1501)
- Add LensRendererExtension.isEnabledForCluster (#1502)
- Track more events from adding a cluster (#1481)
- Enable object-shorthand rule (#1500)
- Add React Developers Tools (#1410)
- Update EULA url (#1498)
- Watch for added/removed local extensions (#1482)
- Fix azure pipeline yarn cache (#1491)
- Doc/renderer extension guide (#1476)
- Add extensions to lint & lint:fix (#1490)
- Change BaseRegistry to only have one type parameter (#1474)
- Report enabled extensions (#1451)
- Catch errors return error response when fetching chart or chart values fails (#1478)
- Replace support-page extension with a link to the documentation support page (#1469)
- Add support page to docs (#1473)
- Add contributing/development pages (#1480)
- Replace deprecated stable helm repository with bitnami (#1479)
- Open last active cluster after switching workspaces (#1444)