### PR TITLE
Activate survey extension only in main renderer process

### DIFF
--- a/extensions/survey/renderer.tsx
+++ b/extensions/survey/renderer.tsx
@@ -15,7 +15,10 @@ export default class SurveyRendererExtension extends LensRendererExtension {
     }
   ];
   async onActivate() {
-    await surveyPreferencesStore.loadExtension(this);
-    survey.start();
+    // Activate extension only on main renderer
+    if (window.location.hostname === "localhost") {
+      await surveyPreferencesStore.loadExtension(this);
+      survey.start();
+    }
   }
 }


### PR DESCRIPTION
This PR activates survey functionality only in main renderer process and thus prevents multiple survey elements appearing from the same survey.