### PR TITLE
Fix: charts stripes alignment

### DIFF
--- a/src/renderer/components/chart/bar-chart.tsx
+++ b/src/renderer/components/chart/bar-chart.tsx
@@ -136,7 +136,8 @@ export class BarChart extends React.Component<Props> {
       },
       plugins: {
         ZebraStripes: {
-          stripeColor: chartStripesColor
+          stripeColor: chartStripesColor,
+          interval: chartData.datasets.length ? chartData.datasets[0].data.length : 61
         }
       }
     };

--- a/src/renderer/components/chart/bar-chart.tsx
+++ b/src/renderer/components/chart/bar-chart.tsx
@@ -137,7 +137,7 @@ export class BarChart extends React.Component<Props> {
       plugins: {
         ZebraStripes: {
           stripeColor: chartStripesColor,
-          interval: chartData.datasets.length ? chartData.datasets[0].data.length : 61
+          interval: chartData.datasets[0].data.length
         }
       }
     };

--- a/src/renderer/components/chart/zebra-stripes.plugin.ts
+++ b/src/renderer/components/chart/zebra-stripes.plugin.ts
@@ -6,7 +6,6 @@ import moment, { Moment } from "moment";
 import get from "lodash/get";
 
 const defaultOptions = {
-  interval: 61,
   stripeColor: "#ffffff08",
 };
 

--- a/src/renderer/components/chart/zebra-stripes.plugin.ts
+++ b/src/renderer/components/chart/zebra-stripes.plugin.ts
@@ -7,7 +7,6 @@ import get from "lodash/get";
 
 const defaultOptions = {
   interval: 61,
-  stripeMinutes: 10,
   stripeColor: "#ffffff08",
 };
 
@@ -36,12 +35,23 @@ export const ZebraStripes = {
     chart.canvas.parentElement.removeChild(elem);
   },
 
+  updateOptions(chart: ChartJS) {
+    this.options = {
+      ...defaultOptions,
+      ...this.getOptions(chart)
+    };
+  },
+
+  getStripeMinutes() {
+    return this.options.interval < 10 ? 0 : 10;
+  },
+
   renderStripes(chart: ChartJS) {
     if (!chart.data.datasets.length) return;
-    const { interval, stripeMinutes, stripeColor } = this.options;
+    const { interval, stripeColor } = this.options;
     const { top, left, bottom, right } = chart.chartArea;
     const step = (right - left) / interval;
-    const stripeWidth = step * stripeMinutes;
+    const stripeWidth = step * this.getStripeMinutes();
     const cover = document.createElement("div");
     const styles = cover.style;
 
@@ -61,14 +71,12 @@ export const ZebraStripes = {
 
   afterInit(chart: ChartJS) {
     if (!chart.data.datasets.length) return;
-    this.options = {
-      ...defaultOptions,
-      ...this.getOptions(chart)
-    };
+    this.updateOptions(chart);
     this.updated = this.getLastUpdate(chart);
   },
 
   afterUpdate(chart: ChartJS) {
+    this.updateOptions(chart);
     this.renderStripes(chart);
   },
 


### PR DESCRIPTION
* Updating chart stripes width and position on every dataset update
* Hide stripes if less than 10 minutes presented (one stripe covers 10 min period normally)

![fixed stripes](https://user-images.githubusercontent.com/9607060/106462821-a2e27c00-64a7-11eb-985c-f51c3466e38e.png)
![fixed stripes 15 minutes](https://user-images.githubusercontent.com/9607060/106462826-a413a900-64a7-11eb-8689-310ac97df647.png)

Fixes #2008 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>