### PR TITLE
Add check to extension file watch

### DIFF
--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -1,0 +1,99 @@
+import { watch } from "chokidar";
+import { ExtensionDiscovery, InstalledExtension } from "../extension-discovery";
+
+jest.mock("../../common/ipc");
+jest.mock("fs-extra");
+jest.mock("chokidar", () => ({
+  watch: jest.fn()
+}));
+jest.mock("../extension-installer", () => ({
+  extensionInstaller: {
+    extensionPackagesRoot: "",
+    installPackages: jest.fn()
+  }
+}));
+
+const mockedWatch = watch as jest.MockedFunction<typeof watch>;
+
+describe("ExtensionDiscovery", () => {
+  it("emits add for added extension", async done => {
+    globalThis.__non_webpack_require__.mockImplementationOnce(() => ({
+      name: "my-extension"
+    }));
+    let addHandler: (filePath: string) => void;
+
+    const mockWatchInstance: any = {
+      on: jest.fn((event: string, handler: typeof addHandler) => {
+        if (event === "add") {
+          addHandler = handler;
+        }
+
+        return mockWatchInstance;
+      })
+    };
+
+    mockedWatch.mockImplementationOnce(() =>
+      (mockWatchInstance) as any
+    );
+    const extensionDiscovery = new ExtensionDiscovery();
+
+    // Need to force isLoaded to be true so that the file watching is started
+    extensionDiscovery.isLoaded = true;
+
+    await extensionDiscovery.initMain();
+
+    extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
+      expect(extension).toEqual({
+        absolutePath: "/Users/phorsmalahti/.k8slens/extensions/my-extension",
+        id: "node_modules/my-extension/package.json",
+        isBundled: false,
+        isEnabled: false,
+        manifest:  {
+          name: "my-extension",
+        },
+        manifestPath: "node_modules/my-extension/package.json",
+      });
+      done();
+    });
+
+    addHandler(`${extensionDiscovery.localFolderPath}/my-extension/package.json`);
+  });
+
+  it("doesn't emit add for added file under extension", async done => {
+    globalThis.__non_webpack_require__.mockImplementationOnce(() => ({
+      name: "my-extension"
+    }));
+    let addHandler: (filePath: string) => void;
+
+    const mockWatchInstance: any = {
+      on: jest.fn((event: string, handler: typeof addHandler) => {
+        if (event === "add") {
+          addHandler = handler;
+        }
+
+        return mockWatchInstance;
+      })
+    };
+
+    mockedWatch.mockImplementationOnce(() =>
+      (mockWatchInstance) as any
+    );
+    const extensionDiscovery = new ExtensionDiscovery();
+
+    // Need to force isLoaded to be true so that the file watching is started
+    extensionDiscovery.isLoaded = true;
+
+    await extensionDiscovery.initMain();
+
+    const onAdd = jest.fn();
+
+    extensionDiscovery.events.on("add", onAdd);
+
+    addHandler(`${extensionDiscovery.localFolderPath}/my-extension/node_modules/dep/package.json`);
+
+    setTimeout(() => {
+      expect(onAdd).not.toHaveBeenCalled();
+      done();
+    }, 10);
+  });
+});

--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -44,7 +44,7 @@ describe("ExtensionDiscovery", () => {
 
     extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
       expect(extension).toEqual({
-        absolutePath: "/Users/phorsmalahti/.k8slens/extensions/my-extension",
+        absolutePath: expect.any(String),
         id: "node_modules/my-extension/package.json",
         isBundled: false,
         isEnabled: false,

--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -1,5 +1,5 @@
 import { watch } from "chokidar";
-import { join } from "path";
+import { join, normalize } from "path";
 import { ExtensionDiscovery, InstalledExtension } from "../extension-discovery";
 
 jest.mock("../../common/ipc");
@@ -46,13 +46,13 @@ describe("ExtensionDiscovery", () => {
     extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
       expect(extension).toEqual({
         absolutePath: expect.any(String),
-        id: "node_modules/my-extension/package.json",
+        id: normalize("node_modules/my-extension/package.json"),
         isBundled: false,
         isEnabled: false,
         manifest:  {
           name: "my-extension",
         },
-        manifestPath: "node_modules/my-extension/package.json",
+        manifestPath: normalize("node_modules/my-extension/package.json"),
       });
       done();
     });

--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -1,4 +1,5 @@
 import { watch } from "chokidar";
+import { join } from "path";
 import { ExtensionDiscovery, InstalledExtension } from "../extension-discovery";
 
 jest.mock("../../common/ipc");
@@ -56,7 +57,7 @@ describe("ExtensionDiscovery", () => {
       done();
     });
 
-    addHandler(`${extensionDiscovery.localFolderPath}/my-extension/package.json`);
+    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/package.json"));
   });
 
   it("doesn't emit add for added file under extension", async done => {
@@ -89,7 +90,7 @@ describe("ExtensionDiscovery", () => {
 
     extensionDiscovery.events.on("add", onAdd);
 
-    addHandler(`${extensionDiscovery.localFolderPath}/my-extension/node_modules/dep/package.json`);
+    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/node_modules/dep/package.json"));
 
     setTimeout(() => {
       expect(onAdd).not.toHaveBeenCalled();

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -156,7 +156,6 @@ export class ExtensionDiscovery {
   }
 
   handleWatchFileAdd =  async (filePath: string) => {
-    logger.info(`${logModule} handleWatchFileAdd ${filePath}`);
     // e.g. "foo/package.json"
     const relativePath = path.relative(this.localFolderPath, filePath);
 
@@ -164,8 +163,6 @@ export class ExtensionDiscovery {
     // that the added file is in a folder under local folder path.
     // This safeguards against a file watch being triggered under a sub-directory which is not an extension.
     const isUnderLocalFolderPath = relativePath.split(path.sep).length === 2;
-
-    logger.info(`${logModule} relativePath ${relativePath} isUnderLocalFolderPath ${isUnderLocalFolderPath}`);
 
     if (path.basename(filePath) === manifestFilename && isUnderLocalFolderPath) {
       try {

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -156,6 +156,7 @@ export class ExtensionDiscovery {
   }
 
   handleWatchFileAdd =  async (filePath: string) => {
+    logger.info(`${logModule} handleWatchFileAdd ${filePath}`);
     // e.g. "foo/package.json"
     const relativePath = path.relative(this.localFolderPath, filePath);
 
@@ -163,6 +164,8 @@ export class ExtensionDiscovery {
     // that the added file is in a folder under local folder path.
     // This safeguards against a file watch being triggered under a sub-directory which is not an extension.
     const isUnderLocalFolderPath = relativePath.split(path.sep).length === 2;
+
+    logger.info(`${logModule} relativePath ${relativePath} isUnderLocalFolderPath ${isUnderLocalFolderPath}`);
 
     if (path.basename(filePath) === manifestFilename && isUnderLocalFolderPath) {
       try {

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,3 +1,6 @@
 import fetchMock from "jest-fetch-mock";
 // rewire global.fetch to call 'fetchMock'
 fetchMock.enableMocks();
+
+// Mock __non_webpack_require__ for tests
+globalThis.__non_webpack_require__ = jest.fn();


### PR DESCRIPTION
This can protect the file watch & extension installation starting in error under e.g. node_modules of a dependency. This avoids depending on chokidar "depth" parameter to guarantee it (and it doesn't seem like we can rely on that).

Somebody should test this on Windows.