### PR TITLE
Display error dialog if extensions couldn't be loaded

### DIFF
--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -266,18 +266,30 @@ export class ExtensionDiscovery {
 
     logger.info(`${logModule} loading extensions from ${extensionInstaller.extensionPackagesRoot}`);
 
-    if (fs.existsSync(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"))) {
+    if (await fs.pathExists(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"))) {
       await fs.remove(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"));
     }
 
     try {
+      // Verify write access to static/extensions, which is needed for symlinking
       await fs.access(this.inTreeFolderPath, fs.constants.W_OK);
+
+      // Set bundled folder path to static/extensions
       this.bundledFolderPath = this.inTreeFolderPath;
     } catch {
-      // we need to copy in-tree extensions so that we can symlink them properly on "npm install"
+      // If there is error accessing static/extensions, we need to copy in-tree extensions so that we can symlink them properly on "npm install".
+      // The error can happen if there is read-only rights to static/extensions, which would fail symlinking.
+
+      // Remove e.g. /Users/<username>/Library/Application Support/LensDev/extensions
       await fs.remove(this.inTreeTargetPath);
+
+      // Create folder e.g. /Users/<username>/Library/Application Support/LensDev/extensions
       await fs.ensureDir(this.inTreeTargetPath);
+
+      // Copy static/extensions to e.g. /Users/<username>/Library/Application Support/LensDev/extensions
       await fs.copy(this.inTreeFolderPath, this.inTreeTargetPath);
+
+      // Set bundled folder path to e.g. /Users/<username>/Library/Application Support/LensDev/extensions
       this.bundledFolderPath = this.inTreeTargetPath;
     }
 

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -266,9 +266,9 @@ export class ExtensionDiscovery {
 
     logger.info(`${logModule} loading extensions from ${extensionInstaller.extensionPackagesRoot}`);
 
-    if (await fs.pathExists(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"))) {
-      await fs.remove(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"));
-    }
+    // fs.remove won't throw if path is missing
+    await fs.remove(path.join(extensionInstaller.extensionPackagesRoot, "package-lock.json"));
+
 
     try {
       // Verify write access to static/extensions, which is needed for symlinking

--- a/src/extensions/extension-installer.ts
+++ b/src/extensions/extension-installer.ts
@@ -33,14 +33,24 @@ export class ExtensionInstaller {
   installDependencies(): Promise<void> {
     return new Promise((resolve, reject) => {
       logger.info(`${logModule} installing dependencies at ${extensionPackagesRoot()}`);
-      const child = child_process.fork(this.npmPath, ["install", "--silent", "--no-audit", "--only=prod", "--prefer-offline", "--no-package-lock"], {
+      const child = child_process.fork(this.npmPath, ["install", "--no-audit", "--only=prod", "--prefer-offline", "--no-package-lock"], {
         cwd: extensionPackagesRoot(),
         silent: true
       });
+      let stderr = "";
 
-      child.on("close", () => {
-        resolve();
+      child.stderr.on("data", data => {
+        stderr += String(data);
       });
+
+      child.on("close", (code) => {
+        if (code !== 0) {
+          reject(new Error(stderr));
+        } else {
+          resolve();
+        }
+      });
+
       child.on("error", error => {
         reject(error);
       });

--- a/src/extensions/extension-installer.ts
+++ b/src/extensions/extension-installer.ts
@@ -41,8 +41,8 @@ export class ExtensionInstaller {
       child.on("close", () => {
         resolve();
       });
-      child.on("error", (err) => {
-        reject(err);
+      child.on("error", error => {
+        reject(error);
       });
     });
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,7 +106,7 @@ app.on("ready", async () => {
     });
 
     extensionLoader.initExtensions(extensions);
-  } catch (error ){
+  } catch (error) {
     dialog.showErrorBox("Lens Error", `Could not load extensions: ${error?.message || ""}`);
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -94,17 +94,21 @@ app.on("ready", async () => {
   windowManager = WindowManager.getInstance<WindowManager>(proxyPort);
 
   // call after windowManager to see splash earlier
-  const extensions = await extensionDiscovery.load();
+  try {
+    const extensions = await extensionDiscovery.load();
 
-  // Subscribe to extensions that are copied or deleted to/from the extensions folder
-  extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
-    extensionLoader.addExtension(extension);
-  });
-  extensionDiscovery.events.on("remove", (lensExtensionId: LensExtensionId) => {
-    extensionLoader.removeExtension(lensExtensionId);
-  });
+    // Subscribe to extensions that are copied or deleted to/from the extensions folder
+    extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
+      extensionLoader.addExtension(extension);
+    });
+    extensionDiscovery.events.on("remove", (lensExtensionId: LensExtensionId) => {
+      extensionLoader.removeExtension(lensExtensionId);
+    });
 
-  extensionLoader.initExtensions(extensions);
+    extensionLoader.initExtensions(extensions);
+  } catch (error ){
+    dialog.showErrorBox("Lens Error", `Could not load extensions: ${error?.message || ""}`);
+  }
 
   setTimeout(() => {
     appEventBus.emit({ name: "service", action: "start" });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,8 +83,8 @@ app.on("ready", async () => {
     // eslint-disable-next-line unused-imports/no-unused-vars-ts
     proxyServer = LensProxy.create(proxyPort, clusterManager);
   } catch (error) {
-    logger.error(`Could not start proxy (127.0.0:${proxyPort}): ${error.message}`);
-    dialog.showErrorBox("Lens Error", `Could not start proxy (127.0.0:${proxyPort}): ${error.message || "unknown error"}`);
+    logger.error(`Could not start proxy (127.0.0:${proxyPort}): ${error?.message}`);
+    dialog.showErrorBox("Lens Error", `Could not start proxy (127.0.0:${proxyPort}): ${error?.message || "unknown error"}`);
     app.exit();
   }
 
@@ -107,7 +107,7 @@ app.on("ready", async () => {
 
     extensionLoader.initExtensions(extensions);
   } catch (error) {
-    dialog.showErrorBox("Lens Error", `Could not load extensions: ${error?.message || ""}`);
+    dialog.showErrorBox("Lens Error", `Could not load extensions${error?.message ? `: ${error.message}` : ""}`);
   }
 
   setTimeout(() => {


### PR DESCRIPTION
* Previously errors in npm install were ignored. This change adds error dialog on startup. The startup of the application will continue in any case. This change will hopefully indicate to users of #1690 failure state.
* Also capture npm install failure if the process exit code is not 0.
* Remove "--silent" parameter so we can read the error message.
* Change sync exists check to async