### PR TITLE
Parse jsonPath expressions

### DIFF
--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -46,7 +46,7 @@ export class CrdResourceDetails extends React.Component<Props> {
   renderAdditionalColumns(crd: CustomResourceDefinition, columns: AdditionalPrinterColumnsV1[]) {
     return columns.map(({ name, jsonPath: jp }) => (
       <DrawerItem key={name} name={name} renderBoolean>
-        {convertSpecValue(jsonPath.value(crd, jp.slice(1)))}
+        {convertSpecValue(jsonPath.value(crd, `$..["${jp.slice(1).replace(/\\/g, "")}"]`))}
       </DrawerItem>
     ));
   }

--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -13,6 +13,7 @@ import { crdStore } from "./crd.store";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { Input } from "../input";
 import { AdditionalPrinterColumnsV1, CustomResourceDefinition } from "../../api/endpoints/crd.api";
+import { parseJsonPath } from "../../utils/jsonPath";
 
 interface Props extends KubeObjectDetailsProps<CustomResourceDefinition> {
 }
@@ -46,7 +47,7 @@ export class CrdResourceDetails extends React.Component<Props> {
   renderAdditionalColumns(crd: CustomResourceDefinition, columns: AdditionalPrinterColumnsV1[]) {
     return columns.map(({ name, jsonPath: jp }) => (
       <DrawerItem key={name} name={name} renderBoolean>
-        {convertSpecValue(jsonPath.value(crd, `$..["${jp.slice(1).replace(/\\/g, "")}"]`))}
+        {convertSpecValue(jsonPath.value(crd, parseJsonPath(jp.slice(1))))}
       </DrawerItem>
     ));
   }

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -61,7 +61,7 @@ export class CrdResources extends React.Component<Props> {
     };
 
     extraColumns.forEach(column => {
-      sortingCallbacks[column.name] = (item: KubeObject) => jsonPath.value(item, column.jsonPath.slice(1));
+      sortingCallbacks[column.name] = (item: KubeObject) => jsonPath.value(item, `$..["${column.jsonPath.slice(1).replace(/\\/g, "")}"]`);
     });
 
     return (
@@ -93,7 +93,7 @@ export class CrdResources extends React.Component<Props> {
           isNamespaced && crdInstance.getNs(),
           ...extraColumns.map(column => ({
             renderBoolean: true,
-            children: jsonPath.value(crdInstance, column.jsonPath.slice(1)),
+            children: jsonPath.value(crdInstance, `$..["${column.jsonPath.slice(1).replace(/\\/g, "")}"]`),
           })),
           crdInstance.getAge(),
         ]}

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -97,7 +97,7 @@ export class CrdResources extends React.Component<Props> {
 
             return {
               renderBoolean: true,
-              children: jsonPath.value(crdInstance, pathExpression.replace(/\\/g, "")),
+              children: jsonPath.value(crdInstance, pathExpression),
             };
           }
           ),

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -92,10 +92,18 @@ export class CrdResources extends React.Component<Props> {
         renderTableContents={(crdInstance: KubeObject) => [
           crdInstance.getName(),
           isNamespaced && crdInstance.getNs(),
-          ...extraColumns.map(column => ({
-            renderBoolean: true,
-            children: JSON.stringify(jsonPath.value(crdInstance, parseJsonPath(column.jsonPath.slice(1)))),
-          })),
+          ...extraColumns.map((column) => {
+            let value = jsonPath.value(crdInstance, parseJsonPath(column.jsonPath.slice(1)));
+
+            if (Array.isArray(value) || typeof value === "object") {
+              value = JSON.stringify(value);
+            }
+
+            return {
+              renderBoolean: true,
+              children: value,
+            };
+          }),
           crdInstance.getAge(),
         ]}
       />

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -95,8 +95,6 @@ export class CrdResources extends React.Component<Props> {
           ...extraColumns.map((column) => {
             const pathExpression = parseJsonPath(column.jsonPath.slice(1));
 
-            console.log(pathExpression);
-
             return {
               renderBoolean: true,
               children: jsonPath.value(crdInstance, pathExpression.replace(/\\/g, "")),

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -93,11 +93,9 @@ export class CrdResources extends React.Component<Props> {
           crdInstance.getName(),
           isNamespaced && crdInstance.getNs(),
           ...extraColumns.map((column) => {
-            const pathExpression = parseJsonPath(column.jsonPath.slice(1));
-
             return {
               renderBoolean: true,
-              children: jsonPath.value(crdInstance, pathExpression),
+              children: jsonPath.value(crdInstance, parseJsonPath(column.jsonPath.slice(1))),
             };
           }
           ),

--- a/src/renderer/utils/__tests__/jsonPath.test.tsx
+++ b/src/renderer/utils/__tests__/jsonPath.test.tsx
@@ -1,7 +1,7 @@
 import { parseJsonPath } from "../jsonPath";
 
 describe("parseJsonPath", () => {
-  test("should convert \. to use indexed notation", () => {
+  test("should convert \\. to use indexed notation", () => {
     const res = parseJsonPath(".metadata.labels.kubesphere\\.io/alias-name");
 
     expect(res).toBe(".metadata.labels['kubesphere.io/alias-name']");
@@ -13,20 +13,20 @@ describe("parseJsonPath", () => {
     expect(res).toBe(".metadata.labels['alias-name']");
   });
 
-  test("should handle scenario when both \ and indexed notation is present", () => {
+  test("should handle scenario when both \\. and indexed notation are present", () => {
     const rest = parseJsonPath(".metadata.labels\\.serving['some.other.item']");
 
     expect(rest).toBe(".metadata['labels.serving']['some.other.item']");
   });
 
 
-  test("should not touch given jsonPath if no invalid characters", () => {
+  test("should not touch given jsonPath if no invalid characters present", () => {
     const res = parseJsonPath(".status.conditions[?(@.type=='Ready')].status");
 
     expect(res).toBe(".status.conditions[?(@.type=='Ready')].status");
   });
 
-  test("strips '\' away from the result", () => {
+  test("strips '\\' away from the result", () => {
     const res = parseJsonPath(".metadata.labels['serving\\.knative\\.dev/configuration']");
 
     expect(res).toBe(".metadata.labels['serving.knative.dev/configuration']");

--- a/src/renderer/utils/__tests__/jsonPath.test.tsx
+++ b/src/renderer/utils/__tests__/jsonPath.test.tsx
@@ -1,0 +1,22 @@
+import { parseJsonPath } from "../jsonPath";
+
+describe("parseJsonPath", () => {
+  test("should convert \. to use indexed notation", () => {
+    const res = parseJsonPath(".metadata.labels.kubesphere\\.io/alias-name");
+
+    expect(res).toBe(".metadata['labels']['kubesphere.io/alias-name']");
+
+  });
+
+  test("strips '\' away from the result", () => {
+    const res = parseJsonPath(".metadata.labels['serving\\.knative\\.dev/configuration']");
+
+    expect(res).toBe(".metadata.labels['serving.knative.dev/configuration']");
+  });
+
+  test("should not touch given jsonPath if no invalid characters", () => {
+    const res = parseJsonPath(".status.conditions[?(@.type=='Ready')].status");
+
+    expect(res).toBe(".status.conditions[?(@.type=='Ready')].status");
+  });
+});

--- a/src/renderer/utils/__tests__/jsonPath.test.tsx
+++ b/src/renderer/utils/__tests__/jsonPath.test.tsx
@@ -7,6 +7,12 @@ describe("parseJsonPath", () => {
     expect(res).toBe(".metadata.labels['kubesphere.io/alias-name']");
   });
 
+  test("should convert keys with escpaped charatecrs to use indexed notation", () => {
+    const res = parseJsonPath(".metadata.labels.kubesphere\\\"io/alias-name");
+
+    expect(res).toBe(".metadata.labels['kubesphere\"io/alias-name']");
+  });
+
   test("should convert '-' to use indexed notation", () => {
     const res = parseJsonPath(".metadata.labels.alias-name");
 

--- a/src/renderer/utils/__tests__/jsonPath.test.tsx
+++ b/src/renderer/utils/__tests__/jsonPath.test.tsx
@@ -4,8 +4,26 @@ describe("parseJsonPath", () => {
   test("should convert \. to use indexed notation", () => {
     const res = parseJsonPath(".metadata.labels.kubesphere\\.io/alias-name");
 
-    expect(res).toBe(".metadata['labels']['kubesphere.io/alias-name']");
+    expect(res).toBe(".metadata.labels['kubesphere.io/alias-name']");
+  });
 
+  test("should convert '-' to use indexed notation", () => {
+    const res = parseJsonPath(".metadata.labels.alias-name");
+
+    expect(res).toBe(".metadata.labels['alias-name']");
+  });
+
+  test("should handle scenario when both \ and indexed notation is present", () => {
+    const rest = parseJsonPath(".metadata.labels\\.serving['some.other.item']");
+
+    expect(rest).toBe(".metadata['labels.serving']['some.other.item']");
+  });
+
+
+  test("should not touch given jsonPath if no invalid characters", () => {
+    const res = parseJsonPath(".status.conditions[?(@.type=='Ready')].status");
+
+    expect(res).toBe(".status.conditions[?(@.type=='Ready')].status");
   });
 
   test("strips '\' away from the result", () => {
@@ -14,9 +32,4 @@ describe("parseJsonPath", () => {
     expect(res).toBe(".metadata.labels['serving.knative.dev/configuration']");
   });
 
-  test("should not touch given jsonPath if no invalid characters", () => {
-    const res = parseJsonPath(".status.conditions[?(@.type=='Ready')].status");
-
-    expect(res).toBe(".status.conditions[?(@.type=='Ready')].status");
-  });
 });

--- a/src/renderer/utils/jsonPath.ts
+++ b/src/renderer/utils/jsonPath.ts
@@ -2,20 +2,35 @@
 export function parseJsonPath(jsonPath: string) {
   let pathExpression = jsonPath;
 
-  if (!jsonPath.includes("[") && jsonPath.includes("\\")) {
-    // convert cases where \. is present to use indexed notation,
-    // for example: .metadata.labels.kubesphere\.io/alias-name -> .metadata['labels']['kubesphere\.io/alias-name']
-    const columnArr = jsonPath.split(/(?<=\w)\./);
+  if (jsonPath.match(/[\\-]/g)) { // search for '\' and '-'
+    // convert cases where \. or - is present to use indexed notation,
+    // for example: .metadata.labels.kubesphere\.io/alias-name -> .metadata.labels.['kubesphere\.io/alias-name']
 
-    columnArr.forEach((value, index) => {
-      if (index == 0) {
-        pathExpression = `${value}`;
-      } else {
-        pathExpression += `['${value}']`;
-      }
-    });
+    const [first, ...rest] = jsonPath.split(/(?<=\w)\./); // split jsonPath by '.' (\. cases are ignored)
+
+    pathExpression = `${convertToIndexNotation(first, true)}${rest.map(value => convertToIndexNotation(value)).join("")}`;
   }
 
   // strip '\' characters from the result
   return pathExpression.replace(/\\/g, "");
+}
+
+function convertToIndexNotation(key: string, firstItem = false) {
+  if (key.match(/[\\-]/g)) { // check if found '\' and '-' in key
+    if (key.includes("[")) { // handle cases where key contains [...]
+      const keyToConvert = key.match(/^.*(?=\[)/g); // get the text from the key before '['
+
+      if (keyToConvert && keyToConvert[0].match(/[\\-]/g)) { // check if that part contains illegal characters
+        return key.replace(keyToConvert[0], `['${keyToConvert[0]}']`); // surround key with '[' and ']'
+      } else {
+        return `.${key}`; // otherwise return as is with leading '.'
+      }
+    }
+
+    return `['${key}']`;
+  } else { // no illegal chracters found, do not touch
+    const prefix = firstItem ? "" : ".";
+
+    return `${prefix}${key}`;
+  }
 }

--- a/src/renderer/utils/jsonPath.ts
+++ b/src/renderer/utils/jsonPath.ts
@@ -1,11 +1,10 @@
+// Helper to convert strings used for jsonPath where \. or - is present to use indexed notation,
+// for example: .metadata.labels.kubesphere\.io/alias-name -> .metadata.labels['kubesphere\.io/alias-name']
 
 export function parseJsonPath(jsonPath: string) {
   let pathExpression = jsonPath;
 
   if (jsonPath.match(/[\\-]/g)) { // search for '\' and '-'
-    // convert cases where \. or - is present to use indexed notation,
-    // for example: .metadata.labels.kubesphere\.io/alias-name -> .metadata.labels.['kubesphere\.io/alias-name']
-
     const [first, ...rest] = jsonPath.split(/(?<=\w)\./); // split jsonPath by '.' (\. cases are ignored)
 
     pathExpression = `${convertToIndexNotation(first, true)}${rest.map(value => convertToIndexNotation(value)).join("")}`;

--- a/src/renderer/utils/jsonPath.ts
+++ b/src/renderer/utils/jsonPath.ts
@@ -1,0 +1,21 @@
+
+export function parseJsonPath(jsonPath: string) {
+  let pathExpression = jsonPath;
+
+  if (!jsonPath.includes("[") && jsonPath.includes("\\")) {
+    // convert cases where \. is present to use indexed notation,
+    // for example: .metadata.labels.kubesphere\.io/alias-name -> .metadata['labels']['kubesphere\.io/alias-name']
+    const columnArr = jsonPath.split(/(?<=\w)\./);
+
+    columnArr.forEach((value, index) => {
+      if (index == 0) {
+        pathExpression = `${value}`;
+      } else {
+        pathExpression += `['${value}']`;
+      }
+    });
+  }
+
+  // strip '\' characters from the result
+  return pathExpression.replace(/\\/g, "");
+}


### PR DESCRIPTION
`jsonPath.value()` method does not work well with invalid-indentifier names, so changed these to use indexed notation as suggested [here](https://github.com/dchester/jsonpath/issues/102#issuecomment-422987669). Also required to get rid of `\` characters.

Fixes #503, fixes #1773

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>