### PR TITLE
Release v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0-rc.3 (current version)
+## 4.0.0 (current version)
 
 - Extension API
 - Improved pod logs
@@ -28,6 +28,7 @@ Here you can find description of changes we've built into each release. While we
 - Replace cluster warning event polling with watches
 - Detect more Kubernetes distributions
 - Performance fix when cluster has lots of namespaces
+- Store more than largest kube api request amount in the event store
 - Fix pod usage metrics on Kubernetes >=1.19
 - Fix proxy upgrade socket timeouts
 - Fix UI staleness after network issues


### PR DESCRIPTION
## Changes since v4.0.0-rc.3

- Write up on some ways to publish extensions (#1660)
- Tag cluster & workspace as beta features in extension api (#1589)
- Add initial KubeObjectListLayout sample (#1662)
- Initial FAQ docs (#1667)
- Detect Openshift (#1625)
- Mark conf as dev dependency in extension npm package (#1665)
- Visualize extension loading (#1635)
- Store more than largest kube api request amount in the event store (#1605)
- Persist extension installation state for the duration of the window's life (#1602)
- Status bar item and kube object menu/detail item extension guides (#1629)
- Fixing itemId in SidebarNavItem (#1638)
- Add dependabot config (#1654)
- Add timeout to app start and cluster add events (#1631)
- Backport 3.6.9 what's new items (#1647)