### PR TITLE
Workloads overview: don't block on store load

### DIFF
--- a/src/renderer/components/+workloads-overview/overview.tsx
+++ b/src/renderer/components/+workloads-overview/overview.tsx
@@ -60,10 +60,12 @@ export class WorkloadsOverview extends React.Component<Props> {
       stores.push(eventStore);
     }
 
+    const unsubscribeList: Array<() => void> = [];
+
     for (const store of stores) {
       await store.loadAll();
+      unsubscribeList.push(store.subscribe());
     }
-    const unsubscribeList = stores.map(store => store.subscribe());
 
     await when(() => this.isUnmounting);
     unsubscribeList.forEach(dispose => dispose());


### PR DESCRIPTION
- renders overview immediately (and updates graphs on-demand), no need to wait for all related stores to be fully loaded
- removes concurrent load of stores, this causes too much load on k8s api on big clusters