### PR TITLE
Fix loading all namespaces for users with limited cluster access

### DIFF
--- a/src/renderer/api/kube-api.ts
+++ b/src/renderer/api/kube-api.ts
@@ -272,6 +272,7 @@ export class KubeApi<T extends KubeObject = any> {
   }
 
   protected parseResponse(data: KubeJsonApiData | KubeJsonApiData[] | KubeJsonApiDataList, namespace?: string): any {
+    if (!data) return;
     const KubeObjectConstructor = this.objectConstructor;
 
     if (KubeObject.isJsonApiData(data)) {

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -120,7 +120,7 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   protected async loadItems(params: KubeObjectStoreLoadingParams) {
     const { allowedNamespaces } = this;
 
-    let namespaces = await super.loadItems(params);
+    let namespaces = (await super.loadItems(params)) || [];
 
     namespaces = namespaces.filter(namespace => allowedNamespaces.includes(namespace.getName()));
 


### PR DESCRIPTION
`NamespaceStore.loadAll()` fails if user does not have access to list namespaces. This is because kubernetes api returns 403 and no kube object data are returned. Instead error is raised and, thus, no accessible namespaces are added. This PR fixes this by:

1. not to try to parse response if `KubeJsonApiData` returned from kubernetes api request is `undefined`. If not doing this,  error will be raised and `KubeObjectStore.loadAll()` fails.
2. set initial namespaces as an empty array if `NamespaceStore.loadItems()` returns `undefined`, so it can successfully add accessible namespaces to empty items.