### PR TITLE
Fix: preventing <App/> to render on cluster refresh

### DIFF
--- a/src/renderer/components/+config/config.route.ts
+++ b/src/renderer/components/+config/config.route.ts
@@ -1,12 +1,21 @@
 import { RouteProps } from "react-router";
-import { Config } from "./config";
 import { IURLParams } from "../../../common/utils/buildUrl";
-import { configMapsURL } from "../+config-maps/config-maps.route";
+import { configMapsRoute, configMapsURL } from "../+config-maps/config-maps.route";
+import { hpaRoute } from "../+config-autoscalers";
+import { limitRangesRoute } from "../+config-limit-ranges";
+import { pdbRoute } from "../+config-pod-disruption-budgets";
+import { resourceQuotaRoute } from "../+config-resource-quotas";
+import { secretsRoute } from "../+config-secrets";
 
 export const configRoute: RouteProps = {
-  get path() {
-    return Config.tabRoutes.map(({ routePath }) => routePath).flat();
-  }
+  path: [
+    configMapsRoute,
+    secretsRoute,
+    resourceQuotaRoute,
+    limitRangesRoute,
+    hpaRoute,
+    pdbRoute
+  ].map(route => route.path.toString())
 };
 
 export const configURL = (params?: IURLParams) => configMapsURL(params);

--- a/src/renderer/components/+network/network.route.ts
+++ b/src/renderer/components/+network/network.route.ts
@@ -1,12 +1,17 @@
 import { RouteProps } from "react-router";
-import { Network } from "./network";
-import { servicesURL } from "../+network-services";
+import { endpointRoute } from "../+network-endpoints";
+import { ingressRoute } from "../+network-ingresses";
+import { networkPoliciesRoute } from "../+network-policies";
+import { servicesRoute, servicesURL } from "../+network-services";
 import { IURLParams } from "../../../common/utils/buildUrl";
 
 export const networkRoute: RouteProps = {
-  get path() {
-    return Network.tabRoutes.map(({ routePath }) => routePath).flat();
-  }
+  path: [
+    servicesRoute,
+    endpointRoute,
+    ingressRoute,
+    networkPoliciesRoute
+  ].map(route => route.path.toString())
 };
 
 export const networkURL = (params?: IURLParams) => servicesURL(params);

--- a/src/renderer/components/+pod-security-policies/index.ts
+++ b/src/renderer/components/+pod-security-policies/index.ts
@@ -1,3 +1,2 @@
-export * from "./pod-security-policies.route";
 export * from "./pod-security-policies";
 export * from "./pod-security-policy-details";

--- a/src/renderer/components/+pod-security-policies/pod-security-policies.route.ts
+++ b/src/renderer/components/+pod-security-policies/pod-security-policies.route.ts
@@ -1,8 +1,0 @@
-import type { RouteProps } from "react-router";
-import { buildURL } from "../../../common/utils/buildUrl";
-
-export const podSecurityPoliciesRoute: RouteProps = {
-  path: "/pod-security-policies"
-};
-
-export const podSecurityPoliciesURL = buildURL(podSecurityPoliciesRoute.path);

--- a/src/renderer/components/+storage/storage.route.ts
+++ b/src/renderer/components/+storage/storage.route.ts
@@ -1,12 +1,15 @@
 import { RouteProps } from "react-router";
-import { volumeClaimsURL } from "../+storage-volume-claims";
-import { Storage } from "./storage";
+import { storageClassesRoute } from "../+storage-classes";
+import { volumeClaimsRoute, volumeClaimsURL } from "../+storage-volume-claims";
+import { volumesRoute } from "../+storage-volumes";
 import { IURLParams } from "../../../common/utils/buildUrl";
 
 export const storageRoute: RouteProps = {
-  get path() {
-    return Storage.tabRoutes.map(({ routePath }) => routePath).flat();
-  }
+  path: [
+    volumeClaimsRoute,
+    volumesRoute,
+    storageClassesRoute
+  ].map(route => route.path.toString())
 };
 
 export const storageURL = (params?: IURLParams) => volumeClaimsURL(params);

--- a/src/renderer/components/+user-management/user-management.route.ts
+++ b/src/renderer/components/+user-management/user-management.route.ts
@@ -1,12 +1,5 @@
 import type { RouteProps } from "react-router";
 import { buildURL, IURLParams } from "../../../common/utils/buildUrl";
