### PR TITLE
Add suspend/resume button for CronJobs

### DIFF
--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -18,7 +18,7 @@ export class ApiManager {
   }
 
   getApiByKind(kind: string, apiVersion: string) {
-    return Array.from(this.apis.values()).find((api) => api.kind === kind && api.apiVersion === apiVersion);
+    return Array.from(this.apis.values()).find((api) => api.kind === kind && api.apiVersionWithGroup === apiVersion);
   }
 
   registerApi(apiBase: string, api: KubeApi) {

--- a/src/renderer/api/endpoints/cron-job.api.ts
+++ b/src/renderer/api/endpoints/cron-job.api.ts
@@ -5,6 +5,38 @@ import { formatDuration } from "../../utils/formatDuration";
 import { autobind } from "../../utils";
 import { KubeApi } from "../kube-api";
 
+export class CronJobApi extends KubeApi<CronJob> {
+  suspend(params: { namespace: string; name: string }) {
+    return this.request.patch(this.getUrl(params), {
+      data: {
+        spec: {
+          suspend: true
+        }
+      }
+    },
+    {
+      headers: {
+        "content-type": "application/strategic-merge-patch+json"
+      }
+    });
+  }
+
+  resume(params: { namespace: string; name: string }) {
+    return this.request.patch(this.getUrl(params), {
+      data: {
+        spec: {
+          suspend: false
+        }
+      }
+    },
+    {
+      headers: {
+        "content-type": "application/strategic-merge-patch+json"
+      }
+    });
+  }
+}
+
 @autobind()
 export class CronJob extends KubeObject {
   static kind = "CronJob";
@@ -90,8 +122,12 @@ export class CronJob extends KubeObject {
 
     return day > daysInMonth[month - 1];
   }
+
+  isSuspend() {
+    return this.spec.suspend;
+  }
 }
 
-export const cronJobApi = new KubeApi({
+export const cronJobApi = new CronJobApi({
   objectConstructor: CronJob,
 });


### PR DESCRIPTION
Hi, team. Here is just a small feature. 
`Bug`: I noticed that cronJob `Suspend` field not updated immediately on UI after clicking `Suspend` button. After some research, I found that `kube-watch-api` couldn't find an appropriate api. And console error message(picture 2) related to this issue. I also noticed that all resources that have complex apiVersion not updated on UI without refresh. After debugging, I saw that a server response contains a full (e.g.`batch/v1beta1`) field, but we compare it only with `apiVersion` field. My suggestion is https://github.com/lensapp/lens/compare/master...vshakirova:add-suspend-resume-cronjob-btn?expand=1#diff-bffc0ab32510dc127d9efc665b77c2cda1fc3733f980029a8fc5189e9240ff95R21. Maybe it is not a good solution but it helped me to fix console and UI ussies.
<img width="1124" alt="Screen Shot 2020-12-24 at 4 42 44 PM" src="https://user-images.githubusercontent.com/38247153/103092400-8afa1b80-4610-11eb-9257-61248be292a9.png">

<img width="1409" alt="Screen Shot 2020-12-24 at 4 40 26 PM" src="https://user-images.githubusercontent.com/38247153/103092421-9c432800-4610-11eb-81da-9b5327f0d1ff.png">


Fixes https://github.com/lensapp/lens/issues/1694