### PR TITLE
Add information about the startupProbe

### DIFF
--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2598,6 +2598,10 @@ msgstr "Status"
 #~ msgid "Status URI"
 #~ msgstr "Status URI"
 
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:140
+msgid "Startup"
+msgstr "Startup"
+
 #: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
 #: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -2581,6 +2581,10 @@ msgstr ""
 #~ msgid "Status URI"
 #~ msgstr ""
 
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:140
+msgid "Startup"
+msgstr ""
+
 #: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
 #: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -2599,6 +2599,10 @@ msgstr "Статус"
 #~ msgid "Status URI"
 #~ msgstr "Адрес статуса"
 
+#: src/renderer/components/+workloads-pods/pod-details-container.tsx:140
+msgid "Startup"
+msgstr "Cтарт"
+
 #: src/renderer/components/+storage-volume-claims/volume-claim-details.tsx:56
 #: src/renderer/components/layout/sidebar.tsx:85
 msgid "Storage"

--- a/src/renderer/api/endpoints/deployment.api.ts
+++ b/src/renderer/api/endpoints/deployment.api.ts
@@ -46,6 +46,26 @@ export class DeploymentApi extends KubeApi<Deployment> {
   }
 }
 
+interface IContainerProbe {
+  httpGet?: {
+    path?: string;
+    port: number;
+    scheme: string;
+    host?: string;
+  };
+  exec?: {
+    command: string[];
+  };
+  tcpSocket?: {
+    port: number;
+  };
+  initialDelaySeconds?: number;
+  timeoutSeconds?: number;
+  periodSeconds?: number;
+  successThreshold?: number;
+  failureThreshold?: number;
+}
+
 @autobind()
 export class Deployment extends WorkloadKubeObject {
   static kind = "Deployment";
@@ -89,30 +109,9 @@ export class Deployment extends WorkloadKubeObject {
             name: string;
             mountPath: string;
           }[];
-          livenessProbe?: {
-            httpGet: {
-              path: string;
-              port: number;
-              scheme: string;
-            };
-            initialDelaySeconds: number;
-            timeoutSeconds: number;
-            periodSeconds: number;
-            successThreshold: number;
-            failureThreshold: number;
-          };
-          readinessProbe?: {
-            httpGet: {
-              path: string;
-              port: number;
-              scheme: string;
-            };
-            initialDelaySeconds: number;
-            timeoutSeconds: number;
-            periodSeconds: number;
-            successThreshold: number;
-            failureThreshold: number;
-          };
+          livenessProbe?: IContainerProbe;
+          readinessProbe?: IContainerProbe;
+          startupProbe?: IContainerProbe;
           terminationMessagePath: string;
           terminationMessagePolicy: string;
           imagePullPolicy: string;

--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -111,6 +111,7 @@ export interface IPodContainer {
   }[];
   livenessProbe?: IContainerProbe;
   readinessProbe?: IContainerProbe;
+  startupProbe?: IContainerProbe;
   imagePullPolicy: string;
 }
 
@@ -382,6 +383,10 @@ export class Pod extends WorkloadKubeObject {
 
   getReadinessProbe(container: IPodContainer) {
     return this.getProbe(container.readinessProbe);
+  }
+
+  getStartupProbe(container: IPodContainer) {
+    return this.getProbe(container.startupProbe);
   }
 
   getProbe(probeData: IContainerProbe) {

--- a/src/renderer/components/+workloads-pods/pod-details-container.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-container.tsx
@@ -55,6 +55,7 @@ export class PodDetailsContainer extends React.Component<Props> {
     const ready = status ? status.ready : "";
     const liveness = pod.getLivenessProbe(container);
     const readiness = pod.getReadinessProbe(container);
+    const startup = pod.getStartupProbe(container);
     const isInitContainer = !!pod.getInitContainers().find(c => c.name == name);
     const metricTabs = [
       <Trans>CPU</Trans>,
@@ -130,6 +131,15 @@ export class PodDetailsContainer extends React.Component<Props> {
         <DrawerItem name={<Trans>Readiness</Trans>} labelsOnly>
           {
             readiness.map((value, index) => (
+              <Badge key={index} label={value}/>
+            ))
+          }
+        </DrawerItem>
+        }
+        {startup.length > 0 &&
+        <DrawerItem name={<Trans>Startup</Trans>} labelsOnly>
+          {
+            startup.map((value, index) => (
               <Badge key={index} label={value}/>
             ))
           }


### PR DESCRIPTION
Hello guys. I've implemented this feature according to the issue https://github.com/lensapp/lens/issues/1034. 
just a small comment: StartupProbe should be enabled in your cluster with `--feature-gate` flag if your vers < 1.18
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
Please tell me what do you think
<img width="654" alt="Screen Shot 2020-11-26 at 4 28 42 PM" src="https://user-images.githubusercontent.com/38247153/100353876-a7526a80-3008-11eb-83d8-645f82bc5fac.png">

Fixes https://github.com/lensapp/lens/issues/1034
