### PR TITLE
fix extension-filesystem being called in LensRendererExtension

### DIFF
--- a/src/main/extension-filesystem.ts
+++ b/src/main/extension-filesystem.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import { SHA256 } from "crypto-js";
-import { app } from "electron";
+import { app, remote } from "electron";
 import fse from "fs-extra";
 import { action, observable, toJS } from "mobx";
 import path from "path";
@@ -31,7 +31,7 @@ export class FilesystemProvisionerStore extends BaseStore<FSProvisionModel> {
     if (!this.registeredExtensions.has(extensionName)) {
       const salt = randomBytes(32).toString("hex");
       const hashedName = SHA256(`${extensionName}/${salt}`).toString();
-      const dirPath = path.resolve(app.getPath("userData"), "extension_data", hashedName);
+      const dirPath = path.resolve((app || remote.app).getPath("userData"), "extension_data", hashedName);
 
       this.registeredExtensions.set(extensionName, dirPath);
     }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Without this the application throws an error if this function is called in the renderer thread.