### PR TITLE
fix problem with compact events

### DIFF
--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -215,7 +215,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
       }
     });
 
-    const items = this.props.items ?? allItems;
+    const items = this.applyFilters(this.props.filterItems, this.props.items) ?? allItems;
 
     return this.applyFilters(filterItems, items);
   }


### PR DESCRIPTION
fixes underlying problem with `ItemListLayout` and the `filterItems` prop.  May not be the best way, or there are conditions on using `filterItems` in conjunction with `items`?

This PR could be merged instead of #2113, or as well as, since #2113 doesn't fix the underlying problem.

fixes #2109