### PR TITLE
Fix Azure distribution detection

### DIFF
--- a/src/main/cluster-detectors/distribution-detector.ts
+++ b/src/main/cluster-detectors/distribution-detector.ts
@@ -88,7 +88,7 @@ export class DistributionDetector extends BaseClusterDetector {
   }
 
   protected isAKS() {
-    return this.cluster.apiUrl.endsWith("azmk8s.io");
+    return this.cluster.apiUrl.includes("azmk8s.io");
   }
 
   protected isMirantis() {


### PR DESCRIPTION
There is also port present in kubernetes api url causing azure detection to fail. This pr just checks if `azmk8s.io` is found in api url.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>