### PR TITLE
Preserving line breaks when copiyng logs

### DIFF
--- a/src/renderer/components/dock/pod-log-list.tsx
+++ b/src/renderer/components/dock/pod-log-list.tsx
@@ -195,6 +195,7 @@ export class PodLogList extends React.Component<Props> {
         {contents.length > 1 ? contents : (
           <span dangerouslySetInnerHTML={{ __html: ansiToHtml(item) }} />
         )}
+        {/* For preserving copy-paste experience and keeping line breaks */}
         <br />
       </div>
     );

--- a/src/renderer/components/dock/pod-log-list.tsx
+++ b/src/renderer/components/dock/pod-log-list.tsx
@@ -195,6 +195,7 @@ export class PodLogList extends React.Component<Props> {
         {contents.length > 1 ? contents : (
           <span dangerouslySetInnerHTML={{ __html: ansiToHtml(item) }} />
         )}
+        <br />
       </div>
     );
   };


### PR DESCRIPTION
Fixes #1810 
![Dec-23-2020 14-25-50](https://user-images.githubusercontent.com/9607060/102991697-cb7f6980-452a-11eb-8b34-10b9affea54e.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>