### PR TITLE
Fix status brick alignment in pod-menu extension

### DIFF
--- a/extensions/pod-menu/src/logs-menu.tsx
+++ b/extensions/pod-menu/src/logs-menu.tsx
@@ -47,7 +47,7 @@ export class PodLogsMenu extends React.Component<PodLogsMenuProps> {
                   return (
                     <Component.MenuItem key={name} onClick={Util.prevDefault(() => this.showLogs(container))} className="flex align-center">
                       {brick}
-                      {name}
+                      <span>{name}</span>
                     </Component.MenuItem>
                   );
                 })

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -54,7 +54,7 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
                   return (
                     <Component.MenuItem key={name} onClick={Util.prevDefault(() => this.execShell(name))} className="flex align-center">
                       <Component.StatusBrick/>
-                      {name}
+                      <span>{name}</span>
                     </Component.MenuItem>
                   );
                 })


### PR DESCRIPTION
Just wrapped container name with span
Before the change:
![image](https://user-images.githubusercontent.com/53330707/101484001-65171a80-3972-11eb-9cec-34d81c54e832.png)

After:
![image](https://user-images.githubusercontent.com/53330707/101484022-6ba59200-3972-11eb-89b2-34c356a3151b.png)
