### PR TITLE
Fix: don't reset selected namespaces to defaults in case of "All namespaces" on page reload

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -56,7 +56,7 @@ export class NamespaceSelectFilter extends React.Component {
     if (namespace) {
       namespaceStore.toggleContext(namespace);
     } else {
-      namespaceStore.resetContext(); // "All namespaces" clicked, empty list considered as "all"
+      namespaceStore.toggleAll(false); // "All namespaces" clicked
     }
   }
 

--- a/src/renderer/components/+namespaces/namespace-select.tsx
+++ b/src/renderer/components/+namespaces/namespace-select.tsx
@@ -29,6 +29,7 @@ export class NamespaceSelect extends React.Component<Props> {
     disposeOnUnmount(this, [
       kubeWatchApi.subscribeStores([namespaceStore], {
         preload: true,
+        loadOnce: true, // skip reloading namespaces on every render / page visit
       })
     ]);
   }

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -5,7 +5,7 @@ import { Namespace, namespacesApi } from "../../api/endpoints/namespaces.api";
 import { createPageParam } from "../../navigation";
 import { apiManager } from "../../api/api-manager";
 
-const storage = createStorage<string[]>("context_namespaces", []);
+const storage = createStorage<string[]>("context_namespaces");
 
 export const namespaceUrlParam = createPageParam<string[]>({
   name: "namespaces",
@@ -74,11 +74,11 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   @computed
   private get initialNamespaces(): string[] {
     const namespaces = new Set(this.allowedNamespaces);
-    const prevSelected = storage.get().filter(namespace => namespaces.has(namespace));
+    const prevSelectedNamespaces = storage.get();
 
-    // return previously saved namespaces from local-storage
-    if (prevSelected.length > 0) {
-      return prevSelected;
+    // return previously saved namespaces from local-storage (if any)
+    if (prevSelectedNamespaces) {
+      return prevSelectedNamespaces.filter(namespace => namespaces.has(namespace));
     }
 
     // otherwise select "default" or first allowed namespace
@@ -166,7 +166,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
       if (showAll) {
         this.setContext(this.allowedNamespaces);
       } else {
-        this.contextNs.clear();
+        this.resetContext(); // empty context considered as "All namespaces"
       }
     } else {
       this.toggleAll(!this.hasAllContexts);


### PR DESCRIPTION
_Fixes:_

- fix: don't reset selected namespaces in case of "All namespaces" at page reload (Cmd+R)
- fix: don't make k8s api-request(s) for loading namespaces on every page visit / `NamespaceSelect.componentDidMount()`
- partial-fix for #2166

https://user-images.githubusercontent.com/6377066/108360447-e3f1c480-71f9-11eb-8cea-f20ffb41520b.mov
