### PR TITLE
Hide disabled workspaces/clusters

### DIFF
--- a/src/common/__tests__/cluster-store.test.ts
+++ b/src/common/__tests__/cluster-store.test.ts
@@ -48,6 +48,7 @@ describe("empty config", () => {
       expect(storedCluster.id).toBe("foo");
       expect(storedCluster.preferences.terminalCWD).toBe("/tmp");
       expect(storedCluster.preferences.icon).toBe("data:image/jpeg;base64, iVBORw0KGgoAAAANSUhEUgAAA1wAAAKoCAYAAABjkf5");
+      expect(storedCluster.enabled).toBe(true);
     });
 
     it("adds cluster to default workspace", () => {
@@ -170,7 +171,8 @@ describe("config with existing clusters", () => {
               kubeConfig: "foo",
               contextName: "foo",
               preferences: { terminalCWD: "/foo" },
-              workspace: "foo"
+              workspace: "foo",
+              ownerRef: "foo"
             },
           ]
         })
@@ -207,6 +209,12 @@ describe("config with existing clusters", () => {
     expect(storedClusters[1].id).toBe("cluster2");
     expect(storedClusters[1].preferences.terminalCWD).toBe("/foo2");
     expect(storedClusters[2].id).toBe("cluster3");
+  });
+
+  it("marks owned cluster disabled by default", () => {
+    const storedClusters = clusterStore.clustersList;
+    expect(storedClusters[0].enabled).toBe(true);
+    expect(storedClusters[2].enabled).toBe(false);
   });
 });
 

--- a/src/common/__tests__/cluster-store.test.ts
+++ b/src/common/__tests__/cluster-store.test.ts
@@ -7,6 +7,20 @@ import { workspaceStore } from "../workspace-store";
 
 const testDataIcon = fs.readFileSync("test-data/cluster-store-migration-icon.png");
 
+jest.mock("electron", () => {
+  return {
+    app: {
+      getVersion: () => "99.99.99",
+      getPath: () => "tmp",
+      getLocale: () => "en"
+    },
+    ipcMain: {
+      handle: jest.fn(),
+      on: jest.fn()
+    }
+  };
+});
+
 let clusterStore: ClusterStore;
 
 describe("empty config", () => {

--- a/src/common/__tests__/workspace-store.test.ts
+++ b/src/common/__tests__/workspace-store.test.ts
@@ -6,6 +6,13 @@ jest.mock("electron", () => {
       getVersion: () => "99.99.99",
       getPath: () => "tmp",
       getLocale: () => "en"
+    },
+    ipcRenderer: {
+      invoke: jest.fn(),
+      on: jest.fn()
+    },
+    ipcMain: {
+      handle: jest.fn()
     }
   };
 });
@@ -60,7 +67,9 @@ describe("workspace store tests", () => {
         name: "foobar",
       }));
 
-      expect(ws.getById("123").name).toBe("foobar");
+      const workspace = ws.getById("123");
+      expect(workspace.name).toBe("foobar");
+      expect(workspace.enabled).toBe(true);
     });
 
     it("cannot set a non-existent workspace to be active", () => {

--- a/src/common/__tests__/workspace-store.test.ts
+++ b/src/common/__tests__/workspace-store.test.ts
@@ -7,12 +7,9 @@ jest.mock("electron", () => {
       getPath: () => "tmp",
       getLocale: () => "en"
     },
-    ipcRenderer: {
-      invoke: jest.fn(),
-      on: jest.fn()
-    },
     ipcMain: {
-      handle: jest.fn()
+      handle: jest.fn(),
+      on: jest.fn()
     }
   };
 });

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -205,7 +205,9 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     if (!(model instanceof Cluster)) {
       cluster = new Cluster(model);
     }
