### PR TITLE
Fixing logs scrolling state

### DIFF
--- a/src/renderer/components/dock/info-panel.tsx
+++ b/src/renderer/components/dock/info-panel.tsx
@@ -27,6 +27,7 @@ interface OptionalProps {
   showSubmitClose?: boolean;
   showInlineInfo?: boolean;
   showNotifications?: boolean;
+  showStatusPanel?: boolean;
 }
 
 @observer
@@ -38,6 +39,7 @@ export class InfoPanel extends Component<Props> {
     showSubmitClose: true,
     showInlineInfo: true,
     showNotifications: true,
+    showStatusPanel: true,
   };
 
   @observable error = "";
@@ -93,7 +95,7 @@ export class InfoPanel extends Component<Props> {
   }
 
   render() {
-    const { className, controls, submitLabel, disableSubmit, error, submittingMessage, showButtons, showSubmitClose } = this.props;
+    const { className, controls, submitLabel, disableSubmit, error, submittingMessage, showButtons, showSubmitClose, showStatusPanel } = this.props;
     const { submit, close, submitAndClose, waiting } = this;
     const isDisabled = !!(disableSubmit || waiting || error);
 
@@ -102,9 +104,11 @@ export class InfoPanel extends Component<Props> {
         <div className="controls">
           {controls}
         </div>
-        <div className="info flex gaps align-center">
-          {waiting ? <><Spinner /> {submittingMessage}</> : this.renderErrorIcon()}
-        </div>
+        {showStatusPanel && (
+          <div className="flex gaps align-center">
+            {waiting ? <><Spinner /> {submittingMessage}</> : this.renderErrorIcon()}
+          </div>
+        )}
         {showButtons && (
           <>
             <Button plain label={<Trans>Cancel</Trans>} onClick={close} />

--- a/src/renderer/components/dock/pod-log-controls.tsx
+++ b/src/renderer/components/dock/pod-log-controls.tsx
@@ -22,10 +22,9 @@ interface Props extends PodLogSearchProps {
 }
 
 export const PodLogControls = observer((props: Props) => {
-  const { tabData, save, reload, tabId, logs } = props;
+  const { tabData, save, reload, logs } = props;
   const { selectedContainer, showTimestamps, previous } = tabData;
-  const rawLogs = podLogsStore.logs.get(tabId) || [];
-  const since = rawLogs.length ? podLogsStore.getTimestamps(rawLogs[0]) : null;
+  const since = logs.length ? podLogsStore.getTimestamps(logs[0]) : null;
   const pod = new Pod(tabData.pod);
 
   const toggleTimestamps = () => {
@@ -39,8 +38,9 @@ export const PodLogControls = observer((props: Props) => {
 
   const downloadLogs = () => {
     const fileName = selectedContainer ? selectedContainer.name : pod.getName();
+    const logsToDownload = showTimestamps ? logs : podLogsStore.logsWithoutTimestamps;
 
-    saveFileDialog(`${fileName}.log`, logs.join("\n"), "text/plain");
+    saveFileDialog(`${fileName}.log`, logsToDownload.join("\n"), "text/plain");
   };
 
   const onContainerChange = (option: SelectOption) => {
@@ -118,7 +118,10 @@ export const PodLogControls = observer((props: Props) => {
           tooltip={_i18n._(t`Save`)}
           className="download-icon"
         />
-        <PodLogSearch {...props} />
+        <PodLogSearch
+          {...props}
+          logs={showTimestamps ? logs : podLogsStore.logsWithoutTimestamps}
+        />
       </div>
     </div>
   );

--- a/src/renderer/components/dock/pod-log-list.tsx
+++ b/src/renderer/components/dock/pod-log-list.tsx
@@ -47,11 +47,13 @@ export class PodLogList extends React.Component<Props> {
 
       return;
     }
+
     if (logs == prevProps.logs || !this.virtualListDiv.current) return;
+
     const newLogsLoaded = prevProps.logs.length < logs.length;
     const scrolledToBeginning = this.virtualListDiv.current.scrollTop === 0;
 
-    if (this.isLastLineVisible) {
+    if (this.isLastLineVisible || prevProps.logs.length == 0) {
       this.scrollToBottom(); // Scroll down to keep user watching/reading experience
 
       return;
@@ -129,7 +131,6 @@ export class PodLogList extends React.Component<Props> {
   @action
   scrollToBottom = () => {
     if (!this.virtualListDiv.current) return;
-    this.isJumpButtonVisible = false;
     this.virtualListDiv.current.scrollTop = this.virtualListDiv.current.scrollHeight;
   };
 
@@ -137,7 +138,13 @@ export class PodLogList extends React.Component<Props> {
     this.virtualListRef.current.scrollToItem(index, align);
   };
 
-  onScroll = debounce((props: ListOnScrollProps) => {
+  onScroll = (props: ListOnScrollProps) => {
+    if (!this.virtualListDiv.current) return;
+    this.isLastLineVisible = false;
+    this.onScrollDebounced(props);
+  };
+
+  onScrollDebounced = debounce((props: ListOnScrollProps) => {
     if (!this.virtualListDiv.current) return;
     this.setButtonVisibility(props);
     this.setLastLineVisibility(props);

--- a/src/renderer/components/dock/pod-log-search.tsx
+++ b/src/renderer/components/dock/pod-log-search.tsx
@@ -12,10 +12,13 @@ export interface PodLogSearchProps {
   onSearch: (query: string) => void
   toPrevOverlay: () => void
   toNextOverlay: () => void
+}
+
+interface Props extends PodLogSearchProps {
   logs: string[]
 }
 
-export const PodLogSearch = observer((props: PodLogSearchProps) => {
+export const PodLogSearch = observer((props: Props) => {
   const { logs, onSearch, toPrevOverlay, toNextOverlay } = props;
   const { setNextOverlayActive, setPrevOverlayActive, searchQuery, occurrences, activeFind, totalFinds } = searchStore;
   const jumpDisabled = !searchQuery || !occurrences.length;

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -103,6 +103,7 @@ export class PodLogs extends React.Component<Props> {
           controls={controls}
           showSubmitClose={false}
           showButtons={false}
+          showStatusPanel={false}
         />
         <PodLogList
           logs={logs}

--- a/src/renderer/components/dock/pod-logs.tsx
+++ b/src/renderer/components/dock/pod-logs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { computed, observable, reaction } from "mobx";
+import { observable, reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 
 import { searchStore } from "../../../common/search-store";
@@ -79,31 +79,15 @@ export class PodLogs extends React.Component<Props> {
     }, 100);
   }
 
-  /**
-   * Computed prop which returns logs with or without timestamps added to each line
-   * @returns {Array} An array log items
-   */
-  @computed
-  get logs(): string[] {
-    if (!podLogsStore.logs.has(this.tabId)) return [];
-    const logs = podLogsStore.logs.get(this.tabId);
-    const { getData, removeTimestamps } = podLogsStore;
-    const { showTimestamps } = getData(this.tabId);
-
-    if (!showTimestamps) {
-      return logs.map(item => removeTimestamps(item));
-    }
-
-    return logs;
-  }
-
   render() {
+    const logs = podLogsStore.logs;
+
     const controls = (
       <PodLogControls
         ready={!this.isLoading}
         tabId={this.tabId}
         tabData={this.tabData}
-        logs={this.logs}
+        logs={logs}
         save={this.save}
         reload={this.reload}
         onSearch={this.onSearch}
@@ -121,9 +105,9 @@ export class PodLogs extends React.Component<Props> {
           showButtons={false}
         />
         <PodLogList
+          logs={logs}
           id={this.tabId}
           isLoading={this.isLoading}
-          logs={this.logs}
           load={this.load}
           ref={this.logListElement}
         />


### PR DESCRIPTION
* Fixing scrolling to first line when more logs loaded
* Preventing jump to bottom while user scrolls through logs

Broken behavior:

https://user-images.githubusercontent.com/9607060/102972339-ef7f8280-450b-11eb-850f-469e28c3a457.mp4

Fixed behavior (no jumping while scrolling and valid first line)

https://user-images.githubusercontent.com/9607060/102972396-0a51f700-450c-11eb-8ee3-d8300e62887d.mp4


https://user-images.githubusercontent.com/9607060/102972500-31a8c400-450c-11eb-89f3-d294b4078cda.mp4



Fixes #1791 