### PR TITLE
StatusBarRegistration's component field must be optional for backwards compatability

### DIFF
--- a/src/extensions/registries/status-bar-registry.ts
+++ b/src/extensions/registries/status-bar-registry.ts
@@ -8,7 +8,7 @@ interface StatusBarComponents {
 }
 
 interface StatusBarRegistrationV2 {
-  components: StatusBarComponents;
+  components?: StatusBarComponents; // has to be optional for backwards compatability
 }
 
 export interface StatusBarRegistration extends StatusBarRegistrationV2 {


### PR DESCRIPTION
fix bug related to #1598 

Signed-off-by: Sebastian Malton <sebastian@malton.name>