### PR TITLE
Fixing long list cropping in sidebar

### DIFF
--- a/src/renderer/components/layout/sidebar-nav-item.scss
+++ b/src/renderer/components/layout/sidebar-nav-item.scss
@@ -41,13 +41,13 @@
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: 0px; // hidden by default
-      max-height: 0px;
+      height: 0px;
       opacity: 0;
       transition: 125ms line-height ease-out, 200ms 100ms opacity;
 
       &.visible {
         line-height: 28px;
-        max-height: 1000px;
+        height: auto;
         opacity: 1;
       }
 


### PR DESCRIPTION
Replacing `max-height: 1000px` by `height: auto` for menu items. It turns out that using `max-height` as an animation key is bad idea. You'll definitely will hit the limit value.

https://user-images.githubusercontent.com/9607060/103286617-9d4dce00-49f1-11eb-89a0-cce2c9a16c1b.mp4

Fixes #358 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>