### PR TITLE
fix "not valid as a React child" error while display crds

### DIFF
--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -93,7 +93,7 @@ export class CrdResources extends React.Component<Props> {
           isNamespaced && crdInstance.getNs(),
           ...extraColumns.map(column => ({
             renderBoolean: true,
-            children: jsonPath.value(crdInstance, column.jsonPath.slice(1)),
+            children: JSON.stringify(jsonPath.value(crdInstance, column.jsonPath.slice(1))),
           })),
           crdInstance.getAge(),
         ]}


### PR DESCRIPTION
Convert crd column to string to avoid "not valid as a React child" error while display crds with column which type is object, for example:

```
status:
  leaders:
    center-xx: {}
```

![image](https://user-images.githubusercontent.com/7871070/102078627-31dafc80-3e46-11eb-88ee-59feae3c5b36.png)
