### PR TITLE
Release v4.1.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.1.0-alpha.0",
+  "version": "4.1.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2020, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,80 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.0.2 (current version)
+## 4.1.0-alpha.1 (current version)
+
+- Change: list views default to a namespace (insted of listing resources from all namespaces)
+- Generic logs view with Pod selector
+- Possibility to add custom Helm repository through Lens
+- Possibility to change visibility of Pod list columns
+- Suspend / resume buttons for CronJobs
+- Dock tabs context menu
+- Display node column in Pod list
+- Unify age column output with kubectl
+- Use dark colors in Dock regardless of active theme
+- Improve Pod tolerations layout
+- Lens metrics: scrape only lens-metrics namespace
+- Lens metrics: Prometheus v2.19.3
+- Export PodDetailsList component to extension API
+- Export Wizard components to extension API
+- Export NamespaceSelect component to extension API
+
+## 4.0.8
+
+- Fix: extension cluster sub-menu/page periodic re-render
+- Fix: app hang on boot if started from command line & oh-my-zsh prompts for auto-update
+
+## 4.0.7
+
+- Fix: typo in Prometheus Ingress metrics
+- Fix: catch xterm.js fit error
+- Fix: Windows tray icon click
+- Fix: error on Kubernetes >= 1.20 on object edit
+- Fix: multiline log wrapping
+- Fix: prevent clusters from initializing multiple times
+- Fix: show default workspace on first boot
+
+## 4.0.6
+
+- Don't open Lens at OS login by default
+- Disable GPU acceleration by setting an env variable
+- Catch HTTP Errors in case pod metrics resources do not exist or access is forbidden
+- Check is persistent volume claims resource to allowed for user
+- Share react-router and react-router-dom libraries to extensions
+- Fix: long list cropping in sidebar
+- Fix: k0s distribution detection
+- Fix: Preserve line breaks when copying logs
+- Fix: error on api watch on complex api versions
+
+## 4.0.5
+
+- Fix: add missing Kubernetes distro detectors
+- Fix: improve how Workloads Overview is loaded
+- Fix: race conditions on extension loader
+- Fix: pod logs scrolling issues
+- Fix: render node list before metrics are available
+- Fix: kube-state-metrics v1.9.7
+- Fix: CRD sidebar expand/collapse
+- Fix: disable oh-my-zsh auto-update prompt when resolving shell environment
+- Add kubectl 1.20 support to Lens Smart Terminal
+- Optimise performance during cluster connect
+
+## 4.0.4
+
+- Fix errors on Kubernetes v1.20
+- Update bundled kubectl to v1.17.15
+- Fix: MacOS error on shutdown
+- Fix: Kubernetes distribution detection
+- Fix: error while displaying CRDs with column which type is an object
+
+## 4.0.3
+
+- Fix: install in-tree extensions before others
+- Fix: bundle all dependencies in in-tree extensions
+- Fix: display error dialog if extensions couldn't be loaded
+- Fix: ensure only one app instance
+
+## 4.0.2
 
 We are aware some users are encountering issues and regressions from previous version. Many of these issues are something we have not seen as part of our automated or manual testing process. To make it worse, some of them are really difficult to reproduce. We want to ensure we are putting all our energy and effort trying to resolve these issues. We hope you are patient. Expect to see new patch releases still in the coming days! Fixes in this version:
 


### PR DESCRIPTION
## Changes since v4.0.x

* Generic logs view with Pod selector (#1984)
* Fix extension cluster submenu re-render (#1996) (#2027)
* Always shows .menu table column (#2024)
* Fix Helm repositories and pod logs integration tests (#2015)
* Bump make-plural from 6.2.1 to 6.2.2 (#1982)
* Bump elliptic from 6.5.2 to 6.5.3 (#633)
* Bump marked from 1.1.0 to 1.2.7 (#1976)
* Fix azure pipeline integration test exit code (#1980)
* Display CPU usage percentage with 2 decimal points (#2000)
* Load k8s resources only for selected namespaces (#1918)
* Fixing tolerations list layout (#2002)
* enfore unix line endings and always ending files with line endings (#1997)
* Fixing log tab layout colors (#1995)
* Add age column to cluster overview (#1970)
* fix: chart.digest is the same for all charts and not suited as unique id (#1964)
* do not assume that bitnami is guanteed to be in the helm repo list (#1960)
* Bump @types/hapi from 18.0.3 to 18.0.5 (#1963)
* Generate docs only for releases (#1972)
* Rework extensions guides (#1803)
* Rework extensions guides (#1802)
* Fix Electron 9.4 frame ipc bug (#1888) (#1789)
* Adding logs tab bottom toolbar (#1951)
* Add support for LimitRange (#1796)
* Column filters (#1532)
* Fix fill the gaps logic in normalize metrics (#1940)
* Fixing multiline logs wrapping (#1938)
* gitignore .vscode (#1599)
* Bump @typescript-eslint/eslint-plugin from 4.0.0 to 4.12.0 (#1912)
* bump uuid and @types/uuid to 8.3.x (#1913)
* fix: events pages renders incorrect tooltip as non-parsed template (#1919)
* Disable telemetry extension during integration tests (#1916)
* Windows: support only bash for development (#1915)
* remove array desctructor of Object.values, which is brittle (#1854)
* Bump circular-dependency-plugin from 5.2.0 to 5.2.2 (#1656)
* Fix encoding typo in ClusterAccessibleNamespaces component title (#1901)
* Reset stores before loading them (#1897)
* Expose NamespaceSelect component to extensions (#1880)
* Fix Electron 9.4 frame ipc bug (#1888)
* add version display to extensions (#1604)
* Electron 9.4.0 (#1799)
* Add suspend/resume button for CronJobs (#1860)
* Helm 3.4.2 (#1801)
* Prometheus v2.19.3 (#1868)
* Metrics-cluster-feature: scrape only lens-metrics namespace (#1867)
* Remove lingui (#1874)
* Applying dark colors to dock regardless of active theme (#1873)
* Show toolitp for node name in the nodes list (#1841)
* Dock tabs context menu (#1863)
* Clear Add Namespace and Add secret form data on close (#1771)
* Export wizard components (#1784)
* Unify Age column output with kubectl (#1822)
* Check is persistent volume claims resource to allowed for user (#1850)
* Update intro video links (#1842)
* Optimise Cluster.getAllowedResources() (#1830)
* Navigation refactoring, handling extension page params (#1651)
* Display node column in pods list (#1832)
* Test different kube versions (#1806)
* Switch master branch version to 4.1.0-alpha.0 (#1766)
* Export the pod-details-list component so that it can be used in Extensions (#1746)
* Exclude github actions & docs from azure pipeline (#1655)
* Add information about the startupProbe (#1538)
* ClusterOverview page refactorings (#1696)
* Full support for ReplicaSets (#1704)
* Add posibility to add custom repository (#1368)
* Yet another minor fix to main readme (#1681)
* Adding cluster settings icon into dashboard (#1672)
* minor readability fix for main readme (#1678)
* update main readme to align better with Lens 4.0 features (#1676)
