### PR TITLE
Do not call initMainWindow if windowManager is not ready

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,7 +115,7 @@ app.on("activate", (event, hasVisibleWindows) => {
   logger.info("APP:ACTIVATE", { hasVisibleWindows });
 
   if (!hasVisibleWindows) {
-    windowManager.initMainWindow();
+    windowManager?.initMainWindow(false);
   }
 });
 


### PR DESCRIPTION
Should fix #1687
Should fix #1567