### PR TITLE
Release v3.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "3.6.9",
+  "version": "3.6.10",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,10 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 3.6.9 (current version)
+## 3.6.10 (current version)
+- Fix: option to skip auto-updates
+
+## 3.6.9
 - Use Alpine 3.12 for node shell sessions
 - Fix errors on app quit
 - Fix kube-auth-proxy to accept only target cluster hostname


### PR DESCRIPTION
## Changes since v3.6.9

- Moving notification icons to top (#1987)
- Show single update notification (#1985)
- Fixing button colors in update notification (#1986)
- Fix auto-update to use Lens notifications, and add update confirmation (#1831)
