### PR TITLE
Add missing envFrom.secretRef property to IPodContainer

### DIFF
--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -104,6 +104,9 @@ export interface IPodContainer {
     configMapRef?: {
       name: string;
     };
+    secretRef?: {
+      name: string;
+    }
   }[];
   volumeMounts?: {
     name: string;


### PR DESCRIPTION
This PR adds missing `envFrom.secretRef` to IPodContainer spec: https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/container/#environment-variables