### PR TITLE
Disable oh-my-zsh auto-update prompt when resolving shell environment

### DIFF
--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -120,6 +120,7 @@ export class ShellSession extends EventEmitter {
     if(path.basename(env["PTYSHELL"]) === "zsh") {
       env["OLD_ZDOTDIR"] = env.ZDOTDIR || env.HOME;
       env["ZDOTDIR"] = this.kubectlBinDir;
+      env["DISABLE_AUTO_UPDATE"] = "true";
     }
 
     env["PTYPID"] = process.pid.toString();


### PR DESCRIPTION
Oh-my-zsh auto-update prompt blocks Lens from starting properly.