### PR TITLE
Revert store and watch refactorings

### DIFF
--- a/src/common/rbac.ts
+++ b/src/common/rbac.ts
@@ -7,38 +7,37 @@ export type KubeResource =
   "endpoints" | "customresourcedefinitions" | "horizontalpodautoscalers" | "podsecuritypolicies" | "poddisruptionbudgets";
 
 export interface KubeApiResource {
-  kind: string; // resource type (e.g. "Namespace")
-  apiName: KubeResource; // valid api resource name (e.g. "namespaces")
+  resource: KubeResource; // valid resource name
   group?: string; // api-group
 }
 
 // TODO: auto-populate all resources dynamically (see: kubectl api-resources -o=wide -v=7)
 export const apiResources: KubeApiResource[] = [
-  { kind: "ConfigMap", apiName: "configmaps" },
-  { kind: "CronJob", apiName: "cronjobs", group: "batch" },
-  { kind: "CustomResourceDefinition", apiName: "customresourcedefinitions", group: "apiextensions.k8s.io" },
-  { kind: "DaemonSet", apiName: "daemonsets", group: "apps" },
-  { kind: "Deployment", apiName: "deployments", group: "apps" },
-  { kind: "Endpoint", apiName: "endpoints" },
-  { kind: "Event", apiName: "events" },
-  { kind: "HorizontalPodAutoscaler", apiName: "horizontalpodautoscalers" },
-  { kind: "Ingress", apiName: "ingresses", group: "networking.k8s.io" },
-  { kind: "Job", apiName: "jobs", group: "batch" },
-  { kind: "Namespace", apiName: "namespaces" },
-  { kind: "LimitRange", apiName: "limitranges" },
-  { kind: "NetworkPolicy", apiName: "networkpolicies", group: "networking.k8s.io" },
-  { kind: "Node", apiName: "nodes" },
-  { kind: "PersistentVolume", apiName: "persistentvolumes" },
-  { kind: "PersistentVolumeClaim", apiName: "persistentvolumeclaims" },
-  { kind: "Pod", apiName: "pods" },
-  { kind: "PodDisruptionBudget", apiName: "poddisruptionbudgets" },
-  { kind: "PodSecurityPolicy", apiName: "podsecuritypolicies" },
-  { kind: "ResourceQuota", apiName: "resourcequotas" },
-  { kind: "ReplicaSet", apiName: "replicasets", group: "apps" },
-  { kind: "Secret", apiName: "secrets" },
-  { kind: "Service", apiName: "services" },
-  { kind: "StatefulSet", apiName: "statefulsets", group: "apps" },
-  { kind: "StorageClass", apiName: "storageclasses", group: "storage.k8s.io" },
+  { resource: "configmaps" },
+  { resource: "cronjobs", group: "batch" },
+  { resource: "customresourcedefinitions", group: "apiextensions.k8s.io" },
+  { resource: "daemonsets", group: "apps" },
+  { resource: "deployments", group: "apps" },
+  { resource: "endpoints" },
+  { resource: "events" },
+  { resource: "horizontalpodautoscalers" },
+  { resource: "ingresses", group: "networking.k8s.io" },
+  { resource: "jobs", group: "batch" },
+  { resource: "limitranges" },
+  { resource: "namespaces" },
+  { resource: "networkpolicies", group: "networking.k8s.io" },
+  { resource: "nodes" },
+  { resource: "persistentvolumes" },
+  { resource: "persistentvolumeclaims" },
+  { resource: "pods" },
+  { resource: "poddisruptionbudgets" },
+  { resource: "podsecuritypolicies" },
+  { resource: "resourcequotas" },
+  { resource: "replicasets", group: "apps" },
+  { resource: "secrets" },
+  { resource: "services" },
+  { resource: "statefulsets", group: "apps" },
+  { resource: "storageclasses", group: "storage.k8s.io" },
 ];
 
 export function isAllowedResource(resources: KubeResource | KubeResource[]) {

--- a/src/common/utils/delay.ts
+++ b/src/common/utils/delay.ts
@@ -1,6 +1,0 @@
-// Create async delay for provided timeout in milliseconds
-
-export async function delay(timeoutMs = 1000) {
-  if (!timeoutMs) return;
-  await new Promise(resolve => setTimeout(resolve, timeoutMs));
-}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -7,7 +7,6 @@ export * from "./autobind";
 export * from "./base64";
 export * from "./camelCase";
 export * from "./cloneJson";
-export * from "./delay";
 export * from "./debouncePromise";
 export * from "./defineGlobal";
 export * from "./getRandId";

--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -126,7 +126,6 @@ describe("create clusters", () => {
     };
 
     jest.spyOn(Cluster.prototype, "isClusterAdmin").mockReturnValue(Promise.resolve(true));
-    jest.spyOn(Cluster.prototype, "canUseWatchApi").mockReturnValue(Promise.resolve(true));
     jest.spyOn(Cluster.prototype, "canI")
       .mockImplementation((attr: V1ResourceAttributes): Promise<boolean> => {
         expect(attr.namespace).toBe("default");

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -190,7 +190,7 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @observable metadata: ClusterMetadata = {};
   /**
-   * List of allowed namespaces verified via K8S::SelfSubjectAccessReview api
+   * List of allowed namespaces
    *
    * @observable
    */
@@ -203,7 +203,7 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @observable allowedResources: string[] = [];
   /**
-   * List of accessible namespaces provided by user in the Cluster Settings
+   * List of accessible namespaces
    *
    * @observable
    */
@@ -224,7 +224,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * @computed
    */
   @computed get name() {
-    return this.preferences.clusterName || this.contextName;
+    return this.preferences.clusterName || this.contextName;
   }
 
   /**
@@ -279,8 +279,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * @param port port where internal auth proxy is listening
    * @internal
    */
-  @action
-  async init(port: number) {
+  @action async init(port: number) {
     try {
       this.initializing = true;
       this.contextHandler = new ContextHandler(this);
@@ -335,8 +334,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * @param force force activation
    * @internal
    */
-  @action
-  async activate(force = false) {
+  @action async activate(force = false) {
     if (this.activated && !force) {
       return this.pushState();
     }
@@ -375,8 +373,7 @@ export class Cluster implements ClusterModel, ClusterState {
   /**
    * @internal
    */
-  @action
-  async reconnect() {
+  @action async reconnect() {
     logger.info(`[CLUSTER]: reconnect`, this.getMeta());
     this.contextHandler?.stopServer();
     await this.contextHandler?.ensureServer();
@@ -403,8 +400,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * @internal
    * @param opts refresh options
    */
-  @action
-  async refresh(opts: ClusterRefreshOptions = {}) {
+  @action async refresh(opts: ClusterRefreshOptions = {}) {
     logger.info(`[CLUSTER]: refresh`, this.getMeta());
     await this.whenInitialized;
     await this.refreshConnectionStatus();
@@ -424,8 +420,7 @@ export class Cluster implements ClusterModel, ClusterState {
   /**
    * @internal
    */
-  @action
-  async refreshMetadata() {
+  @action async refreshMetadata() {
     logger.info(`[CLUSTER]: refreshMetadata`, this.getMeta());
     const metadata = await detectorRegistry.detectForCluster(this);
     const existingMetadata = this.metadata;
@@ -436,8 +431,7 @@ export class Cluster implements ClusterModel, ClusterState {
   /**
    * @internal
    */
-  @action
-  async refreshConnectionStatus() {
+  @action async refreshConnectionStatus() {
     const connectionStatus = await this.getConnectionStatus();
 
     this.online = connectionStatus > ClusterStatus.Offline;
@@ -447,8 +441,7 @@ export class Cluster implements ClusterModel, ClusterState {
   /**
    * @internal
    */
-  @action
-  async refreshAllowedResources() {
+  @action async refreshAllowedResources() {
     this.allowedNamespaces = await this.getAllowedNamespaces();
     this.allowedResources = await this.getAllowedResources();
   }
@@ -675,7 +668,7 @@ export class Cluster implements ClusterModel, ClusterState {
           for (const namespace of this.allowedNamespaces.slice(0, 10)) {
             if (!this.resourceAccessStatuses.get(apiResource)) {
               const result = await this.canI({
-                resource: apiResource.apiName,
+                resource: apiResource.resource,
                 group: apiResource.group,
                 verb: "list",
                 namespace
@@ -690,19 +683,9 @@ export class Cluster implements ClusterModel, ClusterState {
 
       return apiResources
         .filter((resource) => this.resourceAccessStatuses.get(resource))
-        .map(apiResource => apiResource.apiName);
+        .map(apiResource => apiResource.resource);
     } catch (error) {
       return [];
     }
-  }
-
-  isAllowedResource(kind: string): boolean {
-    const apiResource = apiResources.find(resource => resource.kind === kind || resource.apiName === kind);
-
-    if (apiResource) {
-      return this.allowedResources.includes(apiResource.apiName);
-    }
-
-    return true; // allowed by default for other resources
   }
 }

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -147,7 +147,7 @@ export class Router {
     this.router.add({ method: "get", path: `${apiPrefix}/kubeconfig/service-account/{namespace}/{account}` }, kubeconfigRoute.routeServiceAccountRoute.bind(kubeconfigRoute));
 
     // Watch API
-    this.router.add({ method: "post", path: `${apiPrefix}/watch` }, watchRoute.routeWatch.bind(watchRoute));
+    this.router.add({ method: "get", path: `${apiPrefix}/watch` }, watchRoute.routeWatch.bind(watchRoute));
 
     // Metrics API
     this.router.add({ method: "post", path: `${apiPrefix}/metrics` }, metricsRoute.routeMetrics.bind(metricsRoute));

--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -2,7 +2,7 @@ import type { KubeObjectStore } from "../kube-object.store";
 
 import { action, observable } from "mobx";
 import { autobind } from "../utils";
-import { KubeApi, parseKubeApi } from "./kube-api";
+import { KubeApi } from "./kube-api";
 
 @autobind()
 export class ApiManager {
@@ -11,7 +11,7 @@ export class ApiManager {
 
   getApi(pathOrCallback: string | ((api: KubeApi) => boolean)) {
     if (typeof pathOrCallback === "string") {
-      return this.apis.get(pathOrCallback) || this.apis.get(parseKubeApi(pathOrCallback).apiBase);
+      return this.apis.get(pathOrCallback) || this.apis.get(KubeApi.parseApi(pathOrCallback).apiBase);
     }
 
     return Array.from(this.apis.values()).find(pathOrCallback ?? (() => true));

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -1,348 +1,201 @@
-// Kubernetes watch-api client
-// API: https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams
+// Kubernetes watch-api consumer
 
-import type { Cluster } from "../../main/cluster";
-import type { IKubeWatchEvent, IKubeWatchEventStreamEnd, IWatchRoutePayload } from "../../main/routes/watch-route";
-import type { KubeObject } from "./kube-object";
-import type { KubeObjectStore } from "../kube-object.store";
-import type { NamespaceStore } from "../components/+namespaces/namespace.store";
-
-import plimit from "p-limit";
-import debounce from "lodash/debounce";
-import { comparer, computed, observable, reaction } from "mobx";
+import { computed, observable, reaction } from "mobx";
+import { stringify } from "querystring";
 import { autobind, EventEmitter } from "../utils";
-import { ensureObjectSelfLink, KubeApi, parseKubeApi } from "./kube-api";
-import { KubeJsonApiData, KubeJsonApiError } from "./kube-json-api";
-import { apiPrefix, isDebugging, isProduction } from "../../common/vars";
+import { KubeJsonApiData } from "./kube-json-api";
+import type { KubeObjectStore } from "../kube-object.store";
+import { ensureObjectSelfLink, KubeApi } from "./kube-api";
 import { apiManager } from "./api-manager";
+import { apiPrefix, isDevelopment } from "../../common/vars";
+import { getHostedCluster } from "../../common/cluster-store";
 
-export { IKubeWatchEvent, IKubeWatchEventStreamEnd };
-
-export interface IKubeWatchMessage<T extends KubeObject = any> {
-  data?: IKubeWatchEvent<KubeJsonApiData>
-  error?: IKubeWatchEvent<KubeJsonApiError>;
-  api?: KubeApi<T>;
-  store?: KubeObjectStore<T>;
+export interface IKubeWatchEvent<T = any> {
+  type: "ADDED" | "MODIFIED" | "DELETED" | "ERROR";
+  object?: T;
 }
 
-export interface IKubeWatchSubscribeStoreOptions {
-  preload?: boolean; // preload store items, default: true
-  waitUntilLoaded?: boolean; // subscribe only after loading all stores, default: true
-  cacheLoading?: boolean; // when enabled loading store will be skipped, default: false
+export interface IKubeWatchRouteEvent {
+  type: "STREAM_END";
+  url: string;
+  status: number;
 }
 
-export interface IKubeWatchReconnectOptions {
-  reconnectAttempts: number;
-  timeout: number;
-}
-
-export interface IKubeWatchLog {
-  message: string | Error;
-  meta?: object;
+export interface IKubeWatchRouteQuery {
+  api: string | string[];
 }
 
 @autobind()
 export class KubeWatchApi {
-  private cluster: Cluster;
-  private namespaceStore: NamespaceStore;
-
-  private requestId = 0;
-  private isConnected = false;
-  private reader: ReadableStreamReader<string>;
-  private subscribers = observable.map<KubeApi, number>();
-
-  // events
-  public onMessage = new EventEmitter<[IKubeWatchMessage]>();
-
-  @computed get isActive(): boolean {
-    return this.apis.length > 0;
-  }
-
-  @computed get apis(): string[] {
-    const { cluster, namespaceStore } = this;
-    const activeApis = Array.from(this.subscribers.keys());
-
-    return activeApis.map(api => {
-      if (!cluster.isAllowedResource(api.kind)) {
-        return [];
-      }
-
-      if (api.isNamespaced) {
-        return namespaceStore.getContextNamespaces().map(namespace => api.getWatchUrl(namespace));
-      } else {
-        return api.getWatchUrl();
-      }
-    }).flat();
-  }
+  protected evtSource: EventSource;
+  protected onData = new EventEmitter<[IKubeWatchEvent]>();
+  protected subscribers = observable.map<KubeApi, number>();
+  protected reconnectTimeoutMs = 5000;
+  protected maxReconnectsOnError = 10;
+  protected reconnectAttempts = this.maxReconnectsOnError;
 
   constructor() {
-    this.init();
-  }
-
-  private async init() {
-    const { getHostedCluster } = await import("../../common/cluster-store");
-    const { namespaceStore } = await import("../components/+namespaces/namespace.store");
-
-    await namespaceStore.whenReady;
-
-    this.cluster = getHostedCluster();
-    this.namespaceStore = namespaceStore;
-    this.bindAutoConnect();
-  }
-
-  private bindAutoConnect() {
-    const connect = debounce(() => this.connect(), 1000);
-
-    reaction(() => this.apis, connect, {
+    reaction(() => this.activeApis, () => this.connect(), {
       fireImmediately: true,
-      equals: comparer.structural,
+      delay: 500,
     });
+  }
 
-    window.addEventListener("online", () => this.connect());
-    window.addEventListener("offline", () => this.disconnect());
-    setInterval(() => this.connectionCheck(), 60000 * 5); // every 5m
+  @computed get activeApis() {
+    return Array.from(this.subscribers.keys());
   }
 
   getSubscribersCount(api: KubeApi) {
     return this.subscribers.get(api) || 0;
   }
 
-  isAllowedApi(api: KubeApi): boolean {
-    return !!this?.cluster.isAllowedResource(api.kind);
-  }
-
-  subscribeApi(api: KubeApi | KubeApi[]): () => void {
-    const apis: KubeApi[] = [api].flat();
-
+  subscribe(...apis: KubeApi[]) {
     apis.forEach(api => {
-      if (!this.isAllowedApi(api)) return; // skip
       this.subscribers.set(api, this.getSubscribersCount(api) + 1);
     });
 
-    return () => {
-      apis.forEach(api => {
-        const count = this.getSubscribersCount(api) - 1;
+    return () => apis.forEach(api => {
+      const count = this.getSubscribersCount(api) - 1;
 
-        if (count <= 0) this.subscribers.delete(api);
-        else this.subscribers.set(api, count);
-      });
-    };
-  }
-
-  subscribeStores(stores: KubeObjectStore[], options: IKubeWatchSubscribeStoreOptions = {}): () => void {
-    const { preload = true, waitUntilLoaded = true, cacheLoading = false } = options;
-    const limitRequests = plimit(1); // load stores one by one to allow quick skipping when fast clicking btw pages
-    const preloading: Promise<any>[] = [];
-    const apis = new Set(stores.map(store => store.getSubscribeApis()).flat());
-    const unsubscribeList: (() => void)[] = [];
-    let isUnsubscribed = false;
-
-    const subscribe = () => {
-      if (isUnsubscribed) return;
-      apis.forEach(api => unsubscribeList.push(this.subscribeApi(api)));
-    };
-
-    if (preload) {
-      for (const store of stores) {
-        preloading.push(limitRequests(async () => {
-          if (cacheLoading && store.isLoaded) return; // skip
-
-          return store.loadAll();
-        }));
-      }
-    }
-
-    if (waitUntilLoaded) {
-      Promise.all(preloading).then(subscribe, error => {
-        this.log({
-          message: new Error("Loading stores has failed"),
-          meta: { stores, error, options },
-        });
-      });
-    } else {
-      subscribe();
-    }
-
-    // unsubscribe
-    return () => {
-      if (isUnsubscribed) return;
-      isUnsubscribed = true;
-      limitRequests.clearQueue();
-      unsubscribeList.forEach(unsubscribe => unsubscribe());
-    };
-  }
-
-  protected async connectionCheck() {
-    if (!this.isConnected) {
-      this.log({ message: "Offline: reconnecting.." });
-      await this.connect();
-    }
-
-    this.log({
-      message: `Connection check: ${this.isConnected ? "online" : "offline"}`,
-      meta: { connected: this.isConnected },
+      if (count <= 0) this.subscribers.delete(api);
+      else this.subscribers.set(api, count);
     });
   }
 
-  protected async connect(apis = this.apis) {
-    this.disconnect(); // close active connections first
+  // FIXME: use POST to send apis for subscribing (list could be huge)
+  // TODO: try to use normal fetch res.body stream to consume watch-api updates
+  // https://github.com/lensapp/lens/issues/1898
+  protected async getQuery() {
+    const { namespaceStore } = await import("../components/+namespaces/namespace.store");
 
-    if (!navigator.onLine || !apis.length) {
-      this.isConnected = false;
+    await namespaceStore.whenReady;
+    const { isAdmin } = getHostedCluster();
 
+    return {
+      api: this.activeApis.map(api => {
+        if (isAdmin && !api.isNamespaced) {
+          return api.getWatchUrl();
+        }
+
+        if (api.isNamespaced) {
+          return namespaceStore.getContextNamespaces().map(namespace => api.getWatchUrl(namespace));
+        }
+
+        return [];
+      }).flat()
+    };
+  }
+
+  // todo: maybe switch to websocket to avoid often reconnects
+  @autobind()
+  protected async connect() {
+    if (this.evtSource) this.disconnect(); // close previous connection
+
+    const query = await this.getQuery();
+
+    if (!this.activeApis.length || !query.api.length) {
       return;
     }
 
-    this.log({
-      message: "Connecting",
-      meta: { apis }
-    });
+    const apiUrl = `${apiPrefix}/watch?${stringify(query)}`;
 
-    try {
-      const requestId = ++this.requestId;
-      const abortController = new AbortController();
+    this.evtSource = new EventSource(apiUrl);
+    this.evtSource.onmessage = this.onMessage;
+    this.evtSource.onerror = this.onError;
+    this.writeLog("CONNECTING", query.api);
+  }
 
-      const request = await fetch(`${apiPrefix}/watch`, {
-        method: "POST",
-        body: JSON.stringify({ apis } as IWatchRoutePayload),
-        signal: abortController.signal,
-        headers: {
-          "content-type": "application/json"
-        }
-      });
-
-      // request above is stale since new request-id has been issued
-      if (this.requestId !== requestId) {
-        abortController.abort();
-
-        return;
-      }
-
-      let jsonBuffer = "";
-      const stream = request.body.pipeThrough(new TextDecoderStream());
-      const reader = stream.getReader();
-
-      this.isConnected = true;
-      this.reader = reader;
-
-      while (true) {
-        const { done, value } = await reader.read();
-
-        if (done) break; // exit
-
-        const events = (jsonBuffer + value).split("\n");
-
-        jsonBuffer = this.processBuffer(events);
-      }
-    } catch (error) {
-      this.log({ message: error });
-    } finally {
-      this.isConnected = false;
+  reconnect() {
+    if (!this.evtSource || this.evtSource.readyState !== EventSource.OPEN) {
+      this.reconnectAttempts = this.maxReconnectsOnError;
+      this.connect();
     }
   }
 
   protected disconnect() {
-    this.reader?.cancel();
-    this.reader = null;
-    this.isConnected = false;
+    if (!this.evtSource) return;
+    this.evtSource.close();
+    this.evtSource.onmessage = null;
+    this.evtSource = null;
   }
 
-  // process received stream events, returns unprocessed buffer chunk if any
-  protected processBuffer(events: string[]): string {
-    for (const json of events) {
-      try {
-        const kubeEvent: IKubeWatchEvent = JSON.parse(json);
-        const message = this.getMessage(kubeEvent);
+  protected onMessage(evt: MessageEvent) {
+    if (!evt.data) return;
+    const data = JSON.parse(evt.data);
 
-        this.onMessage.emit(message);
-      } catch (error) {
-        return json;
-      }
-    }
-
-    return "";
-  }
-
-  protected getMessage(event: IKubeWatchEvent): IKubeWatchMessage {
-    const message: IKubeWatchMessage = {};
-
-    switch (event.type) {
-      case "ADDED":
-      case "DELETED":
-
-      case "MODIFIED": {
-        const data = event as IKubeWatchEvent<KubeJsonApiData>;
-        const api = apiManager.getApiByKind(data.object.kind, data.object.apiVersion);
-
-        message.data = data;
-
-        if (api) {
-          ensureObjectSelfLink(api, data.object);
-
-          const { namespace, resourceVersion } = data.object.metadata;
-
-          api.setResourceVersion(namespace, resourceVersion);
-          api.setResourceVersion("", resourceVersion);
-
-          message.api = api;
-          message.store = apiManager.getStore(api);
-        }
-        break;
-      }
-
-      case "ERROR":
-        message.error = event as IKubeWatchEvent<KubeJsonApiError>;
-        break;
-
-      case "STREAM_END": {
-        this.onServerStreamEnd(event as IKubeWatchEventStreamEnd, {
-          reconnectAttempts: 5,
-          timeout: 1000,
-        });
-        break;
-      }
-    }
-
-    return message;
-  }
-
-  protected async onServerStreamEnd(event: IKubeWatchEventStreamEnd, opts?: IKubeWatchReconnectOptions) {
-    const { apiBase, namespace } = parseKubeApi(event.url);
-    const api = apiManager.getApi(apiBase);
-
-    if (!api) return;
-
-    try {
-      await api.refreshResourceVersion({ namespace });
-      this.connect();
-    } catch (error) {
-      this.log({
-        message: new Error(`Failed to connect on single stream end: ${error}`),
-        meta: { event, error },
-      });
-
-      if (this.isActive && opts?.reconnectAttempts > 0) {
-        opts.reconnectAttempts--;
-        setTimeout(() => this.onServerStreamEnd(event, opts), opts.timeout); // repeat event
-      }
-    }
-  }
-
-  protected log({ message, meta = {} }: IKubeWatchLog) {
-    if (isProduction && !isDebugging) {
-      return;
-    }
-
-    const logMessage = `%c[KUBE-WATCH-API]: ${String(message).toUpperCase()}`;
-    const isError = message instanceof Error;
-    const textStyle = `font-weight: bold;`;
-    const time = new Date().toLocaleString();
-
-    if (isError) {
-      console.error(logMessage, textStyle, { time, ...meta });
+    if ((data as IKubeWatchEvent).object) {
+      this.onData.emit(data);
     } else {
-      console.info(logMessage, textStyle, { time, ...meta });
+      this.onRouteEvent(data);
     }
+  }
+
+  protected async onRouteEvent(event: IKubeWatchRouteEvent) {
+    if (event.type === "STREAM_END") {
+      this.disconnect();
+      const { apiBase, namespace } = KubeApi.parseApi(event.url);
+      const api = apiManager.getApi(apiBase);
+
+      if (api) {
+        try {
+          await api.refreshResourceVersion({ namespace });
+          this.reconnect();
+        } catch (error) {
+          console.error("failed to refresh resource version", error);
+
+          if (this.subscribers.size > 0) {
+            setTimeout(() => {
+              this.onRouteEvent(event);
+            }, 1000);
+          }
+        }
+      }
+    }
+  }
+
+  protected onError(evt: MessageEvent) {
+    const { reconnectAttempts: attemptsRemain, reconnectTimeoutMs } = this;
+
+    if (evt.eventPhase === EventSource.CLOSED) {
+      if (attemptsRemain > 0) {
+        this.reconnectAttempts--;
+        setTimeout(() => this.connect(), reconnectTimeoutMs);
+      }
+    }
+  }
+
+  protected writeLog(...data: any[]) {
+    if (isDevelopment) {
+      console.log("%cKUBE-WATCH-API:", `font-weight: bold`, ...data);
+    }
+  }
+
+  addListener(store: KubeObjectStore, callback: (evt: IKubeWatchEvent) => void) {
+    const listener = (evt: IKubeWatchEvent<KubeJsonApiData>) => {
+      if (evt.type === "ERROR") {
+        return; // e.g. evt.object.message == "too old resource version"
+      }
+
+      const { namespace, resourceVersion } = evt.object.metadata;
+      const api = apiManager.getApiByKind(evt.object.kind, evt.object.apiVersion);
+
+      api.setResourceVersion(namespace, resourceVersion);
+      api.setResourceVersion("", resourceVersion);
+
+      ensureObjectSelfLink(api, evt.object);
+
+      if (store == apiManager.getStore(api)) {
+        callback(evt);
+      }
+    };
+
+    this.onData.addListener(listener);
+
+    return () => this.onData.removeListener(listener);
+  }
+
+  reset() {
+    this.subscribers.clear();
   }
 }
 

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -70,7 +70,6 @@ export class KubeWatchApi {
         return [];
       }
 
-      // TODO: optimize - check when all namespaces are selected and then request all in one
       if (api.isNamespaced && !this.cluster.isGlobalWatchEnabled) {
         return this.namespaces.map(namespace => api.getWatchUrl(namespace));
       }

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -11,7 +11,7 @@ import { apiPrefix, isDevelopment } from "../../common/vars";
 import { getHostedCluster } from "../../common/cluster-store";
 
 export interface IKubeWatchEvent<T = any> {
-  type: "ADDED" | "MODIFIED" | "DELETED" | "ERROR";
+  type: "ADDED" | "MODIFIED" | "DELETED";
   object?: T;
 }
 
@@ -62,41 +62,27 @@ export class KubeWatchApi {
     });
   }
 
-  // FIXME: use POST to send apis for subscribing (list could be huge)
-  // TODO: try to use normal fetch res.body stream to consume watch-api updates
-  // https://github.com/lensapp/lens/issues/1898
-  protected async getQuery() {
-    const { namespaceStore } = await import("../components/+namespaces/namespace.store");
-
-    await namespaceStore.whenReady;
-    const { isAdmin } = getHostedCluster();
+  protected getQuery(): Partial<IKubeWatchRouteQuery> {
+    const { isAdmin, allowedNamespaces } = getHostedCluster();
 
     return {
       api: this.activeApis.map(api => {
-        if (isAdmin && !api.isNamespaced) {
-          return api.getWatchUrl();
-        }
+        if (isAdmin) return api.getWatchUrl();
 
-        if (api.isNamespaced) {
-          return namespaceStore.getContextNamespaces().map(namespace => api.getWatchUrl(namespace));
-        }
-
-        return [];
+        return allowedNamespaces.map(namespace => api.getWatchUrl(namespace));
       }).flat()
     };
   }
 
   // todo: maybe switch to websocket to avoid often reconnects
   @autobind()
-  protected async connect() {
+  protected connect() {
     if (this.evtSource) this.disconnect(); // close previous connection
 
-    const query = await this.getQuery();
-
-    if (!this.activeApis.length || !query.api.length) {
+    if (!this.activeApis.length) {
       return;
     }
-
+    const query = this.getQuery();
     const apiUrl = `${apiPrefix}/watch?${stringify(query)}`;
 
     this.evtSource = new EventSource(apiUrl);
@@ -172,10 +158,6 @@ export class KubeWatchApi {
 
   addListener(store: KubeObjectStore, callback: (evt: IKubeWatchEvent) => void) {
     const listener = (evt: IKubeWatchEvent<KubeJsonApiData>) => {
-      if (evt.type === "ERROR") {
-        return; // e.g. evt.object.message == "too old resource version"
-      }
-
       const { namespace, resourceVersion } = evt.object.metadata;
       const api = apiManager.getApiByKind(evt.object.kind, evt.object.apiVersion);
 

--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -58,11 +58,11 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   }
 
   @action
-  async loadAll(namespaces = namespaceStore.allowedNamespaces) {
+  async loadAll() {
     this.isLoading = true;
 
     try {
-      const items = await this.loadItems(namespaces);
+      const items = await this.loadItems(namespaceStore.getContextNamespaces());
 
       this.items.replace(this.sortItems(items));
       this.isLoaded = true;
@@ -71,10 +71,6 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
     } finally {
       this.isLoading = false;
     }
-  }
-
-  async loadSelectedNamespaces(): Promise<void> {
-    return this.loadAll(namespaceStore.getContextNamespaces());
   }
 
   async loadItems(namespaces: string[]) {
@@ -86,7 +82,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   async create(payload: IReleaseCreatePayload) {
     const response = await helmReleasesApi.create(payload);
 
-    if (this.isLoaded) this.loadSelectedNamespaces();
+    if (this.isLoaded) this.loadAll();
 
     return response;
   }
@@ -94,7 +90,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   async update(name: string, namespace: string, payload: IReleaseUpdatePayload) {
     const response = await helmReleasesApi.update(name, namespace, payload);
 
-    if (this.isLoaded) this.loadSelectedNamespaces();
+    if (this.isLoaded) this.loadAll();
 
     return response;
   }
@@ -102,7 +98,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   async rollback(name: string, namespace: string, revision: number) {
     const response = await helmReleasesApi.rollback(name, namespace, revision);
 
-    if (this.isLoaded) this.loadSelectedNamespaces();
+    if (this.isLoaded) this.loadAll();
 
     return response;
   }

--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -5,7 +5,7 @@ import { HelmRelease, helmReleasesApi, IReleaseCreatePayload, IReleaseUpdatePayl
 import { ItemStore } from "../../item.store";
 import { Secret } from "../../api/endpoints";
 import { secretsStore } from "../+config-secrets/secrets.store";
-import { namespaceStore } from "../+namespaces/namespace.store";
+import { getHostedCluster } from "../../../common/cluster-store";
 
 @autobind()
 export class ReleaseStore extends ItemStore<HelmRelease> {
@@ -60,23 +60,30 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   @action
   async loadAll() {
     this.isLoading = true;
+    let items;
 
     try {
-      const items = await this.loadItems(namespaceStore.getContextNamespaces());
+      const { isAdmin, allowedNamespaces } = getHostedCluster();
 
-      this.items.replace(this.sortItems(items));
-      this.isLoaded = true;
-    } catch (error) {
-      console.error(`Loading Helm Chart releases has failed: ${error}`);
+      items = await this.loadItems(!isAdmin ? allowedNamespaces : null);
     } finally {
+      if (items) {
+        items = this.sortItems(items);
+        this.items.replace(items);
+      }
+      this.isLoaded = true;
       this.isLoading = false;
     }
   }
 
-  async loadItems(namespaces: string[]) {
-    return Promise
-      .all(namespaces.map(namespace => helmReleasesApi.list(namespace)))
-      .then(items => items.flat());
+  async loadItems(namespaces?: string[]) {
+    if (!namespaces) {
+      return helmReleasesApi.list();
+    } else {
+      return Promise
+        .all(namespaces.map(namespace => helmReleasesApi.list(namespace)))
+        .then(items => items.flat());
+    }
   }
 
   async create(payload: IReleaseCreatePayload) {

--- a/src/renderer/components/+cluster/cluster-overview.tsx
+++ b/src/renderer/components/+cluster/cluster-overview.tsx
@@ -3,9 +3,13 @@ import "./cluster-overview.scss";
 import React from "react";
 import { reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
+
+import { eventStore } from "../+events/event.store";
 import { nodesStore } from "../+nodes/nodes.store";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { getHostedCluster } from "../../../common/cluster-store";
+import { isAllowedResource } from "../../../common/rbac";
+import { KubeObjectStore } from "../../kube-object.store";
 import { interval } from "../../utils";
 import { TabLayout } from "../layout/tab-layout";
 import { Spinner } from "../spinner";
@@ -13,33 +17,45 @@ import { ClusterIssues } from "./cluster-issues";
 import { ClusterMetrics } from "./cluster-metrics";
 import { clusterOverviewStore } from "./cluster-overview.store";
 import { ClusterPieCharts } from "./cluster-pie-charts";
-import { eventStore } from "../+events/event.store";
-import { kubeWatchApi } from "../../api/kube-watch-api";
 
 @observer
 export class ClusterOverview extends React.Component {
-  private metricPoller = interval(60, () => this.loadMetrics());
+  private stores: KubeObjectStore<any>[] = [];
+  private subscribers: Array<() => void> = [];
+  private metricPoller = interval(60, this.loadMetrics);
+
+  @disposeOnUnmount
+  fetchMetrics = reaction(
+    () => clusterOverviewStore.metricNodeRole, // Toggle Master/Worker node switcher
+    () => this.metricPoller.restart(true)
+  );
 
   loadMetrics() {
     getHostedCluster().available && clusterOverviewStore.loadMetrics();
   }
 
-  componentDidMount() {
-    this.metricPoller.start(true);
+  async componentDidMount() {
+    if (isAllowedResource("nodes")) {
+      this.stores.push(nodesStore);
+    }
 
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([nodesStore, podsStore, eventStore], {
-        preload: true,
-      }),
+    if (isAllowedResource("pods")) {
+      this.stores.push(podsStore);
+    }
 
-      reaction(
-        () => clusterOverviewStore.metricNodeRole, // Toggle Master/Worker node switcher
-        () => this.metricPoller.restart(true)
-      ),
-    ]);
+    if (isAllowedResource("events")) {
+      this.stores.push(eventStore);
+    }
+
+    await Promise.all(this.stores.map(store => store.loadAll()));
+    this.loadMetrics();
+
+    this.subscribers = this.stores.map(store => store.subscribe());
+    this.metricPoller.start();
   }
 
   componentWillUnmount() {
+    this.subscribers.forEach(dispose => dispose()); // unsubscribe all
     this.metricPoller.stop();
   }
 

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -30,7 +30,7 @@ export class CrdResources extends React.Component<Props> {
         const { store } = this;
 
         if (store && !store.isLoading && !store.isLoaded) {
-          store.loadSelectedNamespaces();
+          store.loadAll();
         }
       })
     ]);

--- a/src/renderer/components/+events/event.store.ts
+++ b/src/renderer/components/+events/event.store.ts
@@ -52,10 +52,6 @@ export class EventStore extends KubeObjectStore<KubeEvent> {
 
     return compact(eventsWithError);
   }
-
-  getWarningsCount() {
-    return this.getWarnings().length;
-  }
 }
 
 export const eventStore = new EventStore();

--- a/src/renderer/components/+events/kube-event-details.tsx
+++ b/src/renderer/components/+events/kube-event-details.tsx
@@ -14,7 +14,7 @@ export interface KubeEventDetailsProps {
 @observer
 export class KubeEventDetails extends React.Component<KubeEventDetailsProps> {
   async componentDidMount() {
-    eventStore.loadSelectedNamespaces();
+    eventStore.loadAll();
   }
 
   render() {

--- a/src/renderer/components/+namespaces/namespace-details.tsx
+++ b/src/renderer/components/+namespaces/namespace-details.tsx
@@ -32,8 +32,8 @@ export class NamespaceDetails extends React.Component<Props> {
   }
 
   componentDidMount() {
-    resourceQuotaStore.loadSelectedNamespaces();
-    limitRangeStore.loadSelectedNamespaces();
+    resourceQuotaStore.loadAll();
+    limitRangeStore.loadAll();
   }
 
   render() {

--- a/src/renderer/components/+namespaces/namespace-select.tsx
+++ b/src/renderer/components/+namespaces/namespace-select.tsx
@@ -85,9 +85,10 @@ export class NamespaceSelectFilter extends React.Component {
     const namespaces = namespaceStore.getContextNamespaces();
 
     switch (namespaces.length) {
-      case 0:
       case namespaceStore.allowedNamespaces.length:
         return <>All namespaces</>;
+      case 0:
+        return <>Select a namespace</>;
       case 1:
         return <>Namespace: {namespaces[0]}</>;
       default:
@@ -115,7 +116,7 @@ export class NamespaceSelectFilter extends React.Component {
     if (namespace) {
       namespaceStore.toggleContext(namespace);
     } else {
-      namespaceStore.resetContext(); // "All namespaces" clicked, empty list considered as "all"
+      namespaceStore.toggleAll(); // "All namespaces" option clicked
     }
   };
 

--- a/src/renderer/components/+namespaces/namespace-select.tsx
+++ b/src/renderer/components/+namespaces/namespace-select.tsx
@@ -2,14 +2,13 @@ import "./namespace-select.scss";
 
 import React from "react";
 import { computed } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import { Select, SelectOption, SelectProps } from "../select";
-import { cssNames } from "../../utils";
+import { cssNames, noop } from "../../utils";
 import { Icon } from "../icon";
 import { namespaceStore } from "./namespace.store";
 import { FilterIcon } from "../item-object-list/filter-icon";
 import { FilterType } from "../item-object-list/page-filters.store";
-import { kubeWatchApi } from "../../api/kube-watch-api";
 
 interface Props extends SelectProps {
   showIcons?: boolean;
@@ -29,13 +28,17 @@ const defaultProps: Partial<Props> = {
 @observer
 export class NamespaceSelect extends React.Component<Props> {
   static defaultProps = defaultProps as object;
+  private unsubscribe = noop;
 
-  componentDidMount() {
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([namespaceStore], {
-        preload: true,
-      })
-    ]);
+  async componentDidMount() {
+    if (!namespaceStore.isLoaded) {
+      await namespaceStore.loadAll();
+    }
+    this.unsubscribe = namespaceStore.subscribe();
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
   }
 
   @computed get options(): SelectOption[] {
@@ -57,7 +60,7 @@ export class NamespaceSelect extends React.Component<Props> {
 
     return label || (
       <>
-        {showIcons && <Icon small material="layers"/>}
+        {showIcons && <Icon small material="layers" />}
         {value}
       </>
     );
@@ -100,9 +103,9 @@ export class NamespaceSelectFilter extends React.Component {
 
           return (
             <div className="flex gaps align-center">
-              <FilterIcon type={FilterType.NAMESPACE}/>
+              <FilterIcon type={FilterType.NAMESPACE} />
               <span>{namespace}</span>
-              {isSelected && <Icon small material="check" className="box right"/>}
+              {isSelected && <Icon small material="check" className="box right" />}
             </div>
           );
         }}

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -103,20 +103,8 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     return [];
   }
 
-  getContextNamespaces(): string[] {
-    const namespaces = Array.from(this.contextNs);
-
-    // show all namespaces when nothing selected
-    if (!namespaces.length) {
-      // return actual namespaces list since "allowedNamespaces" updating every 30s in cluster and thus might be stale
-      if (this.isLoaded) {
-        return this.items.map(namespace => namespace.getName());
-      }
-
-      return this.allowedNamespaces;
-    }
-
-    return namespaces;
+  public getContextNamespaces(): string[] {
+    return Array.from(this.contextNs);
   }
 
   getSubscribeApis() {
@@ -149,11 +137,6 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     const namespaces = [namespace].flat();
 
     this.contextNs.replace(namespaces);
-  }
-
-  @action
-  resetContext() {
-    this.contextNs.clear();
   }
 
   hasContext(namespaces: string | string[]) {

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -117,15 +117,15 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     return namespaces;
   }
 
-  getSubscribeApis() {
+  subscribe(apis = [this.api]) {
     const { accessibleNamespaces } = getHostedCluster();
 
     // if user has given static list of namespaces let's not start watches because watch adds stuff that's not wanted
     if (accessibleNamespaces.length > 0) {
-      return [];
+      return Function; // no-op
     }
 
-    return super.getSubscribeApis();
+    return super.subscribe(apis);
   }
 
   protected async loadItems(params: KubeObjectStoreLoadingParams) {

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -73,7 +73,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   private autoLoadAllowedNamespaces(): IReactionDisposer {
-    return reaction(() => this.allowedNamespaces, namespaces => this.loadAll(namespaces), {
+    return reaction(() => this.allowedNamespaces, () => this.loadAll(), {
       fireImmediately: true,
       equals: comparer.shallow,
     });

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -1,4 +1,4 @@
-import { action, comparer, computed, IReactionDisposer, IReactionOptions, observable, reaction, toJS, when } from "mobx";
+import { action, comparer, IReactionDisposer, IReactionOptions, observable, reaction, toJS, when } from "mobx";
 import { autobind, createStorage } from "../../utils";
 import { KubeObjectStore, KubeObjectStoreLoadingParams } from "../../kube-object.store";
 import { Namespace, namespacesApi } from "../../api/endpoints/namespaces.api";
@@ -6,7 +6,7 @@ import { createPageParam } from "../../navigation";
 import { apiManager } from "../../api/api-manager";
 import { clusterStore, getHostedCluster } from "../../../common/cluster-store";
 
-const storage = createStorage<string[]>("context_namespaces", []);
+const storage = createStorage<string[]>("context_namespaces");
 
 export const namespaceUrlParam = createPageParam<string[]>({
   name: "namespaces",
@@ -34,7 +34,7 @@ export function getDummyNamespace(name: string) {
 export class NamespaceStore extends KubeObjectStore<Namespace> {
   api = namespacesApi;
 
-  @observable private contextNs = observable.set<string>();
+  @observable contextNs = observable.array<string>();
   @observable isReady = false;
 
   whenReady = when(() => this.isReady);
@@ -57,7 +57,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   public onContextChange(callback: (contextNamespaces: string[]) => void, opts: IReactionOptions = {}): IReactionDisposer {
-    return reaction(() => Array.from(this.contextNs), callback, {
+    return reaction(() => this.contextNs.toJS(), callback, {
       equals: comparer.shallow,
       ...opts,
     });
@@ -79,32 +79,42 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     });
   }
 
-  @computed get allowedNamespaces(): string[] {
+  get allowedNamespaces(): string[] {
     return toJS(getHostedCluster().allowedNamespaces);
   }
 
-  @computed
   private get initialNamespaces(): string[] {
-    const namespaces = new Set(this.allowedNamespaces);
-    const prevSelected = storage.get().filter(namespace => namespaces.has(namespace));
+    const allowed = new Set(this.allowedNamespaces);
+    const prevSelected = storage.get();
 
-    // return previously saved namespaces from local-storage
-    if (prevSelected.length > 0) {
-      return prevSelected;
+    if (Array.isArray(prevSelected)) {
+      return prevSelected.filter(namespace => allowed.has(namespace));
     }
 
     // otherwise select "default" or first allowed namespace
-    if (namespaces.has("default")) {
+    if (allowed.has("default")) {
       return ["default"];
-    } else if (namespaces.size) {
-      return [Array.from(namespaces)[0]];
+    } else if (allowed.size) {
+      return [Array.from(allowed)[0]];
     }
 
     return [];
   }
 
-  public getContextNamespaces(): string[] {
-    return Array.from(this.contextNs);
+  getContextNamespaces(): string[] {
+    const namespaces = this.contextNs.toJS();
+
+    // show all namespaces when nothing selected
+    if (!namespaces.length) {
+      if (this.isLoaded) {
+        // return actual namespaces list since "allowedNamespaces" updating every 30s in cluster and thus might be stale
+        return this.items.map(namespace => namespace.getName());
+      }
+
+      return this.allowedNamespaces;
+    }
+
+    return namespaces;
   }
 
   getSubscribeApis() {
@@ -133,46 +143,26 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   @action
-  setContext(namespace: string | string[]) {
-    const namespaces = [namespace].flat();
-
+  setContext(namespaces: string[]) {
     this.contextNs.replace(namespaces);
   }
 
-  hasContext(namespaces: string | string[]) {
-    return [namespaces].flat().every(namespace => this.contextNs.has(namespace));
-  }
+  hasContext(namespace: string | string[]) {
+    const context = Array.isArray(namespace) ? namespace : [namespace];
 
-  @computed get hasAllContexts(): boolean {
-    return this.contextNs.size === this.allowedNamespaces.length;
+    return context.every(namespace => this.contextNs.includes(namespace));
   }
 
   @action
   toggleContext(namespace: string) {
-    if (this.hasContext(namespace)) {
-      this.contextNs.delete(namespace);
-    } else {
-      this.contextNs.add(namespace);
-    }
-  }
-
-  @action
-  toggleAll(showAll?: boolean) {
-    if (typeof showAll === "boolean") {
-      if (showAll) {
-        this.setContext(this.allowedNamespaces);
-      } else {
-        this.contextNs.clear();
-      }
-    } else {
-      this.toggleAll(!this.hasAllContexts);
-    }
+    if (this.hasContext(namespace)) this.contextNs.remove(namespace);
+    else this.contextNs.push(namespace);
   }
 
   @action
   async remove(item: Namespace) {
     await super.remove(item);
-    this.contextNs.delete(item.getName());
+    this.contextNs.remove(item.getName());
   }
 }
 

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -1,120 +1,53 @@
-import { action, comparer, IReactionDisposer, IReactionOptions, observable, reaction, toJS, when } from "mobx";
+import { action, comparer, observable, reaction } from "mobx";
 import { autobind, createStorage } from "../../utils";
-import { KubeObjectStore, KubeObjectStoreLoadingParams } from "../../kube-object.store";
-import { Namespace, namespacesApi } from "../../api/endpoints/namespaces.api";
+import { KubeObjectStore } from "../../kube-object.store";
+import { Namespace, namespacesApi } from "../../api/endpoints";
 import { createPageParam } from "../../navigation";
 import { apiManager } from "../../api/api-manager";
-import { clusterStore, getHostedCluster } from "../../../common/cluster-store";
+import { isAllowedResource } from "../../../common/rbac";
+import { getHostedCluster } from "../../../common/cluster-store";
 
-const storage = createStorage<string[]>("context_namespaces");
+const storage = createStorage<string[]>("context_namespaces", []);
 
 export const namespaceUrlParam = createPageParam<string[]>({
   name: "namespaces",
   isSystem: true,
   multiValues: true,
   get defaultValue() {
-    return storage.get() ?? []; // initial namespaces coming from URL or local-storage (default)
+    return storage.get(); // initial namespaces coming from URL or local-storage (default)
   }
 });
-
-export function getDummyNamespace(name: string) {
-  return new Namespace({
-    kind: Namespace.kind,
-    apiVersion: "v1",
-    metadata: {
-      name,
-      uid: "",
-      resourceVersion: "",
-      selfLink: `/api/v1/namespaces/${name}`
-    }
-  });
-}
 
 @autobind()
 export class NamespaceStore extends KubeObjectStore<Namespace> {
   api = namespacesApi;
-
-  @observable contextNs = observable.array<string>();
-  @observable isReady = false;
-
-  whenReady = when(() => this.isReady);
+  contextNs = observable.array<string>();
 
   constructor() {
     super();
     this.init();
   }
 
-  private async init() {
-    await clusterStore.whenLoaded;
-    if (!getHostedCluster()) return;
-    await getHostedCluster().whenReady; // wait for cluster-state from main
+  private init() {
+    this.setContext(this.initNamespaces);
 
-    this.setContext(this.initialNamespaces);
-    this.autoLoadAllowedNamespaces();
-    this.autoUpdateUrlAndLocalStorage();
-
-    this.isReady = true;
-  }
-
-  public onContextChange(callback: (contextNamespaces: string[]) => void, opts: IReactionOptions = {}): IReactionDisposer {
-    return reaction(() => this.contextNs.toJS(), callback, {
-      equals: comparer.shallow,
-      ...opts,
-    });
-  }
-
-  private autoUpdateUrlAndLocalStorage(): IReactionDisposer {
-    return this.onContextChange(namespaces => {
+    return reaction(() => this.contextNs.toJS(), namespaces => {
       storage.set(namespaces); // save to local-storage
       namespaceUrlParam.set(namespaces, { replaceHistory: true }); // update url
     }, {
       fireImmediately: true,
+      equals: comparer.identity,
     });
   }
 
-  private autoLoadAllowedNamespaces(): IReactionDisposer {
-    return reaction(() => this.allowedNamespaces, () => this.loadAll(), {
-      fireImmediately: true,
-      equals: comparer.shallow,
-    });
+  get initNamespaces() {
+    return namespaceUrlParam.get();
   }
 
-  get allowedNamespaces(): string[] {
-    return toJS(getHostedCluster().allowedNamespaces);
-  }
-
-  private get initialNamespaces(): string[] {
-    const allowed = new Set(this.allowedNamespaces);
-    const prevSelected = storage.get();
-
-    if (Array.isArray(prevSelected)) {
-      return prevSelected.filter(namespace => allowed.has(namespace));
-    }
-
-    // otherwise select "default" or first allowed namespace
-    if (allowed.has("default")) {
-      return ["default"];
-    } else if (allowed.size) {
-      return [Array.from(allowed)[0]];
-    }
-
-    return [];
-  }
-
-  getContextNamespaces(): string[] {
-    const namespaces = this.contextNs.toJS();
-
-    // show all namespaces when nothing selected
-    if (!namespaces.length) {
-      if (this.isLoaded) {
-        // return actual namespaces list since "allowedNamespaces" updating every 30s in cluster and thus might be stale
-        return this.items.map(namespace => namespace.getName());
-      }
-
-      return this.allowedNamespaces;
-    }
-
-    return namespaces;
+  getContextParams() {
+    return {
+      namespaces: this.contextNs.toJS(),
+    };
   }
 
   subscribe(apis = [this.api]) {
@@ -128,18 +61,31 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     return super.subscribe(apis);
   }
 
-  protected async loadItems(params: KubeObjectStoreLoadingParams) {
-    const { allowedNamespaces } = this;
+  protected async loadItems(namespaces?: string[]) {
+    if (!isAllowedResource("namespaces")) {
+      if (namespaces) return namespaces.map(this.getDummyNamespace);
 
-    let namespaces = await super.loadItems(params);
-
-    namespaces = namespaces.filter(namespace => allowedNamespaces.includes(namespace.getName()));
-
-    if (!namespaces.length && allowedNamespaces.length > 0) {
-      return allowedNamespaces.map(getDummyNamespace);
+      return [];
     }
 
-    return namespaces;
+    if (namespaces) {
+      return Promise.all(namespaces.map(name => this.api.get({ name })));
+    } else {
+      return super.loadItems();
+    }
+  }
+
+  protected getDummyNamespace(name: string) {
+    return new Namespace({
+      kind: "Namespace",
+      apiVersion: "v1",
+      metadata: {
+        name,
+        uid: "",
+        resourceVersion: "",
+        selfLink: `/api/v1/namespaces/${name}`
+      }
+    });
   }
 
   @action
@@ -157,6 +103,12 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   toggleContext(namespace: string) {
     if (this.hasContext(namespace)) this.contextNs.remove(namespace);
     else this.contextNs.push(namespace);
+  }
+
+  @action
+  reset() {
+    super.reset();
+    this.contextNs.clear();
   }
 
   @action

--- a/src/renderer/components/+network-services/service-details.tsx
+++ b/src/renderer/components/+network-services/service-details.tsx
@@ -1,18 +1,17 @@
 import "./service-details.scss";
 
 import React from "react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
 import { KubeEventDetails } from "../+events/kube-event-details";
 import { KubeObjectDetailsProps } from "../kube-object";
-import { Service } from "../../api/endpoints";
+import { Service, endpointApi } from "../../api/endpoints";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { ServicePortComponent } from "./service-port-component";
 import { endpointStore } from "../+network-endpoints/endpoints.store";
 import { ServiceDetailsEndpoint } from "./service-details-endpoint";
 import { kubeObjectDetailRegistry } from "../../api/kube-object-detail-registry";
-import { kubeWatchApi } from "../../api/kube-watch-api";
 
 interface Props extends KubeObjectDetailsProps<Service> {
 }
@@ -20,11 +19,10 @@ interface Props extends KubeObjectDetailsProps<Service> {
 @observer
 export class ServiceDetails extends React.Component<Props> {
   componentDidMount() {
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([endpointStore], {
-        preload: true,
-      }),
-    ]);
+    if (!endpointStore.isLoaded) {
+      endpointStore.loadAll();
+    }
+    endpointApi.watch();
   }
 
   render() {
@@ -79,7 +77,7 @@ export class ServiceDetails extends React.Component<Props> {
         )}
         <DrawerTitle title={`Endpoint`}/>
 
-        <ServiceDetailsEndpoint endpoint={endpoint}/>
+        <ServiceDetailsEndpoint endpoint={endpoint} />
       </div>
     );
   }

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -29,7 +29,9 @@ export class NodeDetails extends React.Component<Props> {
   });
 
   async componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/+nodes/nodes.store.ts
+++ b/src/renderer/components/+nodes/nodes.store.ts
@@ -1,4 +1,3 @@
-import { sum } from "lodash";
 import { action, computed, observable } from "mobx";
 import { clusterApi, IClusterMetrics, INodeMetrics, Node, nodesApi } from "../../api/endpoints";
 import { autobind } from "../../utils";
@@ -61,10 +60,6 @@ export class NodesStore extends KubeObjectStore<Node> {
         return 0;
       }
     });
-  }
-
-  getWarningsCount(): number {
-    return sum(this.items.map((node: Node) => node.getWarningConditions().length));
   }
 
   reset() {

--- a/src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx
+++ b/src/renderer/components/+user-management-roles-bindings/add-role-binding-dialog.tsx
@@ -80,7 +80,7 @@ export class AddRoleBindingDialog extends React.Component<Props> {
     ];
 
     this.isLoading = true;
-    await Promise.all(stores.map(store => store.loadSelectedNamespaces()));
+    await Promise.all(stores.map(store => store.loadAll()));
     this.isLoading = false;
   }
 

--- a/src/renderer/components/+user-management-roles-bindings/role-bindings.store.ts
+++ b/src/renderer/components/+user-management-roles-bindings/role-bindings.store.ts
@@ -9,8 +9,8 @@ import { apiManager } from "../../api/api-manager";
 export class RoleBindingsStore extends KubeObjectStore<RoleBinding> {
   api = clusterRoleBindingApi;
 
-  getSubscribeApis() {
-    return [clusterRoleBindingApi, roleBindingApi];
+  subscribe() {
+    return super.subscribe([clusterRoleBindingApi, roleBindingApi]);
   }
 
   protected sortItems(items: RoleBinding[]) {

--- a/src/renderer/components/+user-management-roles/roles.store.ts
+++ b/src/renderer/components/+user-management-roles/roles.store.ts
@@ -7,8 +7,8 @@ import { apiManager } from "../../api/api-manager";
 export class RolesStore extends KubeObjectStore<Role> {
   api = clusterRoleApi;
 
-  getSubscribeApis() {
-    return [roleApi, clusterRoleApi];
+  subscribe() {
+    return super.subscribe([roleApi, clusterRoleApi]);
   }
 
   protected sortItems(items: Role[]) {

--- a/src/renderer/components/+user-management-roles/roles.store.ts
+++ b/src/renderer/components/+user-management-roles/roles.store.ts
@@ -1,6 +1,6 @@
 import { clusterRoleApi, Role, roleApi } from "../../api/endpoints";
 import { autobind } from "../../utils";
-import { KubeObjectStore, KubeObjectStoreLoadingParams } from "../../kube-object.store";
+import { KubeObjectStore } from "../../kube-object.store";
 import { apiManager } from "../../api/api-manager";
 
 @autobind()
@@ -24,13 +24,15 @@ export class RolesStore extends KubeObjectStore<Role> {
     return clusterRoleApi.get(params);
   }
 
-  protected async loadItems(params: KubeObjectStoreLoadingParams): Promise<Role[]> {
-    const items = await Promise.all([
-      super.loadItems({ ...params, api: clusterRoleApi }),
-      super.loadItems({ ...params, api: roleApi }),
-    ]);
-
-    return items.flat();
+  protected loadItems(namespaces?: string[]): Promise<Role[]> {
+    if (namespaces) {
+      return Promise.all(
+        namespaces.map(namespace => roleApi.list({ namespace }))
+      ).then(items => items.flat());
+    } else {
+      return Promise.all([clusterRoleApi.list(), roleApi.list()])
+        .then(items => items.flat());
+    }
   }
 
   protected async createItem(params: { name: string; namespace?: string }, data?: Partial<Role>) {

--- a/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
@@ -20,7 +20,9 @@ interface Props extends KubeObjectDetailsProps<CronJob> {
 @observer
 export class CronJobDetails extends React.Component<Props> {
   async componentDidMount() {
-    jobStore.loadSelectedNamespaces();
+    if (!jobStore.isLoaded) {
+      jobStore.loadAll();
+    }
   }
 
   render() {

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -30,7 +30,9 @@ export class DaemonSetDetails extends React.Component<Props> {
   });
 
   componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -31,7 +31,9 @@ export class DeploymentDetails extends React.Component<Props> {
   });
 
   componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -25,7 +25,9 @@ interface Props extends KubeObjectDetailsProps<Job> {
 @observer
 export class JobDetails extends React.Component<Props> {
   async componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   render() {

--- a/src/renderer/components/+workloads-overview/overview-statuses.tsx
+++ b/src/renderer/components/+workloads-overview/overview-statuses.tsx
@@ -27,7 +27,7 @@ export class OverviewStatuses extends React.Component {
   @autobind()
   renderWorkload(resource: KubeResource): React.ReactElement {
     const store = workloadStores[resource];
-    const items = store.getAllByNs(namespaceStore.getContextNamespaces());
+    const items = store.getAllByNs(namespaceStore.contextNs);
 
     return (
       <div className="workload" key={resource}>

--- a/src/renderer/components/+workloads-overview/overview.tsx
+++ b/src/renderer/components/+workloads-overview/overview.tsx
@@ -1,7 +1,8 @@
 import "./overview.scss";
 
 import React from "react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observable, when } from "mobx";
+import { observer } from "mobx-react";
 import { OverviewStatuses } from "./overview-statuses";
 import { RouteComponentProps } from "react-router";
 import { IWorkloadsOverviewRouteParams } from "../+workloads";
@@ -14,23 +15,60 @@ import { replicaSetStore } from "../+workloads-replicasets/replicasets.store";
 import { jobStore } from "../+workloads-jobs/job.store";
 import { cronJobStore } from "../+workloads-cronjobs/cronjob.store";
 import { Events } from "../+events";
+import { KubeObjectStore } from "../../kube-object.store";
 import { isAllowedResource } from "../../../common/rbac";
-import { kubeWatchApi } from "../../api/kube-watch-api";
+import { namespaceStore } from "../+namespaces/namespace.store";
 
 interface Props extends RouteComponentProps<IWorkloadsOverviewRouteParams> {
 }
 
 @observer
 export class WorkloadsOverview extends React.Component<Props> {
-  componentDidMount() {
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([
-        podsStore, deploymentStore, daemonSetStore, statefulSetStore, replicaSetStore,
-        jobStore, cronJobStore, eventStore,
-      ], {
-        preload: true,
-      }),
-    ]);
+  @observable isLoading = false;
+  @observable isUnmounting = false;
+
+  async componentDidMount() {
+    const stores: KubeObjectStore[] = [
+      isAllowedResource("pods") && podsStore,
+      isAllowedResource("deployments") && deploymentStore,
+      isAllowedResource("daemonsets") && daemonSetStore,
+      isAllowedResource("statefulsets") && statefulSetStore,
+      isAllowedResource("replicasets") && replicaSetStore,
+      isAllowedResource("jobs") && jobStore,
+      isAllowedResource("cronjobs") && cronJobStore,
+      isAllowedResource("events") && eventStore,
+    ].filter(Boolean);
+
+    const unsubscribeMap = new Map<KubeObjectStore, () => void>();
+
+    const loadStores = async () => {
+      this.isLoading = true;
+
+      for (const store of stores) {
+        if (this.isUnmounting) break;
+
+        try {
+          await store.loadAll();
+          unsubscribeMap.get(store)?.(); // unsubscribe previous watcher
+          unsubscribeMap.set(store, store.subscribe());
+        } catch (error) {
+          console.error("loading store error", error);
+        }
+      }
+      this.isLoading = false;
+    };
+
+    namespaceStore.onContextChange(loadStores, {
+      fireImmediately: true,
+    });
+
+    await when(() => this.isUnmounting && !this.isLoading);
+    unsubscribeMap.forEach(dispose => dispose());
+    unsubscribeMap.clear();
+  }
+
+  componentWillUnmount() {
+    this.isUnmounting = true;
   }
 
   render() {

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -19,7 +19,8 @@ import { lookupApiLink } from "../../api/kube-api";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
 import { Badge } from "../badge";
 
-enum columnId {
+
+enum sortBy {
   name = "name",
   namespace = "namespace",
   containers = "containers",
@@ -76,15 +77,15 @@ export class Pods extends React.Component<Props> {
         tableId = "workloads_pods"
         isConfigurable
         sortingCallbacks={{
-          [columnId.name]: (pod: Pod) => pod.getName(),
-          [columnId.namespace]: (pod: Pod) => pod.getNs(),
-          [columnId.containers]: (pod: Pod) => pod.getContainers().length,
-          [columnId.restarts]: (pod: Pod) => pod.getRestartsCount(),
-          [columnId.owners]: (pod: Pod) => pod.getOwnerRefs().map(ref => ref.kind),
-          [columnId.qos]: (pod: Pod) => pod.getQosClass(),
-          [columnId.node]: (pod: Pod) => pod.getNodeName(),
-          [columnId.age]: (pod: Pod) => pod.metadata.creationTimestamp,
-          [columnId.status]: (pod: Pod) => pod.getStatusMessage(),
+          [sortBy.name]: (pod: Pod) => pod.getName(),
+          [sortBy.namespace]: (pod: Pod) => pod.getNs(),
+          [sortBy.containers]: (pod: Pod) => pod.getContainers().length,
+          [sortBy.restarts]: (pod: Pod) => pod.getRestartsCount(),
+          [sortBy.owners]: (pod: Pod) => pod.getOwnerRefs().map(ref => ref.kind),
+          [sortBy.qos]: (pod: Pod) => pod.getQosClass(),
+          [sortBy.node]: (pod: Pod) => pod.getNodeName(),
+          [sortBy.age]: (pod: Pod) => pod.metadata.creationTimestamp,
+          [sortBy.status]: (pod: Pod) => pod.getStatusMessage(),
         }}
         searchFilters={[
           (pod: Pod) => pod.getSearchFields(),
@@ -94,16 +95,16 @@ export class Pods extends React.Component<Props> {
         ]}
         renderHeaderTitle="Pods"
         renderTableHeader={[
-          { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
-          { className: "warning", showWithColumn: columnId.name },
-          { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },
-          { title: "Containers", className: "containers", sortBy: columnId.containers, id: columnId.containers },
-          { title: "Restarts", className: "restarts", sortBy: columnId.restarts, id: columnId.restarts },
-          { title: "Controlled By", className: "owners", sortBy: columnId.owners, id: columnId.owners },
-          { title: "Node", className: "node", sortBy: columnId.node, id: columnId.node },
-          { title: "QoS", className: "qos", sortBy: columnId.qos, id: columnId.qos },
-          { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
-          { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
+          { title: "Name", className: "name", sortBy: sortBy.name },
+          { className: "warning", showWithColumn: "name" },
+          { title: "Namespace", className: "namespace", sortBy: sortBy.namespace },
+          { title: "Containers", className: "containers", sortBy: sortBy.containers },
+          { title: "Restarts", className: "restarts", sortBy: sortBy.restarts },
+          { title: "Controlled By", className: "owners", sortBy: sortBy.owners },
+          { title: "Node", className: "node", sortBy: sortBy.node },
+          { title: "QoS", className: "qos", sortBy: sortBy.qos },
+          { title: "Age", className: "age", sortBy: sortBy.age },
+          { title: "Status", className: "status", sortBy: sortBy.status },
         ]}
         renderTableContents={(pod: Pod) => [
           <Badge flat key="name" label={pod.getName()} tooltip={pod.getName()} />,

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -29,7 +29,9 @@ export class ReplicaSetDetails extends React.Component<Props> {
   });
 
   async componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -30,7 +30,9 @@ export class StatefulSetDetails extends React.Component<Props> {
   });
 
   componentDidMount() {
-    podsStore.loadSelectedNamespaces();
+    if (!podsStore.isLoaded) {
+      podsStore.loadAll();
+    }
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { computed, observable, reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Redirect, Route, Router, Switch } from "react-router";
 import { history } from "../navigation";
@@ -43,7 +42,7 @@ import { ClusterPageMenuRegistration, clusterPageMenuRegistry } from "../../exte
 import { TabLayout, TabLayoutRoute } from "./layout/tab-layout";
 import { StatefulSetScaleDialog } from "./+workloads-statefulsets/statefulset-scale-dialog";
 import { eventStore } from "./+events/event.store";
-import { namespaceStore } from "./+namespaces/namespace.store";
+import { computed, reaction, observable } from "mobx";
 import { nodesStore } from "./+nodes/nodes.store";
 import { podsStore } from "./+workloads-pods/pods.store";
 import { kubeWatchApi } from "../api/kube-watch-api";
@@ -75,12 +74,6 @@ export class App extends React.Component {
       window.location.reload();
     });
     whatInput.ask(); // Start to monitor user input device
-
-    await namespaceStore.whenReady;
-    await kubeWatchApi.init({
-      getCluster: getHostedCluster,
-      getNamespaces: namespaceStore.getContextNamespaces,
-    });
   }
 
   componentDidMount() {

--- a/src/renderer/components/dock/upgrade-chart.store.ts
+++ b/src/renderer/components/dock/upgrade-chart.store.ts
@@ -80,7 +80,7 @@ export class UpgradeChartStore extends DockTabStore<IChartUpgradeData> {
     const values = this.values.getData(tabId);
 
     await Promise.all([
-      !releaseStore.isLoaded && releaseStore.loadSelectedNamespaces(),
+      !releaseStore.isLoaded && releaseStore.loadAll(),
       !values && this.loadValues(tabId)
     ]);
   }

--- a/src/renderer/components/item-object-list/item-list-layout.scss
+++ b/src/renderer/components/item-object-list/item-list-layout.scss
@@ -36,14 +36,3 @@
   }
 }
 
-.ItemListLayoutVisibilityMenu {
-  .MenuItem {
-    padding: 0;
-  }
-
-  .Checkbox {
-    width: 100%;
-    padding: var(--spacing);
-    cursor: pointer;
-  }
-}

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -2,7 +2,7 @@ import "./item-list-layout.scss";
 import groupBy from "lodash/groupBy";
 
 import React, { ReactNode } from "react";
-import { computed, observable, reaction, toJS } from "mobx";
+import { computed, IReactionDisposer, observable, reaction, toJS } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { ConfirmDialog, ConfirmDialogParams } from "../confirm-dialog";
 import { Table, TableCell, TableCellProps, TableHead, TableProps, TableRow, TableRowProps, TableSortCallback } from "../table";
@@ -12,6 +12,7 @@ import { NoItems } from "../no-items";
 import { Spinner } from "../spinner";
 import { ItemObject, ItemStore } from "../../item.store";
 import { SearchInputUrl } from "../input";
+import { namespaceStore } from "../+namespaces/namespace.store";
 import { Filter, FilterType, pageFilters } from "./page-filters.store";
 import { PageFiltersList } from "./page-filters-list";
 import { PageFiltersSelect } from "./page-filters-select";
@@ -21,7 +22,6 @@ import { MenuActions } from "../menu/menu-actions";
 import { MenuItem } from "../menu";
 import { Checkbox } from "../checkbox";
 import { userStore } from "../../../common/user-store";
-import { namespaceStore } from "../+namespaces/namespace.store";
 
 // todo: refactor, split to small re-usable components
 
@@ -40,7 +40,6 @@ export interface ItemListLayoutProps<T extends ItemObject = ItemObject> {
   className: IClassName;
   store: ItemStore<T>;
   dependentStores?: ItemStore[];
-  preloadStores?: boolean;
   isClusterScoped?: boolean;
   hideFilters?: boolean;
   searchFilters?: SearchFilter<T>[];
@@ -83,7 +82,6 @@ const defaultProps: Partial<ItemListLayoutProps> = {
   isSelectable: true,
   isConfigurable: false,
   copyClassNameFromHeadCells: true,
-  preloadStores: true,
   dependentStores: [],
   filterItems: [],
   hasDetailsView: true,
@@ -98,6 +96,10 @@ interface ItemListLayoutUserSettings {
 @observer
 export class ItemListLayout extends React.Component<ItemListLayoutProps> {
   static defaultProps = defaultProps as object;
+
+  private watchDisposers: IReactionDisposer[] = [];
+
+  @observable isUnmounting = false;
 
   @observable userSettings: ItemListLayoutUserSettings = {
     showAppliedFilters: false,
@@ -117,28 +119,54 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
   }
 
   async componentDidMount() {
-    const { isClusterScoped, isConfigurable, tableId, preloadStores } = this.props;
+    const { isClusterScoped, isConfigurable, tableId } = this.props;
 
     if (isConfigurable && !tableId) {
       throw new Error("[ItemListLayout]: configurable list require props.tableId to be specified");
     }
 
-    if (preloadStores) {
-      this.loadStores();
+    this.loadStores();
 
-      if (!isClusterScoped) {
-        disposeOnUnmount(this, [
-          namespaceStore.onContextChange(() => this.loadStores())
-        ]);
+    if (!isClusterScoped) {
+      disposeOnUnmount(this, [
+        namespaceStore.onContextChange(() => this.loadStores())
+      ]);
+    }
+  }
+
+  async componentWillUnmount() {
+    this.isUnmounting = true;
+    this.unsubscribeStores();
+  }
+
+  @computed get stores() {
+    const { store, dependentStores } = this.props;
+
+    return new Set([store, ...dependentStores]);
+  }
+
+  async loadStores() {
+    this.unsubscribeStores(); // reset first
+
+    // load
+    for (const store of this.stores) {
+      if (this.isUnmounting) {
+        this.unsubscribeStores();
+        break;
+      }
+
+      try {
+        await store.loadAll();
+        this.watchDisposers.push(store.subscribe());
+      } catch (error) {
+        console.error("loading store error", error);
       }
     }
   }
 
-  private loadStores() {
-    const { store, dependentStores } = this.props;
-    const stores = Array.from(new Set([store, ...dependentStores]));
-
-    stores.forEach(store => store.loadAll());
+  unsubscribeStores() {
+    this.watchDisposers.forEach(dispose => dispose());
+    this.watchDisposers.length = 0;
   }
 
   private filterCallbacks: { [type: string]: ItemsFilter } = {

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -138,7 +138,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
     const { store, dependentStores } = this.props;
     const stores = Array.from(new Set([store, ...dependentStores]));
 
-    stores.forEach(store => store.loadAll(namespaceStore.getContextNamespaces()));
+    stores.forEach(store => store.loadAll());
   }
 
   private filterCallbacks: { [type: string]: ItemsFilter } = {

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -129,7 +129,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
 
     if (!isClusterScoped) {
       disposeOnUnmount(this, [
-        namespaceStore.onContextChange(() => this.loadStores())
+        reaction(() => namespaceStore.items.toJS(), () => this.loadStores())
       ]);
     }
   }
@@ -440,9 +440,11 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
             return <TableCell key={cellProps.id ?? index} {...cellProps} />;
           }
         })}
-        <TableCell className="menu">
-          {isConfigurable && this.renderColumnVisibilityMenu()}
-        </TableCell>
+        {isConfigurable && (
+          <TableCell className="menu">
+            {this.renderColumnVisibilityMenu()}
+          </TableCell>
+        )}
       </TableHead>
     );
   }

--- a/src/renderer/components/item-object-list/page-filters.store.ts
+++ b/src/renderer/components/item-object-list/page-filters.store.ts
@@ -30,7 +30,7 @@ export class PageFiltersStore {
   protected syncWithContextNamespace() {
     const disposers = [
       reaction(() => this.getValues(FilterType.NAMESPACE), filteredNs => {
-        if (filteredNs.length !== namespaceStore.getContextNamespaces().length) {
+        if (filteredNs.length !== namespaceStore.contextNs.length) {
           namespaceStore.setContext(filteredNs);
         }
       }),

--- a/src/renderer/components/item-object-list/page-filters.store.ts
+++ b/src/renderer/components/item-object-list/page-filters.store.ts
@@ -34,14 +34,14 @@ export class PageFiltersStore {
           namespaceStore.setContext(filteredNs);
         }
       }),
-      namespaceStore.onContextChange(namespaces => {
+      reaction(() => namespaceStore.contextNs.toJS(), contextNs => {
         const filteredNs = this.getValues(FilterType.NAMESPACE);
-        const isChanged = namespaces.length !== filteredNs.length;
+        const isChanged = contextNs.length !== filteredNs.length;
 
         if (isChanged) {
           this.filters.replace([
             ...this.filters.filter(({ type }) => type !== FilterType.NAMESPACE),
-            ...namespaces.map(ns => ({ type: FilterType.NAMESPACE, value: ns })),
+            ...contextNs.map(ns => ({ type: FilterType.NAMESPACE, value: ns })),
           ]);
         }
       }, {

--- a/src/renderer/components/item-object-list/table-menu.scss
+++ b/src/renderer/components/item-object-list/table-menu.scss
@@ -1,0 +1,4 @@
+.MenuCheckbox {
+  width: 100%;
+  height: 100%;
+}

--- a/src/renderer/components/kube-object/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object/kube-object-list-layout.tsx
@@ -1,34 +1,21 @@
 import React from "react";
 import { computed } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import { cssNames } from "../../utils";
 import { KubeObject } from "../../api/kube-object";
 import { ItemListLayout, ItemListLayoutProps } from "../item-object-list/item-list-layout";
 import { KubeObjectStore } from "../../kube-object.store";
 import { KubeObjectMenu } from "./kube-object-menu";
 import { kubeSelectedUrlParam, showDetails } from "./kube-object-details";
-import { kubeWatchApi } from "../../api/kube-watch-api";
 
 export interface KubeObjectListLayoutProps extends ItemListLayoutProps {
   store: KubeObjectStore;
-  dependentStores?: KubeObjectStore[];
 }
 
 @observer
 export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutProps> {
   @computed get selectedItem() {
     return this.props.store.getByPath(kubeSelectedUrlParam.get());
-  }
-
-  componentDidMount() {
-    const { store, dependentStores = [] } = this.props;
-    const stores = Array.from(new Set([store, ...dependentStores]));
-
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores(stores, {
-        preload: true
-      })
-    ]);
   }
 
   onDetails = (item: KubeObject) => {
@@ -46,7 +33,6 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
       <ItemListLayout
         {...layoutProps}
         className={cssNames("KubeObjectListLayout", className)}
-        preloadStores={false} // loading handled in kubeWatchApi.subscribeStores()
         detailsItem={this.selectedItem}
         onDetails={this.onDetails}
         renderItemMenu={(item) => {

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -40,7 +40,9 @@ interface Props {
 @observer
 export class Sidebar extends React.Component<Props> {
   async componentDidMount() {
-    crdStore.loadSelectedNamespaces();
+    if (!crdStore.isLoaded && isAllowedResource("customresourcedefinitions")) {
+      crdStore.loadAll();
+    }
   }
 
   renderCustomResources() {

--- a/src/renderer/components/table/table-cell.tsx
+++ b/src/renderer/components/table/table-cell.tsx
@@ -74,7 +74,7 @@ export class TableCell extends React.Component<TableCellProps> {
     const content = displayBooleans(displayBoolean, title || children);
 
     return (
-      <div {...cellProps} className={classNames} onClick={this.onClick}>
+      <div {...cellProps} id={className} className={classNames} onClick={this.onClick}>
         {this.renderCheckbox()}
         {_nowrap ? <div className="content">{content}</div> : content}
         {this.renderSortIcon()}

--- a/src/renderer/item.store.ts
+++ b/src/renderer/item.store.ts
@@ -9,7 +9,7 @@ export interface ItemObject {
 
 @autobind()
 export abstract class ItemStore<T extends ItemObject = ItemObject> {
-  abstract loadAll(...args: any[]): Promise<void>;
+  abstract loadAll(): Promise<void>;
 
   protected defaultSorting = (item: T) => item.getName();
 
@@ -40,7 +40,8 @@ export abstract class ItemStore<T extends ItemObject = ItemObject> {
 
     if (item) {
       return item;
-    } else {
+    }
+    else {
       const items = this.sortItems([...this.items, newItem]);
 
       this.items.replace(items);
@@ -82,7 +83,8 @@ export abstract class ItemStore<T extends ItemObject = ItemObject> {
         const index = this.items.findIndex(item => item === existingItem);
 
         this.items.splice(index, 1, item);
-      } else {
+      }
+      else {
         let items = [...this.items, item];
 
         if (sortItems) items = this.sortItems(items);
@@ -128,7 +130,8 @@ export abstract class ItemStore<T extends ItemObject = ItemObject> {
   toggleSelection(item: T) {
     if (this.isSelected(item)) {
       this.unselect(item);
-    } else {
+    }
+    else {
       this.select(item);
     }
   }
@@ -139,7 +142,8 @@ export abstract class ItemStore<T extends ItemObject = ItemObject> {
 
     if (allSelected) {
       visibleItems.forEach(this.unselect);
-    } else {
+    }
+    else {
       visibleItems.forEach(this.select);
     }
   }

--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -106,18 +106,17 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
   }
 
   @action
-  async loadAll(namespaces: string[] = []): Promise<void> {
+  async loadAll({ namespaces: contextNamespaces }: { namespaces?: string[] } = {}) {
     this.isLoading = true;
 
     try {
-      if (!namespaces.length) {
+      if (!contextNamespaces) {
         const { namespaceStore } = await import("./components/+namespaces/namespace.store");
 
-        // load all available namespaces by default
-        namespaces.push(...namespaceStore.allowedNamespaces);
+        contextNamespaces = namespaceStore.getContextNamespaces();
       }
 
-      let items = await this.loadItems({ namespaces, api: this.api });
+      let items = await this.loadItems({ namespaces: contextNamespaces, api: this.api });
 
       items = this.filterItemsOnLoad(items);
       items = this.sortItems(items);
@@ -130,12 +129,6 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
     } finally {
       this.isLoading = false;
     }
-  }
-
-  async loadSelectedNamespaces(): Promise<void> {
-    const { namespaceStore } = await import("./components/+namespaces/namespace.store");
-
-    return this.loadAll(namespaceStore.getContextNamespaces());
   }
 
   protected resetOnError(error: any) {


### PR DESCRIPTION
I think we hit into limits of current kube-object-store architecture and we need to go back to the drawing board. Basically current stores were designed to keep full-state of given kubernetes api in-memory. We tried to change this so that we could keep only subset (selected namespaces) but we learned that it has unexpected side-effects because a store can have multiple consumers (with different requirements). 

I hope we can bring watch api fixes back as a separate PR.

Reverts #1918, #1990, #2063 and #2084 . 

Closes #2083