### PR TITLE
Prevent initializing clusters multiple times

### DIFF
--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -14,7 +14,7 @@ export class ClusterManager extends Singleton {
     // auto-init clusters
     autorun(() => {
       clusterStore.enabledClustersList.forEach(cluster => {
-        if (!cluster.initialized) {
+        if (!cluster.initialized && !cluster.initializing) {
           logger.info(`[CLUSTER-MANAGER]: init cluster`, cluster.getMeta());
           cluster.init(port);
         }

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -37,7 +37,6 @@ export type ClusterRefreshOptions = {
 };
 
 export interface ClusterState {
-  initializing: boolean;
   initialized: boolean;
   enabled: boolean;
   apiUrl: string;
@@ -579,7 +578,6 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   getState(): ClusterState {
     const state: ClusterState = {
-      initializing: this.initializing,
       initialized: this.initialized,
       enabled: this.enabled,
       apiUrl: this.apiUrl,

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -37,6 +37,7 @@ export type ClusterRefreshOptions = {
 };
 
 export interface ClusterState {
+  initializing: boolean;
   initialized: boolean;
   enabled: boolean;
   apiUrl: string;
@@ -76,6 +77,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * If extension sets this it needs to also mark cluster as enabled on activate (or when added to a store)
    */
   public ownerRef: string;
+  public initializing = false;
   protected kubeconfigManager: KubeconfigManager;
   protected eventDisposers: Function[] = [];
   protected activated = false;
@@ -273,10 +275,12 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @action async init(port: number) {
     try {
+      this.initializing = true;
       this.contextHandler = new ContextHandler(this);
       this.kubeconfigManager = await KubeconfigManager.create(this, this.contextHandler, port);
       this.kubeProxyUrl = `http://localhost:${port}${apiKubePrefix}`;
       this.initialized = true;
+      this.initializing = false;
       logger.info(`[CLUSTER]: "${this.contextName}" init success`, {
         id: this.id,
         context: this.contextName,
@@ -575,6 +579,7 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   getState(): ClusterState {
     const state: ClusterState = {
+      initializing: this.initializing,
       initialized: this.initialized,
       enabled: this.enabled,
       apiUrl: this.apiUrl,

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -76,7 +76,6 @@ export class Cluster implements ClusterModel, ClusterState {
    * If extension sets this it needs to also mark cluster as enabled on activate (or when added to a store)
    */
   public ownerRef: string;
-  public initializing = false;
   protected kubeconfigManager: KubeconfigManager;
   protected eventDisposers: Function[] = [];
   protected activated = false;
@@ -84,6 +83,14 @@ export class Cluster implements ClusterModel, ClusterState {
 
   whenInitialized = when(() => this.initialized);
   whenReady = when(() => this.ready);
+
+  /**
+   * Is cluster object initializinng on-going
+   *
+   * @observable
+   */
+  @observable initializing = false;
+
 
   /**
    * Is cluster object initialized
@@ -279,7 +286,6 @@ export class Cluster implements ClusterModel, ClusterState {
       this.kubeconfigManager = await KubeconfigManager.create(this, this.contextHandler, port);
       this.kubeProxyUrl = `http://localhost:${port}${apiKubePrefix}`;
       this.initialized = true;
-      this.initializing = false;
       logger.info(`[CLUSTER]: "${this.contextName}" init success`, {
         id: this.id,
         context: this.contextName,
@@ -290,6 +296,8 @@ export class Cluster implements ClusterModel, ClusterState {
         id: this.id,
         error: err,
       });
+    } finally {
+      this.initializing = false;
     }
   }
 


### PR DESCRIPTION
`cluster.init()` takes some time and that leads to the situation where `ClusterManager` can init the same cluster multiple times. This PR will add boolean `initializing` property to `Cluster` and `ClusterManager` checks that too when initializing a cluster.