### PR TITLE
Fix: cluster-settings page back-button navigation is broken

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -138,13 +138,12 @@ export class WindowManager extends Singleton {
 
   async navigate(url: string, frameId?: number) {
     await this.ensureMainWindow();
-    let frameInfo: ClusterFrameInfo;
 
-    if (frameId) {
-      frameInfo = Array.from(clusterFrameMap.values()).find((frameInfo) => frameInfo.frameId === frameId);
-    }
+    const frameInfo = Array.from(clusterFrameMap.values()).find((frameInfo) => frameInfo.frameId === frameId);
+    const channel = frameInfo ? "renderer:navigate-in-cluster" : "renderer:navigate";
+
     this.sendToView({
-      channel: "renderer:navigate",
+      channel,
       frameInfo,
       data: [url],
     });

--- a/src/renderer/navigation/events.ts
+++ b/src/renderer/navigation/events.ts
@@ -10,22 +10,37 @@ export function bindEvents() {
   }
 
   if (process.isMainFrame) {
-    // Keep track of active cluster-id for handling IPC/menus/etc.
-    reaction(() => getMatchedClusterId(), clusterId => {
-      broadcastMessage("cluster-view:current-id", clusterId);
-    }, {
-      fireImmediately: true
-    });
+    bindClusterManagerRouteEvents();
+  } else {
+    bindClusterFrameRouteEvents();
   }
-
-  // Handle navigation via IPC (e.g. from top menu)
-  subscribeToBroadcast("renderer:navigate", (event, url: string) => {
-    logger.info(`[IPC]: ${event.type} ${JSON.stringify(url)}`, event);
-    navigate(url);
-  });
 
   // Reload dashboard window
   subscribeToBroadcast("renderer:reload", () => {
     location.reload();
+  });
+}
+
+// Handle events only in main window renderer process (see also: cluster-manager.tsx)
+function bindClusterManagerRouteEvents() {
+  // Keep track of active cluster-id for handling IPC/menus/etc.
+  reaction(() => getMatchedClusterId(), clusterId => {
+    broadcastMessage("cluster-view:current-id", clusterId);
+  }, {
+    fireImmediately: true
+  });
+
+  // Handle navigation via IPC
+  subscribeToBroadcast("renderer:navigate", (event, url: string) => {
+    logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
+    navigate(url);
+  });
+}
+
+// Handle cluster-view renderer process events within iframes
+function bindClusterFrameRouteEvents() {
+  subscribeToBroadcast("renderer:navigate-cluster-view", (event, url: string) => {
+    logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
+    navigate(url);
   });
 }


### PR DESCRIPTION
Broadcasting IPC event `renderer:navigate` from cluster-view (iframe -> main-layout-header) was triggered within iframe too which is not desired behaviour.

_Before_

https://user-images.githubusercontent.com/6377066/110957068-f15f2200-8353-11eb-91f2-4ce19d225eb4.mov

_After:_

https://user-images.githubusercontent.com/6377066/110957050-ed330480-8353-11eb-875d-fb70fb653b5d.mov
