### PR TITLE
Register existing store with new apiBase when re-registering Kube API

### DIFF
--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -23,6 +23,12 @@ export class ApiManager {
 
   registerApi(apiBase: string, api: KubeApi) {
     if (!this.apis.has(apiBase)) {
+      this.stores.forEach((store) => {
+        if(store.api === api) {
+          this.stores.set(apiBase, store);
+        }
+      });
+
       this.apis.set(apiBase, api);
     }
   }
@@ -41,14 +47,6 @@ export class ApiManager {
 
       if (entry) this.unregisterApi(entry[0]);
     }
-  }
-
-  updateStoreKey(oldKey: string) {
-    const store = this.stores.get(oldKey);
-
-    if (!store) return;
-    this.stores.delete(oldKey);
-    this.registerStore(store, [store.api]);
   }
 
   @action

--- a/src/renderer/api/api-manager.ts
+++ b/src/renderer/api/api-manager.ts
@@ -43,6 +43,14 @@ export class ApiManager {
     }
   }
 
+  updateStoreKey(oldKey: string) {
+    const store = this.stores.get(oldKey);
+
+    if (!store) return;
+    this.stores.delete(oldKey);
+    this.registerStore(store, [store.api]);
+  }
+
   @action
   registerStore(store: KubeObjectStore, apis: KubeApi[] = [store.api]) {
     apis.forEach(api => {

--- a/src/renderer/api/kube-api.ts
+++ b/src/renderer/api/kube-api.ts
@@ -229,9 +229,7 @@ export class KubeApi<T extends KubeObject = any> {
       });
 
       if (this.apiVersionPreferred) {
-        const apiBase = this.getUrl();
-
-        Object.defineProperty(this, "apiBase", { value: apiBase });
+        Object.defineProperty(this, "apiBase", { value: this.getUrl() });
         apiManager.registerApi(this.apiBase, this);
       }
     }

--- a/src/renderer/api/kube-api.ts
+++ b/src/renderer/api/kube-api.ts
@@ -233,7 +233,6 @@ export class KubeApi<T extends KubeObject = any> {
 
         Object.defineProperty(this, "apiBase", { value: apiBase });
         apiManager.registerApi(this.apiBase, this);
-        apiManager.updateStoreKey(this.objectConstructor.apiBase);
       }
     }
   }

--- a/src/renderer/api/kube-api.ts
+++ b/src/renderer/api/kube-api.ts
@@ -229,8 +229,11 @@ export class KubeApi<T extends KubeObject = any> {
       });
 
       if (this.apiVersionPreferred) {
-        Object.defineProperty(this, "apiBase", { value: this.getUrl() });
+        const apiBase = this.getUrl();
+
+        Object.defineProperty(this, "apiBase", { value: apiBase });
         apiManager.registerApi(this.apiBase, this);
+        apiManager.updateStoreKey(this.objectConstructor.apiBase);
       }
     }
   }


### PR DESCRIPTION
This PR fix issue when api version is resolved from Kubernetes API and respective store has been already registered with default api version.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>