### PR TITLE
Fixing multiline logs wrapping

### DIFF
--- a/src/renderer/components/dock/pod-log-list.scss
+++ b/src/renderer/components/dock/pod-log-list.scss
@@ -22,7 +22,7 @@
         height: 18px;  // Must be equal to lineHeight variable in pod-log-list.tsx
         font-family: var(--font-monospace);
         font-size: smaller;
-        white-space: pre;
+        white-space: nowrap;
 
         &:hover {
           background: var(--logRowHoverBackground);


### PR DESCRIPTION
Keeping all log rows in one line.

Before
![multy line log](https://user-images.githubusercontent.com/9607060/104182408-75af2a80-5421-11eb-91ca-56bf151cd6e9.png)

After
![one line log](https://user-images.githubusercontent.com/9607060/104182419-78aa1b00-5421-11eb-82c7-0a32d67c3e5d.png)

Fixes #1706 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>