### PR TITLE
Fix: compact-mode for Workloads overview -> Events

### DIFF
--- a/src/renderer/api/endpoints/events.api.ts
+++ b/src/renderer/api/endpoints/events.api.ts
@@ -28,7 +28,7 @@ export class KubeEvent extends KubeObject {
   firstTimestamp: string;
   lastTimestamp: string;
   count: number;
-  type: string;
+  type: "Normal" | "Warning" | string;
   eventTime: null;
   reportingComponent: string;
   reportingInstance: string;

--- a/src/renderer/components/kube-object/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object/kube-object-list-layout.tsx
@@ -42,13 +42,13 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
   };
 
   render() {
-    const items = this.props.store.contextItems;
-    const { className, ...layoutProps } = this.props;
+    const { className, store, items = store.contextItems, ...layoutProps } = this.props;
 
     return (
       <ItemListLayout
         {...layoutProps}
         className={cssNames("KubeObjectListLayout", className)}
+        store={store}
         items={items}
         preloadStores={false} // loading handled in kubeWatchApi.subscribeStores()
         detailsItem={this.selectedItem}


### PR DESCRIPTION
- fix: compact-mode for `<Events/>` page component in workloads overview (`limit = 10` by default)
- fix: type of event previously has shown as `involvedObject.kind` (moved to `Involved Object` column)
- show `warning` items on the top (default sorting: `event.type:desc`)

![image](https://user-images.githubusercontent.com/6377066/107537851-036e6900-6bcc-11eb-8aed-91b7d176d315.png)

close #2109 