### PR TITLE
Fix: export Dialog to extensions-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev-run": "nodemon --watch static/build/main.js --exec \"electron --inspect .\"",
     "dev:main": "yarn run compile:main --watch",
     "dev:renderer": "yarn run webpack-dev-server --config webpack.renderer.ts",
-    "dev:extension-types": "yarn run compile:extension-types --watch",
+    "dev:extension-types": "yarn run compile:extension-types --watch --progress",
     "compile": "env NODE_ENV=production concurrently yarn:compile:*",
     "compile:main": "yarn run webpack --config webpack.main.ts",
     "compile:renderer": "yarn run webpack --config webpack.renderer.ts",

--- a/src/renderer/components/dialog/dialog.tsx
+++ b/src/renderer/components/dialog/dialog.tsx
@@ -146,11 +146,10 @@ export class Dialog extends React.PureComponent<DialogProps, DialogState> {
           {dialog}
         </Animate>
       );
-    }
-    else if (!this.isOpen) {
+    } else if (!this.isOpen) {
       return null;
     }
 
-    return createPortal(dialog, document.body);
+    return createPortal(dialog, document.body) as React.ReactPortal;
   }
 }

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -1,9 +1,9 @@
 
 import path from "path";
 import webpack from "webpack";
-import { sassCommonVars } from "./src/common/vars";
+import { sassCommonVars, isDevelopment } from "./src/common/vars";
 
-export default function (): webpack.Configuration {
+export default function generateExtensionTypes(): webpack.Configuration {
   const entry = "./src/extensions/extension-api.ts";
   const outDir = "./src/extensions/npm/extensions/dist";
 
@@ -21,6 +21,10 @@ export default function (): webpack.Configuration {
       // can be use in commonjs environments
       // e.g. require('@k8slens/extensions')
       libraryTarget: "commonjs"
+    },
+    cache: isDevelopment,
+    optimization: {
+      minimize: false, // speed up types compilation
     },
     module: {
       rules: [


### PR DESCRIPTION
_Intro:_

For some reasons generating type from `ReactDOM.createPortal` is failing and stops producing `dialog.d.ts`
