### PR TITLE
Fix BarChart component to return "No metrics" immediately if metrics data are missing

### DIFF
--- a/src/renderer/components/chart/bar-chart.tsx
+++ b/src/renderer/components/chart/bar-chart.tsx
@@ -50,6 +50,10 @@ export class BarChart extends React.Component<Props> {
         })
     };
 
+    if (chartData.datasets.length == 0) {
+      return <NoMetrics/>;
+    }
+
     const formatTimeLabels = (timestamp: string, index: number) => {
       const label = moment(parseInt(timestamp)).format("HH:mm");
       const offset = "     ";
@@ -142,10 +146,6 @@ export class BarChart extends React.Component<Props> {
       }
     };
     const options = merge(barOptions, customOptions);
-
-    if (chartData.datasets.length == 0) {
-      return <NoMetrics/>;
-    }
 
     return (
       <Chart


### PR DESCRIPTION
Fixes regression from #2054 in `BarChart` component, where interval of ZebraStripes was set based on the first dataset's data length. This was causing error if the first dataset does not exist. This PR will return `<NoMetrics/>` immediately if length of `chartData.datasets` is zero.