### PR TITLE
Performance fix when cluster has lots of namespaces

### DIFF
--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -127,13 +127,6 @@ describe("create clusters", () => {
 
     jest.spyOn(Cluster.prototype, "isClusterAdmin").mockReturnValue(Promise.resolve(true));
     jest.spyOn(Cluster.prototype, "canI")
-      .mockImplementationOnce((attr: V1ResourceAttributes): Promise<boolean> => {
-        expect(attr.namespace).toBe("default");
-        expect(attr.resource).toBe("pods");
-        expect(attr.verb).toBe("list");
-
-        return Promise.resolve(true);
-      })
       .mockImplementation((attr: V1ResourceAttributes): Promise<boolean> => {
         expect(attr.namespace).toBe("default");
         expect(attr.verb).toBe("list");

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -425,17 +425,8 @@ export class Cluster implements ClusterModel, ClusterState {
 
     try {
       const namespaceList = await api.listNamespace();
-      const nsAccessStatuses = await Promise.all(
-        namespaceList.body.items.map(ns => this.canI({
-          namespace: ns.metadata.name,
-          resource: "pods",
-          verb: "list",
-        }))
-      );
 
-      return namespaceList.body.items
-        .filter((ns, i) => nsAccessStatuses[i])
-        .map(ns => ns.metadata.name);
+      return namespaceList.body.items.map(ns => ns.metadata.name);
     } catch (error) {
       const ctx = this.getProxyKubeconfig().getContextObject(this.contextName);
 


### PR DESCRIPTION
Cluster object triggers unnecessarily one "can-i" request per namespace concurrently every 30 seconds. This behaviour is not needed anymore because Lens actually uses `allowedResources` for checking if user has access to different resources.

If a cluster has hundreds of namespaces this will cause huge load on Kubernetes API server.