### PR TITLE
Check is persistent volume claims resource to allowed for user

### DIFF
--- a/src/common/rbac.ts
+++ b/src/common/rbac.ts
@@ -1,8 +1,8 @@
 import { getHostedCluster } from "./cluster-store";
 
 export type KubeResource =
-  "namespaces" | "nodes" | "events" | "resourcequotas" |
-  "services" | "secrets" | "configmaps" | "ingresses" | "networkpolicies" | "persistentvolumes" | "storageclasses" |
+  "namespaces" | "nodes" | "events" | "resourcequotas" | "services" |
+  "secrets" | "configmaps" | "ingresses" | "networkpolicies" | "persistentvolumeclaims" | "persistentvolumes" | "storageclasses" |
   "pods" | "daemonsets" | "deployments" | "statefulsets" | "replicasets" | "jobs" | "cronjobs" |
   "endpoints" | "customresourcedefinitions" | "horizontalpodautoscalers" | "podsecuritypolicies" | "poddisruptionbudgets";
 
@@ -27,6 +27,7 @@ export const apiResources: KubeApiResource[] = [
   { resource: "networkpolicies", group: "networking.k8s.io" },
   { resource: "nodes" },
   { resource: "persistentvolumes" },
+  { resource: "persistentvolumeclaims" },
   { resource: "pods" },
   { resource: "poddisruptionbudgets" },
   { resource: "podsecuritypolicies" },

--- a/src/renderer/components/+storage/storage.tsx
+++ b/src/renderer/components/+storage/storage.tsx
@@ -16,12 +16,14 @@ export class Storage extends React.Component {
     const tabRoutes: TabLayoutRoute[] = [];
     const query = namespaceUrlParam.toObjectParam();
 
-    tabRoutes.push({
-      title: <Trans>Persistent Volume Claims</Trans>,
-      component: PersistentVolumeClaims,
-      url: volumeClaimsURL({ query }),
-      routePath: volumeClaimsRoute.path.toString(),
-    });
+    if (isAllowedResource("persistentvolumeclaims")) {
+      tabRoutes.push({
+        title: <Trans>Persistent Volume Claims</Trans>,
+        component: PersistentVolumeClaims,
+        url: volumeClaimsURL({ query }),
+        routePath: volumeClaimsRoute.path.toString(),
+      });
+    }
 
     if (isAllowedResource("persistentvolumes")) {
       tabRoutes.push({

--- a/src/renderer/utils/rbac.ts
+++ b/src/renderer/utils/rbac.ts
@@ -11,6 +11,7 @@ export const ResourceNames: Record<KubeResource, string> = {
   "configmaps": _i18n._("Config Maps"),
   "ingresses": _i18n._("Ingresses"),
   "networkpolicies": _i18n._("Network Policies"),
+  "persistentvolumeclaims": _i18n._("Persistent Volume Claims"),
   "persistentvolumes": _i18n._("Persistent Volumes"),
   "storageclasses": _i18n._("Storage Classes"),
   "pods": _i18n._("Pods"),


### PR DESCRIPTION
Previously there was not check if user is allowed to see persistent volume claims when displaying that on side bar. This PR will add `persistentvolumeclaims` resource to resources that can be checked and checks is resource allowed before adding tabRoute on storage section.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>