### PR TITLE
Fix: saving apiManager store keys with string type

### DIFF
--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -7,7 +7,7 @@ import { KubeApi, parseKubeApi } from "./kube-api";
 @autobind()
 export class ApiManager {
   private apis = observable.map<string, KubeApi>();
-  private stores = observable.map<KubeApi, KubeObjectStore>();
+  private stores = observable.map<string, KubeObjectStore>();
 
   getApi(pathOrCallback: string | ((api: KubeApi) => boolean)) {
     if (typeof pathOrCallback === "string") {
@@ -46,12 +46,12 @@ export class ApiManager {
   @action
   registerStore(store: KubeObjectStore, apis: KubeApi[] = [store.api]) {
     apis.forEach(api => {
-      this.stores.set(api, store);
+      this.stores.set(api.kind, store);
     });
   }
 
   getStore<S extends KubeObjectStore>(api: string | KubeApi): S {
-    return this.stores.get(this.resolveApi(api)) as S;
+    return this.stores.get(this.resolveApi(api)?.kind) as S;
   }
 }
 

--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -46,12 +46,12 @@ export class ApiManager {
   @action
   registerStore(store: KubeObjectStore, apis: KubeApi[] = [store.api]) {
     apis.forEach(api => {
-      this.stores.set(api.kind, store);
+      this.stores.set(api.apiBase, store);
     });
   }
 
   getStore<S extends KubeObjectStore>(api: string | KubeApi): S {
-    return this.stores.get(this.resolveApi(api)?.kind) as S;
+    return this.stores.get(this.resolveApi(api)?.apiBase) as S;
   }
 }
 


### PR DESCRIPTION
Using `string` instead of `KubeApi` type for keys in `stores` map.

This allows extensions to rewrite stores while registering them. Previously shallow comparison decided that `KubeApi` passing as key is always a new object and should be added to the end of `stores` map.

Fixes https://github.com/aquasecurity/starboard-lens-extension/issues/48

Relates to #2077 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>