### PR TITLE
attempt to recover the ui after failing to load cluster store

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -103,7 +103,7 @@ app.on("ready", async () => {
 
   logger.info("💾 Loading stores");
   // preload
-  await Promise.all([
+  await Promise.allSettled([
     userStore.load(),
     clusterStore.load(),
     workspaceStore.load(),


### PR DESCRIPTION
Trying to improve the situation when the app starts without the main UI appearing (menu is present) due to an unknown problem with loading the cluster store after an update. This PR recovers the UI (with an empty cluster store) but any clusters that are added can't connect (spins forever)  
```
info: [APP]: Init dashboard, clusterId=1fdef426-95cd-443b-ade0-8d5a4374075c, frameId=5
...
Uncaught (in promise) TypeError: Cannot read property 'whenReady' of undefined
```

addresses #2195