### PR TITLE
Fixing misaligned table columns

### DIFF
--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -440,11 +440,9 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
             return <TableCell key={cellProps.id ?? index} {...cellProps} />;
           }
         })}
-        {isConfigurable && (
-          <TableCell className="menu">
-            {this.renderColumnVisibilityMenu()}
-          </TableCell>
-        )}
+        <TableCell className="menu">
+          {isConfigurable && this.renderColumnVisibilityMenu()}
+        </TableCell>
       </TableHead>
     );
   }


### PR DESCRIPTION
It always show menu column in Table head. This results equal amount of columns for each row and fixes misalign issue.

Fixes #2023 

![aligned table](https://user-images.githubusercontent.com/9607060/105836202-e471b380-5fdd-11eb-81a3-fe65066d5019.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>