### PR TITLE
Fix: list each namespace seperately if from accessibleNamespaces

### DIFF
--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -111,7 +111,7 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
 
       const isLoadingAll = this.context.allNamespaces.every(ns => namespaces.includes(ns));
 
-      if (isLoadingAll) {
+      if (isLoadingAll && this.context.cluster.accessibleNamespaces.length === 0) {
         this.loadedNamespaces = [];
 
         return api.list({}, this.query);


### PR DESCRIPTION
don't use list all optimization when operating in accessible namespaces mode

Follow up from #2138

Signed-off-by: Sebastian Malton <sebastian@malton.name>