### PR TITLE
Lens should point to the release docs

### DIFF
--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -42,5 +42,8 @@ export const apiKubePrefix = "/api-kube"; // k8s cluster apis
 // Links
 export const issuesTrackerUrl = "https://github.com/lensapp/lens/issues";
 export const slackUrl = "https://join.slack.com/t/k8slens/shared_invite/enQtOTc5NjAyNjYyOTk4LWU1NDQ0ZGFkOWJkNTRhYTc2YjVmZDdkM2FkNGM5MjhiYTRhMDU2NDQ1MzIyMDA4ZGZlNmExOTc0N2JmY2M3ZGI";
-export const docsUrl = "https://docs.k8slens.dev/";
 export const supportUrl = "https://docs.k8slens.dev/latest/support/";
+
+const docsVersion = isProduction ? `v${packageInfo.version}` : "latest";
+
+export const docsUrl = `https://docs.k8slens.dev/${docsVersion}`;

--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -1,5 +1,6 @@
 // App's common configuration for any process (main, renderer, build pipeline, etc.)
 import path from "path";
+import { SemVer } from "semver";
 import packageInfo from "../../package.json";
 import { defineGlobal } from "./utils/defineGlobal";
 
@@ -44,6 +45,9 @@ export const issuesTrackerUrl = "https://github.com/lensapp/lens/issues";
 export const slackUrl = "https://join.slack.com/t/k8slens/shared_invite/enQtOTc5NjAyNjYyOTk4LWU1NDQ0ZGFkOWJkNTRhYTc2YjVmZDdkM2FkNGM5MjhiYTRhMDU2NDQ1MzIyMDA4ZGZlNmExOTc0N2JmY2M3ZGI";
 export const supportUrl = "https://docs.k8slens.dev/latest/support/";
 
-const docsVersion = isProduction ? `v${packageInfo.version}` : "latest";
+// This explicitly ignores the prerelease info on the package version
+const { major, minor, patch } = new SemVer(packageInfo.version);
+const mmpVersion = [major, minor, patch].join(".");
+const docsVersion = isProduction ? `v${mmpVersion}` : "latest";
 
 export const docsUrl = `https://docs.k8slens.dev/${docsVersion}`;


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

- On production builds Lens should point to its version of the docs.
- On dev builds it should point to latest (as the next version hasn't been released yet)