### PR TITLE
Prometheus v2.19.3

### DIFF
--- a/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
@@ -53,7 +53,7 @@ spec:
               mountPath: /var/lib/prometheus
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v2.17.2
+          image: quay.io/prometheus/prometheus:v2.19.3
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml

--- a/extensions/metrics-cluster-feature/resources/10-node-exporter-ds.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/10-node-exporter-ds.yml.hb
@@ -41,12 +41,12 @@ spec:
       hostPID: true
       containers:
       - name: node-exporter
-        image: docker.io/prom/node-exporter:v1.0.0-rc.0
+        image: quay.io/prometheus/node-exporter:v1.0.1
         args:
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys
           - --path.rootfs=/host/root
-          - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker|var/lib/containers/.+)($|/)
+          - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker|var/lib/containerd|var/lib/containers/.+)($|/)
           - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         ports:
           - name: metrics

--- a/extensions/metrics-cluster-feature/src/metrics-feature.ts
+++ b/extensions/metrics-cluster-feature/src/metrics-feature.ts
@@ -26,7 +26,7 @@ export interface MetricsConfiguration {
 
 export class MetricsFeature extends ClusterFeature.Feature {
   name = "metrics";
-  latestVersion = "v2.17.2-lens2";
+  latestVersion = "v2.19.3-lens1";
 
   templateContext: MetricsConfiguration = {
     persistence: {


### PR DESCRIPTION
- Prometheus v2.19.3
- node-exporter v1.0.1
- switch to use quay.io