### PR TITLE
Adding paddings to auto-update notification elements

### DIFF
--- a/src/renderer/components/notifications/notifications.scss
+++ b/src/renderer/components/notifications/notifications.scss
@@ -15,7 +15,7 @@
 
   .notification {
     flex: 0 0;
-    padding: $padding;
+    padding: $padding * 1.5;
     border-radius: 3px;
     min-width: 350px;
     max-width: 35vw;

--- a/src/renderer/ipc/index.tsx
+++ b/src/renderer/ipc/index.tsx
@@ -34,14 +34,14 @@ function UpdateAvailableHandler(event: IpcRendererEvent, ...[backchannel, update
 
   Notifications.info(
     (
-      <>
+      <div className="flex column gaps">
         <b>Update Available</b>
         <p>Version {updateInfo.version} of Lens IDE is now available. Would you like to update?</p>
         <div className="flex gaps row align-left box grow">
           <RenderYesButtons backchannel={backchannel} notificationId={notificationId} />
           <Button active outlined label="No" onClick={() => sendToBackchannel(backchannel, notificationId, { doUpdate: false })} />
         </div>
-      </>
+      </div>
     ), {
       id: notificationId,
       onClose() {


### PR DESCRIPTION
This PR adds some paddings to notification container and to auto-update notification itself.

Before:
![no paddings for auto update](https://user-images.githubusercontent.com/9607060/108073542-39eb2e80-7079-11eb-8146-6f1bddffb69b.png)

After:
![good paddings for auto update](https://user-images.githubusercontent.com/9607060/108073656-55eed000-7079-11eb-91fd-acbbc5b80827.png)
![sucessfull notification](https://user-images.githubusercontent.com/9607060/108073663-57b89380-7079-11eb-8d04-d32e131800ba.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>