### PR TITLE
Backport: fix ApiManager.getApiByKind

### DIFF
--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -18,7 +18,7 @@ export class ApiManager {
   }
 
   getApiByKind(kind: string, apiVersion: string) {
-    return Array.from(this.apis.values()).find((api) => api.kind === kind && api.apiVersion === apiVersion);
+    return Array.from(this.apis.values()).find((api) => api.kind === kind && api.apiVersionWithGroup === apiVersion);
   }
 
   registerApi(apiBase: string, api: KubeApi) {


### PR DESCRIPTION
Backports fix from #1860 