-import { UserManagement } from "./user-management";
-
-export const usersManagementRoute: RouteProps = {
-  get path() {
-    return UserManagement.tabRoutes.map(({ routePath }) => routePath).flat();
-  }
-};
 
 // Routes
 export const serviceAccountsRoute: RouteProps = {
@@ -17,6 +10,18 @@ export const rolesRoute: RouteProps = {
 };
 export const roleBindingsRoute: RouteProps = {
   path: "/role-bindings"
+};
+export const podSecurityPoliciesRoute: RouteProps = {
+  path: "/pod-security-policies"
+};
+
+export const usersManagementRoute: RouteProps = {
+  path: [
+    serviceAccountsRoute,
+    roleBindingsRoute,
+    rolesRoute,
+    podSecurityPoliciesRoute
+  ].map(route => route.path.toString())
 };
 
 // Route params
@@ -34,3 +39,4 @@ export const usersManagementURL = (params?: IURLParams) => serviceAccountsURL(pa
 export const serviceAccountsURL = buildURL<IServiceAccountsRouteParams>(serviceAccountsRoute.path);
 export const roleBindingsURL = buildURL<IRoleBindingsRouteParams>(roleBindingsRoute.path);
 export const rolesURL = buildURL<IRoleBindingsRouteParams>(rolesRoute.path);
+export const podSecurityPoliciesURL = buildURL(podSecurityPoliciesRoute.path);

--- a/src/renderer/components/+user-management/user-management.tsx
+++ b/src/renderer/components/+user-management/user-management.tsx
@@ -5,9 +5,9 @@ import { TabLayout, TabLayoutRoute } from "../layout/tab-layout";
 import { Roles } from "../+user-management-roles";
 import { RoleBindings } from "../+user-management-roles-bindings";
 import { ServiceAccounts } from "../+user-management-service-accounts";
-import { roleBindingsRoute, roleBindingsURL, rolesRoute, rolesURL, serviceAccountsRoute, serviceAccountsURL } from "./user-management.route";
+import { podSecurityPoliciesRoute, podSecurityPoliciesURL, roleBindingsRoute, roleBindingsURL, rolesRoute, rolesURL, serviceAccountsRoute, serviceAccountsURL } from "./user-management.route";
 import { namespaceUrlParam } from "../+namespaces/namespace.store";
-import { PodSecurityPolicies, podSecurityPoliciesRoute, podSecurityPoliciesURL } from "../+pod-security-policies";
+import { PodSecurityPolicies } from "../+pod-security-policies";
 import { isAllowedResource } from "../../../common/rbac";
 
 @observer

--- a/src/renderer/components/+workloads/workloads.route.ts
+++ b/src/renderer/components/+workloads/workloads.route.ts
@@ -1,13 +1,6 @@
 import type { RouteProps } from "react-router";
 import { buildURL, IURLParams } from "../../../common/utils/buildUrl";
 import { KubeResource } from "../../../common/rbac";
-import { Workloads } from "./workloads";
-
-export const workloadsRoute: RouteProps = {
-  get path() {
-    return Workloads.tabRoutes.map(({ routePath }) => routePath).flat();
-  }
-};
 
 // Routes
 export const overviewRoute: RouteProps = {
@@ -33,6 +26,19 @@ export const jobsRoute: RouteProps = {
 };
 export const cronJobsRoute: RouteProps = {
   path: "/cronjobs"
+};
+
+export const workloadsRoute: RouteProps = {
+  path: [
+    overviewRoute,
+    podsRoute,
+    deploymentsRoute,
+    daemonSetsRoute,
+    statefulSetsRoute,
+    replicaSetsRoute,
+    jobsRoute,
+    cronJobsRoute
+  ].map(route => route.path.toString())
 };
 
 // Route params

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -51,7 +51,6 @@ import { CommandContainer } from "./command-palette/command-container";
 import { KubeObjectStore } from "../kube-object.store";
 import { clusterContext } from "./context";
 
-@observer
 export class App extends React.Component {
   static async init() {
     const frameId = webFrame.routingId;

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -91,21 +91,13 @@ export class App extends React.Component {
       reaction(() => this.warningsTotal, (count: number) => {
         broadcastMessage(`cluster-warning-event-count:${getHostedCluster().id}`, count);
       }),
-
-      reaction(getHostedCluster, () => {
-        this.setStartUrl();
-      })
     ]);
   }
 
-  @observable startUrl: string = clusterURL();
+  @observable startUrl = isAllowedResource(["events", "nodes", "pods"]) ? clusterURL() : workloadsURL();
 
   @computed get warningsTotal(): number {
     return nodesStore.getWarningsCount() + eventStore.getWarningsCount();
-  }
-
-  setStartUrl() {
-    this.startUrl = isAllowedResource(["events", "nodes", "pods"]) ? clusterURL() : workloadsURL();
   }
 
   getTabLayoutRoutes(menuItem: ClusterPageMenuRegistration) {
@@ -190,7 +182,7 @@ export class App extends React.Component {
           <StatefulSetScaleDialog/>
           <ReplicaSetScaleDialog/>
           <CronJobTriggerDialog/>
-          <CommandContainer/>
+          <CommandContainer clusterId={getHostedCluster()?.id}/>
         </ErrorBoundary>
       </Router>
     );

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { computed, observable, reaction } from "mobx";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { disposeOnUnmount } from "mobx-react";
 import { Redirect, Route, Router, Switch } from "react-router";
 import { history } from "../navigation";
 import { Notifications } from "./notifications";

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -90,12 +90,6 @@ export class App extends React.Component {
       reaction(() => this.warningsTotal, (count: number) => {
         broadcastMessage(`cluster-warning-event-count:${getHostedCluster().id}`, count);
       }),
-
-      reaction(() => clusterPageMenuRegistry.getRootItems(), (rootItems) => {
-        this.generateExtensionTabLayoutRoutes(rootItems);
-      }, {
-        fireImmediately: true
-      })
     ]);
   }
 
@@ -151,38 +145,6 @@ export class App extends React.Component {
     });
   }
 
