### PR TITLE
Add extension-api facades to cluster & workspace stores

### DIFF
--- a/src/extensions/core-api/stores.ts
+++ b/src/extensions/core-api/stores.ts
@@ -1,6 +1,8 @@
 export { ExtensionStore } from "../extension-store";
-export { clusterStore } from "../../common/cluster-store";
-export type { ClusterModel } from "../../common/cluster-store";
-export { Cluster } from "../../main/cluster";
-export { workspaceStore, Workspace } from "../../common/workspace-store";
-export type { WorkspaceModel } from "../../common/workspace-store";
+
+export { clusterStore, Cluster } from "../stores/cluster-store";
+export type { ClusterModel, ClusterId } from "../stores/cluster-store";
+
+export { workspaceStore, Workspace } from "../stores/workspace-store";
+export type { WorkspaceId, WorkspaceModel } from "../stores/workspace-store";
+

--- a/src/extensions/stores/cluster-store.ts
+++ b/src/extensions/stores/cluster-store.ts
@@ -2,6 +2,7 @@ import { clusterStore as internalClusterStore, ClusterId } from "../../common/cl
 import type { ClusterModel } from "../../common/cluster-store";
 import { Cluster } from "../../main/cluster";
 import { Singleton } from "../core-api/utils";
+import { ObservableMap } from "mobx";
 
 export { Cluster } from "../../main/cluster";
 export type { ClusterModel, ClusterId } from "../../common/cluster-store";
