### PR TITLE
Fix: allow scrolling in main-layout's content area

### DIFF
--- a/src/renderer/components/layout/main-layout.scss
+++ b/src/renderer/components/layout/main-layout.scss
@@ -44,6 +44,11 @@
 
   > main {
     display: contents;
+
+    > * {
+      grid-area: main;
+      overflow: auto;
+    }
   }
 
   footer {


### PR DESCRIPTION
_Can't scroll error area_
<img width="1536" alt="Screenshot 2021-02-20 at 19 29 41" src="https://user-images.githubusercontent.com/6377066/108604843-0120c180-73b9-11eb-9c1c-2e69f57015e4.png">

_Main area messed up with sidebar in `compact`-mode:_
<img width="1536" alt="Screenshot 2021-02-20 at 19 29 48" src="https://user-images.githubusercontent.com/6377066/108604851-04b44880-73b9-11eb-91a5-ea44decacd2b.png">

_After fix (both sidebar and scrollbar are handled)_
<img width="1536" alt="Screenshot 2021-02-20 at 20 07 12" src="https://user-images.githubusercontent.com/6377066/108604852-05e57580-73b9-11eb-9c76-5abb02f3775e.png">

_How to reproduce?_

```ts
  // events.tsx
  render() {
    throw {
      message: "Boom!"
    };
    // ...
```