### PR TITLE
Release v4.0.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,20 +2,22 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0-rc.1 (current version)
+## 4.0.0-rc.2 (current version)
 
 - Extension API
 - Improved pod logs
 - Mechanism for users to specify accessible namespaces
 - Tray icon
+- Support networking.k8s.io/v1 for Ingress
 - Add last-status information for container
 - Add LoadBalancer information to Ingress view
 - Add search by ip to Pod view
+- Add Ready status column in the Deployment view
+- Add +/- buttons in scale deployment popup screen
+- Add stateful set scale slider
 - Move tracker to an extension
 - Ability to restart deployment
-- Add stateful set scale slider
 - Status bar visual fixes
-- Add +/- buttons in scale deployment popup screen
 - Update chart details when selecting another chart
 - Use latest alpine version (3.12) for shell sessions
 - Open last active cluster after switching workspaces
@@ -29,6 +31,7 @@ Here you can find description of changes we've built into each release. While we
 - Fix UI staleness after network issues
 - Fix errors on app quit
 - Fix kube-auth-proxy to accept only target cluster hostname
+- Fix link to metrics stack resources
 
 ## 3.6.8
 - Fix cluster connection issue when opening cluster settings for disconnected clusters


### PR DESCRIPTION
## Changes since v4.0.0-rc.1

- Fix getExtensionPageUrl on Windows (#1609)
- Add Ready status column in the Deployment view (#1586)
- Add <BottomBar /> support rendering if item is a function (#1606)
- Disable extension install button immediately (#1591)
- Enable installed extensions by default (#1572)
- Lint whole repo (#1600)
- Add eslint rule padding-line-between-statements (#1593)
- Fix extensions installation on Windows (#1596)
- Fixing tray icon color on macOS Big Sur (#1595)
- Add basic usage docs for extensions (#1583)
- Fix symlinking extensions into .k8slens/extensions folder (#1579)
- AppPreferences guide (#1584)
- Hide disabled workspaces/clusters (#1573)
- Handle errors from getLatestApiPrefixGroup. (#1575)
- Tweak extensions page texts (#1550)
- Fix link to metrics resources (#1585)
- Fix extension status-bar item default styles (#1578)
- Add bug label by default on bug issue template (#1580)
- Bump eslint-plugin-unused-imports to 1.0.1 (#1577)
- Fix: moving lens views behind extension views (#1565)
- Add section for extension testing (#1576)
- Enforce template strings in eslint (#1574)
- Add extension-api facades to cluster & workspace stores (#1546)
- Electron 9.3.5 (#1562)
- Remove unused data field in abstract BaseStore (#1554)
- Add a telemetry preferences observable for the observer to observe (#1555)
- Lint the repo as a github action (#1541)
- Add step to verify docs on area/documentation PRs (#1528)
- Disable Install button while installing. Fix install notification. (#1551)
- Add no-unused and react/recommended to eslint (#1523)
- Fix: add-cluster page D&D is broken (#1549)
- Add confirmation dialog to extension uninstall (#1547)
- Adding links to styling samples (#1534)
- Disable Uninstall and Enable/Disable buttons while uninstalling. Add Notification for uninstall. (#1539)
- Include *.yml* files from in-tree extensions (#1545)
- Add initial Helm documentation (#1540)