### PR TITLE
Release v4.0.1

### DIFF
--- a/docs/extensions/guides/stores.md
+++ b/docs/extensions/guides/stores.md
@@ -1,11 +1,155 @@
----
-WIP
----
-
 # Stores
 
-## ClusterStore
+Stores are components that persist and synchronize state data. Lens utilizes a number of stores for maintaining a variety of state information.
+A few of these are exposed by the extensions api for use by the extension developer.
 
-## WorkspaceStore
+- The `ClusterStore` manages cluster state data such as cluster details, and which cluster is active.
+- The `WorkspaceStore` similarly manages workspace state data, such as workspace name, and which clusters belong to a given workspace.
+- The `ExtensionStore` is a store for managing custom extension state data.
 
 ## ExtensionStore
+
+Extension developers can create their own store for managing state data by extending the `ExtensionStore` class.
+This guide shows how to create a store for the [`appPreferences` guide example](../renderer-extension#apppreferences), which demonstrates how to add a custom preference to the Preferences page.
+The preference is a simple boolean that indicates whether something is enabled or not.
+The problem with that example is that the enabled state is not stored anywhere, and reverts to the default the next time Lens is started.
+
+The following example code creates a store for the `appPreferences` guide example:
+
+``` typescript
+import { Store } from "@k8slens/extensions";
+import { observable, toJS } from "mobx";
+
+export type ExamplePreferencesModel = {
+  enabled: boolean;
+};
+
+export class ExamplePreferencesStore extends Store.ExtensionStore<ExamplePreferencesModel> {
+
+  @observable  enabled = false;
+
+  private constructor() {
+    super({
+      configName: "example-preferences-store",
+      defaults: {
+        enabled: false
+      }
+    });
+  }
+ 
+  protected fromStore({ enabled }: ExamplePreferencesModel): void {
+    this.enabled = enabled;
+  }
+
+  toJSON(): ExamplePreferencesModel {
+    return toJS({
+      enabled: this.enabled
+    }, {
+      recurseEverything: true
+    });
+  }
+}
+
+export const examplePreferencesStore = ExamplePreferencesStore.getInstance<ExamplePreferencesStore>();
+```
+
+First the extension's data model is defined using a simple type, `ExamplePreferencesModel`, which has a single field, `enabled`, representing the preference's state.
+`ExamplePreferencesStore` extends `Store.ExtensionStore`, based on the `ExamplePreferencesModel`.
+The field `enabled` is added to the `ExamplePreferencesStore` class to hold the "live" or current state of the preference.
+Note the use of the `observer` decorator on the `enabled` field.
+As for the [`appPreferences` guide example](../renderer-extension#apppreferences), [`mobx`](https://mobx.js.org/README.html) is used for the UI state management, ensuring the checkbox updates when activated by the user.
+
+Then the constructor and two abstract methods are implemented.
+In the constructor, the name of the store (`"example-preferences-store"`), and the default (initial) value for the preference state (`enabled: false`) are specified. 
+The `fromStore()` method is called by Lens internals when the store is loaded, and gives the extension the opportunity to retrieve the stored state data values based on the defined data model.
+Here, the `enabled` field of the `ExamplePreferencesStore` is set to the value from the store whenever `fromStore()` is invoked.
+The `toJSON()` method is complementary to `fromStore()`, and is called when the store is being saved.
+`toJSON()` must provide a JSON serializable object, facilitating its storage in JSON format.
+The `toJS()` function from [`mobx`](https://mobx.js.org/README.html) is convenient for this purpose, and is used here.
+
+Finally, `examplePreferencesStore` is created by calling `ExamplePreferencesStore.getInstance<ExamplePreferencesStore>()`, and exported for use by other parts of the extension.
+Note that `examplePreferencesStore` is a singleton, calling this function again will not create a new store.
+
+The following example code, modified from the [`appPreferences` guide example](../renderer-extension#apppreferences) demonstrates how to use the extension store.
+`examplePreferencesStore` must be loaded in the main process, where loaded stores are automatically saved when exiting Lens. This can be done in `./main.ts`:
+
+``` typescript
+import { LensMainExtension } from "@k8slens/extensions";
+import { examplePreferencesStore } from "./src/example-preference-store";
+
+export default class ExampleMainExtension extends LensMainExtension {
+  async onActivate() {
+    await examplePreferencesStore.loadExtension(this);
+  }
+}
+```
+
+Here, `examplePreferencesStore` is loaded with `examplePreferencesStore.loadExtension(this)`, which is conveniently called from the `onActivate()` method of `ExampleMainExtension`.
+Similarly, `examplePreferencesStore` must be loaded in the renderer process where the `appPreferences` are handled. This can be done in `./renderer.ts`:
+
+``` typescript
+import { LensRendererExtension } from "@k8slens/extensions";
+import { ExamplePreferenceHint, ExamplePreferenceInput } from "./src/example-preference";
+import { examplePreferencesStore } from "./src/example-preference-store";
+import React from "react";
+
+export default class ExampleRendererExtension extends LensRendererExtension {
+
+  async onActivate() {
+    await examplePreferencesStore.loadExtension(this);
+  }
+
+  appPreferences = [
+    {
+      title: "Example Preferences",
+      components: {
+        Input: () => <ExamplePreferenceInput preference={examplePreferencesStore}/>,
+        Hint: () => <ExamplePreferenceHint/>
+      }
+    }
+  ];
+}
+```
+
+Again, `examplePreferencesStore.loadExtension(this)` is called to load `examplePreferencesStore`, this time from the `onActivate()` method of `ExampleRendererExtension`.
+Also, there is no longer the need for the `preference` field in the `ExampleRendererExtension` class, as the props for `ExamplePreferenceInput` is now `examplePreferencesStore`.
+`ExamplePreferenceInput` is defined in `./src/example-preference.tsx`:
+
+``` typescript
+import { Component } from "@k8slens/extensions";
+import { observer } from "mobx-react";
+import React from "react";
+import { ExamplePreferencesStore } from "./example-preference-store";
+
+export class ExamplePreferenceProps {
+  preference: ExamplePreferencesStore;
+}
+
+@observer
+export class ExamplePreferenceInput extends React.Component<ExamplePreferenceProps> {
+
+  render() {
+    const { preference } = this.props;
+    
+    return (
+      <Component.Checkbox
+        label="I understand appPreferences"
+        value={preference.enabled}
+        onChange={v => { preference.enabled = v; }}
+      />
+    );
+  }
+}
+
+export class ExamplePreferenceHint extends React.Component {
+  render() {
+    return (
+      <span>This is an example of an appPreference for extensions.</span>
+    );
+  }
+}
+```
+
+The only change here is that `ExamplePreferenceProps` defines its `preference` field as an `ExamplePreferencesStore` type.
+Everything else works as before except now the `enabled` state persists across Lens restarts because it is managed by the 
+`examplePreferencesStore`.

--- a/extensions/pod-menu/src/logs-menu.tsx
+++ b/extensions/pod-menu/src/logs-menu.tsx
@@ -47,7 +47,7 @@ export class PodLogsMenu extends React.Component<PodLogsMenuProps> {
                   return (
                     <Component.MenuItem key={name} onClick={Util.prevDefault(() => this.showLogs(container))} className="flex align-center">
                       {brick}
-                      {name}
+                      <span>{name}</span>
                     </Component.MenuItem>
                   );
                 })

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -54,7 +54,7 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
                   return (
                     <Component.MenuItem key={name} onClick={Util.prevDefault(() => this.execShell(name))} className="flex align-center">
                       <Component.StatusBrick/>
-                      {name}
+                      <span>{name}</span>
                     </Component.MenuItem>
                   );
                 })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,10 @@ nav:
       - Color Reference: extensions/capabilities/color-reference.md
     - Extension Guides:
       - Overview: extensions/guides/README.md
+      - Generator: extensions/guides/generator.md
       - Main Extension: extensions/guides/main-extension.md
       - Renderer Extension: extensions/guides/renderer-extension.md
-      - Generator: extensions/guides/generator.md
+      - Stores: extensions/guides/stores.md
       - Working with mobx: extensions/guides/working-with-mobx.md
     - Testing and Publishing:
       - Testing Extensions: extensions/testing-and-publishing/testing.md

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -1,0 +1,100 @@
+import { watch } from "chokidar";
+import { join, normalize } from "path";
+import { ExtensionDiscovery, InstalledExtension } from "../extension-discovery";
+
+jest.mock("../../common/ipc");
+jest.mock("fs-extra");
+jest.mock("chokidar", () => ({
+  watch: jest.fn()
+}));
+jest.mock("../extension-installer", () => ({
+  extensionInstaller: {
+    extensionPackagesRoot: "",
+    installPackages: jest.fn()
+  }
+}));
+
+const mockedWatch = watch as jest.MockedFunction<typeof watch>;
+
+describe("ExtensionDiscovery", () => {
+  it("emits add for added extension", async done => {
+    globalThis.__non_webpack_require__.mockImplementationOnce(() => ({
+      name: "my-extension"
+    }));
+    let addHandler: (filePath: string) => void;
+
+    const mockWatchInstance: any = {
+      on: jest.fn((event: string, handler: typeof addHandler) => {
+        if (event === "add") {
+          addHandler = handler;
+        }
+
+        return mockWatchInstance;
+      })
+    };
+
+    mockedWatch.mockImplementationOnce(() =>
+      (mockWatchInstance) as any
+    );
+    const extensionDiscovery = new ExtensionDiscovery();
+
+    // Need to force isLoaded to be true so that the file watching is started
+    extensionDiscovery.isLoaded = true;
+
+    await extensionDiscovery.initMain();
+
+    extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
+      expect(extension).toEqual({
+        absolutePath: expect.any(String),
+        id: normalize("node_modules/my-extension/package.json"),
+        isBundled: false,
+        isEnabled: false,
+        manifest:  {
+          name: "my-extension",
+        },
+        manifestPath: normalize("node_modules/my-extension/package.json"),
+      });
+      done();
+    });
+
+    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/package.json"));
+  });
+
+  it("doesn't emit add for added file under extension", async done => {
+    globalThis.__non_webpack_require__.mockImplementationOnce(() => ({
+      name: "my-extension"
+    }));
+    let addHandler: (filePath: string) => void;
+
+    const mockWatchInstance: any = {
+      on: jest.fn((event: string, handler: typeof addHandler) => {
+        if (event === "add") {
+          addHandler = handler;
+        }
+
+        return mockWatchInstance;
+      })
+    };
+
+    mockedWatch.mockImplementationOnce(() =>
+      (mockWatchInstance) as any
+    );
+    const extensionDiscovery = new ExtensionDiscovery();
+
+    // Need to force isLoaded to be true so that the file watching is started
+    extensionDiscovery.isLoaded = true;
+
+    await extensionDiscovery.initMain();
+
+    const onAdd = jest.fn();
+
+    extensionDiscovery.events.on("add", onAdd);
+
+    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/node_modules/dep/package.json"));
+
+    setTimeout(() => {
+      expect(onAdd).not.toHaveBeenCalled();
+      done();
+    }, 10);
+  });
+});

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,3 +1,6 @@
 import fetchMock from "jest-fetch-mock";
 // rewire global.fetch to call 'fetchMock'
 fetchMock.enableMocks();
