### PR TITLE
Fix: making error boundary layout responsive

### DIFF
--- a/src/renderer/components/error-boundary/error-boundary.scss
+++ b/src/renderer/components/error-boundary/error-boundary.scss
@@ -4,6 +4,17 @@
   padding: var(--flex-gap);
   word-break: break-all;
 
+  .wrapper {
+    display: grid;
+    grid-template-columns: minmax(300px, 1fr) minmax(300px, 1fr);
+    column-gap: 12px;
+    row-gap: 12px;
+
+    @media screen and (max-width: 900px) {
+      grid-template-columns: auto;
+    }
+  }
+
   code {
     max-height: none;
     border: 5px solid $borderFaintColor;

--- a/src/renderer/components/error-boundary/error-boundary.tsx
+++ b/src/renderer/components/error-boundary/error-boundary.tsx
@@ -49,7 +49,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
           <p>
             To help us improve the product please report bugs to {slackLink} community or {githubLink} issues tracker.
           </p>
-          <div className="flex gaps">
+          <div className="wrapper">
             <code className="block">
               <p className="contrast">Component stack:</p>
               {errorInfo.componentStack}


### PR DESCRIPTION
Now it's impossible to read error message on medium-sized window.
<img width="994" alt="broken error boundary" src="https://user-images.githubusercontent.com/9607060/107624396-da051a00-6c6b-11eb-9f6d-de4341030de8.png">

This PR fixes layout and allows columns to be rearranged one under the other.

https://user-images.githubusercontent.com/9607060/107624471-fa34d900-6c6b-11eb-93b7-af583c9dfee8.mp4

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>