### PR TITLE
Fix: deprecated helm chart filtering

### DIFF
--- a/src/main/helm/__mocks__/helm-chart-manager.ts
+++ b/src/main/helm/__mocks__/helm-chart-manager.ts
@@ -88,14 +88,14 @@ export class HelmChartManager {
             {
               apiVersion: "3.0.0",
               name: "pretzel",
-              version: "1.0.0-beta2",
+              version: "1.0",
               repo: "bitnami",
               digest: "test",
             },
             {
               apiVersion: "3.0.0",
               name: "pretzel",
-              version: "1.0.0",
+              version: "1.0.1",
               repo: "bitnami",
               digest: "test"
             }

--- a/src/main/helm/__mocks__/helm-chart-manager.ts
+++ b/src/main/helm/__mocks__/helm-chart-manager.ts
@@ -1,0 +1,115 @@
+import { HelmRepo, HelmRepoManager } from "../helm-repo-manager";
+
+export class HelmChartManager {
+  private cache: any = {};
+  private repo: HelmRepo;
+
+  constructor(repo: HelmRepo){
+    this.cache = HelmRepoManager.cache;
+    this.repo = repo;
+  }
+
+  public async charts(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let groups: any = {};
+
+      if (this.repo.name == "stable") {
+        groups = {
+          "apm-server": [
+            {
+              apiVersion: "3.0.0",
+              name: "apm-server",
+              version: "2.1.7",
+              repo: "stable",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "apm-server",
+              version: "2.1.6",
+              repo: "stable",
+              digest: "test"
+            }
+          ],
+          "redis": [
+            {
+              apiVersion: "3.0.0",
+              name: "apm-server",
+              version: "1.0.0",
+              repo: "stable",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "apm-server",
+              version: "0.0.9",
+              repo: "stable",
+              digest: "test"
+            }
+          ]
+        };
+      }
+
+      if (this.repo.name == "experiment") {
+        groups = {
+          "fairwind": [
+            {
+              apiVersion: "3.0.0",
+              name: "fairwind",
+              version: "0.0.1",
+              repo: "experiment",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "fairwind",
+              version: "0.0.2",
+              repo: "experiment",
+              digest: "test",
+              deprecated: true
+            }
+          ]
+        };
+      }
+
+      if (this.repo.name == "bitnami") {
+        groups = {
+          "hotdog": [
+            {
+              apiVersion: "3.0.0",
+              name: "hotdog",
+              version: "1.0.1",
+              repo: "bitnami",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "hotdog",
+              version: "1.0.2",
+              repo: "bitnami",
+              digest: "test",
+            }
+          ],
+          "pretzel": [
+            {
+              apiVersion: "3.0.0",
+              name: "pretzel",
+              version: "1.0.0-beta2",
+              repo: "bitnami",
+              digest: "test",
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "pretzel",
+              version: "1.0.0",
+              repo: "bitnami",
+              digest: "test"
+            }
+          ]
+        };
+      }
+
+      resolve(groups);
+    });
+  }
+}

