### PR TITLE
Refactor the Extensions settings page

### DIFF
--- a/src/common/protocol-handler/router.ts
+++ b/src/common/protocol-handler/router.ts
@@ -23,8 +23,8 @@ export const ProtocolHandlerExtension= `${ProtocolHandlerIpcPrefix}:extension`;
  * Though under the current (2021/01/18) implementation, these are never matched
  * against in the final matching so their names are less of a concern.
  */
-const EXTENSION_PUBLISHER_MATCH = "LENS_INTERNAL_EXTENSION_PUBLISHER_MATCH";
-const EXTENSION_NAME_MATCH = "LENS_INTERNAL_EXTENSION_NAME_MATCH";
+export const EXTENSION_PUBLISHER_MATCH = "LENS_INTERNAL_EXTENSION_PUBLISHER_MATCH";
+export const EXTENSION_NAME_MATCH = "LENS_INTERNAL_EXTENSION_NAME_MATCH";
 
 export abstract class LensProtocolRouter extends Singleton {
   // Map between path schemas and the handlers
@@ -32,7 +32,7 @@ export abstract class LensProtocolRouter extends Singleton {
 
   public static readonly LoggingPrefix = "[PROTOCOL ROUTER]";
 
-  protected static readonly ExtensionUrlSchema = `/:${EXTENSION_PUBLISHER_MATCH}(\@[A-Za-z0-9_]+)?/:${EXTENSION_NAME_MATCH}`;
+  static readonly ExtensionUrlSchema = `/:${EXTENSION_PUBLISHER_MATCH}(\@[A-Za-z0-9_]+)?/:${EXTENSION_NAME_MATCH}`;
 
   /**
    *

--- a/src/common/utils/disposer.ts
+++ b/src/common/utils/disposer.ts
@@ -1,0 +1,18 @@
+export type Disposer = () => void;
+
+interface Extendable<T> {
+  push(...vals: T[]): void;
+}
+
+export function disposer(...args: Disposer[]): Disposer & Extendable<Disposer> {
+  const res = () => {
+    args.forEach(dispose => dispose?.());
+    args.length = 0;
+  };
+
+  res.push = (...vals: Disposer[]) => {
+    args.push(...vals);
+  };
+
+  return res;
+}

--- a/src/common/utils/disposer.ts
+++ b/src/common/utils/disposer.ts
@@ -4,7 +4,9 @@ interface Extendable<T> {
   push(...vals: T[]): void;
 }
 
-export function disposer(...args: Disposer[]): Disposer & Extendable<Disposer> {
+export type ExtendableDisposer = Disposer & Extendable<Disposer>;
+
+export function disposer(...args: Disposer[]): ExtendableDisposer {
   const res = () => {
     args.forEach(dispose => dispose?.());
     args.length = 0;

--- a/src/common/utils/downloadFile.ts
+++ b/src/common/utils/downloadFile.ts
@@ -6,13 +6,13 @@ export interface DownloadFileOptions {
   timeout?: number;
 }
 
-export interface DownloadFileTicket {
+export interface DownloadFileTicket<T> {
   url: string;
-  promise: Promise<Buffer>;
+  promise: Promise<T>;
   cancel(): void;
 }
 
-export function downloadFile({ url, timeout, gzip = true }: DownloadFileOptions): DownloadFileTicket {
+export function downloadFile({ url, timeout, gzip = true }: DownloadFileOptions): DownloadFileTicket<Buffer> {
   const fileChunks: Buffer[] = [];
   const req = request(url, { gzip, timeout });
   const promise: Promise<Buffer> = new Promise((resolve, reject) => {
@@ -33,5 +33,14 @@ export function downloadFile({ url, timeout, gzip = true }: DownloadFileOptions)
     cancel() {
       req.abort();
     }
+  };
+}
+
+export function downloadJson(args: DownloadFileOptions): DownloadFileTicket<any> {
+  const { promise, ...rest } = downloadFile(args);
+
+  return {
+    promise: promise.then(res => JSON.parse(res.toString())),
+    ...rest
   };
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -19,3 +19,4 @@ export * from "./downloadFile";
 export * from "./escapeRegExp";
 export * from "./tar";
 export * from "./type-narrowing";
+export * from "./disposer";

--- a/src/extensions/__tests__/extension-discovery.test.ts
+++ b/src/extensions/__tests__/extension-discovery.test.ts
@@ -1,9 +1,11 @@
+import mockFs from "mock-fs";
 import { watch } from "chokidar";
-import { join, normalize } from "path";
-import { ExtensionDiscovery, InstalledExtension } from "../extension-discovery";
+import path from "path";
+import { ExtensionDiscovery } from "../extension-discovery";
+import os from "os";
+import { Console } from "console";
 
 jest.mock("../../common/ipc");
-jest.mock("fs-extra");
 jest.mock("chokidar", () => ({
   watch: jest.fn()
 }));
@@ -14,50 +16,62 @@ jest.mock("../extension-installer", () => ({
   }
 }));
 
+console = new Console(process.stdout, process.stderr); // fix mockFS
 const mockedWatch = watch as jest.MockedFunction<typeof watch>;
 
 describe("ExtensionDiscovery", () => {
-  it("emits add for added extension", async done => {
-    globalThis.__non_webpack_require__.mockImplementation(() => ({
-      name: "my-extension"
-    }));
-    let addHandler: (filePath: string) => void;
-
-    const mockWatchInstance: any = {
-      on: jest.fn((event: string, handler: typeof addHandler) => {
-        if (event === "add") {
-          addHandler = handler;
-        }
-
-        return mockWatchInstance;
-      })
-    };
-
-    mockedWatch.mockImplementationOnce(() =>
-      (mockWatchInstance) as any
-    );
-    const extensionDiscovery = new ExtensionDiscovery();
-
-    // Need to force isLoaded to be true so that the file watching is started
-    extensionDiscovery.isLoaded = true;
-
-    await extensionDiscovery.watchExtensions();
-
-    extensionDiscovery.events.on("add", (extension: InstalledExtension) => {
-      expect(extension).toEqual({
-        absolutePath: expect.any(String),
-        id: normalize("node_modules/my-extension/package.json"),
-        isBundled: false,
-        isEnabled: false,
-        manifest:  {
-          name: "my-extension",
-        },
-        manifestPath: normalize("node_modules/my-extension/package.json"),
+  describe("with mockFs", () => {
+    beforeEach(() => {
+      mockFs({
+        [`${os.homedir()}/.k8slens/extensions/my-extension/package.json`]: JSON.stringify({
+          name: "my-extension"
+        }),
       });
-      done();
     });
 
-    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/package.json"));
+    afterEach(() => {
+      mockFs.restore();
+    });
+
+    it("emits add for added extension", async (done) => {
+      let addHandler: (filePath: string) => void;
+
+      const mockWatchInstance: any = {
+        on: jest.fn((event: string, handler: typeof addHandler) => {
+          if (event === "add") {
+            addHandler = handler;
+          }
+
+          return mockWatchInstance;
+        })
+      };
+
+      mockedWatch.mockImplementationOnce(() =>
+        (mockWatchInstance) as any
+      );
+      const extensionDiscovery = new ExtensionDiscovery();
+
+      // Need to force isLoaded to be true so that the file watching is started
+      extensionDiscovery.isLoaded = true;
+
+      await extensionDiscovery.watchExtensions();
+
+      extensionDiscovery.events.on("add", extension => {
+        expect(extension).toEqual({
+          absolutePath: expect.any(String),
+          id: path.normalize("node_modules/my-extension/package.json"),
+          isBundled: false,
+          isEnabled: false,
+          manifest:  {
+            name: "my-extension",
+          },
+          manifestPath: path.normalize("node_modules/my-extension/package.json"),
+        });
+        done();
+      });
+
+      addHandler(path.join(extensionDiscovery.localFolderPath, "/my-extension/package.json"));
+    });
   });
 
   it("doesn't emit add for added file under extension", async done => {
@@ -87,7 +101,7 @@ describe("ExtensionDiscovery", () => {
 
     extensionDiscovery.events.on("add", onAdd);
 
-    addHandler(join(extensionDiscovery.localFolderPath, "/my-extension/node_modules/dep/package.json"));
+    addHandler(path.join(extensionDiscovery.localFolderPath, "/my-extension/node_modules/dep/package.json"));
 
     setTimeout(() => {
       expect(onAdd).not.toHaveBeenCalled();

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -9,23 +9,24 @@ import { broadcastMessage, handleRequest, requestMain, subscribeToBroadcast } fr
 import { getBundledExtensions } from "../common/utils/app-version";
 import logger from "../main/logger";
 import { extensionInstaller, PackageJson } from "./extension-installer";
+import { extensionLoader } from "./extension-loader";
 import { extensionsStore } from "./extensions-store";
 import type { LensExtensionId, LensExtensionManifest } from "./lens-extension";
 
 export interface InstalledExtension {
-    id: LensExtensionId;
+  id: LensExtensionId;
 
-    readonly manifest: LensExtensionManifest;
+  readonly manifest: LensExtensionManifest;
 
-    // Absolute path to the non-symlinked source folder,
-    // e.g. "/Users/user/.k8slens/extensions/helloworld"
-    readonly absolutePath: string;
+  // Absolute path to the non-symlinked source folder,
+  // e.g. "/Users/user/.k8slens/extensions/helloworld"
+  readonly absolutePath: string;
 
-    // Absolute to the symlinked package.json file
-    readonly manifestPath: string;
-    readonly isBundled: boolean; // defined in project root's package.json
-    isEnabled: boolean;
-  }
+  // Absolute to the symlinked package.json file
+  readonly manifestPath: string;
+  readonly isBundled: boolean; // defined in project root's package.json
+  isEnabled: boolean;
+}
 
 const logModule = "[EXTENSION-DISCOVERY]";
 
@@ -236,9 +237,11 @@ export class ExtensionDiscovery {
   /**
    * Uninstalls extension.
    * The application will detect the folder unlink and remove the extension from the UI automatically.
-   * @param extension Extension to unistall.
+   * @param extensionId The ID of the extension to uninstall.
    */
-  async uninstallExtension({ absolutePath, manifest }: InstalledExtension) {
+  async uninstallExtension(extensionId: LensExtensionId) {
+    const { manifest, absolutePath } = this.extensions.get(extensionId) ?? extensionLoader.getExtension(extensionId);
+
     logger.info(`${logModule} Uninstalling ${manifest.name}`);
 
     await this.removeSymlinkByPackageName(manifest.name);

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -311,10 +311,7 @@ export class ExtensionDiscovery {
    */
   protected async getByManifest(manifestPath: string, { isBundled = false } = {}): Promise<InstalledExtension | null> {
     try {
-      console.log(manifestPath);
       const manifest = await fse.readJson(manifestPath);
-
-      console.log(manifest);
       const installedManifestPath = this.getInstalledManifestPath(manifest.name);
       const isEnabled = isBundled || extensionsStore.isEnabled(installedManifestPath);
 

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -66,11 +66,7 @@ export class ExtensionDiscovery {
   // IPC channel to broadcast changes to extension-discovery from main
   protected static readonly extensionDiscoveryChannel = "extension-discovery:main";
 
-  public events: EventEmitter;
-
-  constructor() {
-    this.events = new EventEmitter();
-  }
+  public events = new EventEmitter();
 
   get localFolderPath(): string {
     return path.join(os.homedir(), ".k8slens", "extensions");
@@ -172,7 +168,7 @@ export class ExtensionDiscovery {
 
         if (extension) {
           // Remove a broken symlink left by a previous installation if it exists.
-          await this.removeSymlinkByManifestPath(manifestPath);
+          await fse.remove(extension.manifestPath);
 
           // Install dependencies for the new extension
           await this.installPackage(extension.absolutePath);
@@ -229,16 +225,6 @@ export class ExtensionDiscovery {
    */
   removeSymlinkByPackageName(name: string) {
     return fse.remove(this.getInstalledPath(name));
-  }
-
-  /**
-   * Remove the symlink under node_modules if it exists.
-   * @param manifestPath Path to package.json
-   */
-  removeSymlinkByManifestPath(manifestPath: string) {
-    const manifestJson = __non_webpack_require__(manifestPath);
-
-    return this.removeSymlinkByPackageName(manifestJson.name);
   }
 
   /**
@@ -325,7 +311,10 @@ export class ExtensionDiscovery {
    */
   protected async getByManifest(manifestPath: string, { isBundled = false } = {}): Promise<InstalledExtension | null> {
     try {
+      console.log(manifestPath);
       const manifest = await fse.readJson(manifestPath);
+
+      console.log(manifest);
       const installedManifestPath = this.getInstalledManifestPath(manifest.name);
       const isEnabled = isBundled || extensionsStore.isEnabled(installedManifestPath);
 

--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -290,18 +290,18 @@ export class ExtensionLoader {
 
   protected requireExtension(extension: InstalledExtension): LensExtensionConstructor | null {
     const entryPointName = ipcRenderer ? "renderer" : "main";
-    const extensionEntryPointRelativePath = extension.manifest[entryPointName];
+    const extRelativePath = extension.manifest[entryPointName];
 
-    if (!extensionEntryPointRelativePath) {
+    if (!extRelativePath) {
       return null;
     }
 
-    const extensionEntryPointAbsolutePath = path.resolve(path.join(path.dirname(extension.manifestPath), extensionEntryPointRelativePath));
+    const extAbsolutePath = path.resolve(path.join(path.dirname(extension.manifestPath), extRelativePath));
 
     try {
-      return __non_webpack_require__(extensionEntryPointAbsolutePath).default;
+      return __non_webpack_require__(extAbsolutePath).default;
     } catch (error) {
-      logger.error(`${logModule}: can't load extension main at ${extensionEntryPointAbsolutePath}: ${error}`, { extension, error });
+      logger.error(`${logModule}: can't load extension main at ${extAbsolutePath}: ${error}`, { extension, error });
     }
   }
 

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -19,6 +19,7 @@ import { filesystemProvisionerStore } from "../main/extension-filesystem";
 import { App } from "./components/app";
 import { LensApp } from "./lens-app";
 import { themeStore } from "./theme.store";
+import { ExtensionInstallationStateStore } from "./components/+extensions/extension-install.store";
 
 /**
  * If this is a development buid, wait a second to attach
@@ -50,6 +51,7 @@ export async function bootstrap(App: AppComponent) {
   await attachChromeDebugger();
   rootElem.classList.toggle("is-mac", isMac);
 
+  ExtensionInstallationStateStore.bindIpcListeners();
   extensionLoader.init();
   extensionDiscovery.init();
 

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { extensionDiscovery } from "../../../../extensions/extension-discovery";
 import { ConfirmDialog } from "../../confirm-dialog";
 import { Notifications } from "../../notifications";
-import { ExtensionStateStore } from "../extension-install.store";
+import { ExtensionInstallationStateStore } from "../extension-install.store";
 import { Extensions } from "../extensions";
 
 jest.mock("fs-extra");
@@ -54,7 +54,7 @@ jest.mock("../../notifications", () => ({
 
 describe("Extensions", () => {
   beforeEach(() => {
-    ExtensionStateStore.resetInstance();
+    ExtensionInstallationStateStore.reset();
   });
 
   it("disables uninstall and disable buttons while uninstalling", async () => {
@@ -122,7 +122,7 @@ describe("Extensions", () => {
 
     extensionDiscovery.isLoaded = true;
 
-    waitFor(() => 
+    waitFor(() =>
       expect(container.querySelector(".Spinner")).not.toBeInTheDocument()
     );
   });

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/extend-expect";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import fse from "fs-extra";
 import React from "react";
 import { extensionDiscovery } from "../../../../extensions/extension-discovery";
@@ -8,7 +8,9 @@ import { Notifications } from "../../notifications";
 import { ExtensionInstallationStateStore } from "../extension-install.store";
 import { Extensions } from "../extensions";
 
+jest.setTimeout(30000);
 jest.mock("fs-extra");
+jest.mock("../../notifications");
 
 jest.mock("../../../../common/utils", () => ({
   ...jest.requireActual("../../../../common/utils"),
@@ -46,58 +48,56 @@ jest.mock("../../../../extensions/extension-loader", () => ({
   }
 }));
 
-jest.mock("../../notifications", () => ({
-  ok: jest.fn(),
-  error: jest.fn(),
-  info: jest.fn()
-}));
-
 describe("Extensions", () => {
   beforeEach(() => {
     ExtensionInstallationStateStore.reset();
   });
 
   it("disables uninstall and disable buttons while uninstalling", async () => {
-    render(<><Extensions /><ConfirmDialog/></>);
+    const res = render(<><Extensions /><ConfirmDialog /></>);
 
-    expect(screen.getByText("Disable").closest("button")).not.toBeDisabled();
-    expect(screen.getByText("Uninstall").closest("button")).not.toBeDisabled();
+    expect(res.getByText("Disable").closest("button")).not.toBeDisabled();
+    expect(res.getByText("Uninstall").closest("button")).not.toBeDisabled();
 
-    fireEvent.click(screen.getByText("Uninstall"));
+    fireEvent.click(res.getByText("Uninstall"));
 
     // Approve confirm dialog
-    fireEvent.click(screen.getByText("Yes"));
+    fireEvent.click(res.getByText("Yes"));
 
     expect(extensionDiscovery.uninstallExtension).toHaveBeenCalled();
-    expect(screen.getByText("Disable").closest("button")).toBeDisabled();
-    expect(screen.getByText("Uninstall").closest("button")).toBeDisabled();
+    expect(res.getByText("Disable").closest("button")).toBeDisabled();
+    expect(res.getByText("Uninstall").closest("button")).toBeDisabled();
   });
 
-  it("displays error notification on uninstall error", () => {
+  it("displays error notification on uninstall error", async () => {
     (extensionDiscovery.uninstallExtension as any).mockImplementationOnce(() =>
       Promise.reject()
     );
-    render(<><Extensions /><ConfirmDialog/></>);
+    const res = render(<><Extensions /><ConfirmDialog /></>);
 
-    expect(screen.getByText("Disable").closest("button")).not.toBeDisabled();
-    expect(screen.getByText("Uninstall").closest("button")).not.toBeDisabled();
+    expect(res.getByText("Disable").closest("button")).not.toBeDisabled();
+    expect(res.getByText("Uninstall").closest("button")).not.toBeDisabled();
 
-    fireEvent.click(screen.getByText("Uninstall"));
+    fireEvent.click(res.getByText("Uninstall"));
 
     // Approve confirm dialog
-    fireEvent.click(screen.getByText("Yes"));
+    fireEvent.click(res.getByText("Yes"));
 
-    waitFor(() => {
-      expect(screen.getByText("Disable").closest("button")).not.toBeDisabled();
-      expect(screen.getByText("Uninstall").closest("button")).not.toBeDisabled();
+    await waitFor(() => {
+      expect(res.getByText("Disable").closest("button")).not.toBeDisabled();
+      expect(res.getByText("Uninstall").closest("button")).not.toBeDisabled();
       expect(Notifications.error).toHaveBeenCalledTimes(1);
+    }, {
+      timeout: 30000,
     });
   });
 
-  it("disables install button while installing", () => {
-    render(<Extensions />);
+  it("disables install button while installing", async () => {
+    const res = render(<Extensions />);
 
-    fireEvent.change(screen.getByPlaceholderText("Path or URL to an extension package", {
+    (fse.unlink as jest.MockedFunction<typeof fse.unlink>).mockReturnValue(Promise.resolve() as any);
+
+    fireEvent.change(res.getByPlaceholderText("Path or URL to an extension package", {
       exact: false
     }), {
       target: {
@@ -105,25 +105,27 @@ describe("Extensions", () => {
       }
     });
 
-    fireEvent.click(screen.getByText("Install"));
+    fireEvent.click(res.getByText("Install"));
 
-    waitFor(() => {
-      expect(screen.getByText("Install").closest("button")).toBeDisabled();
-      expect(fse.move).toHaveBeenCalledWith("");
-      expect(Notifications.error).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(res.getByText("Install").closest("button")).toBeDisabled();
+    }, {
+      timeout: 10000,
     });
   });
 
-  it("displays spinner while extensions are loading", () => {
+  it("displays spinner while extensions are loading", async () => {
     extensionDiscovery.isLoaded = false;
-    const { container } = render(<Extensions />);
+    const res = render(<Extensions />);
 
-    expect(container.querySelector(".Spinner")).toBeInTheDocument();
+    expect(res.container.querySelector(".Spinner")).toBeInTheDocument();
 
     extensionDiscovery.isLoaded = true;
 
-    waitFor(() =>
-      expect(container.querySelector(".Spinner")).not.toBeInTheDocument()
-    );
+    await waitFor(() => {
+      expect(res.container.querySelector(".Spinner")).not.toBeInTheDocument();
+    }, {
+      timeout: 30000,
+    });
   });
 });

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -1,10 +1,9 @@
 import "@testing-library/jest-dom/extend-expect";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import fse from "fs-extra";
 import React from "react";
 import { extensionDiscovery } from "../../../../extensions/extension-discovery";
 import { ConfirmDialog } from "../../confirm-dialog";
-import { Notifications } from "../../notifications";
 import { ExtensionInstallationStateStore } from "../extension-install.store";
 import { Extensions } from "../extensions";
 
@@ -67,29 +66,6 @@ describe("Extensions", () => {
     expect(extensionDiscovery.uninstallExtension).toHaveBeenCalled();
     expect(res.getByText("Disable").closest("button")).toBeDisabled();
     expect(res.getByText("Uninstall").closest("button")).toBeDisabled();
-  });
-
-  it("displays error notification on uninstall error", async () => {
-    (extensionDiscovery.uninstallExtension as any).mockImplementationOnce(() =>
-      Promise.reject()
-    );
-    const res = render(<><Extensions /><ConfirmDialog /></>);
-
-    expect(res.getByText("Disable").closest("button")).not.toBeDisabled();
-    expect(res.getByText("Uninstall").closest("button")).not.toBeDisabled();
-
-    fireEvent.click(res.getByText("Uninstall"));
-
-    // Approve confirm dialog
-    fireEvent.click(res.getByText("Yes"));
-
-    await waitFor(() => {
-      expect(res.getByText("Disable").closest("button")).not.toBeDisabled();
-      expect(res.getByText("Uninstall").closest("button")).not.toBeDisabled();
-      expect(Notifications.error).toHaveBeenCalledTimes(1);
-    }, {
-      timeout: 30000,
-    });
   });
 
   it("disables install button while installing", async () => {

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/extend-expect";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import fse from "fs-extra";
 import React from "react";
 import { extensionDiscovery } from "../../../../extensions/extension-discovery";
@@ -43,7 +43,8 @@ jest.mock("../../../../extensions/extension-loader", () => ({
         isBundled: false,
         isEnabled: true
       }]
-    ])
+    ]),
+    getExtension: jest.fn(() => ({ manifest: {} })),
   }
 }));
 
@@ -63,9 +64,13 @@ describe("Extensions", () => {
     // Approve confirm dialog
     fireEvent.click(res.getByText("Yes"));
 
-    expect(extensionDiscovery.uninstallExtension).toHaveBeenCalled();
-    expect(res.getByText("Disable").closest("button")).toBeDisabled();
-    expect(res.getByText("Uninstall").closest("button")).toBeDisabled();
+    await waitFor(() => {
+      expect(extensionDiscovery.uninstallExtension).toHaveBeenCalled();
+      expect(res.getByText("Disable").closest("button")).toBeDisabled();
+      expect(res.getByText("Uninstall").closest("button")).toBeDisabled();
+    }, {
+      timeout: 30000,
+    });
   });
 
   it("disables install button while installing", async () => {

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -106,12 +106,7 @@ describe("Extensions", () => {
     });
 
     fireEvent.click(res.getByText("Install"));
-
-    await waitFor(() => {
-      expect(res.getByText("Install").closest("button")).toBeDisabled();
-    }, {
-      timeout: 10000,
-    });
+    expect(res.getByText("Install").closest("button")).toBeDisabled();
   });
 
   it("displays spinner while extensions are loading", async () => {
@@ -119,13 +114,12 @@ describe("Extensions", () => {
     const res = render(<Extensions />);
 
     expect(res.container.querySelector(".Spinner")).toBeInTheDocument();
+  });
 
+  it("does not display the spinner while extensions are not loading", async () => {
     extensionDiscovery.isLoaded = true;
+    const res = render(<Extensions />);
 
-    await waitFor(() => {
-      expect(res.container.querySelector(".Spinner")).not.toBeInTheDocument();
-    }, {
-      timeout: 30000,
-    });
+    expect(res.container.querySelector(".Spinner")).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/+extensions/extension-install.store.ts
+++ b/src/renderer/components/+extensions/extension-install.store.ts
@@ -1,13 +1,187 @@
-import { observable } from "mobx";
-import { autobind, Singleton } from "../../utils";
+import { action, computed, observable } from "mobx";
+import logger from "../../../main/logger";
+import { disposer, Disposer } from "../../utils";
+import * as uuid from "uuid";
 
-interface ExtensionState {
-  displayName: string;
-  // Possible states the extension can be
-  state: "installing" | "uninstalling";
+export enum ExtensionInstallationState {
+  INSTALLING = "installing",
+  UNINSTALLING = "uninstalling",
+  IDLE = "IDLE",
 }
 
-@autobind()
-export class ExtensionStateStore extends Singleton {
-  extensionState = observable.map<string, ExtensionState>();
+const Prefix = "[ExtensionInstallationStore]";
+const installingExtensions = observable.set<string>();
+const uninstallingExtensions = observable.set<string>();
+const preInstallIds = observable.set<string>();
+
+export class ExtensionInstallationStateStore {
+  @action static reset() {
+    logger.warn(`${Prefix}: resetting, may throw errors`);
+    installingExtensions.clear();
+    uninstallingExtensions.clear();
+    preInstallIds.clear();
+  }
+
+  /**
+   * Strictly transitions an extension from not installing to installing
+   * @param extId the ID of the extension
+   * @throws if state is not IDLE
+   */
+  @action static setInstalling(extId: string): void {
+    logger.debug(`${Prefix}: trying to set ${extId} as installing`);
+
+    const curState = ExtensionInstallationStateStore.getInstallationState(extId);
+
+    if (curState !== ExtensionInstallationState.IDLE) {
+      throw new Error(`${Prefix}: cannot set ${extId} as installing. Is currently ${curState}.`);
+    }
+
+    installingExtensions.add(extId);
+  }
+
+  /**
+   * Marks the start of a pre-install phase of an extension installation. The
+   * part of the installation before the tarball has been unpacked and the ID
+   * determined.
+   * @returns a disposer which should be called to mark the end of the install phase
+   */
+  @action static startPreInstall(): Disposer {
+    const preInstallStepId = uuid.v4();
+
+    logger.debug(`${Prefix}: starting a new preinstall phase: ${preInstallStepId}`);
+    preInstallIds.add(preInstallStepId);
+
+    return disposer(() => {
+      preInstallIds.delete(preInstallStepId);
+      logger.debug(`${Prefix}: ending a preinstall phase: ${preInstallStepId}`);
+    });
+  }
+
+  /**
+   * Strictly transitions an extension from not uninstalling to uninstalling
+   * @param extId the ID of the extension
+   * @throws if state is not IDLE
+   */
+  @action static setUninstalling(extId: string): void {
+    logger.debug(`${Prefix}: trying to set ${extId} as uninstalling`);
+
+    const curState = ExtensionInstallationStateStore.getInstallationState(extId);
+
+    if (curState !== ExtensionInstallationState.IDLE) {
+      throw new Error(`${Prefix}: cannot set ${extId} as uninstalling. Is currently ${curState}.`);
+    }
+
+    uninstallingExtensions.add(extId);
+  }
+
+  /**
+   * Strictly clears the INSTALLING state of an extension
+   * @param extId The ID of the extension
+   * @throws if state is not INSTALLING
+   */
+  @action static clearInstalling(extId: string): void {
+    logger.debug(`${Prefix}: trying to clear ${extId} as installing`);
+
+    const curState = ExtensionInstallationStateStore.getInstallationState(extId);
+
+    switch (curState) {
+      case ExtensionInstallationState.INSTALLING:
+        return void installingExtensions.delete(extId);
+      default:
+        throw new Error(`${Prefix}: cannot clear INSTALLING state for ${extId}, it is currently ${curState}`);
+    }
+  }
+
+  /**
+   * Strictly clears the UNINSTALLING state of an extension
+   * @param extId The ID of the extension
+   * @throws if state is not UNINSTALLING
+   */
+  @action static clearUninstalling(extId: string): void {
+    logger.debug(`${Prefix}: trying to clear ${extId} as uninstalling`);
+
+    const curState = ExtensionInstallationStateStore.getInstallationState(extId);
+
+    switch (curState) {
+      case ExtensionInstallationState.UNINSTALLING:
+        return void uninstallingExtensions.delete(extId);
+      default:
+        throw new Error(`${Prefix}: cannot clear UNINSTALLING state for ${extId}, it is currently ${curState}`);
+    }
+  }
+
+  /**
+   * Returns the current state of the extension. IDLE is default value.
+   * @param extId The ID of the extension
+   */
+  static getInstallationState(extId: string): ExtensionInstallationState {
+    if (installingExtensions.has(extId)) {
+      return ExtensionInstallationState.INSTALLING;
+    }
+
+    if (uninstallingExtensions.has(extId)) {
+      return ExtensionInstallationState.UNINSTALLING;
+    }
+
+    return ExtensionInstallationState.IDLE;
+  }
+
+  /**
+   * Returns true if the extension is currently INSTALLING
+   * @param extId The ID of the extension
+   */
+  static isExtensionInstalling(extId: string): boolean {
+    return ExtensionInstallationStateStore.getInstallationState(extId) === ExtensionInstallationState.INSTALLING;
+  }
+
+  /**
+   * Returns true if the extension is currently UNINSTALLING
+   * @param extId The ID of the extension
+   */
+  static isExtensionUninstalling(extId: string): boolean {
+    return ExtensionInstallationStateStore.getInstallationState(extId) === ExtensionInstallationState.UNINSTALLING;
+  }
+
+  /**
+   * Returns true if the extension is currently IDLE
+   * @param extId The ID of the extension
+   */
+  static isExtensionIdle(extId: string): boolean {
+    return ExtensionInstallationStateStore.getInstallationState(extId) === ExtensionInstallationState.IDLE;
+  }
+
+  /**
+   * The current number of extensions installing
+   */
+  @computed static get installing(): number {
+    return installingExtensions.size;
+  }
+
+  /**
+   * If there is at least one extension currently installing
+   */
+  @computed static get anyInstalling(): boolean {
+    return ExtensionInstallationStateStore.installing > 0;
+  }
+
+  /**
+   * The current number of extensions preinstallig
+   */
+  @computed static get preinstalling(): number {
+    return preInstallIds.size;
+  }
+
+  /**
+   * If there is at least one extension currently downloading
+   */
+  @computed static get anyPreinstalling(): boolean {
+    return ExtensionInstallationStateStore.preinstalling > 0;
+  }
+
+  /**
+   * If there is at least one installing or preinstalling step taking place
+   */
+  @computed static get anyPreInstallingOrInstalling(): boolean {
+    return ExtensionInstallationStateStore.anyInstalling || ExtensionInstallationStateStore.anyPreinstalling;
+  }
 }

--- a/src/renderer/components/+extensions/extension-install.store.ts
+++ b/src/renderer/components/+extensions/extension-install.store.ts
@@ -1,6 +1,6 @@
 import { action, computed, observable } from "mobx";
 import logger from "../../../main/logger";
-import { disposer, Disposer } from "../../utils";
+import { disposer, ExtendableDisposer } from "../../utils";
 import * as uuid from "uuid";
 import { broadcastMessage } from "../../../common/ipc";
 import { ipcRenderer } from "electron";
@@ -76,7 +76,7 @@ export class ExtensionInstallationStateStore {
    * determined.
    * @returns a disposer which should be called to mark the end of the install phase
    */
-  @action static startPreInstall(): Disposer {
+  @action static startPreInstall(): ExtendableDisposer {
     const preInstallStepId = uuid.v4();
 
     logger.debug(`${Prefix}: starting a new preinstall phase: ${preInstallStepId}`);

--- a/src/renderer/components/+extensions/extension-install.store.ts
+++ b/src/renderer/components/+extensions/extension-install.store.ts
@@ -8,7 +8,7 @@ import { ipcRenderer } from "electron";
 export enum ExtensionInstallationState {
   INSTALLING = "installing",
   UNINSTALLING = "uninstalling",
-  IDLE = "IDLE",
+  IDLE = "idle",
 }
 
 const Prefix = "[ExtensionInstallationStore]";

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -159,7 +159,7 @@ async function validatePackage(filePath: string): Promise<LensExtensionManifest>
     parseJson: true,
   });
 
-  if (!manifest.lens && !manifest.renderer) {
+  if (!manifest.main && !manifest.renderer) {
     throw new Error(`${manifestFilename} must specify "main" and/or "renderer" fields`);
   }
 
@@ -335,7 +335,7 @@ async function attemptInstall(request: InstallRequest, d?: Disposer): Promise<vo
       <div className="flex column gaps">
         <b>Extension Install Collision:</b>
         <p>The <em>{name}</em> extension is currently {curState.toLowerCase()}.</p>
-        <p>Will not procede with this current install request.</p>
+        <p>Will not proceed with this current install request.</p>
       </div>
     );
   }
@@ -366,12 +366,14 @@ async function attemptInstall(request: InstallRequest, d?: Disposer): Promise<vo
             await unpackExtension(validatedRequest, dispose);
           } else {
             dispose();
+            await fse.unlink(validatedRequest.tempFile).catch(noop);
           }
         }} />
       </div>,
       {
         onClose() {
           dispose();
+          fse.unlink(validatedRequest.tempFile).catch(noop);
         }
       }
     );

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -1,15 +1,16 @@
+import "./extensions.scss";
 import { remote, shell } from "electron";
 import fse from "fs-extra";
-import { computed, observable, reaction } from "mobx";
+import { computed, observable, reaction, when } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import os from "os";
 import path from "path";
 import React from "react";
-import { downloadFile, extractTar, listTarEntries, readFileFromTar } from "../../../common/utils";
+import { autobind, disposer, Disposer, downloadFile, extractTar, listTarEntries, noop, readFileFromTar } from "../../../common/utils";
 import { docsUrl } from "../../../common/vars";
 import { extensionDiscovery, InstalledExtension, manifestFilename } from "../../../extensions/extension-discovery";
 import { extensionLoader } from "../../../extensions/extension-loader";
-import { extensionDisplayName, LensExtensionManifest, sanitizeExtensionName } from "../../../extensions/lens-extension";
+import { extensionDisplayName, LensExtensionId, LensExtensionManifest, sanitizeExtensionName } from "../../../extensions/lens-extension";
 import logger from "../../../main/logger";
 import { prevDefault } from "../../utils";
 import { Button } from "../button";
@@ -21,8 +22,7 @@ import { SubTitle } from "../layout/sub-title";
 import { Notifications } from "../notifications";
 import { Spinner } from "../spinner/spinner";
 import { TooltipPosition } from "../tooltip";
-import { ExtensionStateStore } from "./extension-install.store";
-import "./extensions.scss";
+import { ExtensionInstallationState, ExtensionInstallationStateStore } from "./extension-install.store";
 
 interface InstallRequest {
   fileName: string;
@@ -35,14 +35,324 @@ interface InstallRequestPreloaded extends InstallRequest {
 }
 
 interface InstallRequestValidated extends InstallRequestPreloaded {
+  id: LensExtensionId;
   manifest: LensExtensionManifest;
   tempFile: string; // temp system path to packed extension for unpacking
 }
 
+async function uninstallExtension(extensionId: LensExtensionId, manifest: LensExtensionManifest): Promise<boolean> {
+  const displayName = extensionDisplayName(manifest.name, manifest.version);
+
+  try {
+    logger.debug(`[EXTENSIONS]: trying to uninstall ${extensionId}`);
+    ExtensionInstallationStateStore.setUninstalling(extensionId);
+
+    await extensionDiscovery.uninstallExtension(extensionId);
+
+    // wait for the extensionLoader to actually uninstall the extension
+    await when(() => !extensionLoader.userExtensions.has(extensionId));
+
+    Notifications.ok(
+      <p>Extension <b>{displayName}</b> successfully uninstalled!</p>
+    );
+
+    return true;
+  } catch (error) {
+    Notifications.error(
+      <p>Uninstalling extension <b>{displayName}</b> has failed: <em>{error?.message ?? ""}</em></p>
+    );
+
+    return false;
+  } finally {
+    // Remove uninstall state on uninstall failure
+    ExtensionInstallationStateStore.clearUninstalling(extensionId);
+  }
+}
+
+function confirmUninstallExtension(extension: InstalledExtension): void {
+  const displayName = extensionDisplayName(extension.manifest.name, extension.manifest.version);
+
+  ConfirmDialog.open({
+    message: <p>Are you sure you want to uninstall extension <b>{displayName}</b>?</p>,
+    labelOk: "Yes",
+    labelCancel: "No",
+    ok: () => {
+      // Don't want the confirm dialog to stay up longer than the click
+      uninstallExtension(extension.id, extension.manifest);
+    }
+  });
+}
+
+function getExtensionDestFolder(name: string) {
+  return path.join(extensionDiscovery.localFolderPath, sanitizeExtensionName(name));
+}
+
+function getExtensionPackageTemp(fileName = "") {
+  return path.join(os.tmpdir(), "lens-extensions", fileName);
+}
+
+async function preloadExtension({ fileName, data, filePath }: InstallRequest, { showError = true } = {}): Promise<InstallRequestPreloaded | null> {
+  if(data) {
+    return { filePath, data, fileName };
+  }
+
+  try {
+    const data = await fse.readFile(filePath);
+
+    return { filePath, data, fileName };
+  } catch(error) {
+    if (showError) {
+      Notifications.error(`Error while reading "${filePath}": ${String(error)}`);
+    }
+  }
+
+  return null;
+}
+
+async function validatePackage(filePath: string): Promise<LensExtensionManifest> {
+  const tarFiles = await listTarEntries(filePath);
+
+  // tarball from npm contains single root folder "package/*"
+  const firstFile = tarFiles[0];
+
+  if(!firstFile) {
+    throw new Error(`invalid extension bundle,  ${manifestFilename} not found`);
+  }
+
+  const rootFolder = path.normalize(firstFile).split(path.sep)[0];
+  const packedInRootFolder = tarFiles.every(entry => entry.startsWith(rootFolder));
+  const manifestLocation = packedInRootFolder ? path.join(rootFolder, manifestFilename) : manifestFilename;
+
+  if(!tarFiles.includes(manifestLocation)) {
+    throw new Error(`invalid extension bundle, ${manifestFilename} not found`);
+  }
+
+  const manifest = await readFileFromTar<LensExtensionManifest>({
+    tarPath: filePath,
+    filePath: manifestLocation,
+    parseJson: true,
+  });
+
+  if (!manifest.lens && !manifest.renderer) {
+    throw new Error(`${manifestFilename} must specify "main" and/or "renderer" fields`);
+  }
+
+  return manifest;
+}
+
+async function createTempFilesAndValidate(request: InstallRequestPreloaded, { showErrors = true } = {}): Promise<InstallRequestValidated | null> {
+  // copy files to temp
+  await fse.ensureDir(getExtensionPackageTemp());
+
+  // validate packages
+  const tempFile = getExtensionPackageTemp(request.fileName);
+
+  try {
+    await fse.writeFile(tempFile, request.data);
+    const manifest = await validatePackage(tempFile);
+    const id = path.join(extensionDiscovery.nodeModulesPath, manifest.name, "package.json");
+
+    return {
+      ...request,
+      manifest,
+      tempFile,
+      id,
+    };
+  } catch (error) {
+    fse.unlink(tempFile).catch(noop); // remove invalid temp package
+
+    if (showErrors) {
+      Notifications.error(
+        <div className="flex column gaps">
+          <p>Installing <em>{request.fileName}</em> has failed, skipping.</p>
+          <p>Reason: <em>{String(error)}</em></p>
+        </div>
+      );
+    }
+  }
+
+  return null;
+}
+
+async function unpackExtension(request: InstallRequestValidated, disposeDownloading: Disposer) {
+  const { id, fileName, tempFile, manifest: { name, version } } = request;
+
+  ExtensionInstallationStateStore.setInstalling(id);
+  disposeDownloading?.();
+
+  const displayName = extensionDisplayName(name, version);
+  const extensionFolder = getExtensionDestFolder(name);
+  const unpackingTempFolder = path.join(path.dirname(tempFile), `${path.basename(tempFile)}-unpacked`);
+
+  logger.info(`Unpacking extension ${displayName}`, { fileName, tempFile });
+
+  try {
+    // extract to temp folder first
+    await fse.remove(unpackingTempFolder).catch(noop);
+    await fse.ensureDir(unpackingTempFolder);
+    await extractTar(tempFile, { cwd: unpackingTempFolder });
+
+    // move contents to extensions folder
+    const unpackedFiles = await fse.readdir(unpackingTempFolder);
+    let unpackedRootFolder = unpackingTempFolder;
+
+    if (unpackedFiles.length === 1) {
+      // check if %extension.tgz was packed with single top folder,
+      // e.g. "npm pack %ext_name" downloads file with "package" root folder within tarball
+      unpackedRootFolder = path.join(unpackingTempFolder, unpackedFiles[0]);
+    }
+
+    await fse.ensureDir(extensionFolder);
+    await fse.move(unpackedRootFolder, extensionFolder, { overwrite: true });
+
+    // wait for the loader has actually install it
+    await when(() => extensionLoader.userExtensions.has(id));
+
+    // Enable installed extensions by default.
+    extensionLoader.userExtensions.get(id).isEnabled = true;
+
+    Notifications.ok(
+      <p>Extension <b>{displayName}</b> successfully installed!</p>
+    );
+  } catch (error) {
+    Notifications.error(
+      <p>Installing extension <b>{displayName}</b> has failed: <em>{error}</em></p>
+    );
+  } finally {
+    // Remove install state once finished
+    ExtensionInstallationStateStore.clearInstalling(id);
+
+    // clean up
+    fse.remove(unpackingTempFolder).catch(noop);
+    fse.unlink(tempFile).catch(noop);
+  }
+}
+
+/**
+ *
+ * @param request The information needed to install the extension
+ * @param fromUrl The optional URL
+ */
+async function requestInstall(request: InstallRequest, d?: Disposer): Promise<void> {
+  const dispose = disposer(ExtensionInstallationStateStore.startPreInstall(), d);
+  const loadedRequest = await preloadExtension(request);
+
+  if (!loadedRequest) {
+    return;
+  }
+
+  const validatedRequest = await createTempFilesAndValidate(loadedRequest);
+
+  if (!validatedRequest) {
+    return;
+  }
+
+  const { name, version, description } = validatedRequest.manifest;
+  const curState = ExtensionInstallationStateStore.getInstallationState(validatedRequest.id);
+
+  if (curState !== ExtensionInstallationState.IDLE) {
+    dispose();
+
+    return Notifications.error(
+      <div className="flex column gaps">
+        <b>Extension Install Collision:</b>
+        <p>The <em>{name}</em> extension is currently {curState.toLowerCase()}.</p>
+        <p>Will not procede with this current install request.</p>
+      </div>
+    );
+  }
+
+  const extensionFolder = getExtensionDestFolder(name);
+  const folderExists = await fse.pathExists(extensionFolder);
+
+  if (!folderExists) {
+    // install extension if not yet exists
+    unpackExtension(validatedRequest, dispose);
+  } else {
+    // otherwise confirmation required (re-install / update)
+    const removeNotification = Notifications.info(
+      <div className="InstallingExtensionNotification flex gaps align-center">
+        <div className="flex column gaps">
+          <p>Install extension <b>{name}@{version}</b>?</p>
+          <p>Description: <em>{description}</em></p>
+          <div className="remove-folder-warning" onClick={() => shell.openPath(extensionFolder)}>
+            <b>Warning:</b> <code>{extensionFolder}</code> will be removed before installation.
+          </div>
+        </div>
+        <Button autoFocus label="Install" onClick={async () => {
+          removeNotification();
+
+          await uninstallExtension(validatedRequest.id, validatedRequest.manifest)
+            && await unpackExtension(validatedRequest, dispose);
+        }} />
+      </div>
+    );
+  }
+}
+
+async function requestInstalls(filePaths: string[]): Promise<void> {
+  const promises: Promise<void>[] = [];
+
+  for (const filePath of filePaths) {
+    promises.push(requestInstall({
+      fileName: path.basename(filePath),
+      filePath,
+    }));
+  }
+
+  await Promise.allSettled(promises);
+}
+
+async function installOnDrop(files: File[]) {
+  logger.info("Install from D&D");
+  await requestInstalls(files.map(({ path }) => path));
+}
+
+async function installFromUrlOrPath(installPath: string) {
+  const fileName = path.basename(installPath);
+
+  try {
+    // install via url
+    // fixme: improve error messages for non-tar-file URLs
+    if (InputValidators.isUrl.validate(installPath)) {
+      const disposer = ExtensionInstallationStateStore.startPreInstall();
+      const { promise: filePromise } = downloadFile({ url: installPath, timeout: 60000 /*1m*/ });
+      const data = await filePromise;
+
+      await requestInstall({ fileName, data }, disposer);
+    }
+    // otherwise installing from system path
+    else if (InputValidators.isPath.validate(installPath)) {
+      await requestInstall({ fileName, filePath: installPath });
+    }
+  } catch (error) {
+    Notifications.error(
+      <p>Installation has failed: <b>{String(error)}</b></p>
+    );
+  }
+}
+
+const supportedFormats = ["tar", "tgz"];
+
+async function installFromSelectFileDialog() {
+  const { dialog, BrowserWindow, app } = remote;
+  const { canceled, filePaths } = await dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), {
+    defaultPath: app.getPath("downloads"),
+    properties: ["openFile", "multiSelections"],
+    message: `Select extensions to install (formats: ${supportedFormats.join(", ")}), `,
+    buttonLabel: "Use configuration",
+    filters: [
+      { name: "tarball", extensions: supportedFormats }
+    ]
+  });
+
+  if (!canceled) {
+    await requestInstalls(filePaths);
+  }
+}
+
 @observer
 export class Extensions extends React.Component {
-  private static supportedFormats = ["tar", "tgz"];
-
   private static installPathValidator: InputValidator = {
     message: "Invalid URL or absolute path",
     validate(value: string) {
@@ -50,71 +360,10 @@ export class Extensions extends React.Component {
     }
   };
 
-  get extensionStateStore() {
-    return ExtensionStateStore.getInstance<ExtensionStateStore>();
-  }
-
   @observable search = "";
   @observable installPath = "";
 
-  // True if the preliminary install steps have started, but unpackExtension has not started yet
-  @observable startingInstall = false;
-
-  /**
-   * Extensions that were removed from extensions but are still in "uninstalling" state
-   */
-  @computed get removedUninstalling() {
-    return Array.from(this.extensionStateStore.extensionState.entries())
-      .filter(([id, extension]) =>
-        extension.state === "uninstalling"
-        && !this.extensions.find(extension => extension.id === id)
-      )
-      .map(([id, extension]) => ({ ...extension, id }));
-  }
-
-  /**
-   * Extensions that were added to extensions but are still in "installing" state
-   */
-  @computed get addedInstalling() {
-    return Array.from(this.extensionStateStore.extensionState.entries())
-      .filter(([id, extension]) =>
-        extension.state === "installing"
-        && this.extensions.find(extension => extension.id === id)
-      )
-      .map(([id, extension]) => ({ ...extension, id }));
-  }
-
-  componentDidMount() {
-    disposeOnUnmount(this,
-      reaction(() => this.extensions, () => {
-        this.removedUninstalling.forEach(({ id, displayName }) => {
-          Notifications.ok(
-            <p>Extension <b>{displayName}</b> successfully uninstalled!</p>
-          );
-          this.extensionStateStore.extensionState.delete(id);
-        });
-
-        this.addedInstalling.forEach(({ id, displayName }) => {
-          const extension = this.extensions.find(extension => extension.id === id);
-
-          if (!extension) {
-            throw new Error("Extension not found");
-          }
-
-          Notifications.ok(
-            <p>Extension <b>{displayName}</b> successfully installed!</p>
-          );
-          this.extensionStateStore.extensionState.delete(id);
-          this.installPath = "";
-
-          // Enable installed extensions by default.
-          extension.isEnabled = true;
-        });
-      })
-    );
-  }
-
-  @computed get extensions() {
+  @computed get searchedForExtensions() {
     const searchText = this.search.toLowerCase();
 
     return Array.from(extensionLoader.userExtensions.values())
@@ -124,361 +373,95 @@ export class Extensions extends React.Component {
       ));
   }
 
-  get extensionsPath() {
-    return extensionDiscovery.localFolderPath;
-  }
+  componentDidMount() {
+    // TODO: change this after upgrading to mobx6 as that versions' reactions have this functionality
+    let prevSize = extensionLoader.userExtensions.size;
 
-  getExtensionPackageTemp(fileName = "") {
-    return path.join(os.tmpdir(), "lens-extensions", fileName);
-  }
-
-  getExtensionDestFolder(name: string) {
-    return path.join(this.extensionsPath, sanitizeExtensionName(name));
-  }
-
-  installFromSelectFileDialog = async () => {
-    const { dialog, BrowserWindow, app } = remote;
-    const { canceled, filePaths } = await dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), {
-      defaultPath: app.getPath("downloads"),
-      properties: ["openFile", "multiSelections"],
-      message: `Select extensions to install (formats: ${Extensions.supportedFormats.join(", ")}), `,
-      buttonLabel: `Use configuration`,
-      filters: [
-        { name: "tarball", extensions: Extensions.supportedFormats }
-      ]
-    });
-
-    if (!canceled && filePaths.length) {
-      this.requestInstall(
-        filePaths.map(filePath => ({
-          fileName: path.basename(filePath),
-          filePath,
-        }))
-      );
-    }
-  };
-
-  installFromUrlOrPath = async () => {
-    const { installPath } = this;
-
-    if (!installPath) return;
-
-    this.startingInstall = true;
-    const fileName = path.basename(installPath);
-
-    try {
-      // install via url
-      // fixme: improve error messages for non-tar-file URLs
-      if (InputValidators.isUrl.validate(installPath)) {
-        const { promise: filePromise } = downloadFile({ url: installPath, timeout: 60000 /*1m*/ });
-        const data = await filePromise;
-
-        await this.requestInstall({ fileName, data });
-      }
-      // otherwise installing from system path
-      else if (InputValidators.isPath.validate(installPath)) {
-        await this.requestInstall({ fileName, filePath: installPath });
-      }
-    } catch (error) {
-      this.startingInstall = false;
-      Notifications.error(
-        <p>Installation has failed: <b>{String(error)}</b></p>
-      );
-    }
-  };
-
-  installOnDrop = (files: File[]) => {
-    logger.info("Install from D&D");
-
-    return this.requestInstall(
-      files.map(file => ({
-        fileName: path.basename(file.path),
-        filePath: file.path,
-      }))
-    );
-  };
-
-  async preloadExtensions(requests: InstallRequest[], { showError = true } = {}) {
-    const preloadedRequests = requests.filter(request => request.data);
-
-    await Promise.all(
-      requests
-        .filter(request => !request.data && request.filePath)
-        .map(async request => {
-          try {
-            const data = await fse.readFile(request.filePath);
-
-            request.data = data;
-            preloadedRequests.push(request);
-
-            return request;
-          } catch(error) {
-            if (showError) {
-              Notifications.error(`Error while reading "${request.filePath}": ${String(error)}`);
-            }
-          }
-        })
-    );
-
-    return preloadedRequests as InstallRequestPreloaded[];
-  }
-
-  async validatePackage(filePath: string): Promise<LensExtensionManifest> {
-    const tarFiles = await listTarEntries(filePath);
-
-    // tarball from npm contains single root folder "package/*"
-    const firstFile = tarFiles[0];
-
-    if (!firstFile) {
-      throw new Error(`invalid extension bundle,  ${manifestFilename} not found`);
-    }
-
-    const rootFolder = path.normalize(firstFile).split(path.sep)[0];
-    const packedInRootFolder = tarFiles.every(entry => entry.startsWith(rootFolder));
-    const manifestLocation = packedInRootFolder ? path.join(rootFolder, manifestFilename) : manifestFilename;
-
-    if (!tarFiles.includes(manifestLocation)) {
-      throw new Error(`invalid extension bundle, ${manifestFilename} not found`);
-    }
-
-    const manifest = await readFileFromTar<LensExtensionManifest>({
-      tarPath: filePath,
-      filePath: manifestLocation,
-      parseJson: true,
-    });
-
-    if (!manifest.lens && !manifest.renderer) {
-      throw new Error(`${manifestFilename} must specify "main" and/or "renderer" fields`);
-    }
-
-    return manifest;
-  }
-
-  async createTempFilesAndValidate(requests: InstallRequestPreloaded[], { showErrors = true } = {}) {
-    const validatedRequests: InstallRequestValidated[] = [];
-
-    // copy files to temp
-    await fse.ensureDir(this.getExtensionPackageTemp());
-
-    for (const request of requests) {
-      const tempFile = this.getExtensionPackageTemp(request.fileName);
-
-      await fse.writeFile(tempFile, request.data);
-    }
-
-    // validate packages
-    await Promise.all(
-      requests.map(async req => {
-        const tempFile = this.getExtensionPackageTemp(req.fileName);
-
+    disposeOnUnmount(this, [
+      reaction(() => extensionLoader.userExtensions.size, curSize => {
         try {
-          const manifest = await this.validatePackage(tempFile);
-
-          validatedRequests.push({
-            ...req,
-            manifest,
-            tempFile,
-          });
-        } catch (error) {
-          fse.unlink(tempFile).catch(() => null); // remove invalid temp package
-
-          if (showErrors) {
-            Notifications.error(
-              <div className="flex column gaps">
-                <p>Installing <em>{req.fileName}</em> has failed, skipping.</p>
-                <p>Reason: <em>{String(error)}</em></p>
-              </div>
-            );
+          if (curSize > prevSize) {
+            when(() => !ExtensionInstallationStateStore.anyInstalling)
+              .then(() => this.installPath = "");
           }
+        } finally {
+          prevSize = curSize;
         }
       })
+    ]);
+  }
+
+  renderNoExtensionsHelpText() {
+    if (this.search) {
+      return <p>No search results found</p>;
+    }
+
+    return (
+      <p>
+        There are no installed extensions.
+        See list of <a href="https://github.com/lensapp/lens-extensions/blob/main/README.md" target="_blank" rel="noreferrer">available extensions</a>.
+      </p>
     );
-
-    return validatedRequests;
   }
 
-  async requestInstall(init: InstallRequest | InstallRequest[]) {
-    const requests = Array.isArray(init) ? init : [init];
-    const preloadedRequests = await this.preloadExtensions(requests);
-    const validatedRequests = await this.createTempFilesAndValidate(preloadedRequests);
-
-    // If there are no requests for installing, reset startingInstall state
-    if (validatedRequests.length === 0) {
-      this.startingInstall = false;
-    }
-
-    for (const install of validatedRequests) {
-      const { name, version, description } = install.manifest;
-      const extensionFolder = this.getExtensionDestFolder(name);
-      const folderExists = await fse.pathExists(extensionFolder);
-
-      if (!folderExists) {
-        // auto-install extension if not yet exists
-        this.unpackExtension(install);
-      } else {
-        // If we show the confirmation dialog, we stop the install spinner until user clicks ok
-        // and the install continues
-        this.startingInstall = false;
-
-        // otherwise confirmation required (re-install / update)
-        const removeNotification = Notifications.info(
-          <div className="InstallingExtensionNotification flex gaps align-center">
-            <div className="flex column gaps">
-              <p>Install extension <b>{name}@{version}</b>?</p>
-              <p>Description: <em>{description}</em></p>
-              <div className="remove-folder-warning" onClick={() => shell.openPath(extensionFolder)}>
-                <b>Warning:</b> <code>{extensionFolder}</code> will be removed before installation.
-              </div>
-            </div>
-            <Button autoFocus label="Install" onClick={() => {
-              removeNotification();
-              this.unpackExtension(install);
-            }}/>
-          </div>
-        );
-      }
-    }
+  renderNoExtensions() {
+    return (
+      <div className="no-extensions flex box gaps justify-center">
+        <Icon material="info" />
+        <div>
+          {this.renderNoExtensionsHelpText()}
+        </div>
+      </div>
+    );
   }
 
-  async unpackExtension({ fileName, tempFile, manifest: { name, version } }: InstallRequestValidated) {
-    const displayName = extensionDisplayName(name, version);
-    const extensionId = path.join(extensionDiscovery.nodeModulesPath, name, "package.json");
+  @autobind()
+  renderExtension(extension: InstalledExtension) {
+    const { id, isEnabled, manifest } = extension;
+    const { name, description, version } = manifest;
+    const isUninstalling = ExtensionInstallationStateStore.isExtensionUninstalling(id);
 
-    logger.info(`Unpacking extension ${displayName}`, { fileName, tempFile });
-
-    this.extensionStateStore.extensionState.set(extensionId, {
-      state: "installing",
-      displayName
-    });
-    this.startingInstall = false;
-
-    const extensionFolder = this.getExtensionDestFolder(name);
-    const unpackingTempFolder = path.join(path.dirname(tempFile), `${path.basename(tempFile)}-unpacked`);
-
-    logger.info(`Unpacking extension ${displayName}`, { fileName, tempFile });
-
-    try {
-      // extract to temp folder first
-      await fse.remove(unpackingTempFolder).catch(Function);
-      await fse.ensureDir(unpackingTempFolder);
-      await extractTar(tempFile, { cwd: unpackingTempFolder });
-
-      // move contents to extensions folder
-      const unpackedFiles = await fse.readdir(unpackingTempFolder);
-      let unpackedRootFolder = unpackingTempFolder;
-
-      if (unpackedFiles.length === 1) {
-        // check if %extension.tgz was packed with single top folder,
-        // e.g. "npm pack %ext_name" downloads file with "package" root folder within tarball
-        unpackedRootFolder = path.join(unpackingTempFolder, unpackedFiles[0]);
-      }
-
-      await fse.ensureDir(extensionFolder);
-      await fse.move(unpackedRootFolder, extensionFolder, { overwrite: true });
-    } catch (error) {
-      Notifications.error(
-        <p>Installing extension <b>{displayName}</b> has failed: <em>{error}</em></p>
-      );
-
-      // Remove install state on install failure
-      if (this.extensionStateStore.extensionState.get(extensionId)?.state === "installing") {
-        this.extensionStateStore.extensionState.delete(extensionId);
-      }
-    } finally {
-      // clean up
-      fse.remove(unpackingTempFolder).catch(Function);
-      fse.unlink(tempFile).catch(Function);
-    }
-  }
-
-  confirmUninstallExtension = (extension: InstalledExtension) => {
-    const displayName = extensionDisplayName(extension.manifest.name, extension.manifest.version);
-
-    ConfirmDialog.open({
-      message: <p>Are you sure you want to uninstall extension <b>{displayName}</b>?</p>,
-      labelOk: "Yes",
-      labelCancel: "No",
-      ok: () => this.uninstallExtension(extension)
-    });
-  };
-
-  async uninstallExtension(extension: InstalledExtension) {
-    const displayName = extensionDisplayName(extension.manifest.name, extension.manifest.version);
-
-    try {
-      this.extensionStateStore.extensionState.set(extension.id, {
-        state: "uninstalling",
-        displayName
-      });
-
-      await extensionDiscovery.uninstallExtension(extension);
-    } catch (error) {
-      Notifications.error(
-        <p>Uninstalling extension <b>{displayName}</b> has failed: <em>{error?.message ?? ""}</em></p>
-      );
-
-      // Remove uninstall state on uninstall failure
-      if (this.extensionStateStore.extensionState.get(extension.id)?.state === "uninstalling") {
-        this.extensionStateStore.extensionState.delete(extension.id);
-      }
-    }
+    return (
+      <div key={id} className="extension flex gaps align-center">
+        <div className="box grow">
+          <h5>{name}</h5>
+          <h6>{version}</h6>
+          <p>{description}</p>
+        </div>
+        <div className="actions">
+          {
+            isEnabled
+              ? <Button accent disabled={isUninstalling} onClick={() => extension.isEnabled = false}>Disable</Button>
+              : <Button plain active disabled={isUninstalling} onClick={() => extension.isEnabled = true}>Enable</Button>
+          }
+          <Button plain active disabled={isUninstalling} waiting={isUninstalling} onClick={() => {
+            confirmUninstallExtension(extension);
+          }}>Uninstall</Button>
+        </div>
+      </div>
+    );
   }
 
   renderExtensions() {
-    const { extensions, search } = this;
-
-    if (!extensions.length) {
-      return (
-        <div className="no-extensions flex box gaps justify-center">
-          <Icon material="info"/>
-          <div>
-            {
-              search
-                ? <p>No search results found</p>
-                : <p>There are no installed extensions. See list of <a href="https://github.com/lensapp/lens-extensions/blob/main/README.md" target="_blank" rel="noreferrer">available extensions</a>.</p>
-            }
-          </div>
-        </div>
-      );
+    if (!extensionDiscovery.isLoaded) {
+      return <div className="spinner-wrapper"><Spinner /></div>;
     }
 
-    return extensions.map(extension => {
-      const { id, isEnabled, manifest } = extension;
-      const { name, description, version } = manifest;
-      const isUninstalling = this.extensionStateStore.extensionState.get(id)?.state === "uninstalling";
+    const { searchedForExtensions } = this;
 
-      return (
-        <div key={id} className="extension flex gaps align-center">
-          <div className="box grow">
-            <h5>{name}</h5>
-            <h6>{version}</h6>
-            <p>{description}</p>
-          </div>
-          <div className="actions">
-            {!isEnabled && (
-              <Button plain active disabled={isUninstalling} onClick={() => {
-                extension.isEnabled = true;
-              }}>Enable</Button>
-            )}
-            {isEnabled && (
-              <Button accent disabled={isUninstalling} onClick={() => {
-                extension.isEnabled = false;
-              }}>Disable</Button>
-            )}
-            <Button plain active disabled={isUninstalling} waiting={isUninstalling} onClick={() => {
-              this.confirmUninstallExtension(extension);
-            }}>Uninstall</Button>
-          </div>
-        </div>
-      );
-    });
-  }
+    if (!searchedForExtensions.length) {
+      return this.renderNoExtensions();
+    }
 
-  /**
-   * True if at least one extension is in installing state
-   */
-  @computed get isInstalling() {
-    return [...this.extensionStateStore.extensionState.values()].some(extension => extension.state === "installing");
+    return (
+      <>
+        {...searchedForExtensions.map(this.renderExtension)}
+        {
+          ExtensionInstallationStateStore.anyPreInstallingOrInstalling
+          && <div className="spinner-wrapper"><Spinner /></div>
+        }
+      </>
+    );
   }
 
   render() {
@@ -486,7 +469,7 @@ export class Extensions extends React.Component {
     const { installPath } = this;
 
     return (
-      <DropFileInput onDropFiles={this.installOnDrop}>
+      <DropFileInput onDropFiles={installOnDrop}>
         <PageLayout showOnTop className="Extensions" header={topHeader} contentGaps={false}>
           <h2>Lens Extensions</h2>
           <div>
@@ -500,19 +483,19 @@ export class Extensions extends React.Component {
               <Input
                 className="box grow"
                 theme="round-black"
-                disabled={this.isInstalling}
-                placeholder={`Path or URL to an extension package (${Extensions.supportedFormats.join(", ")})`}
+                disabled={ExtensionInstallationStateStore.anyPreInstallingOrInstalling}
+                placeholder={`Path or URL to an extension package (${supportedFormats.join(", ")})`}
                 showErrorsAsTooltip={{ preferredPositions: TooltipPosition.BOTTOM }}
                 validators={installPath ? Extensions.installPathValidator : undefined}
                 value={installPath}
                 onChange={value => this.installPath = value}
-                onSubmit={this.installFromUrlOrPath}
+                onSubmit={() => installFromUrlOrPath(this.installPath)}
                 iconLeft="link"
                 iconRight={
                   <Icon
                     interactive
                     material="folder"
-                    onClick={prevDefault(this.installFromSelectFileDialog)}
+                    onClick={prevDefault(installFromSelectFileDialog)}
                     tooltip="Browse"
                   />
                 }
@@ -521,9 +504,8 @@ export class Extensions extends React.Component {
             <Button
               primary
               label="Install"
-              disabled={this.isInstalling || !Extensions.installPathValidator.validate(installPath)}
-              waiting={this.isInstalling}
-              onClick={this.installFromUrlOrPath}
+              disabled={ExtensionInstallationStateStore.anyPreInstallingOrInstalling || !Extensions.installPathValidator.validate(installPath)}
+              onClick={() => installFromUrlOrPath(this.installPath)}
             />
             <small className="hint">
               <b>Pro-Tip</b>: you can also drag-n-drop tarball-file to this area
@@ -537,7 +519,7 @@ export class Extensions extends React.Component {
               value={this.search}
               onChange={(value) => this.search = value}
             />
-            {extensionDiscovery.isLoaded ? this.renderExtensions() : <div className="spinner-wrapper"><Spinner/></div>}
+            {this.renderExtensions()}
           </div>
         </PageLayout>
       </DropFileInput>

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -6,7 +6,7 @@ import { disposeOnUnmount, observer } from "mobx-react";
 import os from "os";
 import path from "path";
 import React from "react";
-import { autobind, disposer, Disposer, downloadFile, extractTar, listTarEntries, noop, readFileFromTar } from "../../../common/utils";
+import { autobind, disposer, Disposer, downloadFile, downloadJson, extractTar, listTarEntries, noop, readFileFromTar } from "../../../common/utils";
 import { docsUrl } from "../../../common/vars";
 import { extensionDiscovery, InstalledExtension, manifestFilename } from "../../../extensions/extension-discovery";
 import { extensionLoader } from "../../../extensions/extension-loader";
@@ -23,6 +23,9 @@ import { Notifications } from "../notifications";
 import { Spinner } from "../spinner/spinner";
 import { TooltipPosition } from "../tooltip";
 import { ExtensionInstallationState, ExtensionInstallationStateStore } from "./extension-install.store";
+import URLParse from "url-parse";
+import { SemVer } from "semver";
+import _ from "lodash";
 
 function getMessageFromError(error: any): string {
   if (!error || typeof error !== "object") {
@@ -46,23 +49,27 @@ function getMessageFromError(error: any): string {
   return rawMessage;
 }
 
+interface ExtensionInfo {
+  name: string;
+  version?: string;
+  requireConfirmation?: boolean;
+}
+
 interface InstallRequest {
   fileName: string;
-  filePath?: string;
-  data?: Buffer;
+  dataP: Promise<Buffer | null>;
 }
 
-interface InstallRequestPreloaded extends InstallRequest {
+interface InstallRequestValidated {
+  fileName: string;
   data: Buffer;
-}
-
-interface InstallRequestValidated extends InstallRequestPreloaded {
   id: LensExtensionId;
   manifest: LensExtensionManifest;
   tempFile: string; // temp system path to packed extension for unpacking
 }
 
-async function uninstallExtension(extensionId: LensExtensionId, manifest: LensExtensionManifest): Promise<boolean> {
+async function uninstallExtension(extensionId: LensExtensionId): Promise<boolean> {
+  const { manifest } = extensionLoader.getExtension(extensionId);
   const displayName = extensionDisplayName(manifest.name, manifest.version);
 
   try {
@@ -92,18 +99,17 @@ async function uninstallExtension(extensionId: LensExtensionId, manifest: LensEx
   }
 }
 
-function confirmUninstallExtension(extension: InstalledExtension): void {
+async function confirmUninstallExtension(extension: InstalledExtension): Promise<void> {
   const displayName = extensionDisplayName(extension.manifest.name, extension.manifest.version);
-
-  ConfirmDialog.open({
+  const confirmed = await ConfirmDialog.confirm({
     message: <p>Are you sure you want to uninstall extension <b>{displayName}</b>?</p>,
     labelOk: "Yes",
     labelCancel: "No",
-    ok: () => {
-      // Don't want the confirm dialog to stay up longer than the click
-      uninstallExtension(extension.id, extension.manifest);
-    }
   });
+
+  if (confirmed) {
+    await uninstallExtension(extension.id);
+  }
 }
 
 function getExtensionDestFolder(name: string) {
@@ -114,16 +120,10 @@ function getExtensionPackageTemp(fileName = "") {
   return path.join(os.tmpdir(), "lens-extensions", fileName);
 }
 
-async function preloadExtension({ fileName, data, filePath }: InstallRequest, { showError = true } = {}): Promise<InstallRequestPreloaded | null> {
-  if(data) {
-    return { filePath, data, fileName };
-  }
-
+async function readFileNotify(filePath: string, showError = true): Promise<Buffer | null> {
   try {
-    const data = await fse.readFile(filePath);
-
-    return { filePath, data, fileName };
-  } catch(error) {
+    return await fse.readFile(filePath);
+  } catch (error) {
     if (showError) {
       const message = getMessageFromError(error);
 
@@ -166,20 +166,27 @@ async function validatePackage(filePath: string): Promise<LensExtensionManifest>
   return manifest;
 }
 
-async function createTempFilesAndValidate(request: InstallRequestPreloaded, { showErrors = true } = {}): Promise<InstallRequestValidated | null> {
+async function createTempFilesAndValidate({ fileName, dataP }: InstallRequest, { showErrors = true } = {}): Promise<InstallRequestValidated | null> {
   // copy files to temp
   await fse.ensureDir(getExtensionPackageTemp());
 
   // validate packages
-  const tempFile = getExtensionPackageTemp(request.fileName);
+  const tempFile = getExtensionPackageTemp(fileName);
 
   try {
-    await fse.writeFile(tempFile, request.data);
+    const data = await dataP;
+
+    if (!data) {
+      return;
+    }
+
+    await fse.writeFile(tempFile, data);
     const manifest = await validatePackage(tempFile);
     const id = path.join(extensionDiscovery.nodeModulesPath, manifest.name, "package.json");
 
     return {
-      ...request,
+      fileName,
+      data,
       manifest,
       tempFile,
       id,
@@ -190,10 +197,10 @@ async function createTempFilesAndValidate(request: InstallRequestPreloaded, { sh
     if (showErrors) {
       const message = getMessageFromError(error);
 
-      logger.info(`[EXTENSION-INSTALLATION]: installing ${request.fileName} has failed: ${message}`, { error });
+      logger.info(`[EXTENSION-INSTALLATION]: installing ${fileName} has failed: ${message}`, { error });
       Notifications.error(
         <div className="flex column gaps">
-          <p>Installing <em>{request.fileName}</em> has failed, skipping.</p>
+          <p>Installing <em>{fileName}</em> has failed, skipping.</p>
           <p>Reason: <em>{message}</em></p>
         </div>
       );
@@ -258,20 +265,61 @@ async function unpackExtension(request: InstallRequestValidated, disposeDownload
   }
 }
 
-/**
- *
- * @param request The information needed to install the extension
- * @param fromUrl The optional URL
- */
-async function requestInstall(request: InstallRequest, d?: Disposer): Promise<void> {
-  const dispose = disposer(ExtensionInstallationStateStore.startPreInstall(), d);
-  const loadedRequest = await preloadExtension(request);
+export async function attemptInstallByInfo({ name, version, requireConfirmation = false }: ExtensionInfo) {
+  const disposer = ExtensionInstallationStateStore.startPreInstall();
+  const registryUrl = new URLParse("https://registry.npmjs.com").set("pathname", name).toString();
+  const { promise } = downloadJson({ url: registryUrl });
+  const json = await promise.catch(console.error);
 
-  if (!loadedRequest) {
-    return dispose();
+  if (!json || json.error || typeof json.versions !== "object" || !json.versions) {
+    const message = json?.error ? `: ${json.error}` : "";
+
+    Notifications.error(`Failed to get registry information for that extension${message}`);
+
+    return disposer();
   }
 
-  const validatedRequest = await createTempFilesAndValidate(loadedRequest);
+  if (version) {
+    if (!json.versions[version]) {
+      Notifications.error(<p>The <em>{name}</em> extension does not have a v{version}.</p>);
+
+      return disposer();
+    }
+  } else {
+    const versions = Object.keys(json.versions)
+      .map(version => new SemVer(version, { loose: true, includePrerelease: true }))
+      // ignore pre-releases for auto picking the version
+      .filter(version => version.prerelease.length === 0);
+
+    version = _.reduce(versions, (prev, curr) => (
+      prev.compareMain(curr) === -1
+        ? curr
+        : prev
+    )).format();
+  }
+
+  if (requireConfirmation) {
+    const proceed = await ConfirmDialog.confirm({
+      message: <p>Are you sure you want to install <b>{name}@{version}</b>?</p>,
+      labelCancel: "Cancel",
+      labelOk: "Install",
+    });
+
+    if (!proceed) {
+      return disposer();
+    }
+  }
+
+  const url = json.versions[version].dist.tarball;
+  const fileName = path.basename(url);
+  const { promise: dataP } = downloadFile({ url, timeout: 10 * 60 * 1000 });
+
+  return attemptInstall({ fileName, dataP }, disposer);
+}
+
+async function attemptInstall(request: InstallRequest, d?: Disposer): Promise<void> {
+  const dispose = disposer(ExtensionInstallationStateStore.startPreInstall(), d);
+  const validatedRequest = await createTempFilesAndValidate(request);
 
   if (!validatedRequest) {
     return dispose();
@@ -299,6 +347,8 @@ async function requestInstall(request: InstallRequest, d?: Disposer): Promise<vo
     // install extension if not yet exists
     await unpackExtension(validatedRequest, dispose);
   } else {
+    const { manifest: { version: oldVersion } } = extensionLoader.getExtension(validatedRequest.id);
+
     // otherwise confirmation required (re-install / update)
     const removeNotification = Notifications.info(
       <div className="InstallingExtensionNotification flex gaps align-center">
@@ -306,13 +356,13 @@ async function requestInstall(request: InstallRequest, d?: Disposer): Promise<vo
           <p>Install extension <b>{name}@{version}</b>?</p>
           <p>Description: <em>{description}</em></p>
           <div className="remove-folder-warning" onClick={() => shell.openPath(extensionFolder)}>
-            <b>Warning:</b> <code>{extensionFolder}</code> will be removed before installation.
+            <b>Warning:</b> {name}@{oldVersion} will be removed before installation.
           </div>
         </div>
         <Button autoFocus label="Install" onClick={async () => {
           removeNotification();
 
-          if (await uninstallExtension(validatedRequest.id, validatedRequest.manifest)) {
+          if (await uninstallExtension(validatedRequest.id)) {
             await unpackExtension(validatedRequest, dispose);
           } else {
             dispose();
@@ -328,13 +378,13 @@ async function requestInstall(request: InstallRequest, d?: Disposer): Promise<vo
   }
 }
 
-async function requestInstalls(filePaths: string[]): Promise<void> {
+async function attemptInstalls(filePaths: string[]): Promise<void> {
   const promises: Promise<void>[] = [];
 
   for (const filePath of filePaths) {
-    promises.push(requestInstall({
+    promises.push(attemptInstall({
       fileName: path.basename(filePath),
-      filePath,
+      dataP: readFileNotify(filePath),
     }));
   }
 
@@ -343,31 +393,35 @@ async function requestInstalls(filePaths: string[]): Promise<void> {
 
 async function installOnDrop(files: File[]) {
   logger.info("Install from D&D");
-  await requestInstalls(files.map(({ path }) => path));
+  await attemptInstalls(files.map(({ path }) => path));
 }
 
-async function installFromUrlOrPath(installPath: string) {
-  const fileName = path.basename(installPath);
+async function installFromInput(input: string) {
   let disposer: Disposer;
 
   try {
-    // install via url
     // fixme: improve error messages for non-tar-file URLs
-    if (InputValidators.isUrl.validate(installPath)) {
+    if (InputValidators.isUrl.validate(input)) {
+      // install via url
       disposer = ExtensionInstallationStateStore.startPreInstall();
-      const { promise: filePromise } = downloadFile({ url: installPath, timeout: 60000 /*1m*/ });
-      const data = await filePromise;
+      const { promise } = downloadFile({ url: input, timeout: 10 * 60 * 1000 });
+      const fileName = path.basename(input);
 
-      await requestInstall({ fileName, data }, disposer);
-    }
-    // otherwise installing from system path
-    else if (InputValidators.isPath.validate(installPath)) {
-      await requestInstall({ fileName, filePath: installPath });
+      await attemptInstall({ fileName, dataP: promise }, disposer);
+    } else if (InputValidators.isPath.validate(input)) {
+      // install from system path
+      const fileName = path.basename(input);
+
+      await attemptInstall({ fileName, dataP: readFileNotify(input) });
+    } else if (InputValidators.isExtensionNameInstall.validate(input)) {
+      const [{ groups: { name, version }}] = [...input.matchAll(InputValidators.isExtensionNameInstallRegex)];
+
+      await attemptInstallByInfo({ name, version });
     }
   } catch (error) {
     const message = getMessageFromError(error);
 
-    logger.info(`[EXTENSION-INSTALL]: installation has failed: ${message}`, { error, installPath });
+    logger.info(`[EXTENSION-INSTALL]: installation has failed: ${message}`, { error, installPath: input });
     Notifications.error(<p>Installation has failed: <b>{message}</b></p>);
   } finally {
     disposer?.();
@@ -389,17 +443,23 @@ async function installFromSelectFileDialog() {
   });
 
   if (!canceled) {
-    await requestInstalls(filePaths);
+    await attemptInstalls(filePaths);
   }
 }
 
 @observer
 export class Extensions extends React.Component {
-  private static installPathValidator: InputValidator = {
-    message: "Invalid URL or absolute path",
-    validate(value: string) {
-      return InputValidators.isUrl.validate(value) || InputValidators.isPath.validate(value);
-    }
+  private static installInputValidators = [
+    InputValidators.isUrl,
+    InputValidators.isPath,
+    InputValidators.isExtensionNameInstall,
+  ];
+
+  private static installInputValidator: InputValidator = {
+    message: "Invalid URL, absolute path, or extension name",
+    validate: (value: string) => (
+      Extensions.installInputValidators.some(({ validate }) => validate(value))
+    ),
   };
 
   @observable search = "";
@@ -476,9 +536,15 @@ export class Extensions extends React.Component {
               ? <Button accent disabled={isUninstalling} onClick={() => extension.isEnabled = false}>Disable</Button>
               : <Button plain active disabled={isUninstalling} onClick={() => extension.isEnabled = true}>Enable</Button>
           }
-          <Button plain active disabled={isUninstalling} waiting={isUninstalling} onClick={() => {
-            confirmUninstallExtension(extension);
-          }}>Uninstall</Button>
+          <Button
+            plain
+            active
+            disabled={isUninstalling}
+            waiting={isUninstalling}
+            onClick={() => confirmUninstallExtension(extension)}
+          >
+            Uninstall
+          </Button>
         </div>
       </div>
     );
@@ -522,12 +588,12 @@ export class Extensions extends React.Component {
                 className="box grow"
                 theme="round-black"
                 disabled={ExtensionInstallationStateStore.anyPreInstallingOrInstalling}
-                placeholder={`Path or URL to an extension package (${supportedFormats.join(", ")})`}
+                placeholder={`Name or file path or URL to an extension package (${supportedFormats.join(", ")})`}
                 showErrorsAsTooltip={{ preferredPositions: TooltipPosition.BOTTOM }}
-                validators={installPath ? Extensions.installPathValidator : undefined}
+                validators={installPath ? Extensions.installInputValidator : undefined}
                 value={installPath}
                 onChange={value => this.installPath = value}
-                onSubmit={() => installFromUrlOrPath(this.installPath)}
+                onSubmit={() => installFromInput(this.installPath)}
                 iconLeft="link"
                 iconRight={
                   <Icon
@@ -542,9 +608,9 @@ export class Extensions extends React.Component {
             <Button
               primary
               label="Install"
-              disabled={ExtensionInstallationStateStore.anyPreInstallingOrInstalling || !Extensions.installPathValidator.validate(installPath)}
+              disabled={ExtensionInstallationStateStore.anyPreInstallingOrInstalling || !Extensions.installInputValidator.validate(installPath)}
               waiting={ExtensionInstallationStateStore.anyPreInstallingOrInstalling}
-              onClick={() => installFromUrlOrPath(this.installPath)}
+              onClick={() => installFromInput(this.installPath)}
             />
             <small className="hint">
               <b>Pro-Tip</b>: you can also drag-n-drop tarball-file to this area

--- a/src/renderer/components/button/button.tsx
+++ b/src/renderer/components/button/button.tsx
@@ -1,5 +1,5 @@
 import "./button.scss";
-import React, { ButtonHTMLAttributes, ReactNode } from "react";
+import React, { ButtonHTMLAttributes } from "react";
 import { cssNames } from "../../utils";
 import { TooltipDecoratorProps, withTooltip } from "../tooltip";
 
@@ -26,29 +26,22 @@ export class Button extends React.PureComponent<ButtonProps, {}> {
 
   render() {
     const {
-      className, waiting, label, primary, accent, plain, hidden, active, big,
-      round, outlined, tooltip, light, children, ...props
+      waiting, label, primary, accent, plain, hidden, active, big,
+      round, outlined, tooltip, light, children, ...btnProps
     } = this.props;
-    const btnProps: Partial<ButtonProps> = props;
 
     if (hidden) return null;
 
-    btnProps.className = cssNames("Button", className, {
+    btnProps.className = cssNames("Button", btnProps.className, {
       waiting, primary, accent, plain, active, big, round, outlined, light,
     });
-
-    const btnContent: ReactNode = (
-      <>
-        {label}
-        {children}
-      </>
-    );
 
     // render as link
     if (this.props.href) {
       return (
         <a {...btnProps} ref={e => this.link = e}>
-          {btnContent}
+          {label}
+          {children}
         </a>
       );
     }
@@ -56,7 +49,8 @@ export class Button extends React.PureComponent<ButtonProps, {}> {
     // render as button
     return (
       <button type="button" {...btnProps} ref={e => this.button = e}>
-        {btnContent}
+        {label}
+        {children}
       </button>
     );
   }

--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -315,6 +315,7 @@ export class Input extends React.Component<InputProps, State> {
       rows: multiLine ? (rows || 1) : null,
       ref: this.bindRef,
       spellCheck: "false",
+      disabled,
     });
     const showErrors = errors.length > 0 && !valid && dirty;
     const errorsInfo = (

--- a/src/renderer/components/input/input_validators.ts
+++ b/src/renderer/components/input/input_validators.ts
@@ -47,6 +47,14 @@ export const isUrl: InputValidator = {
   },
 };
 
+export const isExtensionNameInstallRegex = /^(?<name>(@[-\w]+\/)?[-\w]+)(@(?<version>\d\.\d\.\d(-\w+)?))?$/gi;
+
+export const isExtensionNameInstall: InputValidator = {
+  condition: ({ type }) => type === "text",
+  message: () => "Not an extension name with optional version",
+  validate: value => value.match(isExtensionNameInstallRegex) !== null,
+};
+
 export const isPath: InputValidator = {
   condition: ({ type }) => type === "text",
   message: () => `This field must be a valid path`,

--- a/src/renderer/protocol-handler/app-handlers.ts
+++ b/src/renderer/protocol-handler/app-handlers.ts
@@ -1,6 +1,6 @@
 import { addClusterURL } from "../components/+add-cluster";
 import { clusterSettingsURL } from "../components/+cluster-settings";
-import { extensionsURL } from "../components/+extensions";
+import { attemptInstallByInfo, extensionsURL } from "../components/+extensions";
 import { landingURL } from "../components/+landing-page";
 import { preferencesURL } from "../components/+preferences";
 import { clusterViewURL } from "../components/cluster-manager/cluster-view.route";
@@ -8,6 +8,7 @@ import { LensProtocolRouterRenderer } from "./router";
 import { navigate } from "../navigation/helpers";
 import { clusterStore } from "../../common/cluster-store";
 import { workspaceStore } from "../../common/workspace-store";
+import { EXTENSION_NAME_MATCH, EXTENSION_PUBLISHER_MATCH, LensProtocolRouter } from "../../common/protocol-handler";
 
 export function bindProtocolAddRouteHandlers() {
   LensProtocolRouterRenderer
@@ -54,5 +55,15 @@ export function bindProtocolAddRouteHandlers() {
     })
     .addInternalHandler("/extensions", () => {
       navigate(extensionsURL());
+    })
+    .addInternalHandler(`/extensions/install${LensProtocolRouter.ExtensionUrlSchema}`, ({ pathname, search: { version } }) => {
+      const name = [
+        pathname[EXTENSION_PUBLISHER_MATCH],
+        pathname[EXTENSION_NAME_MATCH],
+      ].filter(Boolean)
+        .join("/");
+
+      navigate(extensionsURL());
+      attemptInstallByInfo({ name, version, requireConfirmation: true });
     });
 }


### PR DESCRIPTION
- Simplify the install logic by refactoring out the multi-install logic

- Revamp the `ExtensionInstallStateStore` to more strictly track the lifetime of an install or uninstall request

- Fix the install of an already installed extension just hanging visually

- Display a spinner more often for more visual feedback

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #2116 