### PR TITLE
Release v4.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/src/common/__tests__/workspace-store.test.ts
+++ b/src/common/__tests__/workspace-store.test.ts
@@ -36,6 +36,13 @@ describe("workspace store tests", () => {
       expect(ws.getById(WorkspaceStore.defaultId)).not.toBe(null);
     });
 
+    it("default workspace should be enabled", () => {
+      const ws = WorkspaceStore.getInstance<WorkspaceStore>();
+
+      expect(ws.workspaces.size).toBe(1);
+      expect(ws.getById(WorkspaceStore.defaultId).enabled).toBe(true);
+    });
+
     it("cannot remove the default workspace", () => {
       const ws = WorkspaceStore.getInstance<WorkspaceStore>();
 

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -14,7 +14,7 @@ export class ClusterManager extends Singleton {
     // auto-init clusters
     autorun(() => {
       clusterStore.enabledClustersList.forEach(cluster => {
-        if (!cluster.initialized) {
+        if (!cluster.initialized && !cluster.initializing) {
           logger.info(`[CLUSTER-MANAGER]: init cluster`, cluster.getMeta());
           cluster.init(port);
         }

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -85,6 +85,14 @@ export class Cluster implements ClusterModel, ClusterState {
   whenReady = when(() => this.ready);
 
   /**
+   * Is cluster object initializinng on-going
+   *
+   * @observable
+   */
+  @observable initializing = false;
+
+
+  /**
    * Is cluster object initialized
    *
    * @observable
@@ -273,6 +281,7 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @action async init(port: number) {
     try {
+      this.initializing = true;
       this.contextHandler = new ContextHandler(this);
       this.kubeconfigManager = await KubeconfigManager.create(this, this.contextHandler, port);
       this.kubeProxyUrl = `http://localhost:${port}${apiKubePrefix}`;
@@ -287,6 +296,8 @@ export class Cluster implements ClusterModel, ClusterState {
         id: this.id,
         error: err,
       });
+    } finally {
+      this.initializing = false;
     }
   }
 

--- a/src/main/prometheus/lens.ts
+++ b/src/main/prometheus/lens.ts
@@ -75,8 +75,8 @@ export class PrometheusLens implements PrometheusProvider {
           `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.igress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingres, "^5\\\\d*"),
+          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
           requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
           responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
         };

--- a/src/main/prometheus/operator.ts
+++ b/src/main/prometheus/operator.ts
@@ -85,8 +85,8 @@ export class PrometheusOperator implements PrometheusProvider {
           `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.igress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingres, "^5\\\\d*"),
+          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
           requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
           responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
         };

--- a/src/main/prometheus/stacklight.ts
+++ b/src/main/prometheus/stacklight.ts
@@ -75,8 +75,8 @@ export class PrometheusStacklight implements PrometheusProvider {
           `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.igress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingres, "^5\\\\d*"),
+          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
           requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
           responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
         };

--- a/src/renderer/api/endpoints/resource-applier.api.ts
+++ b/src/renderer/api/endpoints/resource-applier.api.ts
@@ -18,7 +18,7 @@ export const resourceApplierApi = {
       .post<KubeJsonApiData[]>("/stack", { data: resource })
       .then(data => {
         const items = data.map(obj => {
-          const api = apiManager.getApi(obj.metadata.selfLink);
+          const api = apiManager.getApiByKind(obj.kind, obj.apiVersion);
 
           if (api) {
             return new api.objectConstructor(obj);

--- a/src/renderer/components/dock/pod-log-list.scss
+++ b/src/renderer/components/dock/pod-log-list.scss
@@ -22,7 +22,7 @@
         height: 18px;  // Must be equal to lineHeight variable in pod-log-list.tsx
         font-family: $font-monospace;
         font-size: smaller;
-        white-space: pre;
+        white-space: nowrap;
 
         &:hover {
           background: $logRowHoverBackground;

--- a/src/renderer/components/dock/terminal.ts
+++ b/src/renderer/components/dock/terminal.ts
@@ -130,10 +130,17 @@ export class Terminal {
   fit = () => {
     // Since this function is debounced we need to read this value as late as possible
     if (!this.isActive) return;
-    this.fitAddon.fit();
-    const { cols, rows } = this.xterm;
 
-    this.api.sendTerminalSize(cols, rows);
+    try {
+      this.fitAddon.fit();
+      const { cols, rows } = this.xterm;
+
+      this.api.sendTerminalSize(cols, rows);
+    } catch(error) {
+      console.error(error);
+
+      return; // see https://github.com/lensapp/lens/issues/1891
+    }
   };
 
   fitLazy = debounce(this.fit, 250);

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,17 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.6 (current version)
+## 4.0.7 (current version)
+
+- Fix: typo in Prometheus Ingress metrics
+- Fix: catch xterm.js fit error
+- Fix: Windows tray icon click
+- Fix: error on Kubernetes >= 1.20 on object edit
+- Fix: multiline log wrapping
+- Fix: prevent clusters from initializing multiple times
+- Fix: show default workspace on first boot
+
+## 4.0.6
 
 - Don't open Lens at OS login by default
 - Disable GPU acceleration by setting an env variable

--- a/yarn.lock
+++ b/yarn.lock
@@ -7756,9 +7756,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 init-package-json@^1.10.3:
   version "1.10.3"


### PR DESCRIPTION
## Changes since v4.0.6

- Enable default workspace on first boot (#1965)
- Bump ini from 1.3.5 to 1.3.8 (#1760)
- Prevent initializing clusters multiple times (#1950)
- Fixing multiline logs wrapping (#1938)
- Getting api by kind when editing an object (#1936)
- Fix windows tray icon click (#1908)
- Catch xtermjs fit error (#1907)
- Fix typo in prometheus ingress metrics (#1896)
