### PR TITLE
Refactor helm-release.api to use free functions instead of an object

### DIFF
--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -6,7 +6,7 @@ import isEqual from "lodash/isEqual";
 import { observable, reaction } from "mobx";
 import { Link } from "react-router-dom";
 import kebabCase from "lodash/kebabCase";
-import { HelmRelease, helmReleasesApi, IReleaseDetails } from "../../api/endpoints/helm-releases.api";
+import { getRelease, getReleaseValues, HelmRelease, IReleaseDetails } from "../../api/endpoints/helm-releases.api";
 import { HelmReleaseMenu } from "./release-menu";
 import { Drawer, DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
@@ -65,14 +65,14 @@ export class ReleaseDetails extends Component<Props> {
     const { release } = this.props;
 
     this.details = null;
-    this.details = await helmReleasesApi.get(release.getName(), release.getNs());
+    this.details = await getRelease(release.getName(), release.getNs());
   }
 
   async loadValues() {
     const { release } = this.props;
 
     this.values = "";
-    this.values = await helmReleasesApi.getValues(release.getName(), release.getNs());
+    this.values = await getReleaseValues(release.getName(), release.getNs());
   }
 
   updateValues = async () => {

--- a/src/renderer/components/+apps-releases/release-rollback-dialog.tsx
+++ b/src/renderer/components/+apps-releases/release-rollback-dialog.tsx
@@ -5,7 +5,7 @@ import { observable } from "mobx";
 import { observer } from "mobx-react";
 import { Dialog, DialogProps } from "../dialog";
 import { Wizard, WizardStep } from "../wizard";
-import { HelmRelease, helmReleasesApi, IReleaseRevision } from "../../api/endpoints/helm-releases.api";
+import { getReleaseHistory, HelmRelease, IReleaseRevision } from "../../api/endpoints/helm-releases.api";
 import { releaseStore } from "./release.store";
 import { Select, SelectOption } from "../select";
 import { Notifications } from "../notifications";
@@ -39,7 +39,7 @@ export class ReleaseRollbackDialog extends React.Component<Props> {
   onOpen = async () => {
     this.isLoading = true;
     const currentRevision = this.release.getRevision();
-    let releases = await helmReleasesApi.getHistory(this.release.getName(), this.release.getNs());
+    let releases = await getReleaseHistory(this.release.getName(), this.release.getNs());
 
     releases = releases.filter(item => item.revision !== currentRevision); // remove current
     releases = orderBy(releases, "revision", "desc"); // sort

--- a/src/renderer/components/dock/upgrade-chart.store.ts
+++ b/src/renderer/components/dock/upgrade-chart.store.ts
@@ -1,7 +1,7 @@
 import { action, autorun, IReactionDisposer, reaction } from "mobx";
 import { dockStore, IDockTab, TabId, TabKind } from "./dock.store";
 import { DockTabStore } from "./dock-tab.store";
-import { HelmRelease, helmReleasesApi } from "../../api/endpoints/helm-releases.api";
+import { getReleaseValues, HelmRelease } from "../../api/endpoints/helm-releases.api";
 import { releaseStore } from "../+apps-releases/release.store";
 
 export interface IChartUpgradeData {
@@ -89,7 +89,7 @@ export class UpgradeChartStore extends DockTabStore<IChartUpgradeData> {
   async loadValues(tabId: TabId) {
     this.values.clearData(tabId); // reset
     const { releaseName, releaseNamespace } = this.getData(tabId);
-    const values = await helmReleasesApi.getValues(releaseName, releaseNamespace);
+    const values = await getReleaseValues(releaseName, releaseNamespace);
 
     this.values.setData(tabId, values);
   }


### PR DESCRIPTION
- Rename functions to be more descriptive

- Change all functions to be Promise based

Signed-off-by: Sebastian Malton <sebastian@malton.name>

split off from #2003 

The change to promises is done in anticipation of removing `CancaliblePromise` in the final version of #2003 (since it is fundamentally broken and we should just use the native `AbortController` instead).