### PR TITLE
Flush response headers always when proxy gets a response

### DIFF
--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -120,11 +120,15 @@ export class LensProxy {
   protected createProxy(): httpProxy {
     const proxy = httpProxy.createProxyServer();
 
-    proxy.on("proxyRes", (proxyRes, req) => {
+    proxy.on("proxyRes", (proxyRes, req, res) => {
       const retryCounterId = this.getRequestId(req);
 
       if (this.retryCounters.has(retryCounterId)) {
         this.retryCounters.delete(retryCounterId);
+      }
+
+      if (!res.headersSent) {
+        res.flushHeaders();
       }
     });
 

--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -127,8 +127,10 @@ export class LensProxy {
         this.retryCounters.delete(retryCounterId);
       }
 
-      if (!res.headersSent) {
-        res.flushHeaders();
+      if (!res.headersSent && req.url) {
+        const url = new URL(req.url, "http://localhost");
+
+        if (url.searchParams.has("watch")) res.flushHeaders();
       }
     });
 


### PR DESCRIPTION
Headers were automatically flushed when response got data. That might not happen with watch requests and that's why we need to force flush.

Fixes #1988