### PR TITLE
VSCode launch configurations for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ types/extension-renderer-api.d.ts
 extensions/*/dist
 docs/extensions/api
 site/
-.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,8 +34,24 @@
             "name": "Integration Tests",
             "type": "node",
             "request": "launch",
-            "console": "externalTerminal",
-            "runtimeArgs": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "integration"],
+            "console": "integratedTerminal",
+            "runtimeArgs": [
+                "${workspaceFolder}/node_modules/.bin/jest",
+                "--runInBand",
+                "integration"
+            ],
         },
+        {
+            "name": "Unit Tests",
+            "type": "node",
+            "request": "launch",
+            "internalConsoleOptions": "openOnSessionStart",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "args": [
+                "--env=jsdom",
+                "-i",
+                "src"
+            ]
+        }
     ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,23 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Main Process",
             "type": "node",
             "request": "launch",
-            "name": "Integration tests",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+            "windows": {
+              "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+            },
+            "args" : ["."],
+            "outputCapture": "std"
+        },
+        {
+            "name": "Integration Tests",
+            "type": "node",
+            "request": "launch",
             "console": "externalTerminal",
             "runtimeArgs": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "integration"],
-        }
+        },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,26 @@
             "type": "node",
             "request": "launch",
             "cwd": "${workspaceFolder}",
+            "protocol": "inspector",
+            "preLaunchTask": "compile-dev",
             "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
             "windows": {
               "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
             },
-            "args" : ["."],
+            "runtimeArgs": [
+                "--remote-debugging-port=9223",
+                "--inspect",
+                "."
+            ],
             "outputCapture": "std"
+        },
+        {
+            "name": "Renderer Process",
+            "type": "pwa-chrome",
+            "request": "attach",
+            "port": 9223,
+            "webRoot": "${workspaceFolder}",
+            "timeout": 30000
         },
         {
             "name": "Integration Tests",
@@ -23,5 +37,5 @@
             "console": "externalTerminal",
             "runtimeArgs": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "integration"],
         },
-    ]
+    ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Integration tests",
+            "console": "externalTerminal",
+            "runtimeArgs": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "integration"],
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,34 +5,12 @@
     "tasks": [
         {
             "type": "shell",
-            "label": "dev-server-renderer",
-            "group": "build",
-            "command": "yarn",
-            "args": [
-                "run",
-                "dev:renderer",
-                "&"
-            ],
-            "isBackground": true,
-            "problemMatcher": {
-                "background": {
-                    "activeOnStart": false,
-                    "beginsPattern": "Compiling\\.\\.\\.$",
-                    "endsPattern": "^No issues found\\.$"
-                }
-            }
-        },
-        {
-            "type": "shell",
             "group": "build",
             "command": "yarn",
             "args": [
                 "debug-build"
             ],
             "problemMatcher": [],
-            // "dependsOn": [
-            //     "dev-server-renderer"
-            // ],
             "label": "compile-dev",
             "detail": "Compiles main and extension types"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "dev-server-renderer",
+            "group": "build",
+            "command": "yarn",
+            "args": [
+                "run",
+                "dev:renderer",
+                "&"
+            ],
+            "isBackground": true,
+            "problemMatcher": {
+                "background": {
+                    "activeOnStart": false,
+                    "beginsPattern": "Compiling\\.\\.\\.$",
+                    "endsPattern": "^No issues found\\.$"
+                }
+            }
+        },
+        {
+            "type": "shell",
+            "group": "build",
+            "command": "yarn",
+            "args": [
+                "debug-build"
+            ],
+            "problemMatcher": [],
+            // "dependsOn": [
+            //     "dev-server-renderer"
+            // ],
+            "label": "compile-dev",
+            "detail": "Compiles main and extension types"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "conf": "^7.0.1",
     "crypto-js": "^4.0.0",
     "electron-devtools-installer": "^3.1.1",
-    "electron-is-dev": "^2.0.0",
     "electron-updater": "^4.3.1",
     "electron-window-state": "^5.0.3",
     "filenamify": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "dev": "concurrently -k \"yarn run dev-run -C\" yarn:dev:*",
     "dev-build": "concurrently yarn:compile:*",
-    "dev-run": "nodemon --watch static/build/main.js --exec \"electron --inspect .\"",
+    "debug-build": "concurrently yarn:compile:main yarn:compile:extension-types",
+    "dev-run": "nodemon --watch static/build/main.js --exec \"electron --remote-debugging-port=9223 --inspect .\"",
     "dev:main": "yarn run compile:main --watch",
     "dev:renderer": "yarn run webpack-dev-server --config webpack.renderer.ts",
     "dev:extension-types": "yarn run compile:extension-types --watch --progress",
@@ -196,6 +197,7 @@
     "conf": "^7.0.1",
     "crypto-js": "^4.0.0",
     "electron-devtools-installer": "^3.1.1",
+    "electron-is-dev": "^2.0.0",
     "electron-updater": "^4.3.1",
     "electron-window-state": "^5.0.3",
     "filenamify": "^4.1.0",

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -1,6 +1,7 @@
 import "./components/app.scss";
 
 import React from "react";
+import { remote } from "electron";
 import * as Mobx from "mobx";
 import * as MobxReact from "mobx-react";
 import * as ReactRouter from "react-router";
@@ -18,6 +19,17 @@ import { filesystemProvisionerStore } from "../main/extension-filesystem";
 import { App } from "./components/app";
 import { LensApp } from "./lens-app";
 import { themeStore } from "./theme.store";
+
+/**
+ * If this is a development buid, wait a second to attach
+ * Chrome Debugger to renderer process
+ * https://stackoverflow.com/questions/52844870/debugging-electron-renderer-process-with-vscode
+ */
+async function attachChromeDebugger() {
+  if (remote.process.defaultApp) {
+    await new Promise(r => setTimeout(r, 1000));
+  }
+}
 
 type AppComponent = React.ComponentType & {
   init?(): Promise<void>;
@@ -75,3 +87,4 @@ export async function bootstrap(App: AppComponent) {
 
 // run
 bootstrap(process.isMainFrame ? LensApp : App);
+attachChromeDebugger();

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -47,6 +47,7 @@ export {
 export async function bootstrap(App: AppComponent) {
   const rootElem = document.getElementById("app");
 
+  await attachChromeDebugger();
   rootElem.classList.toggle("is-mac", isMac);
 
   extensionLoader.init();
@@ -87,4 +88,3 @@ export async function bootstrap(App: AppComponent) {
 
 // run
 bootstrap(process.isMainFrame ? LensApp : App);
-await attachChromeDebugger();

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -8,6 +8,7 @@ import * as ReactRouterDom from "react-router-dom";
 import { render, unmountComponentAtNode } from "react-dom";
 import { clusterStore } from "../common/cluster-store";
 import { userStore } from "../common/user-store";
+import { delay } from "../common/utils";
 import { isMac, isDevelopment } from "../common/vars";
 import { workspaceStore } from "../common/workspace-store";
 import * as LensExtensions from "../extensions/extension-api";

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -26,7 +26,7 @@ import { themeStore } from "./theme.store";
  */
 async function attachChromeDebugger() {
   if (isDevelopment) {
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await delay(1000);
   }
 }
 

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -27,7 +27,7 @@ import { themeStore } from "./theme.store";
  */
 async function attachChromeDebugger() {
   if (remote.process.defaultApp) {
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1000));
   }
 }
 

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -1,7 +1,6 @@
 import "./components/app.scss";
 
 import React from "react";
-import { remote } from "electron";
 import * as Mobx from "mobx";
 import * as MobxReact from "mobx-react";
 import * as ReactRouter from "react-router";
@@ -9,7 +8,7 @@ import * as ReactRouterDom from "react-router-dom";
 import { render, unmountComponentAtNode } from "react-dom";
 import { clusterStore } from "../common/cluster-store";
 import { userStore } from "../common/user-store";
-import { isMac } from "../common/vars";
+import { isMac, isDevelopment } from "../common/vars";
 import { workspaceStore } from "../common/workspace-store";
 import * as LensExtensions from "../extensions/extension-api";
 import { extensionDiscovery } from "../extensions/extension-discovery";
@@ -26,7 +25,7 @@ import { themeStore } from "./theme.store";
  * https://stackoverflow.com/questions/52844870/debugging-electron-renderer-process-with-vscode
  */
 async function attachChromeDebugger() {
-  if (remote.process.defaultApp) {
+  if (isDevelopment) {
     await new Promise(resolve => setTimeout(resolve, 1000));
   }
 }

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -87,4 +87,4 @@ export async function bootstrap(App: AppComponent) {
 
 // run
 bootstrap(process.isMainFrame ? LensApp : App);
-attachChromeDebugger();
+await attachChromeDebugger();


### PR DESCRIPTION
## Changes
 - `/.gitignore` - Remove `.vscode` directory from;
 - `/.vscode/launch.json` - Add launch configurations for debugging Electron's renderer and main processes, unit and integrations tests;
 - `/package.json` - Add `debug-build` script to build main process for debugging;
 - `/.vscode/tasks.json` - Add a task to build main process for debugging;
 - `/src/renderer/bootstrap.tsx` - Add code to wait for Chrome debugger attachment in development builds.

## Debugging workflow
### Main process
1. In a separate terminal launch dev-server (`yarn dev:renderer`) so Electron can pull renderer resources from it;
1. Set up breakpoints in VSCode or use `debugger` keyword;
1. Use `Main Process` configuration to launch.

### Renderer Process
1. Launch dev build (`make dev`);
1. Set up breakpoints in VSCode or use `debugger` keyword;
1. Use `Renderer Process` configuration to attach debugger.

**Note:** Since VSCode doesn't support background dependent tasks in launch configurations, I couldn't find a setup that would allow to debug both main and renderer processes in Electron simultaneously.

### Integration and Unit Tests
1. Set up breakpoints in VSCode or use `debugger` keyword;
1. Use `Integration Tests` and `Unit Tests` configurations respectively.

 