### PR TITLE
Wait for cluster to be ready before loading iframe

### DIFF
--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -24,6 +24,9 @@ export async function initView(clusterId: ClusterId) {
   if (!cluster) {
     return;
   }
+
+  logger.info(`[LENS-VIEW]: waiting cluster to be ready, clusterId=${clusterId}`);
+  await cluster.whenReady;
   logger.info(`[LENS-VIEW]: init dashboard, clusterId=${clusterId}`);
   const parentElem = document.getElementById("lens-views");
   const iframe = document.createElement("iframe");


### PR DESCRIPTION
Otherwise there is a possibility that `autoCleanOnRemove` triggers too fast.

Should fix #2176 
Should fix #2152