### PR TITLE
Install in-tree extensions before others

### DIFF
--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -299,7 +299,7 @@ export class ExtensionDiscovery {
     const extensions = await this.loadExtensions();
 
     this.isLoaded = true;
-    
+
     return extensions;
   }
 
@@ -355,6 +355,8 @@ export class ExtensionDiscovery {
 
   async loadExtensions(): Promise<Map<LensExtensionId, InstalledExtension>> {
     const bundledExtensions = await this.loadBundledExtensions();
+
+    await this.installPackages(); // install in-tree as a separate step
     const localExtensions = await this.loadFromFolder(this.localFolderPath);
 
     await this.installPackages();


### PR DESCRIPTION
While debugging #1690 I saw that it's possible for a broken 3rd party extension to block installation of in-tree extensions. This PR aims to fix that by installing in-tree extensions in a separate step before 3rd party extensions.