### PR TITLE
Fix auto update on quit with newer version

### DIFF
--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -54,11 +54,10 @@ export function startUpdateChecking(interval = 1000 * 60 * 60 * 24): void {
        * didn't ask for.
        */
       autoUpdater.autoInstallOnAppQuit = false;
+      installVersion = args.version;
 
       try {
         const backchannel = `auto-update:${args.version}`;
-
-        installVersion = args.version;
 
         ipcMain.removeAllListeners(backchannel); // only one handler should be present
 
@@ -73,6 +72,7 @@ export function startUpdateChecking(interval = 1000 * 60 * 60 * 24): void {
         broadcastMessage(UpdateAvailableChannel, backchannel, args);
       } catch (error) {
         logger.error(`${AutoUpdateLogPrefix}: broadcasting failed`, { error });
+        installVersion = undefined;
       }
     });
 

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -5,6 +5,8 @@ import { delay } from "../common/utils";
 import { areArgsUpdateAvailableToBackchannel, AutoUpdateLogPrefix, broadcastMessage, onceCorrect, UpdateAvailableChannel, UpdateAvailableToBackchannel } from "../common/ipc";
 import { ipcMain } from "electron";
 
+let installVersion: null | string = null;
+
 function handleAutoUpdateBackChannel(event: Electron.IpcMainEvent, ...[arg]: UpdateAvailableToBackchannel) {
   if (arg.doUpdate) {
     if (arg.now) {
@@ -38,8 +40,25 @@ export function startUpdateChecking(interval = 1000 * 60 * 60 * 24): void {
 
   autoUpdater
     .on("update-available", (args: UpdateInfo) => {
+      if (autoUpdater.autoInstallOnAppQuit) {
+        // a previous auto-update loop was completed with YES+LATER, check if same version
+        if (installVersion === args.version) {
+          // same version, don't broadcast
+          return;
+        }
+      }
+
+      /**
+       * This should be always set to false here because it is the reasonable
+       * default. Namely, if a don't auto update to a version that the user
+       * didn't ask for.
+       */
+      autoUpdater.autoInstallOnAppQuit = false;
+
       try {
         const backchannel = `auto-update:${args.version}`;
+
+        installVersion = args.version;
 
         ipcMain.removeAllListeners(backchannel); // only one handler should be present
 


### PR DESCRIPTION
- If the user specifies that Lens should auto update on quit to a specific version, and before they quit the auto-updater finds a newer version. Then disregard the previous request to update

Signed-off-by: Sebastian Malton <sebastian@malton.name>