### PR TITLE
Add horizontal scrolling to NamespaceSelect

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select.scss
+++ b/src/renderer/components/+namespaces/namespace-select.scss
@@ -4,7 +4,7 @@
   }
 }
 
-.GradientControl {
+.GradientValueContainer {
   width: 8px;
   height: var(--font-size);
   position: absolute;

--- a/src/renderer/components/+namespaces/namespace-select.scss
+++ b/src/renderer/components/+namespaces/namespace-select.scss
@@ -4,6 +4,23 @@
   }
 }
 
+.GradientControl {
+  width: 8px;
+  height: var(--font-size);
+  position: absolute;
+  z-index: 20;
+
+  &.front {
+    left: 0px;
+    background: linear-gradient(to right, var(--layoutTabsBackground) 0px, transparent);
+  }
+
+  &.back {
+    right: 28px;
+    background: linear-gradient(to left, var(--layoutTabsBackground) 0px, transparent);
+  }
+}
+
 .NamespaceSelect {
   @include namespaceSelectCommon;
 
@@ -11,8 +28,15 @@
     &__placeholder {
       width: 100%;
       white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
+      overflow: scroll;
+      margin-left: -8px;
+      padding-left: 8px;
+      margin-right: -8px;
+      padding-right: 8px;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
   }
 }

--- a/src/renderer/components/+namespaces/namespace-select.scss
+++ b/src/renderer/components/+namespaces/namespace-select.scss
@@ -12,12 +12,12 @@
 
   &.front {
     left: 0px;
-    background: linear-gradient(to right, var(--layoutTabsBackground) 0px, transparent);
+    background: linear-gradient(to right, var(--contentColor) 0px, transparent);
   }
 
   &.back {
-    right: 28px;
-    background: linear-gradient(to left, var(--layoutTabsBackground) 0px, transparent);
+    right: 0px;
+    background: linear-gradient(to left, var(--contentColor) 0px, transparent);
   }
 }
 

--- a/src/renderer/components/+namespaces/namespace-select.tsx
+++ b/src/renderer/components/+namespaces/namespace-select.tsx
@@ -8,6 +8,7 @@ import { cssNames } from "../../utils";
 import { Icon } from "../icon";
 import { namespaceStore } from "./namespace.store";
 import { kubeWatchApi } from "../../api/kube-watch-api";
+import { components, ValueContainerProps } from "react-select";
 
 interface Props extends SelectProps {
   showIcons?: boolean;
@@ -20,6 +21,16 @@ const defaultProps: Partial<Props> = {
   showIcons: true,
   showClusterOption: false,
 };
+
+function GradientValueContainer<T>({children, ...rest}: ValueContainerProps<T>) {
+  return (
+    <components.ValueContainer {...rest}>
+      <div className="GradientValueContainer front" />
+      {children}
+      <div className="GradientValueContainer back" />
+    </components.ValueContainer>
+  );
+}
 
 @observer
 export class NamespaceSelect extends React.Component<Props> {
@@ -64,7 +75,9 @@ export class NamespaceSelect extends React.Component<Props> {
   };
 
   render() {
-    const { className, showIcons, customizeOptions, ...selectProps } = this.props;
+    const { className, showIcons, customizeOptions, components = {}, ...selectProps } = this.props;
+
+    components.ValueContainer ??= GradientValueContainer;
 
     return (
       <Select
@@ -72,6 +85,7 @@ export class NamespaceSelect extends React.Component<Props> {
         menuClass="NamespaceSelectMenu"
         formatOptionLabel={this.formatOptionLabel}
         options={this.options}
+        components={components}
         {...selectProps}
       />
     );

--- a/src/renderer/components/select/select.tsx
+++ b/src/renderer/components/select/select.tsx
@@ -103,6 +103,7 @@ export class Select extends React.Component<SelectProps> {
       value, options, components = {}, ...props
     } = this.props;
     const themeClass = `theme-${this.theme}`;
+    const WrappedMenu = components.Menu ?? Menu;
 
     const selectProps: Partial<SelectProps> = {
       ...props,
@@ -116,9 +117,9 @@ export class Select extends React.Component<SelectProps> {
       components: {
         ...components,
         Menu: props => (
-          <Menu
+          <WrappedMenu
             {...props}
-            className={cssNames(menuClass, themeClass)}
+            className={cssNames(menuClass, themeClass, props.className)}
           />
         ),
       }


### PR DESCRIPTION
- And by corollary `NamespaceSelectFilter`

- Also adds a gradient as a nudge to the user that the component is scrollable (when it is)

- Fix `Select` to properly pass in the additional classNames if a derived component also overrides the Menu component.

Signed-off-by: Sebastian Malton <sebastian@malton.name>


https://user-images.githubusercontent.com/8225332/109867339-60da6080-7c34-11eb-935a-12f45ba12ef1.mov