+
+// Mock __non_webpack_require__ for tests
+globalThis.__non_webpack_require__ = jest.fn();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,7 +115,7 @@ app.on("activate", (event, hasVisibleWindows) => {
   logger.info("APP:ACTIVATE", { hasVisibleWindows });
 
   if (!hasVisibleWindows) {
-    windowManager.initMainWindow();
+    windowManager?.initMainWindow(false);
   }
 });
 

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -68,7 +68,7 @@ describe("Extensions", () => {
     // Approve confirm dialog
     fireEvent.click(screen.getByText("Yes"));
 
-    expect(extensionDiscovery.uninstallExtension).toHaveBeenCalledWith("/absolute/path");
+    expect(extensionDiscovery.uninstallExtension).toHaveBeenCalled();
     expect(screen.getByText("Disable").closest("button")).toBeDisabled();
     expect(screen.getByText("Uninstall").closest("button")).toBeDisabled();
   });

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -413,7 +413,7 @@ export class Extensions extends React.Component {
         displayName
       });
 
-      await extensionDiscovery.uninstallExtension(extension.absolutePath);
+      await extensionDiscovery.uninstallExtension(extension);
     } catch (error) {
       Notifications.error(
         <p>Uninstalling extension <b>{displayName}</b> has failed: <em>{error?.message ?? ""}</em></p>

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -157,9 +157,7 @@ export class App extends React.Component {
         const page = clusterPageRegistry.getByPageMenuTarget(menu.target);
 
         if (page) {
-          const pageComponent = () => <page.components.Page />;
-
-          return <Route key={`extension-tab-layout-route-${index}`} path={page.routePath} exact={page.exact} component={pageComponent}/>;
+          return <Route key={`extension-tab-layout-route-${index}`} path={page.routePath} exact={page.exact} component={page.components.Page}/>;
         }
       }
     });

