### PR TITLE
Fix: chart.digest is the same for all charts and not suited as unique id

### DIFF
--- a/src/renderer/api/endpoints/helm-charts.api.ts
+++ b/src/renderer/api/endpoints/helm-charts.api.ts
@@ -86,7 +86,7 @@ export class HelmChart {
   tillerVersion?: string;
 
   getId() {
-    return this.digest;
+    return `${this.apiVersion}/${this.name}@${this.getAppVersion()}`;
   }
 
   getName() {


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/6377066/104724032-cb911480-5738-11eb-927d-0c0a18f384fd.png)

**After:**
![image](https://user-images.githubusercontent.com/6377066/104724043-cf249b80-5738-11eb-9c1e-6d6d4d7776f1.png)
