### PR TITLE
Column filters

### DIFF
--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -28,6 +28,7 @@ export interface UserPreferences {
   downloadBinariesPath?: string;
   kubectlBinariesPath?: string;
   openAtLogin?: boolean;
+  hiddenTableColumns?: Record<string, string[]>
 }
 
 export class UserStore extends BaseStore<UserStoreModel> {
@@ -54,6 +55,7 @@ export class UserStore extends BaseStore<UserStoreModel> {
     downloadMirror: "default",
     downloadKubectlBinaries: true,  // Download kubectl binaries matching cluster version
     openAtLogin: false,
+    hiddenTableColumns: {},
   };
 
   protected async handleOnLoad() {

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -74,6 +74,8 @@ export class Pods extends React.Component<Props> {
       <KubeObjectListLayout
         className="Pods" store={podsStore}
         dependentStores={[volumeClaimStore, eventStore]}
+        tableId = "workloads_pods"
+        isConfigurable
         sortingCallbacks={{
           [sortBy.name]: (pod: Pod) => pod.getName(),
           [sortBy.namespace]: (pod: Pod) => pod.getNs(),

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -96,7 +96,7 @@ export class Pods extends React.Component<Props> {
         renderHeaderTitle="Pods"
         renderTableHeader={[
           { title: "Name", className: "name", sortBy: sortBy.name },
-          { className: "warning" },
+          { className: "warning", showWithColumn: "name" },
           { title: "Namespace", className: "namespace", sortBy: sortBy.namespace },
           { title: "Containers", className: "containers", sortBy: sortBy.containers },
           { title: "Restarts", className: "restarts", sortBy: sortBy.restarts },

--- a/src/renderer/components/item-object-list/table-menu.scss
+++ b/src/renderer/components/item-object-list/table-menu.scss
@@ -1,0 +1,4 @@
+.MenuCheckbox {
+  width: 100%;
+  height: 100%;
+}

--- a/src/renderer/components/menu/menu-actions.tsx
+++ b/src/renderer/components/menu/menu-actions.tsx
@@ -13,6 +13,7 @@ import isString from "lodash/isString";
 export interface MenuActionsProps extends Partial<MenuProps> {
   className?: string;
   toolbar?: boolean; // display menu as toolbar with icons
+  autoCloseOnSelect?: boolean;
   triggerIcon?: string | IconProps | React.ReactNode;
   removeConfirmationMessage?: React.ReactNode | (() => React.ReactNode);
   updateAction?(): void;
@@ -80,7 +81,7 @@ export class MenuActions extends React.Component<MenuActionsProps> {
 
   render() {
     const {
-      className, toolbar, children, updateAction, removeAction, triggerIcon, removeConfirmationMessage,
+      className, toolbar, autoCloseOnSelect, children, updateAction, removeAction, triggerIcon, removeConfirmationMessage,
       ...menuProps
     } = this.props;
     const menuClassName = cssNames("MenuActions flex", className, {
@@ -98,7 +99,7 @@ export class MenuActions extends React.Component<MenuActionsProps> {
           className={menuClassName}
           usePortal={autoClose}
           closeOnScroll={autoClose}
-          closeOnClickItem={autoClose}
+          closeOnClickItem={autoCloseOnSelect ?? autoClose }
           closeOnClickOutside={autoClose}
           {...menuProps}
         >

--- a/src/renderer/components/table/table-cell.tsx
+++ b/src/renderer/components/table/table-cell.tsx
@@ -15,6 +15,7 @@ export interface TableCellProps extends React.DOMAttributes<HTMLDivElement> {
   isChecked?: boolean; // mark checkbox as checked or not
   renderBoolean?: boolean; // show "true" or "false" for all of the children elements are "typeof boolean"
   sortBy?: TableSortBy; // column name, must be same as key in sortable object <Table sortable={}/>
+  showWithColumn?: string // className of another column, if it is not empty the current column is not shown in the filter menu, visibility of this one is the same as a specified column, applicable to headers only
   _sorting?: Partial<TableSortParams>; // <Table> sorting state, don't use this prop outside (!)
   _sort?(sortBy: TableSortBy): void; // <Table> sort function, don't use this prop outside (!)
   _nowrap?: boolean; // indicator, might come from parent <TableHead>, don't use this prop outside (!)
@@ -63,7 +64,7 @@ export class TableCell extends React.Component<TableCellProps> {
   }
 
   render() {
-    const { className, checkbox, isChecked, sortBy, _sort, _sorting, _nowrap, children, title, renderBoolean: displayBoolean, ...cellProps } = this.props;
+    const { className, checkbox, isChecked, sortBy, _sort, _sorting, _nowrap, children, title, renderBoolean: displayBoolean, showWithColumn, ...cellProps } = this.props;
     const classNames = cssNames("TableCell", className, {
       checkbox,
       nowrap: _nowrap,


### PR DESCRIPTION
the PR adds a new menu where a user can change the visibility of columns
![image](https://user-images.githubusercontent.com/53330707/100587446-00244a80-330a-11eb-97b2-efd0bb28bb17.png)

Now this feature is available to Pods table only (just for example) , we can add the column filters adding 2 props in ItemListLayout (tableId = "some uniq name" and isConfigurable = true)
All changed filtering information is stored in .config/LensDev/config.json
 as "hiddenTableColumns": {"tableId": \<array of hidden columns\>} 

Also, the commit adds a new showWithCollumn property to TableCellProps, this property is for some columns, which have no title and its behaviour should be the same as specified header