--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -91,9 +91,14 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
     let items: T[];
 
     try {
-      const { allowedNamespaces } = getHostedCluster();
+      const { allowedNamespaces, accessibleNamespaces, isAdmin } = getHostedCluster();
 
-      items = await this.loadItems(allowedNamespaces);
+      if (isAdmin && accessibleNamespaces.length == 0) {
+        items = await this.loadItems();
+      } else {
+        items = await this.loadItems(allowedNamespaces);
+      }
+
       items = this.filterItemsOnLoad(items);
     } finally {
       if (items) {

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,15 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.0 (current version)
+## 4.0.1 (current version)
+
+- Extension install/uninstall fixes
+- Fix status brick styles in pod-menu-extension
+- MacOS: fix error on app start
+- Performance fix: query all objects using single api call if admin and namespace list is not overridden
+- Extension API fix: register a cluster page component properly to a route
+
+## 4.0.0
 
 - Extension API
 - Improved pod logs


### PR DESCRIPTION
## Changelog

- Do not call initMainWindow if windowManager is not ready (#1714)
- Remove broken symlink from node_modules on uninstall (#1695)
- Add check to extension file watch (#1677)
- Fix status brick in pod-menu-extension (#1698)
- Query all objects using single api call if admin and namespace list is not overridden (#1692)
- Register cluster page component properly to a route (#1688)
- Extension store guide (#1663)