### PR TITLE
Fix: load releases for all namespaces at once

### DIFF
--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -33,7 +33,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
       });
 
       if (amountChanged || labelsChanged) {
-        this.loadAll();
+        this.loadFromContextNamespaces();
       }
       this.releaseSecrets = [...secrets];
     });
@@ -58,7 +58,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   }
 
   @action
-  async loadAll(namespaces = namespaceStore.allowedNamespaces) {
+  async loadAll(namespaces: string[]) {
     this.isLoading = true;
 
     try {

--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -79,8 +79,9 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
 
   async loadItems(namespaces: string[]) {
     const isLoadingAll = namespaceStore.allowedNamespaces.every(ns => namespaces.includes(ns));
+    const noAccessibleNamespaces = namespaceStore.context.cluster.accessibleNamespaces.length === 0;
 
-    if (isLoadingAll) {
+    if (isLoadingAll && noAccessibleNamespaces) {
       return helmReleasesApi.list();
     } else {
       return Promise

--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -78,9 +78,15 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
   }
 
   async loadItems(namespaces: string[]) {
-    return Promise
-      .all(namespaces.map(namespace => helmReleasesApi.list(namespace)))
-      .then(items => items.flat());
+    const isLoadingAll = namespaceStore.allowedNamespaces.every(ns => namespaces.includes(ns));
+
+    if (isLoadingAll) {
+      return helmReleasesApi.list();
+    } else {
+      return Promise
+        .all(namespaces.map(namespace => helmReleasesApi.list(namespace)))
+        .then(items => items.flat());
+    }
   }
 
   async create(payload: IReleaseCreatePayload) {


### PR DESCRIPTION
Load releases for all namespaces at once if `All namespaces` context is selected

https://user-images.githubusercontent.com/9607060/107771327-a994ad00-6d4b-11eb-968e-71a930b71311.mp4
 
Fixes #2137 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>