### PR TITLE
Export the pod-details-list component so that it can be used in Extensions

### DIFF
--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -27,6 +27,7 @@ export * from "../../renderer/components/menu";
 export * from "../../renderer/components/notifications";
 export * from "../../renderer/components/spinner";
 export * from "../../renderer/components/stepper";
+export * from "../../renderer/components/+workloads-pods/pod-details-list";
 
 // kube helpers
 export * from "../../renderer/components/kube-object";


### PR DESCRIPTION
See an example of the pod-details-list usage in an Extension here:

![Bildschirmfoto 2020-12-11 um 08 17 03](https://user-images.githubusercontent.com/26629812/101874657-96b5fe80-3b89-11eb-9978-50af7a606d94.png)


Signed-off-by: Mario Sarcher <msarcher@mirantis.com>