### PR TITLE
Fixing object API after editing resouce

### DIFF
--- a/src/renderer/api/endpoints/resource-applier.api.ts
+++ b/src/renderer/api/endpoints/resource-applier.api.ts
@@ -18,7 +18,7 @@ export const resourceApplierApi = {
       .post<KubeJsonApiData[]>("/stack", { data: resource })
       .then(data => {
         const items = data.map(obj => {
-          const api = apiManager.getApi(obj.metadata.selfLink);
+          const api = apiManager.getApiByKind(obj.kind, obj.apiVersion);
 
           if (api) {
             return new api.objectConstructor(obj);


### PR DESCRIPTION
As it turned out, k8s 1.20.x doesn't provide `selfLink` anymore which breaks workload editing process.

Fixes #1903 
Fixes #1923 
Relates to #1767 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>