### PR TITLE
Removing "filterItems" prop from ItemListLayout

### DIFF
--- a/src/renderer/api/endpoints/events.api.ts
+++ b/src/renderer/api/endpoints/events.api.ts
@@ -28,7 +28,7 @@ export class KubeEvent extends KubeObject {
   firstTimestamp: string;
   lastTimestamp: string;
   count: number;
-  type: string;
+  type: "Normal" | "Warning" | string;
   eventTime: null;
   reportingComponent: string;
   reportingInstance: string;

--- a/src/renderer/components/+apps-helm-charts/helm-charts.tsx
+++ b/src/renderer/components/+apps-helm-charts/helm-charts.tsx
@@ -34,6 +34,10 @@ export class HelmCharts extends Component<Props> {
     return helmChartStore.getByName(chartName, repo);
   }
 
+  get items() {
+    return helmChartStore.items.filter(item => !item.deprecated);
+  }
+
   showDetails = (chart: HelmChart) => {
     if (!chart) {
       navigation.merge(helmChartsURL());
@@ -72,9 +76,7 @@ export class HelmCharts extends Component<Props> {
             (chart: HelmChart) => chart.getAppVersion(),
             (chart: HelmChart) => chart.getKeywords(),
           ]}
-          filterItems={[
-            (items: HelmChart[]) => items.filter(item => !item.deprecated)
-          ]}
+          items={this.items}
           customizeHeader={() => (
             <SearchInputUrl placeholder={`Search Helm Charts`} />
           )}

--- a/src/renderer/components/+apps-releases/releases.tsx
+++ b/src/renderer/components/+apps-releases/releases.tsx
@@ -86,6 +86,7 @@ export class HelmReleases extends Component<Props> {
           isConfigurable
           tableId="helm_releases"
           className="HelmReleases"
+          items={releaseStore.items}
           store={releaseStore}
           dependentStores={[secretsStore]}
           sortingCallbacks={{

--- a/src/renderer/components/+custom-resources/crd-list.tsx
+++ b/src/renderer/components/+custom-resources/crd-list.tsx
@@ -33,6 +33,15 @@ export class CrdList extends React.Component {
     return crdGroupsUrlParam.get();
   }
 
+  get items() {
+    const selectedGroups = this.groups;
+    const storeItems = crdStore.items;
+
+    return selectedGroups.length ?
+      storeItems.filter(item => selectedGroups.includes(item.getGroup())) :
+      storeItems;
+  }
+
   onSelectGroup(group: string) {
     const groups = new Set(this.groups);
 
@@ -62,11 +71,7 @@ export class CrdList extends React.Component {
         store={crdStore}
         sortingCallbacks={sortingCallbacks}
         searchFilters={Object.values(sortingCallbacks)}
-        filterItems={[
-          (items: CustomResourceDefinition[]) => {
-            return selectedGroups.length ? items.filter(item => selectedGroups.includes(item.getGroup())) : items;
-          }
-        ]}
+        items={this.items}
         renderHeaderTitle="Custom Resources"
         customizeHeader={() => {
           let placeholder = <>All groups</>;

--- a/src/renderer/components/+custom-resources/crd-list.tsx
+++ b/src/renderer/components/+custom-resources/crd-list.tsx
@@ -35,7 +35,7 @@ export class CrdList extends React.Component {
 
   get items() {
     const selectedGroups = this.groups;
-    const storeItems = crdStore.items;
+    const storeItems = crdStore.contextItems;
 
     return selectedGroups.length ?
       storeItems.filter(item => selectedGroups.includes(item.getGroup())) :

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -45,7 +45,6 @@ export interface ItemListLayoutProps<T extends ItemObject = ItemObject> {
   isClusterScoped?: boolean;
   hideFilters?: boolean;
   searchFilters?: SearchFilter<T>[];
-  filterItems?: ItemsFilter<T>[];
 
   // header (title, filtering, searching, etc.)
   showHeader?: boolean;
@@ -86,7 +85,6 @@ const defaultProps: Partial<ItemListLayoutProps> = {
   copyClassNameFromHeadCells: true,
   preloadStores: true,
   dependentStores: [],
-  filterItems: [],
   hasDetailsView: true,
   onDetails: noop,
   virtual: true
@@ -196,14 +194,8 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
     return filters.reduce((items, filter) => filter(items), items);
   }
 
-  @computed get allItems() {
-    const { filterItems, store } = this.props;
-
-    return this.applyFilters(filterItems, store.items);
-  }
-
   @computed get items() {
-    const { allItems, filters, filterCallbacks } = this;
+    const { filters, filterCallbacks } = this;
     const filterItems: ItemsFilter[] = [];
     const filterGroups = groupBy<Filter>(filters, ({ type }) => type);
 
@@ -215,9 +207,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
       }
     });
 
-    const items = this.props.items ?? allItems;
-
-    return this.applyFilters(filterItems, items);
+    return this.applyFilters(filterItems, this.props.items);
   }
 
   @autobind()

--- a/src/renderer/components/kube-object/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object/kube-object-list-layout.tsx
@@ -42,13 +42,13 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
   };
 
   render() {
-    const items = this.props.store.contextItems;
-    const { className, ...layoutProps } = this.props;
+    const { className, store, items = store.contextItems, ...layoutProps } = this.props;
 
     return (
       <ItemListLayout
         {...layoutProps}
         className={cssNames("KubeObjectListLayout", className)}
+        store={store}
         items={items}
         preloadStores={false} // loading handled in kubeWatchApi.subscribeStores()
         detailsItem={this.selectedItem}


### PR DESCRIPTION
This PR follows this one https://github.com/lensapp/lens/pull/2113 and removes all usage of `filterItems` prop described in `ItemListComponent`.

This allows to remove dualism from choosing items to present inside `ItemListLayout` component here https://github.com/lensapp/lens/pull/2114 and moves filtering responsibility to specified components.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>