-  @observable extensionRoutes: Map<ClusterPageMenuRegistration, React.ReactNode> = new Map();
-
-  generateExtensionTabLayoutRoutes(rootItems: ClusterPageMenuRegistration[]) {
-    rootItems.forEach((menu, index) => {
-      let route = this.extensionRoutes.get(menu);
-
-      if (!route) {
-        const tabRoutes = this.getTabLayoutRoutes(menu);
-
-        if (tabRoutes.length > 0) {
-          const pageComponent = () => <TabLayout tabs={tabRoutes}/>;
-
-          route = <Route key={`extension-tab-layout-route-${index}`} component={pageComponent} path={tabRoutes.map((tab) => tab.routePath)}/>;
-          this.extensionRoutes.set(menu, route);
-        } else {
-          const page = clusterPageRegistry.getByPageTarget(menu.target);
-
-          if (page) {
-            route = <Route key={`extension-tab-layout-route-${index}`} path={page.url} component={page.components.Page}/>;
-            this.extensionRoutes.set(menu, route);
-          }
-        }
-      }
-    });
-
-    for (const menu of this.extensionRoutes.keys()) {
-      if (!rootItems.includes(menu)) {
-        this.extensionRoutes.delete(menu);
-      }
-    }
-  }
-
   renderExtensionRoutes() {
     return clusterPageRegistry.getItems().map((page, index) => {
       const menu = clusterPageMenuRegistry.getByPage(page);
@@ -201,6 +163,7 @@ export class App extends React.Component {
         <ErrorBoundary>
           <MainLayout>
             <Switch>
+              <Redirect exact from="/" to={this.startURL}/>
               <Route component={ClusterOverview} {...clusterRoute}/>
               <Route component={Nodes} {...nodesRoute}/>
               <Route component={Workloads} {...workloadsRoute}/>
@@ -214,7 +177,6 @@ export class App extends React.Component {
               <Route component={Apps} {...appsRoute}/>
               <ExtensionTabLayoutRoutes/>
               <ExtensionRoutes/>
-              <Redirect exact from="/" to={this.startURL}/>
               <Route component={NotFound}/>
             </Switch>
           </MainLayout>

--- a/src/renderer/components/command-palette/command-container.tsx
+++ b/src/renderer/components/command-palette/command-container.tsx
@@ -8,9 +8,8 @@ import { EventEmitter } from "../../../common/event-emitter";
 import { subscribeToBroadcast } from "../../../common/ipc";
 import { CommandDialog } from "./command-dialog";
 import { CommandRegistration, commandRegistry } from "../../../extensions/registries/command-registry";
-import { clusterStore } from "../../../common/cluster-store";
+import { clusterStore, getHostedCluster } from "../../../common/cluster-store";
 import { workspaceStore } from "../../../common/workspace-store";
-import { Cluster } from "../../../main/cluster";
 
 export type CommandDialogEvent = {
   component: React.ReactElement
@@ -29,8 +28,9 @@ export class CommandOverlay {
 }
 
 @observer
-export class CommandContainer extends React.Component<{cluster?: Cluster}> {
+export class CommandContainer extends React.Component {
   @observable.ref commandComponent: React.ReactElement;
+  @observable cluster = getHostedCluster();
 
   private escHandler(event: KeyboardEvent) {
     if (event.key === "Escape") {
@@ -56,8 +56,8 @@ export class CommandContainer extends React.Component<{cluster?: Cluster}> {
   }
 
   componentDidMount() {
-    if (this.props.cluster) {
-      subscribeToBroadcast(`command-palette:run-action:${this.props.cluster.id}`, (event, commandId: string) => {
+    if (this.cluster) {
+      subscribeToBroadcast(`command-palette:run-action:${this.cluster.id}`, (event, commandId: string) => {
         const command = this.findCommandById(commandId);
 
         if (command) {

--- a/src/renderer/components/command-palette/command-container.tsx
+++ b/src/renderer/components/command-palette/command-container.tsx
@@ -8,7 +8,7 @@ import { EventEmitter } from "../../../common/event-emitter";
 import { subscribeToBroadcast } from "../../../common/ipc";
 import { CommandDialog } from "./command-dialog";
 import { CommandRegistration, commandRegistry } from "../../../extensions/registries/command-registry";
-import { clusterStore, getHostedCluster } from "../../../common/cluster-store";
+import { clusterStore } from "../../../common/cluster-store";
 import { workspaceStore } from "../../../common/workspace-store";
 
 export type CommandDialogEvent = {
@@ -28,9 +28,8 @@ export class CommandOverlay {
 }
 
 @observer
-export class CommandContainer extends React.Component {
+export class CommandContainer extends React.Component<{ clusterId?: string }> {
   @observable.ref commandComponent: React.ReactElement;
-  @observable cluster = getHostedCluster();
 
   private escHandler(event: KeyboardEvent) {
     if (event.key === "Escape") {
@@ -56,8 +55,8 @@ export class CommandContainer extends React.Component {
   }
 
   componentDidMount() {
-    if (this.cluster) {
-      subscribeToBroadcast(`command-palette:run-action:${this.cluster.id}`, (event, commandId: string) => {
+    if (this.props.clusterId) {
+      subscribeToBroadcast(`command-palette:run-action:${this.props.clusterId}`, (event, commandId: string) => {
         const command = this.findCommandById(commandId);
 
         if (command) {

--- a/src/renderer/components/layout/main-layout-header.tsx
+++ b/src/renderer/components/layout/main-layout-header.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import React from "react";
 
 import { clusterSettingsURL } from "../+cluster-settings";
@@ -11,7 +12,7 @@ interface Props {
   className?: string
 }
 
-export function MainLayoutHeader({ cluster, className }: Props) {
+export const MainLayoutHeader = observer(({ cluster, className }: Props) => {
   return (
     <header className={cssNames("flex gaps align-center justify-space-between", className)}>
       <span className="cluster">{cluster.name}</span>
@@ -29,4 +30,4 @@ export function MainLayoutHeader({ cluster, className }: Props) {
       />
     </header>
   );
-}
+});


### PR DESCRIPTION
Removing all references to observable cluster object from `<App/>` render method. This prevents app to rerender (and loose state in extension pages) on cluster refresh. Changed route files because of same references inside `isAllowedResource` method.

Also, adding `observer` wrapper to `<MainLayoutHeader/>` to properly catch cluster renaming from Settings.

Fixes #2208

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>