### PR TITLE
Fix snap packaging

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,7 @@ categories:
       - 'chore'
       - 'area/ci'
       - 'area/tests'
+      - 'dependencies'
 
 template: |
   ## Changes since $PREVIOUS_TAG
@@ -20,8 +21,10 @@ template: |
 
   ### Download
 
-  - [Lens v$RESOLVED_VERSION - Linux](https://snapcraft.io/kontena-lens)
-    - [AppImage](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-$RESOLVED_VERSION.AppImage)
+  - Lens v$RESOLVED_VERSION - Linux
+    - [AppImage](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-$RESOLVED_VERSION.x86_64.AppImage)
+    - [DEB](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-$RESOLVED_VERSION.amd64.deb)
+    - [RPM](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-$RESOLVED_VERSION.x86_64.rpm)
     - [Snapcraft](https://snapcraft.io/kontena-lens)
   - [Lens v$RESOLVED_VERSION - MacOS](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-$RESOLVED_VERSION.dmg)
   - [Lens v$RESOLVED_VERSION - Windows](https://github.com/lensapp/lens/releases/download/v$RESOLVED_VERSION/Lens-Setup-$RESOLVED_VERSION.exe)

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -4,7 +4,7 @@ import { exec } from "child_process";
 
 const AppPaths: Partial<Record<NodeJS.Platform, string>> = {
   "win32": "./dist/win-unpacked/Lens.exe",
-  "linux": "./dist/linux-unpacked/lens",
+  "linux": "./dist/linux-unpacked/kontena-lens",
   "darwin": "./dist/mac/Lens.app/Contents/MacOS/Lens",
 };
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     ],
     "linux": {
       "category": "Network",
-      "executableName": "lens",
       "artifactName": "${productName}-${version}.${arch}.${ext}",
       "target": [
         "deb",
@@ -162,16 +161,16 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
     },
+    "snap": {
+      "confinement": "classic"
+    },
     "publish": [
       {
         "provider": "github",
         "repo": "lens",
         "owner": "lensapp"
       }
-    ],
-    "snap": {
-      "confinement": "classic"
-    }
+    ]
   },
   "lens": {
     "extensions": [


### PR DESCRIPTION
- revert executable name back to `kontena-lens` because snap uses that for package name (this cannot be changed per linux target)
- fix release-drafter template to match artifact names (less manual editing)
- adds `dependencies` to release-drafter "maintenance" group

Fixes #2078 