### PR TITLE
Open file select dialog from onClick event

### DIFF
--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -313,7 +313,7 @@ export class Extensions extends React.Component {
       const { name, version, description } = install.manifest;
       const extensionFolder = this.getExtensionDestFolder(name);
       const folderExists = await fse.pathExists(extensionFolder);
-  
+
       if (!folderExists) {
         // auto-install extension if not yet exists
         this.unpackExtension(install);
@@ -515,7 +515,7 @@ export class Extensions extends React.Component {
                   <Icon
                     interactive
                     material="folder"
-                    onMouseDown={prevDefault(this.installFromSelectFileDialog)}
+                    onClick={prevDefault(this.installFromSelectFileDialog)}
                     tooltip={<Trans>Browse</Trans>}
                   />
                 }


### PR DESCRIPTION
If file select dialog is opened from `onMouseDown` it will cause issues on ubuntu versions and user is not able to select anything. `onClick` event seems to work without any issues.

Fixes #1633 

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>