### PR TITLE
Allow for changing installation directory on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,9 @@
       ]
     },
     "nsis": {
-      "include": "build/installer.nsh"
+      "include": "build/installer.nsh",
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true	  
     },
     "publish": [
       {


### PR DESCRIPTION
At the cost of the one-click installer, allow for choosing a custom install path.

Solves: #1968