### PR TITLE
Change Cluster Settings button to be consistent with cluster icon menu

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -225,6 +225,12 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
     workspaceStore.setLastActiveClusterId(clusterId);
   }
 
+  deactivate(id: ClusterId) {
+    if (this.isActive(id)) {
+      this.setActive(null);
+    }
+  }
+
   @action
   swapIconOrders(workspace: WorkspaceId, from: number, to: number) {
     const clusters = this.getByWorkspaceId(workspace);

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -21,7 +21,7 @@ const deactivateCluster = (clusterId: string) => {
 /**
  * Creates handlers for high-level actions
  * that could be performed on an individual cluster
- * @param cluster Cluster>
+ * @param cluster Cluster
  */
 export const ClusterActions = (cluster: Cluster) => ({
   "SHOW_SETTINGS": () => navigate(clusterSettingsURL({

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -11,13 +11,6 @@ import { Cluster } from "../../../main/cluster";
 const navigate = (route: string) =>
   broadcastMessage("renderer:navigate", route);
 
-const deactivateCluster = (clusterId: string) => {
-  if (clusterStore.isActive(clusterId)) {
-    clusterStore.setActive(null);
-  }
-  navigate(landingURL());
-};
-
 /**
  * Creates handlers for high-level actions
  * that could be performed on an individual cluster
@@ -28,7 +21,8 @@ export const ClusterActions = (cluster: Cluster) => ({
     params: { clusterId: cluster.id }
   })),
   disconnect: async () => {
-    deactivateCluster(cluster.id);
+    clusterStore.deactivate(cluster.id);
+    navigate(landingURL());
     await requestMain(clusterDisconnectHandler, cluster.id);
   },
   remove: () => ConfirmDialog.open({
@@ -38,8 +32,9 @@ export const ClusterActions = (cluster: Cluster) => ({
       label: "Remove"
     },
     ok: () => {
-      deactivateCluster(cluster.id);
+      clusterStore.deactivate(cluster.id);
       clusterStore.removeById(cluster.id);
+      navigate(landingURL());
     },
     message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
   })

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -13,9 +13,9 @@ const navigate = (route: string) =>
 
 const deactivateCluster = (clusterId: string) => {
   if (clusterStore.isActive(clusterId)) {
-    navigate(landingURL());
     clusterStore.setActive(null);
   }
+  navigate(landingURL());
 };
 
 /**

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { clusterSettingsURL } from "../+cluster-settings";
+import { landingURL } from "../+landing-page";
+
+import { clusterStore } from "../../../common/cluster-store";
+import { broadcastMessage, requestMain } from "../../../common/ipc";
+import { clusterDisconnectHandler } from "../../../common/cluster-ipc";
+import { ConfirmDialog } from "../confirm-dialog";
+import { Cluster } from "../../../main/cluster";
+
+const navigate = (route: string) =>
+  broadcastMessage("renderer:navigate", route);
+
+const deactivateCluster = (clusterId: string) => {
+  if (clusterStore.isActive(clusterId)) {
+    navigate(landingURL());
+    clusterStore.setActive(null);
+  }
+};
+
+/**
+ * Creates hanndlers for high-level actions
+ * that could be performed on an individual cluster
+ * @param cluster Cluster>
+ */
+export const ClusterActions = (cluster: Cluster) => ({
+  "SHOW_SETTINGS": () => navigate(clusterSettingsURL({
+    params: { clusterId: cluster.id }
+  })),
+  "DISCONNECT": async () => {
+    deactivateCluster(cluster.id);
+    await requestMain(clusterDisconnectHandler, cluster.id);
+  },
+  "REMOVE": () => ConfirmDialog.open({
+    okButtonProps: {
+      primary: false,
+      accent: true,
+      label: "Remove"
+    },
+    ok: () => {
+      deactivateCluster(cluster.id);
+      clusterStore.removeById(cluster.id);
+    },
+    message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
+  })
+});

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -24,14 +24,14 @@ const deactivateCluster = (clusterId: string) => {
  * @param cluster Cluster
  */
 export const ClusterActions = (cluster: Cluster) => ({
-  "SHOW_SETTINGS": () => navigate(clusterSettingsURL({
+  showSettings: () => navigate(clusterSettingsURL({
     params: { clusterId: cluster.id }
   })),
-  "DISCONNECT": async () => {
+  disconnect: async () => {
     deactivateCluster(cluster.id);
     await requestMain(clusterDisconnectHandler, cluster.id);
   },
-  "REMOVE": () => ConfirmDialog.open({
+  remove: () => ConfirmDialog.open({
     okButtonProps: {
       primary: false,
       accent: true,

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import uniqueId from "lodash/uniqueId";
 import { clusterSettingsURL } from "../+cluster-settings";
 import { landingURL } from "../+landing-page";
 
@@ -7,6 +8,7 @@ import { broadcastMessage, requestMain } from "../../../common/ipc";
 import { clusterDisconnectHandler } from "../../../common/cluster-ipc";
 import { ConfirmDialog } from "../confirm-dialog";
 import { Cluster } from "../../../main/cluster";
+import { Tooltip } from "../../components//tooltip";
 
 const navigate = (route: string) =>
   broadcastMessage("renderer:navigate", route);
@@ -25,17 +27,24 @@ export const ClusterActions = (cluster: Cluster) => ({
     navigate(landingURL());
     await requestMain(clusterDisconnectHandler, cluster.id);
   },
-  remove: () => ConfirmDialog.open({
-    okButtonProps: {
-      primary: false,
-      accent: true,
-      label: "Remove"
-    },
-    ok: () => {
-      clusterStore.deactivate(cluster.id);
-      clusterStore.removeById(cluster.id);
-      navigate(landingURL());
-    },
-    message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
-  })
+  remove: () => {
+    const tooltipId = uniqueId("tooltip_target_");
+
+    return ConfirmDialog.open({
+      okButtonProps: {
+        primary: false,
+        accent: true,
+        label: "Remove"
+      },
+      ok: () => {
+        clusterStore.deactivate(cluster.id);
+        clusterStore.removeById(cluster.id);
+        navigate(landingURL());
+      },
+      message: <p>
+        Are you sure want to remove cluster <b id={tooltipId}>{cluster.name}</b>?
+        <Tooltip  targetId={tooltipId}>{cluster.id}</Tooltip>
+      </p>
+    });
+  }
 });

--- a/src/renderer/components/cluster-manager/cluster-actions.tsx
+++ b/src/renderer/components/cluster-manager/cluster-actions.tsx
@@ -19,7 +19,7 @@ const deactivateCluster = (clusterId: string) => {
 };
 
 /**
- * Creates hanndlers for high-level actions
+ * Creates handlers for high-level actions
  * that could be performed on an individual cluster
  * @param cluster Cluster>
  */

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -2,7 +2,6 @@ import "./clusters-menu.scss";
 
 import React from "react";
 import { remote } from "electron";
-import { requestMain } from "../../../common/ipc";
 import type { Cluster } from "../../../main/cluster";
 import { DragDropContext, Draggable, DraggableProvided, Droppable, DroppableProvided, DropResult } from "react-beautiful-dnd";
 import { observer } from "mobx-react";
@@ -13,12 +12,10 @@ import { Icon } from "../icon";
 import { autobind, cssNames, IClassName } from "../../utils";
 import { isActiveRoute, navigate } from "../../navigation";
 import { addClusterURL } from "../+add-cluster";
-import { clusterSettingsURL } from "../+cluster-settings";
 import { landingURL } from "../+landing-page";
-import { ConfirmDialog } from "../confirm-dialog";
 import { clusterViewURL } from "./cluster-view.route";
+import { ClusterActions } from "./cluster-actions";
 import { getExtensionPageUrl, globalPageMenuRegistry, globalPageRegistry } from "../../../extensions/registries";
-import { clusterDisconnectHandler } from "../../../common/cluster-ipc";
 import { commandRegistry } from "../../../extensions/registries/command-registry";
 import { CommandOverlay } from "../command-palette/command-container";
 import { computed, observable } from "mobx";
@@ -40,51 +37,24 @@ export class ClustersMenu extends React.Component<Props> {
   showContextMenu = (cluster: Cluster) => {
     const { Menu, MenuItem } = remote;
     const menu = new Menu();
+    const actions = ClusterActions(cluster);
 
     menu.append(new MenuItem({
       label: `Settings`,
-      click: () => {
-        navigate(clusterSettingsURL({
-          params: {
-            clusterId: cluster.id
-          }
-        }));
-      }
+      click: actions.SHOW_SETTINGS
     }));
 
     if (cluster.online) {
       menu.append(new MenuItem({
         label: `Disconnect`,
-        click: async () => {
-          if (clusterStore.isActive(cluster.id)) {
-            navigate(landingURL());
-            clusterStore.setActive(null);
-          }
-          await requestMain(clusterDisconnectHandler, cluster.id);
-        }
+        click: actions.DISCONNECT
       }));
     }
 
     if (!cluster.isManaged) {
       menu.append(new MenuItem({
         label: `Remove`,
-        click: () => {
-          ConfirmDialog.open({
-            okButtonProps: {
-              primary: false,
-              accent: true,
-              label: `Remove`,
-            },
-            ok: () => {
-              if (clusterStore.activeClusterId === cluster.id) {
-                navigate(landingURL());
-                clusterStore.setActive(null);
-              }
-              clusterStore.removeById(cluster.id);
-            },
-            message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
-          });
-        }
+        click: actions.REMOVE
       }));
     }
     menu.popup({

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -41,20 +41,20 @@ export class ClustersMenu extends React.Component<Props> {
 
     menu.append(new MenuItem({
       label: `Settings`,
-      click: actions.SHOW_SETTINGS
+      click: actions.showSettings
     }));
 
     if (cluster.online) {
       menu.append(new MenuItem({
         label: `Disconnect`,
-        click: actions.DISCONNECT
+        click: actions.disconnect
       }));
     }
 
     if (!cluster.isManaged) {
       menu.append(new MenuItem({
         label: `Remove`,
-        click: actions.REMOVE
+        click: actions.remove
       }));
     }
     menu.popup({

--- a/src/renderer/components/cluster-manager/index.tsx
+++ b/src/renderer/components/cluster-manager/index.tsx
@@ -1,1 +1,2 @@
 export * from "./cluster-manager";
+export * from "./cluster-actions";

--- a/src/renderer/components/layout/__test__/main-layout-header.test.tsx
+++ b/src/renderer/components/layout/__test__/main-layout-header.test.tsx
@@ -7,15 +7,18 @@ import "@testing-library/jest-dom/extend-expect";
 import { MainLayoutHeader } from "../main-layout-header";
 import { Cluster } from "../../../../main/cluster";
 import { workspaceStore } from "../../../../common/workspace-store";
-import { broadcastMessage } from "../../../../common/ipc";
+import { broadcastMessage, requestMain } from "../../../../common/ipc";
+import { clusterDisconnectHandler } from "../../../../common/cluster-ipc";
+import { ConfirmDialog } from "../../confirm-dialog";
 
 const mockBroadcastIpc = broadcastMessage as jest.MockedFunction<typeof broadcastMessage>;
+const mockRequestMain = requestMain as jest.MockedFunction<typeof requestMain>;
 
 const cluster: Cluster = new Cluster({
   id: "foo",
   contextName: "minikube",
   kubeConfigPath: "minikube-config.yml",
-  workspace: workspaceStore.currentWorkspaceId
+  workspace: workspaceStore.currentWorkspaceId,
 });
 
 describe("<MainLayoutHeader />", () => {
@@ -33,22 +36,67 @@ describe("<MainLayoutHeader />", () => {
     expect(icon).toHaveTextContent("more_vert");
   });
 
-  it("navigates to cluster settings", () => {
-    const { container } = render(<MainLayoutHeader cluster={cluster} />);
-    const icon = container.querySelector(".Icon");
-
-    fireEvent.click(icon);
-    
-    const settingsBtn = document.querySelectorAll("ul.ClusterActionsMenu > li > span")[0];
-    
-    expect(settingsBtn.textContent).toBe("Settings");
-    fireEvent.click(settingsBtn);
-    expect(mockBroadcastIpc).toBeCalledWith("renderer:navigate", "/cluster/foo/settings");
-  });
-
   it("renders cluster name", () => {
     const { getByText } = render(<MainLayoutHeader cluster={cluster} />);
 
     expect(getByText("minikube")).toBeInTheDocument();
+  });
+
+  describe("Cluster Actions Menu", () => {
+    let settingsBtn: Element;
+    let disconnectBtn: Element;
+    let removeBtn: Element;
+
+    beforeEach(() => {
+      const { container } = render(<div>
+        <MainLayoutHeader cluster={cluster} />
+        <ConfirmDialog />
+      </div>);
+      const icon = container.querySelector(".Icon");
+
+      cluster.online = true;
+      fireEvent.click(icon);
+
+      [settingsBtn, disconnectBtn, removeBtn] = Array.from(document.querySelectorAll("ul.ClusterActionsMenu > li"))
+        .map(el => el.querySelector("span"));
+    });
+
+    afterEach(() => {
+      cluster.online = false;
+    });
+
+    it("renders cluster menu items", () => {
+      expect(settingsBtn).toBeDefined();
+      expect(settingsBtn.textContent).toBe("Settings");
+      expect(disconnectBtn).toBeDefined();
+      expect(disconnectBtn.textContent).toBe("Disconnect");
+      expect(removeBtn).toBeDefined();
+      expect(removeBtn.textContent).toBe("Remove");
+    });
+
+    it("navigates to cluster settings", () => {
+      fireEvent.click(settingsBtn);
+      expect(mockBroadcastIpc).toBeCalledWith("renderer:navigate", "/cluster/foo/settings");
+    });
+
+    it("disconnects from cluster", () => {
+      fireEvent.click(disconnectBtn);
+      expect(mockRequestMain).toBeCalledWith(clusterDisconnectHandler, cluster.id);
+    });
+
+    it("opens 'Remove cluster' dialog", async () => {
+      fireEvent.click(removeBtn);
+      
+      const dialog = document.querySelector(".ConfirmDialog");
+
+      expect(dialog).toBeDefined();
+      expect(dialog).not.toBe(null);
+
+      const okBtn = dialog.querySelector("button.ok");
+
+      expect(okBtn.textContent).toBe("Remove");
+      // console.log(dialog);
+      
+    });
   });
 });

--- a/src/renderer/components/layout/__test__/main-layout-header.test.tsx
+++ b/src/renderer/components/layout/__test__/main-layout-header.test.tsx
@@ -94,9 +94,7 @@ describe("<MainLayoutHeader />", () => {
 
       const okBtn = dialog.querySelector("button.ok");
 
-      expect(okBtn.textContent).toBe("Remove");
-      // console.log(dialog);
-      
+      expect(okBtn.textContent).toBe("Remove");      
     });
   });
 });

--- a/src/renderer/components/layout/__test__/main-layout-header.test.tsx
+++ b/src/renderer/components/layout/__test__/main-layout-header.test.tsx
@@ -25,12 +25,12 @@ describe("<MainLayoutHeader />", () => {
     expect(container).toBeInstanceOf(HTMLElement);
   });
 
-  it("renders gear icon", () => {
+  it("renders three dots icon", () => {
     const { container } = render(<MainLayoutHeader cluster={cluster} />);
     const icon = container.querySelector(".Icon .icon");
 
     expect(icon).toBeInstanceOf(HTMLElement);
-    expect(icon).toHaveTextContent("settings");
+    expect(icon).toHaveTextContent("more_vert");
   });
 
   it("navigates to cluster settings", () => {
@@ -38,6 +38,11 @@ describe("<MainLayoutHeader />", () => {
     const icon = container.querySelector(".Icon");
 
     fireEvent.click(icon);
+    
+    const settingsBtn = document.querySelectorAll("ul.ClusterActionsMenu > li > span")[0];
+    
+    expect(settingsBtn.textContent).toBe("Settings");
+    fireEvent.click(settingsBtn);
     expect(mockBroadcastIpc).toBeCalledWith("renderer:navigate", "/cluster/foo/settings");
   });
 

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -13,7 +13,8 @@ interface Props {
 
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   const actions = ClusterActions(cluster);
-  const renderMenu = () => <MenuActions autoCloseOnSelect className="ClusterActionsMenu">
+  const renderMenu = () => (
+    <MenuActions autoCloseOnSelect className="ClusterActionsMenu">
     <MenuItem onClick={actions.showSettings}>
       <span>Settings</span>
     </MenuItem>

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -20,9 +20,13 @@ export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
     <MenuItem onClick={actions.disconnect}>
       <span>Disconnect</span>
     </MenuItem>
-    { !cluster.isManaged && <MenuItem onClick={actions.remove}>
-      <span>Remove</span>
-    </MenuItem> }
+    {
+       !cluster.isManaged && (
+         <MenuItem onClick={actions.remove}>
+	       <span>Remove</span>
+	     </MenuItem> 
+       )
+    }
   </MenuActions>;
 
   return (

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -29,10 +29,10 @@ export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
     <MenuItem onClick={actions.SHOW_SETTINGS}>
       <span>Settings</span>
     </MenuItem>
-    { cluster.online && <MenuItem onClick={actions.DISCONNECT}>
+    <MenuItem onClick={actions.DISCONNECT}>
       <span>Disconnect</span>
-    </MenuItem> }
-    { cluster.online && !cluster.isManaged && <MenuItem onClick={actions.REMOVE}>
+    </MenuItem>
+    { !cluster.isManaged && <MenuItem onClick={actions.REMOVE}>
       <span>Remove</span>
     </MenuItem> }
   </Menu>;

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   const actions = ClusterActions(cluster);
-  const renderMenu = () => <MenuActions className="ClusterActionsMenu">
+  const renderMenu = () => <MenuActions autoCloseOnSelect className="ClusterActionsMenu">
     <MenuItem onClick={actions.SHOW_SETTINGS}>
       <span>Settings</span>
     </MenuItem>

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -15,20 +15,20 @@ export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   const actions = ClusterActions(cluster);
   const renderMenu = () => (
     <MenuActions autoCloseOnSelect className="ClusterActionsMenu">
-    <MenuItem onClick={actions.showSettings}>
-      <span>Settings</span>
-    </MenuItem>
-    <MenuItem onClick={actions.disconnect}>
-      <span>Disconnect</span>
-    </MenuItem>
-    {
-       !cluster.isManaged && (
-         <MenuItem onClick={actions.remove}>
+      <MenuItem onClick={actions.showSettings}>
+        <span>Settings</span>
+      </MenuItem>
+      <MenuItem onClick={actions.disconnect}>
+        <span>Disconnect</span>
+      </MenuItem>
+      {
+        !cluster.isManaged && (
+          <MenuItem onClick={actions.remove}>
 	       <span>Remove</span>
 	     </MenuItem> 
-       )
-    }
-  </MenuActions>;
+        )
+      }
+    </MenuActions>);
 
   return (
     <header className={cssNames("flex gaps align-center justify-space-between", className)}>

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -14,13 +14,13 @@ interface Props {
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   const actions = ClusterActions(cluster);
   const renderMenu = () => <MenuActions autoCloseOnSelect className="ClusterActionsMenu">
-    <MenuItem onClick={actions.SHOW_SETTINGS}>
+    <MenuItem onClick={actions.showSettings}>
       <span>Settings</span>
     </MenuItem>
-    <MenuItem onClick={actions.DISCONNECT}>
+    <MenuItem onClick={actions.disconnect}>
       <span>Disconnect</span>
     </MenuItem>
-    { !cluster.isManaged && <MenuItem onClick={actions.REMOVE}>
+    { !cluster.isManaged && <MenuItem onClick={actions.remove}>
       <span>Remove</span>
     </MenuItem> }
   </MenuActions>;

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -1,8 +1,13 @@
 import { observer } from "mobx-react";
 import React from "react";
+import { remote } from "electron";
 
 import { clusterSettingsURL } from "../+cluster-settings";
-import { broadcastMessage } from "../../../common/ipc";
+import { landingURL } from "../+landing-page";
+import { ConfirmDialog } from "../confirm-dialog";
+import { clusterStore } from "../../../common/cluster-store";
+import { clusterDisconnectHandler } from "../../../common/cluster-ipc";
+import { broadcastMessage, requestMain } from "../../../common/ipc";
 import { Cluster } from "../../../main/cluster";
 import { cssNames } from "../../utils";
 import { Icon } from "../icon";
@@ -13,20 +18,69 @@ interface Props {
 }
 
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
+  const showContextMenu = () => {
+    const { Menu, MenuItem } = remote;
+    const menu = new Menu();
+
+    menu.append(new MenuItem({
+      label: "Settings",
+      click: () => {
+        broadcastMessage("renderer:navigate", clusterSettingsURL({
+          params: {
+            clusterId: cluster.id
+          }
+        }));
+      }
+    }));
+
+    if (cluster.online) {
+      menu.append(new MenuItem({
+        label: "Disconnect",
+        click: async () => {
+          if (clusterStore.isActive(cluster.id)) {
+            broadcastMessage("renderer:navigate", landingURL());
+            clusterStore.setActive(null);
+          }
+          await requestMain(clusterDisconnectHandler, cluster.id);
+        }
+      }));
+
+      if (!cluster.isManaged) {
+        menu.append(new MenuItem({
+          label: "Remove",
+          click: () => {
+            ConfirmDialog.open({
+              okButtonProps: {
+                primary: false,
+                accent: true,
+                label: "Remove"
+              },
+              ok: () => {
+                if (clusterStore.activeClusterId === cluster.id) {
+                  broadcastMessage("renderer:navigate", landingURL());
+                  clusterStore.setActive(null);
+                }
+                clusterStore.removeById(cluster.id);
+              },
+              message: <p>Are you sure want to remove cluster <b title={cluster.id}>{cluster.contextName}</b>?</p>,
+            });
+          }
+        }));
+      }
+    }
+    menu.popup({
+      window: remote.getCurrentWindow()
+    });
+  };
+
   return (
     <header className={cssNames("flex gaps align-center justify-space-between", className)}>
       <span className="cluster">{cluster.name}</span>
       <Icon
-        material="settings"
-        tooltip="Open cluster settings"
+        material="more_vert"
+        tooltip="Cluster actions"
         interactive
-        onClick={() => {
-          broadcastMessage("renderer:navigate", clusterSettingsURL({
-            params: {
-              clusterId: cluster.id
-            }
-          }));
-        }}
+        onClick={showContextMenu}
       />
     </header>
   );

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   const actions = ClusterActions(cluster);
-  const renderMenu = () => <MenuActions>
+  const renderMenu = () => <MenuActions className="ClusterActionsMenu">
     <MenuItem onClick={actions.SHOW_SETTINGS}>
       <span>Settings</span>
     </MenuItem>

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -1,12 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 import { observer } from "mobx-react";
-import { uniqueId } from "lodash";
 
 import { ClusterActions } from "../cluster-manager";
 import { Cluster } from "../../../main/cluster";
 import { cssNames } from "../../utils";
-import { Icon } from "../icon";
-import { Menu, MenuItem } from "../menu";
+import { MenuActions, MenuItem } from "../menu";
 
 interface Props {
   cluster: Cluster
@@ -14,18 +12,8 @@ interface Props {
 }
 
 export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
-  const [isMenuOpen, setMenuOpen] = useState(false);
-  const id = uniqueId("cluster_actions_");
   const actions = ClusterActions(cluster);
-
-  const renderMenu = () => <Menu
-    usePortal
-    isOpen={isMenuOpen}
-    open={() => setMenuOpen(true)}
-    close={() => setMenuOpen(false)}
-    className="ClusterActionsMenu"
-    htmlFor={id}
-    toggleEvent="click">
+  const renderMenu = () => <MenuActions>
     <MenuItem onClick={actions.SHOW_SETTINGS}>
       <span>Settings</span>
     </MenuItem>
@@ -35,16 +23,11 @@ export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
     { !cluster.isManaged && <MenuItem onClick={actions.REMOVE}>
       <span>Remove</span>
     </MenuItem> }
-  </Menu>;
+  </MenuActions>;
 
   return (
     <header className={cssNames("flex gaps align-center justify-space-between", className)}>
       <span className="cluster">{cluster.name}</span>
-      <Icon
-        id={id}
-        material="more_vert"
-        interactive
-      />
       {renderMenu()}
     </header>
   );

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -43,7 +43,6 @@ export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
       <Icon
         id={id}
         material="more_vert"
-        tooltip="Cluster actions"
         interactive
       />
       {renderMenu()}

--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "../error-boundary";
 import { ResizeDirection, ResizeGrowthDirection, ResizeSide, ResizingAnchor } from "../resizing-anchor";
 import { MainLayoutHeader } from "./main-layout-header";
 import { Sidebar } from "./sidebar";
+import { workspaceStore } from "../../../common/workspace-store";
 
 export interface MainLayoutProps {
   className?: any;

--- a/src/renderer/components/layout/main-layout.tsx
+++ b/src/renderer/components/layout/main-layout.tsx
@@ -10,7 +10,6 @@ import { ErrorBoundary } from "../error-boundary";
 import { ResizeDirection, ResizeGrowthDirection, ResizeSide, ResizingAnchor } from "../resizing-anchor";
 import { MainLayoutHeader } from "./main-layout-header";
 import { Sidebar } from "./sidebar";
-import { workspaceStore } from "../../../common/workspace-store";
 
 export interface MainLayoutProps {
   className?: any;


### PR DESCRIPTION
The top-right button in the cluster frame now has vertical-dots icon, clicking on it now produces the same menu, as right-clicking on the cluster icon. Popup at this button now says "Cluster actions". Closes #1895 
<img width="298" alt="Screen Shot 2021-02-02 at 6 44 27 PM" src="https://user-images.githubusercontent.com/22235527/106632671-af89d180-6586-11eb-9f4e-02f2189d477a.png">
