### PR TITLE
Add tooltip for the node name in the nodes list

### DIFF
--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -17,6 +17,7 @@ import { Tooltip, TooltipPosition } from "../tooltip";
 import kebabCase from "lodash/kebabCase";
 import upperFirst from "lodash/upperFirst";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
+import { Badge } from "../badge/badge";
 
 enum sortBy {
   name = "name",
@@ -171,7 +172,7 @@ export class Nodes extends React.Component<Props> {
             const tooltipId = `node-taints-${node.getId()}`;
 
             return [
-              node.getName(),
+              <Badge flat key="name" label={node.getName()} tooltip={node.getName()} />,
               <KubeObjectStatusIcon key="icon" object={node} />,
               this.renderCpuUsage(node),
               this.renderMemoryUsage(node),


### PR DESCRIPTION
This PR will add tooltip for the node name in the nodes list. It reveals the node's full name when no enough space on table cell.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>