### PR TITLE
Enable default workspace on first boot

### DIFF
--- a/src/common/__tests__/workspace-store.test.ts
+++ b/src/common/__tests__/workspace-store.test.ts
@@ -36,6 +36,13 @@ describe("workspace store tests", () => {
       expect(ws.getById(WorkspaceStore.defaultId)).not.toBe(null);
     });
 
+    it("default workspace should be enabled", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      expect(ws.workspaces.size).toBe(1);
+      expect(ws.getById(WorkspaceStore.defaultId).enabled).toBe(true);
+    });
+
     it("cannot remove the default workspace", () => {
       const ws = WorkspaceStore.getInstance<WorkspaceStore>();
 

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -58,20 +58,16 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
    * @observable
    */
   @observable ownerRef?: string;
-  /**
-   * Is workspace enabled
-   *
-   * Workspaces that don't have ownerRef will be enabled by default. Workspaces with ownerRef need to explicitly enable a workspace.
-   *
-   * @observable
-   */
-  @observable enabled: boolean;
+
   /**
    * Last active cluster id
    *
    * @observable
    */
   @observable lastActiveClusterId?: ClusterId;
+
+
+  @observable private _enabled: boolean;
 
   constructor(data: WorkspaceModel) {
     Object.assign(this, data);
@@ -81,6 +77,21 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
         this.pushState();
       });
     }
+  }
+
+  /**
+   * Is workspace enabled
+   *
+   * Workspaces that don't have ownerRef will be enabled by default. Workspaces with ownerRef need to explicitly enable a workspace.
+   *
+   * @observable
+   */
+  get enabled(): boolean {
+    return !this.isManaged || this._enabled;
+  }
+
+  set enabled(enabled: boolean) {
+    this._enabled = enabled;
   }
 
   /**
@@ -141,13 +152,11 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     super({
       configName: "lens-workspace-store",
     });
-    const defaultWorkspace = new Workspace({
+
+    this.workspaces.set(WorkspaceStore.defaultId, new Workspace({
       id: WorkspaceStore.defaultId,
       name: "default"
-    });
-
-    defaultWorkspace.enabled = true;
-    this.workspaces.set(WorkspaceStore.defaultId, defaultWorkspace);
+    }));
   }
 
   async load() {

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -138,6 +138,7 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     super({
       configName: "lens-workspace-store",
     });
+    this.workspaces.get(WorkspaceStore.defaultId).enabled = true;
   }
 
   async load() {

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -134,11 +134,20 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
   static readonly defaultId: WorkspaceId = "default";
   private static stateRequestChannel = "workspace:states";
 
+  @observable currentWorkspaceId = WorkspaceStore.defaultId;
+  @observable workspaces = observable.map<WorkspaceId, Workspace>();
+
   private constructor() {
     super({
       configName: "lens-workspace-store",
     });
-    this.workspaces.get(WorkspaceStore.defaultId).enabled = true;
+    const defaultWorkspace = new Workspace({
+      id: WorkspaceStore.defaultId,
+      name: "default"
+    });
+
+    defaultWorkspace.enabled = true;
+    this.workspaces.set(WorkspaceStore.defaultId, defaultWorkspace);
   }
 
   async load() {
@@ -186,15 +195,6 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     super.unregisterIpcListener();
     ipcRenderer.removeAllListeners("workspace:state");
   }
-
-  @observable currentWorkspaceId = WorkspaceStore.defaultId;
-
-  @observable workspaces = observable.map<WorkspaceId, Workspace>({
-    [WorkspaceStore.defaultId]: new Workspace({
-      id: WorkspaceStore.defaultId,
-      name: "default"
-    })
-  });
 
   @computed get currentWorkspace(): Workspace {
     return this.getById(this.currentWorkspaceId);


### PR DESCRIPTION
Currently first boot does not set `default`  workspace as enabled -> it's not visible in workspace switcher.