### PR TITLE
Add support for viewing 'User-supplied values' of helm release

### DIFF
--- a/src/main/helm/helm-release-manager.ts
+++ b/src/main/helm/helm-release-manager.ts
@@ -91,9 +91,9 @@ export class HelmReleaseManager {
     return stdout;
   }
 
-  public async getValues(name: string, namespace: string, pathToKubeconfig: string) {
+  public async getValues(name: string, namespace: string, all: boolean, pathToKubeconfig: string) {
     const helm = await helmCli.binaryPath();
-    const { stdout,  } = await promiseExec(`"${helm}" get values ${name} --all --output yaml --namespace ${namespace} --kubeconfig ${pathToKubeconfig}`).catch((error) => { throw(error.stderr);});
+    const { stdout,  } = await promiseExec(`"${helm}" get values ${name} ${all? "--all": ""} --output yaml --namespace ${namespace} --kubeconfig ${pathToKubeconfig}`).catch((error) => { throw(error.stderr);});
 
     return stdout;
   }

--- a/src/main/helm/helm-service.ts
+++ b/src/main/helm/helm-service.ts
@@ -66,12 +66,12 @@ class HelmService {
     return await releaseManager.getRelease(releaseName, namespace, cluster);
   }
 
-  public async getReleaseValues(cluster: Cluster, releaseName: string, namespace: string) {
+  public async getReleaseValues(cluster: Cluster, releaseName: string, namespace: string, all: boolean) {
     const proxyKubeconfig = await cluster.getProxyKubeconfigPath();
 
     logger.debug("Fetch release values");
 
-    return await releaseManager.getValues(releaseName, namespace, proxyKubeconfig);
+    return await releaseManager.getValues(releaseName, namespace, all, proxyKubeconfig);
   }
 
   public async getReleaseHistory(cluster: Cluster, releaseName: string, namespace: string) {

--- a/src/main/routes/helm-route.ts
+++ b/src/main/routes/helm-route.ts
@@ -101,10 +101,10 @@ class HelmApiRoute extends LensApi {
   }
 
   public async getReleaseValues(request: LensApiRequest) {
-    const { cluster, params, response } = request;
+    const { cluster, params, response, query } = request;
 
     try {
-      const result = await helmService.getReleaseValues(cluster, params.release, params.namespace);
+      const result = await helmService.getReleaseValues(cluster, params.release, params.namespace, query.has("all"));
 
       this.respondText(response, result);
     } catch (error) {

--- a/src/renderer/api/endpoints/helm-releases.api.ts
+++ b/src/renderer/api/endpoints/helm-releases.api.ts
@@ -112,8 +112,8 @@ export async function deleteRelease(name: string, namespace: string): Promise<Js
   return apiBase.del(path);
 }
 
-export async function getReleaseValues(name: string, namespace: string): Promise<string> {
-  const path = `${endpoint({ name, namespace })}/values`;
+export async function getReleaseValues(name: string, namespace: string, all?: boolean): Promise<string> {
+  const path = `${endpoint({ name, namespace })}/values${all? "?all": ""}`;
 
   return apiBase.get<string>(path);
 }

--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -37,7 +37,7 @@ export class ReleaseDetails extends Component<Props> {
   @observable details: IReleaseDetails;
   @observable values = "";
   @observable valuesLoading = false;
-  @observable userSuppliedOnly = true;
+  @observable userSuppliedOnly = false;
   @observable saving = false;
   @observable releaseSecret: Secret;
 
@@ -76,7 +76,7 @@ export class ReleaseDetails extends Component<Props> {
 
     this.values = "";
     this.valuesLoading = true;
-    this.values = await getReleaseValues(release.getName(), release.getNs(), !this.userSuppliedOnly);
+    this.values = (await getReleaseValues(release.getName(), release.getNs(), !this.userSuppliedOnly)) ?? "";
     this.valuesLoading = false;
   }
 

--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -25,6 +25,7 @@ import { SubTitle } from "../layout/sub-title";
 import { secretsStore } from "../+config-secrets/secrets.store";
 import { Secret } from "../../api/endpoints";
 import { getDetailsUrl } from "../kube-object";
+import { Checkbox } from "../checkbox";
 
 interface Props {
   release: HelmRelease;
@@ -35,6 +36,8 @@ interface Props {
 export class ReleaseDetails extends Component<Props> {
   @observable details: IReleaseDetails;
   @observable values = "";
+  @observable valuesLoading = false;
+  @observable userSuppliedOnly = true;
   @observable saving = false;
   @observable releaseSecret: Secret;
 
@@ -72,7 +75,9 @@ export class ReleaseDetails extends Component<Props> {
     const { release } = this.props;
 
     this.values = "";
-    this.values = await getReleaseValues(release.getName(), release.getNs());
+    this.valuesLoading = true;
+    this.values = await getReleaseValues(release.getName(), release.getNs(), !this.userSuppliedOnly);
+    this.valuesLoading = false;
   }
 
   updateValues = async () => {
@@ -107,21 +112,34 @@ export class ReleaseDetails extends Component<Props> {
   };
 
   renderValues() {
-    const { values, saving } = this;
+    const { values, valuesLoading, saving } = this;
 
     return (
       <div className="values">
         <DrawerTitle title="Values"/>
         <div className="flex column gaps">
-          <AceEditor
-            mode="yaml"
-            value={values}
-            onChange={values => this.values = values}
+          <Checkbox
+            label="User-supplied values only"
+            value={this.userSuppliedOnly}
+            onChange={values => {
+              this.userSuppliedOnly = values;
+              this.loadValues();
+            }}
+            disabled={valuesLoading}
           />
+          {valuesLoading
+            ? <Spinner />
+            : <AceEditor
+              mode="yaml"
+              value={values}
+              onChange={values => this.values = values}
+            />
+          }
           <Button
             primary
             label="Save"
             waiting={saving}
+            disabled={valuesLoading}
             onClick={this.updateValues}
           />
         </div>

--- a/src/renderer/components/dock/upgrade-chart.store.ts
+++ b/src/renderer/components/dock/upgrade-chart.store.ts
@@ -89,7 +89,7 @@ export class UpgradeChartStore extends DockTabStore<IChartUpgradeData> {
   async loadValues(tabId: TabId) {
     this.values.clearData(tabId); // reset
     const { releaseName, releaseNamespace } = this.getData(tabId);
-    const values = await getReleaseValues(releaseName, releaseNamespace);
+    const values = await getReleaseValues(releaseName, releaseNamespace, true);
 
     this.values.setData(tabId, values);
   }


### PR DESCRIPTION
### What's included?
- Add checkbox to view "User-supplied values" instead of "merged with default values" of Helm release
- Essentially toggle `--all` from `helm get values --all -o yaml -n <namespace> <release>`.
### Motivation
- For readability + improve inline edit when lots of configurations are available.
- Reduce the risks when upgrade between Helm chart versions.
- Fix: #553 