### PR TITLE
Fixing workspace menu icon color

### DIFF
--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -35,7 +35,7 @@
       margin-bottom: $margin * 1.5;
       border-radius: $radius;
       padding: $padding / 3;
-      color: #ffffff66;
+      color: var(--textColorPrimary);
       background: unset;
       cursor: pointer;
 
@@ -45,7 +45,7 @@
 
       &:hover {
         box-shadow: none;
-        color: #ffffff;
+        color: var(--textColorAccent);
         background-color: unset;
       }
     }


### PR DESCRIPTION
Fixing menu icon color mainly for light theme.

Workspace icon before the fix:
![white workspace icon](https://user-images.githubusercontent.com/9607060/110920203-29536e80-832e-11eb-8361-76ce5cf487a0.png)

After the fix:
![workspace menu icon](https://user-images.githubusercontent.com/9607060/110920025-f4dfb280-832d-11eb-98e5-789bf46d6907.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>