### PR TITLE
Catch HTTP Errors in case pod metrics resources not exist / access forbidden

### DIFF
--- a/src/renderer/components/+workloads-pods/pods.store.ts
+++ b/src/renderer/components/+workloads-pods/pods.store.ts
@@ -23,9 +23,12 @@ export class PodsStore extends KubeObjectStore<Pod> {
   }
 
   async loadKubeMetrics(namespace?: string) {
-    const metrics = await podMetricsApi.list({ namespace });
-
-    this.kubeMetrics.replace(metrics);
+    try {
+      const metrics = await podMetricsApi.list({ namespace });
+      this.kubeMetrics.replace(metrics);
+    } catch (error) {
+      console.error("loadKubeMetrics failed", error);
+    }
   }
 
   getPodsByOwner(workload: WorkloadKubeObject): Pod[] {


### PR DESCRIPTION
If pod metrics cannot be loaded (not found or access forbidden) this results in a JS error. Its valid in this cases that API returns that error as metrics could just be not there or user does not have access.

Looks like its even causing display errors in the icon bar of the deployment. (Not tested with compiled binary)

![Bildschirmfoto 2020-12-11 um 14 25 34](https://user-images.githubusercontent.com/26629812/101908731-cdf1d300-3bbc-11eb-9200-beef93ef256e.png)


Signed-off-by: Mario Sarcher <msarcher@mirantis.com>