### PR TITLE
Fix openshift distribution detector

### DIFF
--- a/src/main/cluster-detectors/distribution-detector.ts
+++ b/src/main/cluster-detectors/distribution-detector.ts
@@ -56,12 +56,12 @@ export class DistributionDetector extends BaseClusterDetector {
       return { value: "docker-desktop", accuracy: 80};
     }
 
-    if (this.isCustom()) {
-      return { value: "custom", accuracy: 10};
+    if (this.isCustom() && await this.isOpenshift()) {
+      return { value: "openshift", accuracy: 90};
     }
 
-    if (await this.isOpenshift()) {
-      return { value: "openshift", accuracy: 90};
+    if (this.isCustom()) {
+      return { value: "custom", accuracy: 10};
     }
 
     return { value: "unknown", accuracy: 10};


### PR DESCRIPTION
I think this got broken in some merge conflict resolving.. Openshift detect needs to happen before "custom" (because Openshift itself would be reported as custom).