### PR TITLE
Full support for ReplicaSets

### DIFF
--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -274,6 +274,12 @@ describe("Lens integration tests", () => {
           expectedText: "Stateful Sets"
         },
         {
+          name: "ReplicaSets",
+          href: "replicasets",
+          expectedSelector: "h5.title",
+          expectedText: "Replica Sets"
+        },
+        {
           name: "Jobs",
           href: "jobs",
           expectedSelector: "h5.title",

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -186,6 +186,7 @@ msgstr "Affinities"
 #: src/renderer/components/+workloads-pods/pods.tsx:78
 #: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
 #: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:56
 msgid "Age"
 msgstr "Age"
 
@@ -729,6 +730,10 @@ msgstr "Cron Jobs"
 msgid "CronJobs"
 msgstr "CronJobs"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:54
+msgid "Current"
+msgstr "Current"
+
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:50
 msgid "Current / Target"
 msgstr "Current / Target"
@@ -740,6 +745,7 @@ msgstr "Current Healthy"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:101
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:103
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:104
 msgid "Current replica scale: {currentReplicas}"
 msgstr "Current replica scale: {currentReplicas}"
 
@@ -824,6 +830,10 @@ msgstr "Deployments"
 msgid "Description"
 msgstr "Description"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
+msgid "Desired"
+msgstr "Desired"
+
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
@@ -831,6 +841,7 @@ msgstr "Desired Healthy"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:105
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:107
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:108
 msgid "Desired number of replicas"
 msgstr "Desired number of replicas"
 
@@ -1095,6 +1106,7 @@ msgstr "Hide"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:127
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:116
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:131
 msgid "High number of replicas may cause cluster performance issues"
 msgstr "High number of replicas may cause cluster performance issues"
 
@@ -1546,6 +1558,7 @@ msgstr "Mounts"
 #: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
 msgid "Name"
 msgstr "Name"
 
@@ -1595,6 +1608,7 @@ msgstr "Names"
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:144
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
 msgid "Namespace"
 msgstr "Namespace"
 
@@ -2004,6 +2018,7 @@ msgstr "Read-only Root Filesystem"
 msgid "Readiness"
 msgstr "Readiness"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:55
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:145
 msgid "Ready"
 msgstr "Ready"
@@ -2118,6 +2133,10 @@ msgstr "Removing helm branch <0>{0}</0> has failed: {1}"
 #: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
 msgstr "Replicas"
+
+#: src/renderer/components/+workloads/workloads.tsx:70
+msgid "ReplicaSets"
+msgstr "ReplicaSets"
 
 #: src/renderer/components/dock/install-chart.tsx:119
 msgid "Repo/Name"
@@ -2310,12 +2329,17 @@ msgstr "Save"
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
 #: src/renderer/components/+workloads-deployments/deployments.tsx:83
 #: src/renderer/components/+workloads-deployments/deployments.tsx:84
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:160
 msgid "Scale"
 msgstr "Scale"
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:124
 msgid "Scale Deployment <0>{deploymentName}</0>"
 msgstr "Scale Deployment <0>{deploymentName}</0>"
+
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:143
+msgid "Scale Replica Set <0>{replicaSetName}</0>"
+msgstr "Scale Replica Set <0>{replicaSetName}</0>"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:139
 msgid "Scale Stateful Set <0>{statefulSetName}</0>"

--- a/locales/fi/messages.po
+++ b/locales/fi/messages.po
@@ -186,6 +186,7 @@ msgstr ""
 #: src/renderer/components/+workloads-pods/pods.tsx:78
 #: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
 #: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:56
 msgid "Age"
 msgstr ""
 
@@ -725,6 +726,10 @@ msgstr ""
 msgid "CronJobs"
 msgstr ""
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:54
+msgid "Current"
+msgstr ""
+
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:50
 msgid "Current / Target"
 msgstr ""
@@ -736,6 +741,7 @@ msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:101
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:103
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:104
 msgid "Current replica scale: {currentReplicas}"
 msgstr ""
 
@@ -820,6 +826,10 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
+msgid "Desired"
+msgstr ""
+
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
@@ -827,6 +837,7 @@ msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:105
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:107
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:108
 msgid "Desired number of replicas"
 msgstr ""
 
@@ -1086,6 +1097,7 @@ msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:127
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:116
+#: src/renderer/components/+workloads-replicaset/replicaset-scale-dialog.tsx:131
 msgid "High number of replicas may cause cluster performance issues"
 msgstr ""
 
@@ -1537,6 +1549,7 @@ msgstr ""
 #: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
 msgid "Name"
 msgstr ""
 
@@ -1586,6 +1599,7 @@ msgstr ""
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:144
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
 msgid "Namespace"
 msgstr ""
 
@@ -1987,6 +2001,7 @@ msgstr ""
 msgid "Readiness"
 msgstr ""
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:55
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:145
 msgid "Ready"
 msgstr ""
@@ -2100,6 +2115,10 @@ msgstr ""
 #: src/renderer/components/+workloads-deployments/deployments.tsx:59
 #: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
+msgstr ""
+
+#: src/renderer/components/+workloads/workloads.tsx:70
+msgid "ReplicaSets"
 msgstr ""
 
 #: src/renderer/components/dock/install-chart.tsx:119
@@ -2293,11 +2312,16 @@ msgstr ""
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
 #: src/renderer/components/+workloads-deployments/deployments.tsx:83
 #: src/renderer/components/+workloads-deployments/deployments.tsx:84
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:160
 msgid "Scale"
 msgstr ""
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:124
 msgid "Scale Deployment <0>{deploymentName}</0>"
+msgstr ""
+
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:143
+msgid "Scale Replica Set <0>{replicaSetName}</0>"
 msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:139

--- a/locales/ru/messages.po
+++ b/locales/ru/messages.po
@@ -187,6 +187,7 @@ msgstr "Аффинитеты"
 #: src/renderer/components/+workloads-pods/pods.tsx:78
 #: src/renderer/components/+workloads-replicasets/replicasets.tsx:51
 #: src/renderer/components/+workloads-statefulsets/statefulsets.tsx:41
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:56
 msgid "Age"
 msgstr "Возраст"
 
@@ -730,6 +731,10 @@ msgstr ""
 msgid "CronJobs"
 msgstr "CronJobs"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:54
+msgid "Current"
+msgstr "Текущее"
+
 #: src/renderer/components/+config-autoscalers/hpa-details.tsx:50
 msgid "Current / Target"
 msgstr "Текущее / Цель"
@@ -741,6 +746,7 @@ msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:101
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:103
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:104
 msgid "Current replica scale: {currentReplicas}"
 msgstr "Текущий размер реплики: {currentReplicas}"
 
@@ -825,6 +831,10 @@ msgstr "Deployments"
 msgid "Description"
 msgstr "Описание"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:53
+msgid "Desired"
+msgstr "Желаемое"
+
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx:42
 #: src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets.tsx:41
 msgid "Desired Healthy"
@@ -832,6 +842,7 @@ msgstr ""
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:105
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:107
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:108
 msgid "Desired number of replicas"
 msgstr "Нужный уровень реплик"
 
@@ -1096,6 +1107,7 @@ msgstr "Скрыть"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:127
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:116
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:131
 msgid "High number of replicas may cause cluster performance issues"
 msgstr "Большое количество реплик может вызвать проблемы с производительностью кластера"
 
@@ -1547,6 +1559,7 @@ msgstr "Установки"
 #: src/renderer/components/+workspaces/workspaces.tsx:135
 #: src/renderer/components/dock/edit-resource.tsx:89
 #: src/renderer/components/kube-object/kube-object-meta.tsx:20
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:50
 msgid "Name"
 msgstr "Имя"
 
@@ -1596,6 +1609,7 @@ msgstr ""
 #: src/renderer/components/item-object-list/page-filters-select.tsx:57
 #: src/renderer/components/kube-object/kube-object-meta.tsx:23
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:144
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:52
 msgid "Namespace"
 msgstr "Namespace"
 
@@ -2005,6 +2019,7 @@ msgstr ""
 msgid "Readiness"
 msgstr "Готовность"
 
+#: src/renderer/components/+workloads-replicasets/replicasets.tsx:55
 #: src/renderer/components/+workloads-pods/pod-details-list.tsx:145
 msgid "Ready"
 msgstr "Готовы"
@@ -2119,6 +2134,10 @@ msgstr ""
 #: src/renderer/components/+workloads-replicasets/replicaset-details.tsx:79
 msgid "Replicas"
 msgstr "Реплики"
+
+#: src/renderer/components/+workloads/workloads.tsx:70
+msgid "ReplicaSets"
+msgstr "ReplicaSets"
 
 #: src/renderer/components/dock/install-chart.tsx:119
 msgid "Repo/Name"
@@ -2311,12 +2330,17 @@ msgstr "Сохранить"
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:128
 #: src/renderer/components/+workloads-deployments/deployments.tsx:83
 #: src/renderer/components/+workloads-deployments/deployments.tsx:84
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:160
 msgid "Scale"
 msgstr "Масштабировать"
 
 #: src/renderer/components/+workloads-deployments/deployment-scale-dialog.tsx:124
 msgid "Scale Deployment <0>{deploymentName}</0>"
 msgstr "Масштабировать Deployment <0>{deploymentName}</0>"
+
+#: src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx:143
+msgid "Scale Replica Set <0>{replicaSetName}</0>"
+msgstr "Масштабировать Replica Set <0>{replicaSetName}</0>"
 
 #: src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.tsx:139
 msgid "Scale Stateful Set <0>{statefulSetName}</0>"

--- a/src/common/rbac.ts
+++ b/src/common/rbac.ts
@@ -31,6 +31,7 @@ export const apiResources: KubeApiResource[] = [
   { resource: "poddisruptionbudgets" },
   { resource: "podsecuritypolicies" },
   { resource: "resourcequotas" },
+  { resource: "replicasets", group: "apps" },
   { resource: "secrets" },
   { resource: "services" },
   { resource: "statefulsets", group: "apps" },

--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -67,7 +67,7 @@ export interface IPodContainer {
   image: string;
   command?: string[];
   args?: string[];
-  ports: {
+  ports?: {
     name?: string;
     containerPort: number;
     protocol: string;
@@ -137,7 +137,7 @@ interface IContainerProbe {
 
 export interface IPodContainerStatus {
   name: string;
-  state: {
+  state?: {
     [index: string]: object;
     running?: {
       startedAt: string;
@@ -153,21 +153,28 @@ export interface IPodContainerStatus {
       reason: string;
     };
   };
-  lastState: {
+  lastState?: {
     [index: string]: object;
+    running?: {
+      startedAt: string;
+    };
+    waiting?: {
+      reason: string;
+      message: string;
+    };
     terminated?: {
       startedAt: string;
       finishedAt: string;
       exitCode: number;
       reason: string;
-      containerID: string;
     };
   };
   ready: boolean;
   restartCount: number;
   image: string;
   imageID: string;
-  containerID: string;
+  containerID?: string;
+  started?: boolean;
 }
 
 @autobind()
@@ -196,28 +203,44 @@ export class Pod extends WorkloadKubeObject {
     }[];
     initContainers: IPodContainer[];
     containers: IPodContainer[];
-    restartPolicy: string;
-    terminationGracePeriodSeconds: number;
-    dnsPolicy: string;
+    restartPolicy?: string;
+    terminationGracePeriodSeconds?: number;
+    activeDeadlineSeconds?: number;
+    dnsPolicy?: string;
     serviceAccountName: string;
     serviceAccount: string;
-    priority: number;
-    priorityClassName: string;
-    nodeName: string;
+    automountServiceAccountToken?: boolean;
+    priority?: number;
+    priorityClassName?: string;
+    nodeName?: string;
     nodeSelector?: {
       [selector: string]: string;
     };
-    securityContext: {};
-    schedulerName: string;
-    tolerations: {
-      key: string;
-      operator: string;
-      effect: string;
-      tolerationSeconds: number;
+    securityContext?: {};
+    imagePullSecrets?: {
+      name: string;
     }[];
-    affinity: IAffinity;
+    hostNetwork?: boolean;
+    hostPID?: boolean;
+    hostIPC?: boolean;
+    shareProcessNamespace?: boolean;
+    hostname?: string;
+    subdomain?: string;
+    schedulerName?: string;
+    tolerations?: {
+      key?: string;
+      operator?: string;
+      effect?: string;
+      tolerationSeconds?: number;
+      value?: string;
+    }[];
+    hostAliases?: {
+      ip: string;
+      hostnames: string[];
+    };
+    affinity?: IAffinity;
   };
-  status: {
+  status?: {
     phase: string;
     conditions: {
       type: string;
@@ -230,7 +253,7 @@ export class Pod extends WorkloadKubeObject {
     startTime: string;
     initContainerStatuses?: IPodContainerStatus[];
     containerStatuses?: IPodContainerStatus[];
-    qosClass: string;
+    qosClass?: string;
     reason?: string;
   };
 

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -11,7 +11,6 @@ import { cssNames } from "../../utils";
 import { PodDetailsTolerations } from "../+workloads-pods/pod-details-tolerations";
 import { PodDetailsAffinities } from "../+workloads-pods/pod-details-affinities";
 import { KubeEventDetails } from "../+events/kube-event-details";
-import { replicaSetStore } from "../+workloads-replicasets/replicasets.store";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { KubeObjectDetailsProps } from "../kube-object";
 import { _i18n } from "../../i18n";
@@ -20,7 +19,6 @@ import { deploymentStore } from "./deployments.store";
 import { PodCharts, podMetricTabs } from "../+workloads-pods/pod-charts";
 import { reaction } from "mobx";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
-import { ReplicaSets } from "../+workloads-replicasets";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { kubeObjectDetailRegistry } from "../../api/kube-object-detail-registry";
 
@@ -38,10 +36,6 @@ export class DeploymentDetails extends React.Component<Props> {
     if (!podsStore.isLoaded) {
       podsStore.loadAll();
     }
-
-    if (!replicaSetStore.isLoaded) {
-      replicaSetStore.loadAll();
-    }
   }
 
   componentWillUnmount() {
@@ -56,7 +50,6 @@ export class DeploymentDetails extends React.Component<Props> {
     const nodeSelector = deployment.getNodeSelectors();
     const selectors = deployment.getSelectors();
     const childPods = deploymentStore.getChildPods(deployment);
-    const replicaSets = replicaSetStore.getReplicaSetsByOwner(deployment);
     const metrics = deploymentStore.metrics;
 
     return (
@@ -118,7 +111,6 @@ export class DeploymentDetails extends React.Component<Props> {
         <PodDetailsTolerations workload={deployment}/>
         <PodDetailsAffinities workload={deployment}/>
         <ResourceMetricsText metrics={metrics}/>
-        <ReplicaSets replicaSets={replicaSets}/>
         <PodDetailsList pods={childPods} owner={deployment}/>
       </div>
     );

--- a/src/renderer/components/+workloads-overview/overview-statuses.scss
+++ b/src/renderer/components/+workloads-overview/overview-statuses.scss
@@ -15,7 +15,7 @@
 
   .workloads {
     display: grid;
-    grid-template-columns: repeat(auto-fit, 155px);
+    grid-template-columns: repeat(auto-fit, 180px);
     justify-content: space-evenly;
     grid-gap: $margin;
     padding: $padding * 2;

--- a/src/renderer/components/+workloads-overview/overview-statuses.tsx
+++ b/src/renderer/components/+workloads-overview/overview-statuses.tsx
@@ -18,6 +18,7 @@ const resources: KubeResource[] = [
   "deployments",
   "statefulsets",
   "daemonsets",
+  "replicasets",
   "jobs",
   "cronjobs",
 ];

--- a/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.scss
+++ b/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.scss
@@ -1,0 +1,49 @@
+.ReplicaSetScaleDialog {
+  .Wizard {
+    .header {
+      span {
+        color: #a0a0a0;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .WizardStep {
+      .step-content {
+        min-height: 90px;
+        overflow: hidden;
+      }
+    }
+
+    .current-scale {
+      font-weight: bold
+    }
+
+    .desired-scale {
+      flex: 1.1 0;
+    }
+
+    .slider-container {
+      flex: 1 0;
+    }
+
+    .plus-minus-container {
+      margin-left: $margin * 2;
+      .Icon {
+        --color-active: black;
+      }
+    }
+
+    .warning {
+      color: $colorSoftError;
+      font-size: small;
+      display: flex;
+      align-items: center;
+
+      .Icon {
+        margin: 0;
+        margin-right: $margin;
+      }
+    }
+  }
+}

--- a/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.test.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.test.tsx
@@ -1,0 +1,167 @@
+import "@testing-library/jest-dom/extend-expect";
+
+jest.mock("../../api/endpoints");
+import { ReplicaSetScaleDialog } from "./replicaset-scale-dialog";
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+import { replicaSetApi } from "../../api/endpoints/replica-set.api";
+
+const dummyReplicaSet = {
+  apiVersion: "v1",
+  kind: "dummy",
+  metadata: {
+    uid: "dummy",
+    name: "dummy",
+    creationTimestamp: "dummy",
+    resourceVersion: "dummy",
+    selfLink: "link",
+  },
+  selfLink: "link",
+  spec: {
+    replicas: 1,
+    selector: {
+      matchLabels: { "label": "label" }
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: "label",
+        },
+      },
+      spec: {
+        containers: [{
+          name: "dummy",
+          image: "dummy",
+          imagePullPolicy: "dummy",
+        }],
+        initContainers: [{
+          name: "dummy",
+          image: "dummy",
+          imagePullPolicy: "dummy",
+        }],
+        priority: 1,
+        serviceAccountName: "dummy",
+        serviceAccount: "dummy",
+        securityContext: {},
+        schedulerName: "dummy",
+      },
+    },
+    minReadySeconds: 1,
+  },
+  status: {
+    replicas: 1,
+    fullyLabeledReplicas: 1,
+    readyReplicas: 1,
+    availableReplicas: 1,
+    observedGeneration: 1,
+    conditions: [{
+      type: "dummy",
+      status: "dummy",
+      lastUpdateTime: "dummy",
+      lastTransitionTime: "dummy",
+      reason: "dummy",
+      message: "dummy",
+    }],
+  },
+  getDesired: jest.fn(),
+  getCurrent: jest.fn(),
+  getReady: jest.fn(),
+  getImages: jest.fn(),
+  getReplicas: jest.fn(),
+  getSelectors: jest.fn(),
+  getTemplateLabels: jest.fn(),
+  getAffinity: jest.fn(),
+  getTolerations: jest.fn(),
+  getNodeSelectors: jest.fn(),
+  getAffinityNumber: jest.fn(),
+  getId: jest.fn(),
+  getResourceVersion: jest.fn(),
+  getName: jest.fn(),
+  getNs: jest.fn(),
+  getAge: jest.fn(),
+  getFinalizers: jest.fn(),
+  getLabels: jest.fn(),
+  getAnnotations: jest.fn(),
+  getOwnerRefs: jest.fn(),
+  getSearchFields: jest.fn(),
+  toPlainObject: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+describe("<ReplicaSetScaleDialog />", () => {
+  it("renders w/o errors", () => {
+    const { container } = render(<ReplicaSetScaleDialog/>);
+
+    expect(container).toBeInstanceOf(HTMLElement);
+  });
+
+  it("init with a dummy replica set and mocked current/desired scale", async () => {
+    // mock replicaSetApi.getReplicas() which will be called
+    // when <ReplicaSetScaleDialog /> rendered.
+    const initReplicas = 1;
+
+    replicaSetApi.getReplicas = jest.fn().mockImplementationOnce(async () => initReplicas);
+    const { getByTestId } = render(<ReplicaSetScaleDialog/>);
+
+    ReplicaSetScaleDialog.open(dummyReplicaSet);
+    // we need to wait for the replicaSetScaleDialog to show up
+    // because there is an <Animate /> in <Dialog /> which renders null at start.
+    await waitFor(async () => {
+      const [currentScale, desiredScale] = await Promise.all([
+        getByTestId("current-scale"),
+        getByTestId("desired-scale"),
+      ]);
+
+      expect(currentScale).toHaveTextContent(`${initReplicas}`);
+      expect(desiredScale).toHaveTextContent(`${initReplicas}`);
+    });
+  });
+
+  it("changes the desired scale when clicking the icon buttons +/-", async () => {
+    const initReplicas = 1;
+
+    replicaSetApi.getReplicas = jest.fn().mockImplementationOnce(async () => initReplicas);
+    const component = render(<ReplicaSetScaleDialog/>);
+
+    ReplicaSetScaleDialog.open(dummyReplicaSet);
+    await waitFor(async () => {
+      expect(await component.findByTestId("desired-scale")).toHaveTextContent(`${initReplicas}`);
+      expect(await component.findByTestId("current-scale")).toHaveTextContent(`${initReplicas}`);
+      expect((await component.baseElement.querySelector("input").value)).toBe(`${initReplicas}`);
+    });
+
+    const up = await component.findByTestId("desired-replicas-up");
+    const down = await component.findByTestId("desired-replicas-down");
+
+    fireEvent.click(up);
+    expect(await component.findByTestId("desired-scale")).toHaveTextContent(`${initReplicas + 1}`);
+    expect(await component.findByTestId("current-scale")).toHaveTextContent(`${initReplicas}`);
+    expect((await component.baseElement.querySelector("input").value)).toBe(`${initReplicas + 1}`);
+
+    fireEvent.click(down);
+    expect(await component.findByTestId("desired-scale")).toHaveTextContent(`${initReplicas}`);
+    expect(await component.findByTestId("current-scale")).toHaveTextContent(`${initReplicas}`);
+    expect((await component.baseElement.querySelector("input").value)).toBe(`${initReplicas}`);
+
+    // edge case, desiredScale must >= 0
+    let times = 10;
+
+    for (let i = 0; i < times; i++) {
+      fireEvent.click(down);
+    }
+    expect(await component.findByTestId("desired-scale")).toHaveTextContent("0");
+    expect((await component.baseElement.querySelector("input").value)).toBe("0");
+
+    // edge case, desiredScale must <= scaleMax (100)
+    times = 120;
+
+    for (let i = 0; i < times; i++) {
+      fireEvent.click(up);
+    }
+    expect(await component.findByTestId("desired-scale")).toHaveTextContent("100");
+    expect((component.baseElement.querySelector("input").value)).toBe("100");
+    expect(await component.findByTestId("warning"))
+      .toHaveTextContent("High number of replicas may cause cluster performance issues");
+  });
+});

--- a/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.tsx
@@ -1,0 +1,169 @@
+import "./replicaset-scale-dialog.scss";
+
+import React, { Component } from "react";
+import { computed, observable } from "mobx";
+import { observer } from "mobx-react";
+import { Trans } from "@lingui/macro";
+import { Dialog, DialogProps } from "../dialog";
+import { Wizard, WizardStep } from "../wizard";
+import { Icon } from "../icon";
+import { Slider } from "../slider";
+import { Notifications } from "../notifications";
+import { cssNames } from "../../utils";
+import { ReplicaSet, replicaSetApi } from "../../api/endpoints/replica-set.api";
+
+interface Props extends Partial<DialogProps> {
+}
+
+@observer
+export class ReplicaSetScaleDialog extends Component<Props> {
+  @observable static isOpen = false;
+  @observable static data: ReplicaSet = null;
+
+  @observable ready = false;
+  @observable currentReplicas = 0;
+  @observable desiredReplicas = 0;
+
+  static open(replicaSet: ReplicaSet) {
+    ReplicaSetScaleDialog.isOpen = true;
+    ReplicaSetScaleDialog.data = replicaSet;
+  }
+
+  static close() {
+    ReplicaSetScaleDialog.isOpen = false;
+  }
+
+  get replicaSet() {
+    return ReplicaSetScaleDialog.data;
+  }
+
+  close = () => {
+    ReplicaSetScaleDialog.close();
+  };
+
+  onOpen = async () => {
+    const { replicaSet } = this;
+
+    this.currentReplicas = await replicaSetApi.getReplicas({
+      namespace: replicaSet.getNs(),
+      name: replicaSet.getName(),
+    });
+    this.desiredReplicas = this.currentReplicas;
+    this.ready = true;
+  };
+
+  onClose = () => {
+    this.ready = false;
+  };
+
+  onChange = (evt: React.ChangeEvent, value: number) => {
+    this.desiredReplicas = value;
+  };
+
+  @computed get scaleMax() {
+    const { currentReplicas } = this;
+    const defaultMax = 50;
+
+    return currentReplicas <= defaultMax
+      ? defaultMax * 2
+      : currentReplicas * 2;
+  }
+
+  scale = async () => {
+    const { replicaSet } = this;
+    const { currentReplicas, desiredReplicas, close } = this;
+
+    try {
+      if (currentReplicas !== desiredReplicas) {
+        await replicaSetApi.scale({
+          name: replicaSet.getName(),
+          namespace: replicaSet.getNs(),
+        }, desiredReplicas);
+      }
+      close();
+    } catch (err) {
+      Notifications.error(err);
+    }
+  };
+
+  desiredReplicasUp = () => {
+    this.desiredReplicas < this.scaleMax && this.desiredReplicas++;
+  };
+
+  desiredReplicasDown = () => {
+    this.desiredReplicas > 0 && this.desiredReplicas--;
+  };
+
+  renderContents() {
+    const { currentReplicas, desiredReplicas, onChange, scaleMax } = this;
+    const warning = currentReplicas < 10 && desiredReplicas > 90;
+
+    return (
+      <>
+        <div className="current-scale" data-testid="current-scale">
+          <Trans>Current replica scale: {currentReplicas}</Trans>
+        </div>
+        <div className="flex gaps align-center">
+          <div className="desired-scale" data-testid="desired-scale">
+            <Trans>Desired number of replicas</Trans>: {desiredReplicas}
+          </div>
+          <div className="slider-container flex align-center" data-testid="slider">
+            <Slider value={desiredReplicas} max={scaleMax}
+              onChange={onChange as any /** see: https://github.com/mui-org/material-ui/issues/20191 */}
+            />
+          </div>
+          <div className="plus-minus-container flex gaps">
+            <Icon
+              material="add_circle_outline"
+              onClick={this.desiredReplicasUp}
+              data-testid="desired-replicas-up"
+            />
+            <Icon
+              material="remove_circle_outline"
+              onClick={this.desiredReplicasDown}
+              data-testid="desired-replicas-down"
+            />
+          </div>
+        </div>
+        {warning &&
+        <div className="warning" data-testid="warning">
+          <Icon material="warning"/>
+          <Trans>High number of replicas may cause cluster performance issues</Trans>
+        </div>
+        }
+      </>
+    );
+  }
+
+  render() {
+    const { className, ...dialogProps } = this.props;
+    const replicaSetName = this.replicaSet ? this.replicaSet.getName() : "";
+    const header = (
+      <h5>
+        <Trans>Scale Replica Set <span>{replicaSetName}</span></Trans>
+      </h5>
+    );
+
+    return (
+      <Dialog
+        {...dialogProps}
+        isOpen={ReplicaSetScaleDialog.isOpen}
+        className={cssNames("ReplicaSetScaleDialog", className)}
+        onOpen={this.onOpen}
+        onClose={this.onClose}
+        close={this.close}
+      >
+        <Wizard header={header} done={this.close}>
+          <WizardStep
+            contentClass="flex gaps column"
+            next={this.scale}
+            nextLabel={<Trans>Scale</Trans>}
+            disabledNext={!this.ready}
+          >
+            {this.renderContents()}
+          </WizardStep>
+        </Wizard>
+      </Dialog>
+    );
+  }
+}

--- a/src/renderer/components/+workloads-replicasets/replicasets.scss
+++ b/src/renderer/components/+workloads-replicasets/replicasets.scss
@@ -1,34 +1,11 @@
 .ReplicaSets {
-  position: relative;
-  min-height: 80px;
-
-  .Table {
-    margin: 0 (-$margin * 3);
-  }
-
   .TableCell {
-    &:first-child {
-      margin-left: $margin;
-    }
-
-    &:last-child {
-      margin-right: $margin;
-    }
-
     &.name {
       flex-grow: 2;
     }
 
     &.warning {
       @include table-cell-warning;
-    }
-
-    &.namespace {
-      flex-grow: 1.2;
-    }
-
-    &.actions {
-      @include table-cell-action;
     }
   }
 }

--- a/src/renderer/components/+workloads-replicasets/replicasets.store.ts
+++ b/src/renderer/components/+workloads-replicasets/replicasets.store.ts
@@ -4,6 +4,7 @@ import { KubeObjectStore } from "../../kube-object.store";
 import { Deployment, IPodMetrics, podsApi, ReplicaSet, replicaSetApi } from "../../api/endpoints";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { apiManager } from "../../api/api-manager";
+import { PodStatus } from "../../api/endpoints/pods.api";
 
 @autobind()
 export class ReplicaSetStore extends KubeObjectStore<ReplicaSet> {
@@ -18,6 +19,26 @@ export class ReplicaSetStore extends KubeObjectStore<ReplicaSet> {
 
   getChildPods(replicaSet: ReplicaSet) {
     return podsStore.getPodsByOwner(replicaSet);
+  }
+
+  getStatuses(replicaSets: ReplicaSet[]) {
+    const status = { failed: 0, pending: 0, running: 0 };
+
+    replicaSets.forEach(replicaSet => {
+      const pods = this.getChildPods(replicaSet);
+
+      if (pods.some(pod => pod.getStatus() === PodStatus.FAILED)) {
+        status.failed++;
+      }
+      else if (pods.some(pod => pod.getStatus() === PodStatus.PENDING)) {
+        status.pending++;
+      }
+      else {
+        status.running++;
+      }
+    });
+
+    return status;
   }
 
   getReplicaSetsByOwner(deployment: Deployment) {

--- a/src/renderer/components/+workloads/workloads.route.ts
+++ b/src/renderer/components/+workloads/workloads.route.ts
@@ -25,6 +25,9 @@ export const daemonSetsRoute: RouteProps = {
 export const statefulSetsRoute: RouteProps = {
   path: "/statefulsets"
 };
+export const replicaSetsRoute: RouteProps = {
+  path: "/replicasets"
+};
 export const jobsRoute: RouteProps = {
   path: "/jobs"
 };
@@ -48,6 +51,9 @@ export interface IDaemonSetsRouteParams {
 export interface IStatefulSetsRouteParams {
 }
 
+export interface IReplicaSetsRouteParams {
+}
+
 export interface IJobsRouteParams {
 }
 
@@ -61,6 +67,7 @@ export const podsURL = buildURL<IPodsRouteParams>(podsRoute.path);
 export const deploymentsURL = buildURL<IDeploymentsRouteParams>(deploymentsRoute.path);
 export const daemonSetsURL = buildURL<IDaemonSetsRouteParams>(daemonSetsRoute.path);
 export const statefulSetsURL = buildURL<IStatefulSetsRouteParams>(statefulSetsRoute.path);
+export const replicaSetsURL = buildURL<IReplicaSetsRouteParams>(replicaSetsRoute.path);
 export const jobsURL = buildURL<IJobsRouteParams>(jobsRoute.path);
 export const cronJobsURL = buildURL<ICronJobsRouteParams>(cronJobsRoute.path);
 
@@ -69,6 +76,7 @@ export const workloadURL: Partial<Record<KubeResource, ReturnType<typeof buildUR
   "deployments": deploymentsURL,
   "daemonsets": daemonSetsURL,
   "statefulsets": statefulSetsURL,
+  "replicasets": replicaSetsURL,
   "jobs": jobsURL,
   "cronjobs": cronJobsURL,
 };

--- a/src/renderer/components/+workloads/workloads.stores.ts
+++ b/src/renderer/components/+workloads/workloads.stores.ts
@@ -6,12 +6,14 @@ import { statefulSetStore } from "../+workloads-statefulsets/statefulset.store";
 import { jobStore } from "../+workloads-jobs/job.store";
 import { cronJobStore } from "../+workloads-cronjobs/cronjob.store";
 import { KubeResource } from "../../../common/rbac";
+import { replicaSetStore } from "../+workloads-replicasets/replicasets.store";
 
 export const workloadStores: Partial<Record<KubeResource, KubeObjectStore>> = {
   "pods": podsStore,
   "deployments": deploymentStore,
   "daemonsets": daemonSetStore,
   "statefulsets": statefulSetStore,
+  "replicasets": replicaSetStore,
   "jobs": jobStore,
   "cronjobs": cronJobStore,
 };

--- a/src/renderer/components/+workloads/workloads.tsx
+++ b/src/renderer/components/+workloads/workloads.tsx
@@ -5,7 +5,7 @@ import { observer } from "mobx-react";
 import { Trans } from "@lingui/macro";
 import { TabLayout, TabLayoutRoute } from "../layout/tab-layout";
 import { WorkloadsOverview } from "../+workloads-overview/overview";
-import { cronJobsRoute, cronJobsURL, daemonSetsRoute, daemonSetsURL, deploymentsRoute, deploymentsURL, jobsRoute, jobsURL, overviewRoute, overviewURL, podsRoute, podsURL, statefulSetsRoute, statefulSetsURL } from "./workloads.route";
+import { cronJobsRoute, cronJobsURL, daemonSetsRoute, daemonSetsURL, deploymentsRoute, deploymentsURL, jobsRoute, jobsURL, overviewRoute, overviewURL, podsRoute, podsURL, replicaSetsRoute, replicaSetsURL, statefulSetsRoute, statefulSetsURL } from "./workloads.route";
 import { namespaceStore } from "../+namespaces/namespace.store";
 import { Pods } from "../+workloads-pods";
 import { Deployments } from "../+workloads-deployments";
@@ -14,6 +14,7 @@ import { StatefulSets } from "../+workloads-statefulsets";
 import { Jobs } from "../+workloads-jobs";
 import { CronJobs } from "../+workloads-cronjobs";
 import { isAllowedResource } from "../../../common/rbac";
+import { ReplicaSets } from "../+workloads-replicasets";
 
 @observer
 export class Workloads extends React.Component {
@@ -61,6 +62,15 @@ export class Workloads extends React.Component {
         component: StatefulSets,
         url: statefulSetsURL({ query }),
         routePath: statefulSetsRoute.path.toString(),
+      });
+    }
+
+    if (isAllowedResource("replicasets")) {
+      routes.push({
+        title: <Trans>ReplicaSets</Trans>,
+        component: ReplicaSets,
+        url: replicaSetsURL({ query }),
+        routePath: replicaSetsRoute.path.toString(),
       });
     }
 

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -48,6 +48,7 @@ import { reaction, computed } from "mobx";
 import { nodesStore } from "./+nodes/nodes.store";
 import { podsStore } from "./+workloads-pods/pods.store";
 import { sum } from "lodash";
+import { ReplicaSetScaleDialog } from "./+workloads-replicasets/replicaset-scale-dialog";
 
 @observer
 export class App extends React.Component {
@@ -206,6 +207,7 @@ export class App extends React.Component {
             <AddRoleBindingDialog/>
             <DeploymentScaleDialog/>
             <StatefulSetScaleDialog/>
+            <ReplicaSetScaleDialog/>
             <CronJobTriggerDialog/>
           </ErrorBoundary>
         </Router>


### PR DESCRIPTION
Hi guys. I moved ReplicaSet under the workload menu and added a ReplicaSet to the overview page. But I don't know how to arrange all those elements on the Overview page better.  
Also, I'd like to suggest the idea use `Pod["spec"]` in all resources (`template.spec` field) such as Deployments, StatefulSets, JobSpec, and e.t.c (please take a look at 3 screenshot).  It may help avoid code duplication. Of course, I'm not sure whether it is a good idea or not, please let me know. (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core)
And I updated some fields in `Pod.spec` according to this doc, if you don't mind.(https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go)  if I use `Pod[spec]` in replicaSet API it contains a lot of mandatory fields which are actually not required and it's uncomfortable for test cases.  

<img width="1162" alt="Screen Shot 2020-12-07 at 8 10 14 PM" src="https://user-images.githubusercontent.com/38247153/101491894-ba0c5e00-397d-11eb-856b-6cce07f8b573.png">

<img width="1113" alt="Screen Shot 2020-12-07 at 8 09 58 PM" src="https://user-images.githubusercontent.com/38247153/101491879-b7aa0400-397d-11eb-9ea7-44a5cacd88d0.png">

<img width="1122" alt="Screen Shot 2020-12-07 at 7 49 44 PM" src="https://user-images.githubusercontent.com/38247153/101492468-55053800-397e-11eb-88cd-3f4ab36f6b7c.png">

Fixes https://github.com/lensapp/lens/issues/373