@@ -14,12 +15,23 @@ export class ClusterStore extends Singleton {
   /**
    * Active cluster id
    */
-  activeClusterId = internalClusterStore.activeCluster;
+  get activeClusterId(): string {
+    return internalClusterStore.activeCluster;
+  }
+
+  /**
+   * Set active cluster id
+   */
+  set activeClusterId(id : ClusterId) {
+    internalClusterStore.activeCluster = id;
+  }
 
   /**
    * Map of all clusters
    */
-  clusters = internalClusterStore.clusters;
+  get clusters(): ObservableMap<string, Cluster> {
+    return internalClusterStore.clusters;
+  }
 
   /**
    * Get active cluster (a cluster which is currently visible)
@@ -50,14 +62,6 @@ export class ClusterStore extends Singleton {
    */
   get connectedClustersList(): Cluster[] {
     return internalClusterStore.connectedClustersList;
-  }
-
-  isActive(id: ClusterId) {
-    return internalClusterStore.isActive(id);
-  }
-
-  setActive(id: ClusterId) {
-    return internalClusterStore.setActive(id);
   }
 
   /**

--- a/src/extensions/stores/cluster-store.ts
+++ b/src/extensions/stores/cluster-store.ts
@@ -1,0 +1,121 @@
+import { clusterStore as internalClusterStore, ClusterId } from "../../common/cluster-store";
+import type { ClusterModel } from "../../common/cluster-store";
+import { Cluster } from "../../main/cluster";
+import { Singleton } from "../core-api/utils";
+
+export { Cluster } from "../../main/cluster";
+export type { ClusterModel, ClusterId } from "../../common/cluster-store";
+
+/**
+ * Store for all added clusters
+ */
+export class ClusterStore extends Singleton {
+
+  /**
+   * Active cluster id
+   */
+  activeClusterId = internalClusterStore.activeCluster;
+
+  /**
+   * Map of all clusters
+   */
+  clusters = internalClusterStore.clusters;
+
+  /**
+   * Get active cluster (a cluster which is currently visible)
+   */
+  get activeCluster(): Cluster {
+    if (!this.activeClusterId) {
+      return null;
+    }
+    return this.getById(this.activeClusterId);
+  }
+
+  /**
+   * Array of all clusters
+   */
+  get clustersList(): Cluster[] {
+    return internalClusterStore.clustersList;
+  }
+
+  /**
+   * Array of all enabled clusters
+   */
+  get enabledClustersList(): Cluster[] {
+    return internalClusterStore.enabledClustersList;
+  }
+
+  /**
+   * Array of all clusters that have active connection to a Kubernetes cluster
+   */
+  get connectedClustersList(): Cluster[] {
+    return internalClusterStore.connectedClustersList;
+  }
+
+  isActive(id: ClusterId) {
+    return internalClusterStore.isActive(id);
+  }
+
+  setActive(id: ClusterId) {
+    return internalClusterStore.setActive(id);
+  }
+
+  /**
+   * Get cluster object by cluster id
+   * @param id cluster id
+   */
+  getById(id: ClusterId): Cluster {
+    return internalClusterStore.getById(id);
+  }
+
+  /**
+   * Get all clusters belonging to a workspace
+   * @param workspaceId workspace id
+   */
+  getByWorkspaceId(workspaceId: string): Cluster[] {
+    return internalClusterStore.getByWorkspaceId(workspaceId);
+  }
+
+  /**
+   * Add clusters to store
+   * @param models list of cluster models
+   */
+  addClusters(...models: ClusterModel[]): Cluster[] {
+    return internalClusterStore.addClusters(...models);
+  }
+
+  /**
+   * Add a cluster to store
+   * @param model cluster
+   */
+  addCluster(model: ClusterModel | Cluster): Cluster {
+    return internalClusterStore.addCluster(model);
+  }
+
+  /**
+   * Remove a cluster from store
+   * @param model cluster
+   */
+  async removeCluster(model: ClusterModel) {
+    return this.removeById(model.id);
+  }
+
+  /**
+   * Remove a cluster from store by id
+   * @param clusterId cluster id
+   */
+  async removeById(clusterId: ClusterId) {
+    return internalClusterStore.removeById(clusterId);
+  }
+
+  /**
+   * Remove all clusters belonging to a workspaces
+   * @param workspaceId workspace id
+   */
+  removeByWorkspaceId(workspaceId: string) {
+    return internalClusterStore.removeByWorkspaceId(workspaceId);
+  }
+}
+
+
+export const clusterStore = ClusterStore.getInstance<ClusterStore>();

--- a/src/extensions/stores/workspace-store.ts
+++ b/src/extensions/stores/workspace-store.ts
@@ -1,0 +1,104 @@
+import { Singleton } from "../core-api/utils";
+import { workspaceStore as internalWorkspaceStore, WorkspaceStore as InternalWorkspaceStore, Workspace, WorkspaceId } from "../../common/workspace-store";
+
+export { Workspace } from "../../common/workspace-store";
+export type { WorkspaceId, WorkspaceModel } from "../../common/workspace-store";
+
+/**
+ * Stores all workspaces
+ */
+export class WorkspaceStore extends Singleton {
+  /**
+   * Default workspace id, this workspace is always present
+   */
+  static readonly defaultId: WorkspaceId = InternalWorkspaceStore.defaultId;
+
+  /**
+   * Currently active workspace id
+   */
+  currentWorkspaceId = internalWorkspaceStore.currentWorkspaceId;
+
+  /**
+   * Map of all workspaces
+   */
+  workspaces = internalWorkspaceStore.workspaces;
+
+  /**
+   * Currently active workspace
+   */
+  get currentWorkspace(): Workspace {
+    return internalWorkspaceStore.currentWorkspace;
+  }
+
+  /**
+   * Array of all workspaces
+   */
+  get workspacesList(): Workspace[] {
+    return internalWorkspaceStore.workspacesList;
+  }
+
+  /**
+   * Array of all enabled (visible) workspaces
+   */
+  get enabledWorkspacesList(): Workspace[] {
+    return internalWorkspaceStore.enabledWorkspacesList;
+  }
+
+  /**
+   * Get workspace by id
+   * @param id workspace id
+   */
+  getById(id: WorkspaceId): Workspace {
+    return internalWorkspaceStore.getById(id);
+  }
+
+  /**
+   * Get workspace by name
+   * @param name workspace name
+   */
+  getByName(name: string): Workspace {
+    return internalWorkspaceStore.getByName(name);
+  }
+
+  /**
+   * Set active workspace
+   * @param id workspace id
+   */
+  setActive(id = WorkspaceStore.defaultId) {
+    return internalWorkspaceStore.setActive(id);
+  }
+
+  /**
+   * Add a workspace to store
+   * @param workspace workspace
+   */
+  addWorkspace(workspace: Workspace) {
+    return internalWorkspaceStore.addWorkspace(workspace);
+  }
+
+  /**
+   * Update a workspace in store
+   * @param workspace workspace
+   */
+  updateWorkspace(workspace: Workspace) {
+    return internalWorkspaceStore.updateWorkspace(workspace);
+  }
+
+  /**
+   * Remove workspace from store
+   * @param workspace workspace
+   */
+  removeWorkspace(workspace: Workspace) {
+    return internalWorkspaceStore.removeWorkspace(workspace);
+  }
+
+  /**
+   * Remove workspace by id
+   * @param id workspace
+   */
+  removeWorkspaceById(id: WorkspaceId) {
+    return internalWorkspaceStore.removeWorkspaceById(id);
+  }
+}
+
+export const workspaceStore = WorkspaceStore.getInstance<WorkspaceStore>();

--- a/src/extensions/stores/workspace-store.ts
+++ b/src/extensions/stores/workspace-store.ts
@@ -1,5 +1,6 @@
 import { Singleton } from "../core-api/utils";
 import { workspaceStore as internalWorkspaceStore, WorkspaceStore as InternalWorkspaceStore, Workspace, WorkspaceId } from "../../common/workspace-store";
+import { ObservableMap } from "mobx";
 
 export { Workspace } from "../../common/workspace-store";
 export type { WorkspaceId, WorkspaceModel } from "../../common/workspace-store";
@@ -16,12 +17,16 @@ export class WorkspaceStore extends Singleton {
   /**
    * Currently active workspace id
    */
-  currentWorkspaceId = internalWorkspaceStore.currentWorkspaceId;
+  get currentWorkspaceId(): string {
+    return internalWorkspaceStore.currentWorkspaceId;
+  }
 
   /**
    * Map of all workspaces
    */
-  workspaces = internalWorkspaceStore.workspaces;
+  get workspaces(): ObservableMap<string, Workspace> {
+    return internalWorkspaceStore.workspaces;
+  }
 
   /**
    * Currently active workspace

--- a/src/extensions/stores/workspace-store.ts
+++ b/src/extensions/stores/workspace-store.ts
@@ -22,6 +22,13 @@ export class WorkspaceStore extends Singleton {
   }
 
   /**
+   * Set active workspace id
+   */
+  set currentWorkspaceId(id: string) {
+    internalWorkspaceStore.currentWorkspaceId = id;
+  }
+
+  /**
    * Map of all workspaces
    */
   get workspaces(): ObservableMap<string, Workspace> {


### PR DESCRIPTION
Both Cluster and Workspace stores currently leak internals to extension-api. This PR adds a facade store for both of them and exposes only usable apis. 


This also allows us to work more freely on store internals (we only expose apis explicitly). Good example of accidental leaks is #1453 .