--- a/src/main/helm/__mocks__/helm-chart-manager.ts
+++ b/src/main/helm/__mocks__/helm-chart-manager.ts
@@ -10,11 +10,9 @@ export class HelmChartManager {
   }
 
   public async charts(): Promise<any> {
-    return new Promise((resolve, reject) => {
-      let groups: any = {};
-
-      if (this.repo.name == "stable") {
-        groups = {
+    switch (this.repo.name) {
+      case "stable":
+        return Promise.resolve({
           "apm-server": [
             {
               apiVersion: "3.0.0",
@@ -47,11 +45,9 @@ export class HelmChartManager {
               digest: "test"
             }
           ]
-        };
-      }
-
-      if (this.repo.name == "experiment") {
-        groups = {
+        });
+      case "experiment":
+        return Promise.resolve({
           "fairwind": [
             {
               apiVersion: "3.0.0",
@@ -69,11 +65,9 @@ export class HelmChartManager {
               deprecated: true
             }
           ]
-        };
-      }
-
-      if (this.repo.name == "bitnami") {
-        groups = {
+        });
+      case "bitnami":
+        return Promise.resolve({
           "hotdog": [
             {
               apiVersion: "3.0.0",
@@ -106,10 +100,9 @@ export class HelmChartManager {
               digest: "test"
             }
           ]
-        };
-      }
-
-      resolve(groups);
-    });
+        });
+      default:
+        return Promise.resolve({});
+    }
   }
 }

--- a/src/main/helm/__tests__/helm-service.test.ts
+++ b/src/main/helm/__tests__/helm-service.test.ts
@@ -1,0 +1,104 @@
+import { helmService } from "../helm-service";
+import { repoManager } from "../helm-repo-manager";
+
+jest.spyOn(repoManager, "init").mockImplementation();
+
+jest.mock("../helm-chart-manager");
+
+describe("Helm Service tests", () => {
+  test("list charts without deprecated ones", async () => {
+    jest.spyOn(repoManager, "repositories").mockImplementation(async () => {
+      return [
+        { name: "stable", url: "stableurl" },
+        { name: "experiment", url: "experimenturl" }
+      ];
+    });
+
+    const charts = await helmService.listCharts();
+
+    expect(charts).toEqual({
+      stable: {
+        "apm-server": [
+          {
+            apiVersion: "3.0.0",
+            name: "apm-server",
+            version: "2.1.7",
+            repo: "stable",
+            digest: "test"
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "apm-server",
+            version: "2.1.6",
+            repo: "stable",
+            digest: "test"
+          }
+        ],
+        "redis": [
+          {
+            apiVersion: "3.0.0",
+            name: "apm-server",
+            version: "1.0.0",
+            repo: "stable",
+            digest: "test"
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "apm-server",
+            version: "0.0.9",
+            repo: "stable",
+            digest: "test"
+          }
+        ]
+      },
+      experiment: {}
+    });
+  });
+
+  test("list charts sorted by version in descending order", async () => {
+    jest.spyOn(repoManager, "repositories").mockImplementation(async () => {
+      return [
+        { name: "bitnami", url: "bitnamiurl" }
+      ];
+    });
+
+    const charts = await helmService.listCharts();
+
+    expect(charts).toEqual({
+      bitnami: {
+        "hotdog": [
+          {
+            apiVersion: "3.0.0",
+            name: "hotdog",
+            version: "1.0.2",
+            repo: "bitnami",
+            digest: "test",
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "hotdog",
+            version: "1.0.1",
+            repo: "bitnami",
+            digest: "test"
+          },
+        ],
+        "pretzel": [
+          {
+            apiVersion: "3.0.0",
+            name: "pretzel",
+            version: "1.0.0",
+            repo: "bitnami",
+            digest: "test",
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "pretzel",
+            version: "1.0.0-beta2",
+            repo: "bitnami",
+            digest: "test"
+          }
+        ]
+      }
+    });
+  });
+});

--- a/src/main/helm/__tests__/helm-service.test.ts
+++ b/src/main/helm/__tests__/helm-service.test.ts
@@ -86,14 +86,14 @@ describe("Helm Service tests", () => {
           {
             apiVersion: "3.0.0",
             name: "pretzel",
-            version: "1.0.0",
+            version: "1.0.1",
             repo: "bitnami",
             digest: "test",
           },
           {
             apiVersion: "3.0.0",
             name: "pretzel",
-            version: "1.0.0-beta2",
+            version: "1.0",
             repo: "bitnami",
             digest: "test"
           }

--- a/src/main/helm/helm-chart-manager.ts
+++ b/src/main/helm/helm-chart-manager.ts
@@ -4,9 +4,12 @@ import { HelmRepo, HelmRepoManager } from "./helm-repo-manager";
 import logger from "../logger";
 import { promiseExec } from "../promise-exec";
 import { helmCli } from "./helm-cli";
+import { HelmChart } from "../../renderer/api/endpoints/helm-charts.api";
+
+type HelmGroups = { [key: string]: HelmChart[] };
 
 type CachedYaml = {
-  entries: any; // todo: types
+  entries: HelmGroups
 };
 
 export class HelmChartManager {
@@ -24,7 +27,7 @@ export class HelmChartManager {
     return charts[name];
   }
 
-  public async charts(): Promise<any> {
+  public async charts(): Promise<HelmGroups> {
     try {
       const cachedYaml = await this.cachedYaml();
 
@@ -32,7 +35,7 @@ export class HelmChartManager {
     } catch(error) {
       logger.error(error);
 
-      return [];
+      return {};
     }
   }
 

--- a/src/main/helm/helm-chart-manager.ts
+++ b/src/main/helm/helm-chart-manager.ts
@@ -4,12 +4,10 @@ import { HelmRepo, HelmRepoManager } from "./helm-repo-manager";
 import logger from "../logger";
 import { promiseExec } from "../promise-exec";
 import { helmCli } from "./helm-cli";
-import { HelmChart } from "../../renderer/api/endpoints/helm-charts.api";
-
-export type HelmChartGroups = { [key: string]: HelmChart[] };
+import type { RepoHelmChartList } from "../../renderer/api/endpoints/helm-charts.api";
 
 type CachedYaml = {
-  entries: HelmChartGroups
+  entries: RepoHelmChartList
 };
 
 export class HelmChartManager {
@@ -27,7 +25,7 @@ export class HelmChartManager {
     return charts[name];
   }
 
-  public async charts(): Promise<HelmChartGroups> {
+  public async charts(): Promise<RepoHelmChartList> {
     try {
       const cachedYaml = await this.cachedYaml();
 

--- a/src/main/helm/helm-chart-manager.ts
+++ b/src/main/helm/helm-chart-manager.ts
@@ -6,10 +6,10 @@ import { promiseExec } from "../promise-exec";
 import { helmCli } from "./helm-cli";
 import { HelmChart } from "../../renderer/api/endpoints/helm-charts.api";
 
-type HelmGroups = { [key: string]: HelmChart[] };
+export type HelmChartGroups = { [key: string]: HelmChart[] };
 
 type CachedYaml = {
-  entries: HelmGroups
+  entries: HelmChartGroups
 };
 
 export class HelmChartManager {
@@ -27,7 +27,7 @@ export class HelmChartManager {
     return charts[name];
   }
 
-  public async charts(): Promise<HelmGroups> {
+  public async charts(): Promise<HelmChartGroups> {
     try {
       const cachedYaml = await this.cachedYaml();
 

--- a/src/main/helm/helm-chart-manager.ts
+++ b/src/main/helm/helm-chart-manager.ts
@@ -31,7 +31,7 @@ export class HelmChartManager {
 
       return cachedYaml["entries"];
     } catch(error) {
-      logger.error(error);
+      logger.error("HELM-CHART-MANAGER]: failed to list charts", { error });
 
       return {};
     }

--- a/src/main/helm/helm-service.ts
+++ b/src/main/helm/helm-service.ts
@@ -20,10 +20,10 @@ class HelmService {
     for (const repo of repositories) {
       charts[repo.name] = {};
       const manager = new HelmChartManager(repo);
-      const groups = this.excludeDeprecatedChartGroups(await manager.charts());
-      const sortedGroups = this.sortChartsByVersion(groups);
+      const sortedCharts = this.sortChartsByVersion(await manager.charts());
+      const enabledCharts = this.excludeDeprecatedChartGroups(sortedCharts);
 
-      charts[repo.name] = sortedGroups;
+      charts[repo.name] = enabledCharts;
     }
 
     return charts;

--- a/src/main/helm/helm-service.ts
+++ b/src/main/helm/helm-service.ts
@@ -5,6 +5,8 @@ import { HelmChartManager } from "./helm-chart-manager";
 import { releaseManager } from "./helm-release-manager";
 import { HelmChart } from "../../renderer/api/endpoints/helm-charts.api";
 
+import type { HelmChartGroups } from "./helm-chart-manager";
+
 class HelmService {
   public async installChart(cluster: Cluster, data: { chart: string; values: {}; name: string; namespace: string; version: string }) {
     return await releaseManager.installChart(data.chart, data.values, data.name, data.namespace, data.version, cluster.getProxyKubeconfigPath());
@@ -19,7 +21,7 @@ class HelmService {
     for (const repo of repositories) {
       charts[repo.name] = {};
       const manager = new HelmChartManager(repo);
-      const { groups } = new HelmChartGroups(await manager.charts());
+      const { groups } = new ChartGroups(await manager.charts());
 
       charts[repo.name] = groups;
     }
@@ -93,11 +95,11 @@ class HelmService {
   }
 }
 
-class HelmChartGroups {
-  items: Map<string, HelmChart[]>;
+class ChartGroups {
+  private items: Map<string, HelmChart[]>;
 
-  constructor(group: { [chartName: string]: HelmChart[] }) {
-    this.items = new Map(Object.entries(group));
+  constructor(groups: HelmChartGroups) {
+    this.items = new Map(Object.entries(groups));
     this.excludeDeprecatedGroups();
   }
 

--- a/src/main/helm/helm-service.ts
+++ b/src/main/helm/helm-service.ts
@@ -5,7 +5,7 @@ import { HelmChartManager } from "./helm-chart-manager";
 import { releaseManager } from "./helm-release-manager";
 import { HelmChart } from "../../renderer/api/endpoints/helm-charts.api";
 
-import type { HelmChartGroups } from "./helm-chart-manager";
+import type { HelmChartList, RepoHelmChartList } from "../../renderer/api/endpoints/helm-charts.api";
 
 class HelmService {
   public async installChart(cluster: Cluster, data: { chart: string; values: {}; name: string; namespace: string; version: string }) {
@@ -13,7 +13,7 @@ class HelmService {
   }
 
   public async listCharts() {
-    const charts: any = {};
+    const charts: HelmChartList = {};
 
     await repoManager.init();
     const repositories = await repoManager.repositories();
@@ -21,7 +21,7 @@ class HelmService {
     for (const repo of repositories) {
       charts[repo.name] = {};
       const manager = new HelmChartManager(repo);
-      const { groups } = new ChartGroups(await manager.charts());
+      const { groups } = new HelmChartGroups(await manager.charts());
 
       charts[repo.name] = groups;
     }
@@ -95,15 +95,15 @@ class HelmService {
   }
 }
 
-class ChartGroups {
+class HelmChartGroups {
   private items: Map<string, HelmChart[]>;
 
-  constructor(groups: HelmChartGroups) {
+  constructor(groups: RepoHelmChartList) {
     this.items = new Map(Object.entries(groups));
     this.excludeDeprecatedGroups();
   }
 
-  excludeDeprecatedGroups() {
+  private excludeDeprecatedGroups() {
     for (const [chartName, charts] of this.items) {
       if (charts[0].deprecated) {
         this.items.delete(chartName);

--- a/src/main/helm/helm-service.ts
+++ b/src/main/helm/helm-service.ts
@@ -109,7 +109,10 @@ class HelmService {
   private sortChartsByVersion(chartGroups: RepoHelmChartList) {
     for (const key in chartGroups) {
       chartGroups[key] = chartGroups[key].sort((first, second) => {
-        return semver.compare(second.version, first.version);
+        const firstVersion = semver.coerce(first.version || 0);
+        const secondVersion = semver.coerce(second.version || 0);
+
+        return semver.compare(secondVersion, firstVersion);
       });
     }
 

--- a/src/renderer/api/endpoints/helm-charts.api.ts
+++ b/src/renderer/api/endpoints/helm-charts.api.ts
@@ -3,11 +3,8 @@ import { apiBase } from "../index";
 import { stringify } from "querystring";
 import { autobind } from "../../utils";
 
-interface IHelmChartList {
-  [repo: string]: {
-    [name: string]: HelmChart[];
-  };
-}
+export type RepoHelmChartList = Record<string, HelmChart[]>;
+export type HelmChartList = Record<string, RepoHelmChartList>;
 
 export interface IHelmChartDetails {
   readme: string;
@@ -22,12 +19,12 @@ const endpoint = compile(`/v2/charts/:repo?/:name?`) as (params?: {
 export const helmChartsApi = {
   list() {
     return apiBase
-      .get<IHelmChartList>(endpoint())
+      .get<HelmChartList>(endpoint())
       .then(data => {
         return Object
           .values(data)
           .reduce((allCharts, repoCharts) => allCharts.concat(Object.values(repoCharts)), [])
-          .map((charts: HelmChart[]) => HelmChart.create(charts[0]));
+          .map(([chart]) => HelmChart.create(chart));
       });
   },
 

--- a/src/renderer/api/endpoints/helm-charts.api.ts
+++ b/src/renderer/api/endpoints/helm-charts.api.ts
@@ -5,7 +5,7 @@ import { autobind } from "../../utils";
 
 interface IHelmChartList {
   [repo: string]: {
-    [name: string]: HelmChart;
+    [name: string]: HelmChart[];
   };
 }
 
@@ -27,7 +27,7 @@ export const helmChartsApi = {
         return Object
           .values(data)
           .reduce((allCharts, repoCharts) => allCharts.concat(Object.values(repoCharts)), [])
-          .map(HelmChart.create);
+          .map((charts: HelmChart[]) => HelmChart.create(charts[0]));
       });
   },
 

--- a/src/renderer/components/+apps-helm-charts/helm-charts.tsx
+++ b/src/renderer/components/+apps-helm-charts/helm-charts.tsx
@@ -72,9 +72,6 @@ export class HelmCharts extends Component<Props> {
             (chart: HelmChart) => chart.getAppVersion(),
             (chart: HelmChart) => chart.getKeywords(),
           ]}
-          filterItems={[
-            (items: HelmChart[]) => items.filter(item => !item.deprecated)
-          ]}
           customizeHeader={() => (
             <SearchInputUrl placeholder={`Search Helm Charts`} />
           )}


### PR DESCRIPTION
Now deprecated Helm charts are not showed in list.

![no deprecated charts](https://user-images.githubusercontent.com/9607060/108046636-e4515a80-7055-11eb-9081-7a58fd03574e.png)

Fixes #2156

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>