### PR TITLE
Bundle kubectl v1.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typedocs-extensions-api": "yarn run typedoc --ignoreCompilerErrors --readme docs/extensions/typedoc-readme.md.tpl --name @k8slens/extensions --out docs/extensions/api --mode library --excludePrivate --hideBreadcrumbs --includes src/ src/extensions/extension-api.ts"
   },
   "config": {
-    "bundledKubectlVersion": "1.17.11",
+    "bundledKubectlVersion": "1.17.15",
     "bundledHelmVersion": "3.3.4"
   },
   "engines": {


### PR DESCRIPTION
Bumps bundled kubectl from 1.17.11 to 1.17.15.