### PR TITLE
Render only secret name on pod details without access to secrets

### DIFF
--- a/src/renderer/components/+workloads-pods/pod-details-secrets.scss
+++ b/src/renderer/components/+workloads-pods/pod-details-secrets.scss
@@ -1,7 +1,7 @@
 .PodDetailsSecrets {
-  a {
+  > * {
     display: block;
-    margin-bottom: $margin;
+    margin-bottom: var(--margin);
 
     &:last-child {
       margin-bottom: 0;

--- a/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
@@ -13,18 +13,20 @@ interface Props {
 
 @observer
 export class PodDetailsSecrets extends Component<Props> {
-  @observable secrets: Secret[] = [];
+  @observable secrets: Map<string, Secret> = observable.map<string, Secret>();
 
   @disposeOnUnmount
   secretsLoader = autorun(async () => {
     const { pod } = this.props;
 
-    this.secrets = (await Promise.all(
+    const secrets = await Promise.all(
       pod.getSecrets().map(secretName => secretsApi.get({
         name: secretName,
         namespace: pod.getNs(),
       }))
-    )).filter(Boolean);
+    );
+
+    secrets.forEach(secret => secret && this.secrets.set(secret.getName(), secret));
   });
 
   render() {
@@ -34,13 +36,13 @@ export class PodDetailsSecrets extends Component<Props> {
       <div className="PodDetailsSecrets">
         {
           pod.getSecrets().map(secretName => {
-            const secret = this.secrets.find(secret => secret.getName() === secretName);
+            const secret = this.secrets.get(secretName);
 
             if (secret) {
               return this.renderSecretLink(secret);
             } else {
               return (
-                <span>{secretName}</span>
+                <span key={secretName}>{secretName}</span>
               );
             }
           })

--- a/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
@@ -40,9 +40,7 @@ export class PodDetailsSecrets extends Component<Props> {
               return this.renderSecretLink(secret);
             } else {
               return (
-                <>
-                  {secretName}
-                </>
+                <span>{secretName}</span>
               );
             }
           })

--- a/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-secrets.tsx
@@ -19,27 +19,43 @@ export class PodDetailsSecrets extends Component<Props> {
   secretsLoader = autorun(async () => {
     const { pod } = this.props;
 
-    this.secrets = await Promise.all(
+    this.secrets = (await Promise.all(
       pod.getSecrets().map(secretName => secretsApi.get({
         name: secretName,
         namespace: pod.getNs(),
       }))
-    );
+    )).filter(Boolean);
   });
 
   render() {
+    const { pod } = this.props;
+
     return (
       <div className="PodDetailsSecrets">
         {
-          this.secrets.map(secret => {
-            return (
-              <Link key={secret.getId()} to={getDetailsUrl(secret.selfLink)}>
-                {secret.getName()}
-              </Link>
-            );
+          pod.getSecrets().map(secretName => {
+            const secret = this.secrets.find(secret => secret.getName() === secretName);
+
+            if (secret) {
+              return this.renderSecretLink(secret);
+            } else {
+              return (
+                <>
+                  {secretName}
+                </>
+              );
+            }
           })
         }
       </div>
+    );
+  }
+
+  protected renderSecretLink(secret: Secret) {
+    return (
+      <Link key={secret.getId()} to={getDetailsUrl(secret.selfLink)}>
+        {secret.getName()}
+      </Link>
     );
   }
 }


### PR DESCRIPTION
Currently in pod details volume secrets are rendered as links to secret resources. This is causing app crass if user does not have access to secrets. This PR will fix the issue and display only secret name on that case.

Fixes #2227 