### PR TITLE
Render node list before metrics are available

### DIFF
--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -134,7 +134,7 @@ export class Nodes extends React.Component<Props> {
         <KubeObjectListLayout
           className="Nodes"
           store={nodesStore} isClusterScoped
-          isReady={nodesStore.isLoaded && nodesStore.metricsLoaded}
+          isReady={nodesStore.isLoaded}
           dependentStores={[podsStore]}
           isSelectable={false}
           sortingCallbacks={{


### PR DESCRIPTION
Metrics were blocking node list render. There is no reason to block render on metrics, they can be rendered when available.