### PR TITLE
Fix: loading in namespaces under reduced RBAC

### DIFF
--- a/src/common/utils/common-types.ts
+++ b/src/common/utils/common-types.ts
@@ -1,0 +1,1 @@
+export type Disposer = () => void;

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -19,3 +19,4 @@ export * from "./downloadFile";
 export * from "./escapeRegExp";
 export * from "./tar";
 export * from "./delay";
+export * from "./common-types";

--- a/src/renderer/api/kube-watch-api.ts
+++ b/src/renderer/api/kube-watch-api.ts
@@ -78,11 +78,11 @@ export class KubeWatchApi {
       }
     };
 
-    let subscribeP: Promise<void>;
+    let subscribing: Promise<void> = Promise.resolve();
 
     if (preloading) {
       if (waitUntilLoaded) {
-        subscribeP = preloading.loading
+        subscribing = preloading.loading
           .then(() => subscribe(ac.signal))
           .catch(error => {
             this.log({
@@ -91,7 +91,7 @@ export class KubeWatchApi {
             });
           });
       } else {
-        subscribeP = subscribe(ac.signal);
+        subscribing = subscribe(ac.signal);
       }
 
       // reload stores only for context namespaces change
@@ -100,14 +100,14 @@ export class KubeWatchApi {
           preloading.cancelLoading();
         }
         ac.abort();
-        subscribeP.then(() => {
+        subscribing.then(() => {
           unsubscribeList.forEach(unsubscribe => unsubscribe());
           unsubscribeList.length = 0;
 
           ac = new AbortController();
           preloading = load(namespaces);
           preloading.loading
-            .then(() => subscribeP = subscribe(ac.signal));
+            .then(() => subscribing = subscribe(ac.signal));
         });
       }, {
         equals: comparer.shallow,
@@ -124,7 +124,7 @@ export class KubeWatchApi {
         preloading.cancelLoading();
       }
       ac.abort();
-      subscribeP.then(() => {
+      subscribing.then(() => {
         unsubscribeList.forEach(unsubscribe => unsubscribe());
         unsubscribeList.length = 0;
       });

--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -74,7 +74,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   }
 
   async loadFromContextNamespaces(): Promise<void> {
-    return this.loadAll(namespaceStore.contextNamespaces);
+    return this.loadAll(namespaceStore.selectedNamespaces);
   }
 
   async loadItems(namespaces: string[]) {

--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -13,7 +13,7 @@ import { namespaceStore } from "./namespace.store";
 
 const Placeholder = observer((props: PlaceholderProps<any>) => {
   const getPlaceholder = (): React.ReactNode => {
-    const namespaces = namespaceStore.contextNamespaces;
+    const namespaces = namespaceStore.selectedNamespaces;
 
     switch (namespaces.length) {
       case 0:

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -65,11 +65,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   private autoLoadAllowedNamespaces(): IReactionDisposer {
-    return reaction(() => this.allowedNamespaces, namespaces => {
-      console.log("autoLoadAllowedNamespaces", namespaces);
-
-      return this.loadAll({ namespaces });
-    }, {
+    return reaction(() => this.allowedNamespaces, namespaces => this.loadAll({ namespaces }), {
       fireImmediately: true,
       equals: comparer.shallow,
     });

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -65,7 +65,11 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   private autoLoadAllowedNamespaces(): IReactionDisposer {
-    return reaction(() => this.allowedNamespaces, namespaces => this.loadAll({ namespaces }), {
+    return reaction(() => this.allowedNamespaces, namespaces => {
+      console.log("autoLoadAllowedNamespaces", namespaces);
+
+      return this.loadAll({ namespaces });
+    }, {
       fireImmediately: true,
       equals: comparer.shallow,
     });
@@ -98,7 +102,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     ].flat()));
   }
 
-  @computed get contextNamespaces(): string[] {
+  @computed get selectedNamespaces(): string[] {
     const namespaces = Array.from(this.contextNs);
 
     if (!namespaces.length) {
@@ -108,9 +112,11 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     return namespaces;
   }
 
-  getSubscribeApis() {
+  async getSubscribeApis() {
+    await this.contextReady;
+
     // if user has given static list of namespaces let's not start watches because watch adds stuff that's not wanted
-    if (this.context?.cluster.accessibleNamespaces.length > 0) {
+    if (this.context.cluster.accessibleNamespaces.length > 0) {
       return [];
     }
 

--- a/src/renderer/components/+user-management-roles-bindings/role-bindings.store.ts
+++ b/src/renderer/components/+user-management-roles-bindings/role-bindings.store.ts
@@ -9,7 +9,7 @@ import { apiManager } from "../../api/api-manager";
 export class RoleBindingsStore extends KubeObjectStore<RoleBinding> {
   api = clusterRoleBindingApi;
 
-  getSubscribeApis() {
+  async getSubscribeApis() {
     return [clusterRoleBindingApi, roleBindingApi];
   }
 

--- a/src/renderer/components/+user-management-roles/roles.store.ts
+++ b/src/renderer/components/+user-management-roles/roles.store.ts
@@ -7,7 +7,7 @@ import { apiManager } from "../../api/api-manager";
 export class RolesStore extends KubeObjectStore<Role> {
   api = clusterRoleApi;
 
-  getSubscribeApis() {
+  async getSubscribeApis() {
     return [roleApi, clusterRoleApi];
   }
 

--- a/src/renderer/components/+workloads-overview/overview-statuses.tsx
+++ b/src/renderer/components/+workloads-overview/overview-statuses.tsx
@@ -26,7 +26,7 @@ export class OverviewStatuses extends React.Component {
   @autobind()
   renderWorkload(resource: KubeResource): React.ReactElement {
     const store = workloadStores[resource];
-    const items = store.getAllByNs(namespaceStore.contextNamespaces);
+    const items = store.getAllByNs(namespaceStore.selectedNamespaces);
 
     return (
       <div className="workload" key={resource}>

--- a/src/renderer/components/+workloads-overview/overview.tsx
+++ b/src/renderer/components/+workloads-overview/overview.tsx
@@ -30,7 +30,7 @@ export class WorkloadsOverview extends React.Component<Props> {
         jobStore, cronJobStore, eventStore,
       ], {
         preload: true,
-        namespaces: clusterContext.contextNamespaces,
+        namespaces: clusterContext.selectedNamespaces,
       }),
     ]);
   }

--- a/src/renderer/components/context.ts
+++ b/src/renderer/components/context.ts
@@ -5,7 +5,7 @@ import { namespaceStore } from "./+namespaces/namespace.store";
 export interface ClusterContext {
   cluster?: Cluster;
   allNamespaces?: string[]; // available / allowed namespaces from cluster.ts
-  contextNamespaces?: string[]; // selected by user (see: namespace-select.tsx)
+  selectedNamespaces?: string[]; // selected by user (see: namespace-select.tsx)
 }
 
 export const clusterContext: ClusterContext = {
@@ -17,7 +17,7 @@ export const clusterContext: ClusterContext = {
     return this.cluster?.allowedNamespaces ?? [];
   },
 
-  get contextNamespaces(): string[] {
-    return namespaceStore.contextNamespaces ?? [];
+  get selectedNamespaces(): string[] {
+    return namespaceStore.selectedNamespaces ?? [];
   },
 };

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -140,7 +140,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
     const stores = Array.from(new Set([store, ...dependentStores]));
 
     // load context namespaces by default (see also: `<NamespaceSelectFilter/>`)
-    stores.forEach(store => store.loadAll(namespaceStore.contextNamespaces));
+    stores.forEach(store => store.loadAll(namespaceStore.selectedNamespaces));
   }
 
   private filterCallbacks: { [type: string]: ItemsFilter } = {

--- a/src/renderer/components/kube-object/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object/kube-object-list-layout.tsx
@@ -28,7 +28,7 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
     disposeOnUnmount(this, [
       kubeWatchApi.subscribeStores(stores, {
         preload: true,
-        namespaces: clusterContext.contextNamespaces,
+        namespaces: clusterContext.selectedNamespaces,
       })
     ]);
   }

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -2,8 +2,6 @@
 
 export const isElectron = !!navigator.userAgent.match(/Electron/);
 
-export type Disposer = () => void;
-
 export * from "../../common/utils";
 
 export * from "./cssVar";

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -2,6 +2,8 @@
 
 export const isElectron = !!navigator.userAgent.match(/Electron/);
 
+export type Disposer = () => void;
+
 export * from "../../common/utils";
 
 export * from "./cssVar";


### PR DESCRIPTION
- don't assume that loading "all namespaces" that lens knows about is the same as loading "all namespaces" that exist on the cluster

- Track when actually listing namespaces

Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes #2111 