-    cluster.enabled = true;
+    if (!cluster.isManaged) {
+      cluster.enabled = true;
+    }
     this.clusters.set(model.id, cluster);
     return cluster;
   }

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -40,13 +40,30 @@ export interface ClusterStoreModel {
 export type ClusterId = string;
 
 export interface ClusterModel {
+  /** Unique id for a cluster */
   id: ClusterId;
+
+  /** Path to cluster kubeconfig */
   kubeConfigPath: string;
+
+  /** Workspace id */
   workspace?: WorkspaceId;
+
+  /** User context in kubeconfig  */
   contextName?: string;
+
+  /** Preferences */
   preferences?: ClusterPreferences;
+
+  /** Metadata */
   metadata?: ClusterMetadata;
+
+  /**
+   * If extension sets ownerRef it has to explicitly mark a cluster as enabled during onActive (or when cluster is saved)
+   */
   ownerRef?: string;
+
+  /** List of accessible namespaces */
   accessibleNamespaces?: string[];
 
   /** @deprecated */
@@ -89,7 +106,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
   @observable removedClusters = observable.map<ClusterId, Cluster>();
   @observable clusters = observable.map<ClusterId, Cluster>();
 
-  private stateRequestChannel = "cluster:states";
+  private static stateRequestChannel = "cluster:states";
 
   private constructor() {
     super({
@@ -112,7 +129,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     };
     if (ipcRenderer) {
       logger.info("[CLUSTER-STORE] requesting initial state sync");
-      const clusterStates: clusterStateSync[] = await requestMain(this.stateRequestChannel);
+      const clusterStates: clusterStateSync[] = await requestMain(ClusterStore.stateRequestChannel);
       clusterStates.forEach((clusterState) => {
         const cluster = this.getById(clusterState.id);
         if (cluster) {
@@ -120,7 +137,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
         }
       });
     } else {
-      handleRequest(this.stateRequestChannel, (): clusterStateSync[] => {
+      handleRequest(ClusterStore.stateRequestChannel, (): clusterStateSync[] => {
         const states: clusterStateSync[] = [];
         this.clustersList.forEach((cluster) => {
           states.push({

--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -205,6 +205,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     if (!(model instanceof Cluster)) {
       cluster = new Cluster(model);
     }
+    cluster.enabled = true;
     this.clusters.set(model.id, cluster);
     return cluster;
   }

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -94,7 +94,6 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     if (ipcRenderer) {
       logger.info("[WORKSPACE-STORE] requesting initial state sync");
       const workspaceStates: workspaceStateSync[] = await requestMain(this.stateRequestChannel);
-      console.log(workspaceStates);
       workspaceStates.forEach((workspaceState) => {
         const workspace = this.getById(workspaceState.id);
         if (workspace) {
@@ -182,7 +181,10 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
       return;
     }
     this.workspaces.set(id, workspace);
-    workspace.enabled = true;
+    if (!workspace.isManaged) {
+      workspace.enabled = true;
+    }
+
     appEventBus.emit({name: "workspace", action: "add"});
     return workspace;
   }

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -27,11 +27,45 @@ export interface WorkspaceState {
 }
 
 export class Workspace implements WorkspaceModel, WorkspaceState {
+  /**
+   * Unique id for workspace
+   *
+   * @observable
+   */
   @observable id: WorkspaceId;
+  /**
+   * Workspace name
+   *
+   * @observable
+   */
   @observable name: string;
+  /**
+   * Workspace description
+   *
+   * @observable
+   */
   @observable description?: string;
+  /**
+   * Workspace owner reference
+   *
+   * If extension sets ownerRef then it needs to explicitly mark workspace as enabled onActivate (or when workspace is saved)
+   *
+   * @observable
+   */
   @observable ownerRef?: string;
+  /**
+   * Is workspace enabled
+   *
+   * Workspaces that don't have ownerRef will be enabled by default. Workspaces with ownerRef need to explicitly enable a workspace.
+   *
+   * @observable
+   */
   @observable enabled: boolean;
+  /**
+   * Last active cluster id
+   *
+   * @observable
+   */
   @observable lastActiveClusterId?: ClusterId;
 
   constructor(data: WorkspaceModel) {
@@ -77,7 +111,7 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
 
 export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
   static readonly defaultId: WorkspaceId = "default";
-  private stateRequestChannel = "workspace:states";
+  private static stateRequestChannel = "workspace:states";
 
   private constructor() {
     super({
@@ -93,7 +127,7 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     };
     if (ipcRenderer) {
       logger.info("[WORKSPACE-STORE] requesting initial state sync");
-      const workspaceStates: workspaceStateSync[] = await requestMain(this.stateRequestChannel);
+      const workspaceStates: workspaceStateSync[] = await requestMain(WorkspaceStore.stateRequestChannel);
       workspaceStates.forEach((workspaceState) => {
         const workspace = this.getById(workspaceState.id);
         if (workspace) {
@@ -101,7 +135,7 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
         }
       });
     } else {
-      handleRequest(this.stateRequestChannel, (): workspaceStateSync[] => {
+      handleRequest(WorkspaceStore.stateRequestChannel, (): workspaceStateSync[] => {
         const states: workspaceStateSync[] = [];
         this.workspacesList.forEach((workspace) => {
           states.push({

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -37,6 +37,7 @@ export type ClusterRefreshOptions = {
 
 export interface ClusterState {
   initialized: boolean;
+  enabled: boolean;
   apiUrl: string;
   online: boolean;
   disconnected: boolean;
@@ -351,6 +352,7 @@ export class Cluster implements ClusterModel, ClusterState {
   getState(): ClusterState {
     const state: ClusterState = {
       initialized: this.initialized,
+      enabled: this.enabled,
       apiUrl: this.apiUrl,
       online: this.online,
       ready: this.ready,

--- a/src/renderer/components/+workspaces/workspaces.tsx
+++ b/src/renderer/components/+workspaces/workspaces.tsx
@@ -21,7 +21,7 @@ export class Workspaces extends React.Component {
 
   @computed get workspaces(): Workspace[] {
     const currentWorkspaces: Map<WorkspaceId, Workspace> = new Map();
-    workspaceStore.workspacesList.forEach((w) => {
+    workspaceStore.enabledWorkspacesList.forEach((w) => {
       currentWorkspaces.set(w.id, w);
     });
     const allWorkspaces = new Map([

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -65,26 +65,28 @@ export class ClustersMenu extends React.Component<Props> {
         }
       }));
     }
-    menu.append(new MenuItem({
-      label: _i18n._(t`Remove`),
-      click: () => {
-        ConfirmDialog.open({
-          okButtonProps: {
-            primary: false,
-            accent: true,
-            label: _i18n._(t`Remove`),
-          },
-          ok: () => {
-            if (clusterStore.activeClusterId === cluster.id) {
-              navigate(landingURL());
-              clusterStore.setActive(null);
-            }
-            clusterStore.removeById(cluster.id);
-          },
-          message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
-        });
-      }
-    }));
+    if (!cluster.isManaged) {
+      menu.append(new MenuItem({
+        label: _i18n._(t`Remove`),
+        click: () => {
+          ConfirmDialog.open({
+            okButtonProps: {
+              primary: false,
+              accent: true,
+              label: _i18n._(t`Remove`),
+            },
+            ok: () => {
+              if (clusterStore.activeClusterId === cluster.id) {
+                navigate(landingURL());
+                clusterStore.setActive(null);
+              }
+              clusterStore.removeById(cluster.id);
+            },
+            message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
+          });
+        }
+      }));
+    }
     menu.popup({
       window: remote.getCurrentWindow()
     });

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -106,7 +106,7 @@ export class ClustersMenu extends React.Component<Props> {
     const { className } = this.props;
     const { newContexts } = userStore;
     const workspace = workspaceStore.getById(workspaceStore.currentWorkspaceId);
-    const clusters = clusterStore.getByWorkspaceId(workspace.id).filter(cluster => cluster.enabled === true);
+    const clusters = clusterStore.getByWorkspaceId(workspace.id).filter(cluster => cluster.enabled);
     const activeClusterId = clusterStore.activeCluster;
     return (
       <div className={cssNames("ClustersMenu flex column", className)}>

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -106,7 +106,7 @@ export class ClustersMenu extends React.Component<Props> {
     const { className } = this.props;
     const { newContexts } = userStore;
     const workspace = workspaceStore.getById(workspaceStore.currentWorkspaceId);
-    const clusters = clusterStore.getByWorkspaceId(workspace.id);
+    const clusters = clusterStore.getByWorkspaceId(workspace.id).filter(cluster => cluster.enabled === true);
     const activeClusterId = clusterStore.activeCluster;
     return (
       <div className={cssNames("ClustersMenu flex column", className)}>


### PR DESCRIPTION
- fix: workspace/cluster was not enabled automatically on save
- fix: workspace listing listed also disabled workspaces
- fix: workspace-store setInterval leaked during tests, refactored it to use `requestMain()` in `load()`
- fix: cluster enabled not being synced from main to renderer
- fix: cluster with ownerRef removal via context menu

Fixes #1556