### PR TITLE
Export wizard components

### DIFF
--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -27,6 +27,7 @@ export * from "../../renderer/components/menu";
 export * from "../../renderer/components/notifications";
 export * from "../../renderer/components/spinner";
 export * from "../../renderer/components/stepper";
+export * from "../../renderer/components/wizard";
 export * from "../../renderer/components/+workloads-pods/pod-details-list";
 
 // kube helpers


### PR DESCRIPTION
Wizard components are not accessible from @k8slens/extensions/Component alias, just added these ones to components.ts