### PR TITLE
Extract chart version ignoring numbers in chart name

### DIFF
--- a/src/renderer/api/endpoints/helm-releases.api.ts
+++ b/src/renderer/api/endpoints/helm-releases.api.ts
@@ -187,7 +187,7 @@ export class HelmRelease implements ItemObject {
   }
 
   getVersion() {
-    const versions = this.chart.match(/(v?\d+)[^-].*$/);
+    const versions = this.chart.match(/(?<=-)(v?\d+)[^-].*$/);
 
     if (versions) {
       return versions[0];


### PR DESCRIPTION
The commit fixes [this issue](https://github.com/lensapp/lens/issues/571)

Tested on most popular packages, complicated semver2 versions, it looks ok.
![image](https://user-images.githubusercontent.com/53330707/109124456-5fa4c180-7764-11eb-82e0-f1a9bd4ecb5b.png)
