### PR TITLE
Fixing SidebarNavItem to rerender when url changes

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -279,7 +279,9 @@ class SidebarNavItem extends React.Component<SidebarNavItemProps> {
   public context: SidebarContextValue;
 
   get itemId() {
-    return this.props.url;
+    const url = new URL(this.props.url, `${window.location.protocol}//${window.location.host}`);
+
+    return url.pathname; // pathname without get params
   }
 
   @computed get isExpanded() {


### PR DESCRIPTION
The problem is happening when user changing namespace - sidebar items gets collapsed:
![Dec-03-2020 14-21-34](https://user-images.githubusercontent.com/9607060/101009318-079a5c80-3573-11eb-9d4e-d133cf2125e9.gif)

Changed `url` parameter makes sidebar item to rerender and lose it's expanded/collapsed state.

This PR removes search and hash parts from url and passes only pathname to id.

![Dec-03-2020 14-22-28](https://user-images.githubusercontent.com/9607060/101009957-37496480-3573-11eb-9988-3fd9046e4353.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>