### PR TITLE
Share react-router and react-router-dom libraries to extensions

### DIFF
--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -3,6 +3,8 @@ import "./components/app.scss";
 import React from "react";
 import * as Mobx from "mobx";
 import * as MobxReact from "mobx-react";
+import * as ReactRouter from "react-router";
+import * as ReactRouterDom from "react-router-dom";
 import { render, unmountComponentAtNode } from "react-dom";
 import { clusterStore } from "../common/cluster-store";
 import { userStore } from "../common/user-store";
@@ -23,6 +25,8 @@ type AppComponent = React.ComponentType & {
 
 export {
   React,
+  ReactRouter,
+  ReactRouterDom,
   Mobx,
   MobxReact,
   LensExtensions


### PR DESCRIPTION
This PR will share `react-router-dom` and `react-router` libraries to extensions like we already do with `react` and `mobx` etc.  These libraries are needed if extension developer wants to use for example `Link` React component.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>