### PR TITLE
Clear Add Namespace and Add secret form data on close

### DIFF
--- a/src/renderer/components/+config-secrets/add-secret-dialog.tsx
+++ b/src/renderer/components/+config-secrets/add-secret-dialog.tsx
@@ -108,7 +108,6 @@ export class AddSecretDialog extends React.Component<Props> {
       const newSecret = await secretsApi.create({ namespace, name }, secret);
 
       showDetails(newSecret.selfLink);
-      this.reset();
       this.close();
     } catch (err) {
       Notifications.error(err);
@@ -188,6 +187,7 @@ export class AddSecretDialog extends React.Component<Props> {
         {...dialogProps}
         className="AddSecretDialog"
         isOpen={AddSecretDialog.isOpen}
+        onOpen={this.reset}
         close={this.close}
       >
         <Wizard header={header} done={this.close}>

--- a/src/renderer/components/+namespaces/add-namespace-dialog.tsx
+++ b/src/renderer/components/+namespaces/add-namespace-dialog.tsx
@@ -31,6 +31,10 @@ export class AddNamespaceDialog extends React.Component<Props> {
     AddNamespaceDialog.isOpen = false;
   }
 
+  reset = () => {
+    this.namespace = "";
+  };
+
   close = () => {
     AddNamespaceDialog.close();
   };
@@ -58,6 +62,7 @@ export class AddNamespaceDialog extends React.Component<Props> {
         {...dialogProps}
         className="AddNamespaceDialog"
         isOpen={AddNamespaceDialog.isOpen}
+        onOpen={this.reset}
         close={this.close}
       >
         <Wizard header={header} done={this.close}>


### PR DESCRIPTION
The commit fixes clearing data on closing next forms:
Configuration - Secrets - Add secret
Namespaces - Add Namespace

<del> [Fixed]There is some UI issue: validation of inputs is triggered earlier than form is closed despite that I clear data after isOpen property switching, how can I fix it? </del> 
[Solution] Reset data before form appearing