### PR TITLE
Add timeout to app start and cluster add tracking events

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -88,7 +88,9 @@ export class WindowManager extends Singleton {
       await this.mainWindow.loadURL(this.mainUrl);
       this.mainWindow.show();
       this.splashWindow?.close();
-      appEventBus.emit({ name: "app", action: "start" });
+      setTimeout(() => {
+        appEventBus.emit({ name: "app", action: "start" });
+      }, 1000);
     } catch (err) {
       dialog.showErrorBox("ERROR!", err.toString());
     }

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -61,12 +61,14 @@ export class App extends React.Component {
     await requestMain(clusterSetFrameIdHandler, clusterId, frameId);
     await getHostedCluster().whenReady; // cluster.activate() is done at this point
     extensionLoader.loadOnClusterRenderer();
-    appEventBus.emit({
-      name: "cluster",
-      action: "open",
-      params: {
-        clusterId
-      }
+    setTimeout(() => {
+      appEventBus.emit({
+        name: "cluster",
+        action: "open",
+        params: {
+          clusterId
+        }
+      });
     });
     window.addEventListener("online", () => {
       window.location.reload();


### PR DESCRIPTION
When Lens application is opened it opens last active dashboard. At that time telemetry extension might not be active yet and it will miss tracking events. This PR will add timeout when `app start` and `cluster open` events are emitted.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>