### PR TITLE
Pass Lens wslenvs to terminal session on Windows

### DIFF
--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -110,6 +110,14 @@ export class ShellSession extends EventEmitter {
       env["SystemRoot"] = process.env.SystemRoot;
       env["PTYSHELL"] = process.env.SHELL || "powershell.exe";
       env["PATH"] = pathStr;
+      env["LENS_SESSION"] = "true";
+      const lensWslEnv = "KUBECONFIG/up:LENS_SESSION/u";
+
+      if (process.env.WSLENV != undefined) {
+        env["WSLENV"] = `${process.env["WSLENV"]}:${lensWslEnv}`;
+      } else {
+        env["WSLENV"] = lensWslEnv;
+      }
     } else if(typeof(process.env.SHELL) != "undefined") {
       env["PTYSHELL"] = process.env.SHELL;
       env["PATH"] = pathStr;


### PR DESCRIPTION
This PR will pass `KUBECONFIG` environment variable to terminal session running on WSL on Windows enabling terminal sessions points to correct Kubernetes cluster automatically. Also `LENS_SESSION` environment variable is set, so user can configure bash init script based on this, for example:

```bash
if [ -n "$LENS_SESSION" ] ; then
    alias kubectl="kubectl.exe"
fi
```

Which will make `kubectl` command to use correct version of kubectl.exe downloaded by Lens.

Fixes https://github.com/lensapp/lens/issues/2180