### PR TITLE
[3.6] Better aligning notification icons

### DIFF
--- a/src/renderer/components/notifications/notifications.scss
+++ b/src/renderer/components/notifications/notifications.scss
@@ -46,5 +46,9 @@
         box-shadow: 0 0 20px $boxShadow;
       }
     }
+
+    .close {
+      margin-top: -2px;
+    }
   }
 }

--- a/src/renderer/components/notifications/notifications.tsx
+++ b/src/renderer/components/notifications/notifications.tsx
@@ -74,14 +74,14 @@ export class Notifications extends React.Component {
           return (
             <Animate key={id}>
               <div
-                className={cssNames("notification flex align-center", status)}
+                className={cssNames("notification flex", status)}
                 onMouseLeave={() => addAutoHideTimer(notification)}
                 onMouseEnter={() => removeAutoHideTimer(notification)}>
-                <div className="box center">
+                <div className="box">
                   <Icon material="info_outline" />
                 </div>
                 <div className="message box grow">{msgText}</div>
-                <div className="box center">
+                <div className="box">
                   <Icon
                     material="close" className="close"
                     onClick={prevDefault(() => {


### PR DESCRIPTION
Moving icons to top.

![fixed alignment](https://user-images.githubusercontent.com/9607060/105044878-48ddc180-5a78-11eb-8b88-f44e9b294f6c.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>