### PR TITLE
Fix Documentation: fix broken link in getting-started page

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -5,7 +5,7 @@ Lens is lightweight and simple to install. You'll be up and running in just a fe
 
 ## System Requirements
 
-Review the [System Requirements](/supporting/requirements/) to check if your computer configuration is supported.
+Review the [System Requirements](../supporting/requirements.md) to check if your computer configuration is supported.
 
 
 ## macOS


### PR DESCRIPTION
Hi! It's that 1 liner fix broken link in the docs PR. It bugs me when I found a broken link in the docs, so here's the fix (tested locally against your master branch). I also think you need to cherry-pick this commit into your other release branches as well (maybe v4.xx release?), cheers!