### PR TITLE
Fix integration test lifecycle fuctions not failing tests

### DIFF
--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -3,7 +3,6 @@ import * as utils from "../helpers/utils";
 import { listHelmRepositories } from "../helpers/utils";
 import { fail } from "assert";
 
-
 jest.setTimeout(60000);
 
 // FIXME (!): improve / simplify all css-selectors + use [data-test-id="some-id"] (already used in some tests below)
@@ -11,13 +10,15 @@ describe("Lens integration tests", () => {
   let app: Application;
 
   describe("app start", () => {
-    beforeAll(async () => app = await utils.appStart(), 20000);
+    beforeAll(utils.wrapJestLifecycle(async () => {
+      app = await utils.appStart();
+    }));
 
-    afterAll(async () => {
+    afterAll(utils.wrapJestLifecycle(async () => {
       if (app?.isRunning()) {
         await utils.tearDown(app);
       }
-    });
+    }));
 
     it('shows "whats new"', async () => {
       await utils.clickWhatsNew(app);

--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -10,15 +10,15 @@ describe("Lens integration tests", () => {
   let app: Application;
 
   describe("app start", () => {
-    beforeAll(utils.wrapJestLifecycle(async () => {
+    utils.beforeAllWrapped(async () => {
       app = await utils.appStart();
-    }));
+    });
 
-    afterAll(utils.wrapJestLifecycle(async () => {
+    utils.afterAllWrapped(async () => {
       if (app?.isRunning()) {
         await utils.tearDown(app);
       }
-    }));
+    });
 
     it('shows "whats new"', async () => {
       await utils.clickWhatsNew(app);

--- a/integration/__tests__/cluster-pages.tests.ts
+++ b/integration/__tests__/cluster-pages.tests.ts
@@ -32,13 +32,15 @@ describe("Lens cluster pages", () => {
     };
 
     describe("cluster add", () => {
-      beforeAll(async () => app = await utils.appStart(), 20000);
+      beforeAll(utils.wrapJestLifecycle(async () => {
+        app = await utils.appStart();
+      }));
 
-      afterAll(async () => {
+      afterAll(utils.wrapJestLifecycle(async () => {
         if (app && app.isRunning()) {
           return utils.tearDown(app);
         }
-      });
+      }));
 
       it("allows to add a cluster", async () => {
         await addCluster();
@@ -55,13 +57,13 @@ describe("Lens cluster pages", () => {
 
     describe("cluster pages", () => {
 
-      beforeAll(appStartAddCluster, 40000);
+      beforeAll(utils.wrapJestLifecycle(appStartAddCluster));
 
-      afterAll(async () => {
+      afterAll(utils.wrapJestLifecycle(async () => {
         if (app && app.isRunning()) {
           return utils.tearDown(app);
         }
-      });
+      }));
 
       const tests: {
         drawer?: string
@@ -337,13 +339,13 @@ describe("Lens cluster pages", () => {
     });
 
     describe("viewing pod logs", () => {
-      beforeEach(appStartAddCluster, 40000);
+      beforeEach(utils.wrapJestLifecycle(appStartAddCluster));
 
-      afterEach(async () => {
-        if (app && app.isRunning()) {
+      afterEach(utils.wrapJestLifecycle(async () => {
+        if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      });
+      }));
 
       it(`shows a logs for a pod`, async () => {
         expect(clusterAdded).toBe(true);
@@ -387,13 +389,13 @@ describe("Lens cluster pages", () => {
     });
 
     describe("cluster operations", () => {
-      beforeEach(appStartAddCluster, 40000);
+      beforeEach(utils.wrapJestLifecycle(appStartAddCluster));
 
-      afterEach(async () => {
-        if (app && app.isRunning()) {
+      afterEach(utils.wrapJestLifecycle(async () => {
+        if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      });
+      }));
 
       it("shows default namespace", async () => {
         expect(clusterAdded).toBe(true);

--- a/integration/__tests__/cluster-pages.tests.ts
+++ b/integration/__tests__/cluster-pages.tests.ts
@@ -32,15 +32,15 @@ describe("Lens cluster pages", () => {
     };
 
     describe("cluster add", () => {
-      beforeAll(utils.wrapJestLifecycle(async () => {
+      utils.beforeAllWrapped(async () => {
         app = await utils.appStart();
-      }));
+      });
 
-      afterAll(utils.wrapJestLifecycle(async () => {
-        if (app && app.isRunning()) {
+      utils.afterAllWrapped(async () => {
+        if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      }));
+      });
 
       it("allows to add a cluster", async () => {
         await addCluster();
@@ -56,14 +56,13 @@ describe("Lens cluster pages", () => {
     };
 
     describe("cluster pages", () => {
+      utils.beforeAllWrapped(appStartAddCluster);
 
-      beforeAll(utils.wrapJestLifecycle(appStartAddCluster));
-
-      afterAll(utils.wrapJestLifecycle(async () => {
-        if (app && app.isRunning()) {
+      utils.afterAllWrapped(async () => {
+        if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      }));
+      });
 
       const tests: {
         drawer?: string
@@ -339,13 +338,13 @@ describe("Lens cluster pages", () => {
     });
 
     describe("viewing pod logs", () => {
-      beforeEach(utils.wrapJestLifecycle(appStartAddCluster));
+      utils.beforeEachWrapped(appStartAddCluster);
 
-      afterEach(utils.wrapJestLifecycle(async () => {
+      utils.afterEachWrapped(async () => {
         if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      }));
+      });
 
       it(`shows a logs for a pod`, async () => {
         expect(clusterAdded).toBe(true);
@@ -389,13 +388,13 @@ describe("Lens cluster pages", () => {
     });
 
     describe("cluster operations", () => {
-      beforeEach(utils.wrapJestLifecycle(appStartAddCluster));
+      utils.beforeEachWrapped(appStartAddCluster);
 
-      afterEach(utils.wrapJestLifecycle(async () => {
+      utils.afterEachWrapped(async () => {
         if (app?.isRunning()) {
           return utils.tearDown(app);
         }
-      }));
+      });
 
       it("shows default namespace", async () => {
         expect(clusterAdded).toBe(true);

--- a/integration/__tests__/command-palette.tests.ts
+++ b/integration/__tests__/command-palette.tests.ts
@@ -7,13 +7,15 @@ describe("Lens command palette", () => {
   let app: Application;
 
   describe("menu", () => {
-    beforeAll(async () => app = await utils.appStart(), 20000);
+    beforeAll(utils.wrapJestLifecycle(async () => {
+      app = await utils.appStart();
+    }));
 
-    afterAll(async () => {
+    afterAll(utils.wrapJestLifecycle(async () => {
       if (app?.isRunning()) {
         await utils.tearDown(app);
       }
-    });
+    }));
 
     it("opens command dialog from menu", async () => {
       await utils.clickWhatsNew(app);

--- a/integration/__tests__/command-palette.tests.ts
+++ b/integration/__tests__/command-palette.tests.ts
@@ -7,15 +7,15 @@ describe("Lens command palette", () => {
   let app: Application;
 
   describe("menu", () => {
-    beforeAll(utils.wrapJestLifecycle(async () => {
+    utils.beforeAllWrapped(async () => {
       app = await utils.appStart();
-    }));
+    });
 
-    afterAll(utils.wrapJestLifecycle(async () => {
+    utils.afterAllWrapped(async () => {
       if (app?.isRunning()) {
         await utils.tearDown(app);
       }
-    }));
+    });
 
     it("opens command dialog from menu", async () => {
       await utils.clickWhatsNew(app);

--- a/integration/__tests__/workspace.tests.ts
+++ b/integration/__tests__/workspace.tests.ts
@@ -13,16 +13,16 @@ describe("Lens integration tests", () => {
   const ready = minikubeReady("workspace-int-tests");
 
   utils.describeIf(ready)("workspaces", () => {
-    beforeAll(async () => {
+    beforeAll(utils.wrapJestLifecycle(async () => {
       app = await utils.appStart();
       await utils.clickWhatsNew(app);
-    }, 20000);
+    }));
 
-    afterAll(async () => {
-      if (app && app.isRunning()) {
+    afterAll(utils.wrapJestLifecycle(async () => {
+      if (app?.isRunning()) {
         return utils.tearDown(app);
       }
-    });
+    }));
 
     const switchToWorkspace = async (name: string) => {
       await app.client.click("[data-test-id=current-workspace]");

--- a/integration/__tests__/workspace.tests.ts
+++ b/integration/__tests__/workspace.tests.ts
@@ -13,16 +13,16 @@ describe("Lens integration tests", () => {
   const ready = minikubeReady("workspace-int-tests");
 
   utils.describeIf(ready)("workspaces", () => {
-    beforeAll(utils.wrapJestLifecycle(async () => {
+    utils.beforeAllWrapped(async () => {
       app = await utils.appStart();
       await utils.clickWhatsNew(app);
-    }));
+    });
 
-    afterAll(utils.wrapJestLifecycle(async () => {
+    utils.afterAllWrapped(async () => {
       if (app?.isRunning()) {
         return utils.tearDown(app);
       }
-    }));
+    });
 
     const switchToWorkspace = async (name: string) => {
       await app.client.click("[data-test-id=current-workspace]");

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -8,6 +8,23 @@ const AppPaths: Partial<Record<NodeJS.Platform, string>> = {
   "darwin": "./dist/mac/Lens.app/Contents/MacOS/Lens",
 };
 
+interface DoneCallback {
+  (...args: any[]): any;
+  fail(error?: string | { message: string }): any;
+}
+
+/**
+ * This is necessary because Jest doesn't do this correctly.
+ * @param fn The function to call
+ */
+export function wrapJestLifecycle(fn: () => Promise<void>): (done: DoneCallback) => void {
+  return function (done: DoneCallback) {
+    fn()
+      .then(() => done())
+      .catch(error => done.fail(error));
+  };
+}
+
 export function itIf(condition: boolean) {
   return condition ? it : it.skip;
 }

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -25,6 +25,22 @@ export function wrapJestLifecycle(fn: () => Promise<void>): (done: DoneCallback)
   };
 }
 
+export function beforeAllWrapped(fn: () => Promise<void>): void {
+  beforeAll(wrapJestLifecycle(fn));
+}
+
+export function beforeEachWrapped(fn: () => Promise<void>): void {
+  beforeEach(wrapJestLifecycle(fn));
+}
+
+export function afterAllWrapped(fn: () => Promise<void>): void {
+  afterAll(wrapJestLifecycle(fn));
+}
+
+export function afterEachWrapped(fn: () => Promise<void>): void {
+  afterEach(wrapJestLifecycle(fn));
+}
+
 export function itIf(condition: boolean) {
   return condition ? it : it.skip;
 }


### PR DESCRIPTION
- Fail test if an async lifecycle function fails (though a bug in Jest means that the test body is still run)

Signed-off-by: Sebastian Malton <sebastian@malton.name>

part of splitting out #2003 