### PR TITLE
Fix getExtensionFileFolder() to use extension name

### DIFF
--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -46,7 +46,7 @@ export class LensExtension {
    * folder name.
    */
   async getExtensionFileFolder(): Promise<string> {
-    return filesystemProvisionerStore.requestDirectory(this.id);
+    return filesystemProvisionerStore.requestDirectory(this.name);
   }
 
   get description() {


### PR DESCRIPTION
An extension's ID is not a stable field between installs. I think that this should fix that.