### PR TITLE
Release v4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typedocs-extensions-api": "yarn run typedoc --ignoreCompilerErrors --readme docs/extensions/typedoc-readme.md.tpl --name @k8slens/extensions --out docs/extensions/api --mode library --excludePrivate --hideBreadcrumbs --includes src/ src/extensions/extension-api.ts"
   },
   "config": {
-    "bundledKubectlVersion": "1.17.11",
+    "bundledKubectlVersion": "1.17.15",
     "bundledHelmVersion": "3.3.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/src/main/cluster-detectors/distribution-detector.ts
+++ b/src/main/cluster-detectors/distribution-detector.ts
@@ -56,12 +56,12 @@ export class DistributionDetector extends BaseClusterDetector {
       return { value: "docker-desktop", accuracy: 80};
     }
 
-    if (this.isCustom()) {
-      return { value: "custom", accuracy: 10};
+    if (this.isCustom() && await this.isOpenshift()) {
+      return { value: "openshift", accuracy: 90};
     }
 
-    if (await this.isOpenshift()) {
-      return { value: "openshift", accuracy: 90};
+    if (this.isCustom()) {
+      return { value: "custom", accuracy: 10};
     }
 
     return { value: "unknown", accuracy: 10};

--- a/src/main/cluster-detectors/distribution-detector.ts
+++ b/src/main/cluster-detectors/distribution-detector.ts
@@ -88,7 +88,7 @@ export class DistributionDetector extends BaseClusterDetector {
   }
 
   protected isAKS() {
-    return this.cluster.apiUrl.endsWith("azmk8s.io");
+    return this.cluster.apiUrl.includes("azmk8s.io");
   }
 
   protected isMirantis() {

--- a/src/main/extension-filesystem.ts
+++ b/src/main/extension-filesystem.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import { SHA256 } from "crypto-js";
-import { app } from "electron";
+import { app, remote } from "electron";
 import fse from "fs-extra";
 import { action, observable, toJS } from "mobx";
 import path from "path";
@@ -31,7 +31,7 @@ export class FilesystemProvisionerStore extends BaseStore<FSProvisionModel> {
     if (!this.registeredExtensions.has(extensionName)) {
       const salt = randomBytes(32).toString("hex");
       const hashedName = SHA256(`${extensionName}/${salt}`).toString();
-      const dirPath = path.resolve(app.getPath("userData"), "extension_data", hashedName);
+      const dirPath = path.resolve((app || remote.app).getPath("userData"), "extension_data", hashedName);
 
       this.registeredExtensions.set(extensionName, dirPath);
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import "../common/system-ca";
 import "../common/prometheus-providers";
 import * as Mobx from "mobx";
 import * as LensExtensions from "../extensions/core-api";
-import { app, dialog } from "electron";
+import { app, dialog, powerMonitor } from "electron";
 import { appName } from "../common/vars";
 import path from "path";
 import { LensProxy } from "./lens-proxy";
@@ -58,6 +58,10 @@ app.on("second-instance", () => {
 app.on("ready", async () => {
   logger.info(`🚀 Starting Lens from "${workingDir}"`);
   await shellSync();
+
+  powerMonitor.on("shutdown", () => {
+    app.exit();
+  });
 
   const updater = new AppUpdater();
 

--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -17,6 +17,10 @@ export class ApiManager {
     return Array.from(this.apis.values()).find(pathOrCallback ?? (() => true));
   }
 
+  getApiByKind(kind: string, apiVersion: string) {
+    return Array.from(this.apis.values()).find((api) => api.kind === kind && api.apiVersion === apiVersion);
+  }
+
   registerApi(apiBase: string, api: KubeApi) {
     if (!this.apis.has(apiBase)) {
       this.apis.set(apiBase, api);

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -93,7 +93,7 @@ export class CrdResources extends React.Component<Props> {
           isNamespaced && crdInstance.getNs(),
           ...extraColumns.map(column => ({
             renderBoolean: true,
-            children: jsonPath.value(crdInstance, column.jsonPath.slice(1)),
+            children: JSON.stringify(jsonPath.value(crdInstance, column.jsonPath.slice(1))),
           })),
           crdInstance.getAge(),
         ]}

--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -195,10 +195,9 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
     const items = this.items.toJS();
 
     for (const {type, object} of this.eventsBuffer.clear()) {
-      const { uid, selfLink } = object.metadata;
-      const index = items.findIndex(item => item.getId() === uid);
+      const index = items.findIndex(item => item.getId() === object.metadata?.uid);
       const item = items[index];
-      const api = apiManager.getApi(selfLink);
+      const api = apiManager.getApiByKind(object.kind, object.apiVersion);
 
       switch (type) {
         case "ADDED":

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,9 +2,16 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.3 (current version)
+## 4.0.4 (current version)
 
 We are aware some users are encountering issues and regressions from previous version. Many of these issues are something we have not seen as part of our automated or manual testing process. To make it worse, some of them are really difficult to reproduce. We want to ensure we are putting all our energy and effort trying to resolve these issues. We hope you are patient. Expect to see new patch releases still in the coming days! Fixes in this version:
+
+- Fix errors on Kubernetes v1.20
+- Update bundled kubectl to v1.17.15
+- Fix: MacOS error on shutdown
+- Fix: Kubernetes distribution detection
+- Fix: error while displaying CRDs with column which type is an object
+## 4.0.3
 
 - Fix: install in-tree extensions before others
 - Fix: bundle all dependencies in in-tree extensions


### PR DESCRIPTION
## Changes since v4.0.3

- Generate metadata.selfLink if response does not have it (#1804)
- Bundle kubectl v1.17.15 (#1800)
- Fix MacOS error on shutdown (#1798)
- Fix Azure distribution detection (#1795)
- Fix Openshift distribution detector (#1792)
- Fix "not valid as a React child" error while display crds with column which type is object (#1772)
- Use remote.app if app is not defined (#1785)