### PR TITLE
Fix: select all namespaces

### DIFF
--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -70,6 +70,7 @@ export class KubeWatchApi {
         return [];
       }
 
+      // TODO: optimize - check when all namespaces are selected and then request all in one
       if (api.isNamespaced && !this.cluster.isGlobalWatchEnabled) {
         return this.namespaces.map(namespace => api.getWatchUrl(namespace));
       }

--- a/src/renderer/components/+namespaces/namespace-select.tsx
+++ b/src/renderer/components/+namespaces/namespace-select.tsx
@@ -85,10 +85,9 @@ export class NamespaceSelectFilter extends React.Component {
     const namespaces = namespaceStore.getContextNamespaces();
 
     switch (namespaces.length) {
+      case 0:
       case namespaceStore.allowedNamespaces.length:
         return <>All namespaces</>;
-      case 0:
-        return <>Select a namespace</>;
       case 1:
         return <>Namespace: {namespaces[0]}</>;
       default:
@@ -116,7 +115,7 @@ export class NamespaceSelectFilter extends React.Component {
     if (namespace) {
       namespaceStore.toggleContext(namespace);
     } else {
-      namespaceStore.toggleAll(); // "All namespaces" option clicked
+      namespaceStore.resetContext(); // "All namespaces" clicked, empty list considered as "all"
     }
   };
 

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -103,8 +103,20 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     return [];
   }
 
-  public getContextNamespaces(): string[] {
-    return Array.from(this.contextNs);
+  getContextNamespaces(): string[] {
+    const namespaces = Array.from(this.contextNs);
+
+    // show all namespaces when nothing selected
+    if (!namespaces.length) {
+      // return actual namespaces list since "allowedNamespaces" updating every 30s in cluster and thus might be stale
+      if (this.isLoaded) {
+        return this.items.map(namespace => namespace.getName());
+      }
+
+      return this.allowedNamespaces;
+    }
+
+    return namespaces;
   }
 
   getSubscribeApis() {
@@ -137,6 +149,11 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     const namespaces = [namespace].flat();
 
     this.contextNs.replace(namespaces);
+  }
+
+  @action
+  resetContext() {
+    this.contextNs.clear();
   }
 
   hasContext(namespaces: string | string[]) {


### PR DESCRIPTION
Previously "All namespaces" option was working as select/deselect all.
Now it's always reset to all namespaces (empty list).

**Demo**

https://user-images.githubusercontent.com/6377066/106899604-3ad9a300-66fe-11eb-94e2-0ade59d3cdb5.mp4

