### PR TITLE
Start hidden on autostart

### DIFF
--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -74,7 +74,11 @@ export class UserStore extends BaseStore<UserStoreModel> {
 
       // open at system start-up
       reaction(() => this.preferences.openAtLogin, openAtLogin => {
-        app.setLoginItemSettings({ openAtLogin });
+        app.setLoginItemSettings({ 
+          openAtLogin,
+          openAsHidden: true,
+          args: ["--hidden"]
+        });
       }, {
         fireImmediately: true,
       });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import "../common/prometheus-providers";
 import * as Mobx from "mobx";
 import * as LensExtensions from "../extensions/core-api";
 import { app, autoUpdater, ipcMain, dialog, powerMonitor } from "electron";
-import { appName } from "../common/vars";
+import { appName, isMac } from "../common/vars";
 import path from "path";
 import { LensProxy } from "./lens-proxy";
 import { WindowManager } from "./window-manager";
@@ -151,8 +151,16 @@ app.on("ready", async () => {
   extensionLoader.init();
   extensionDiscovery.init();
 
+  // Start the app without showing the main window when auto starting on login
+  // (On Windows and Linux, we get a flag. On MacOS, we get special API.)
+  const startHidden = process.argv.includes("--hidden") || (isMac && app.getLoginItemSettings().wasOpenedAsHidden);
+
   logger.info("🖥️  Starting WindowManager");
   windowManager = WindowManager.getInstance<WindowManager>(proxyPort);
+
+  if (!startHidden) {
+    windowManager.initMainWindow();
+  }
 
   ipcMain.on("renderer:loaded", () => {
     startUpdateChecking();

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -23,7 +23,6 @@ export class WindowManager extends Singleton {
     this.bindEvents();
     this.initMenu();
     this.initTray();
-    this.initMainWindow();
   }
 
   get mainUrl() {


### PR DESCRIPTION
Makes autostart lighter & less annoying. Also helps with `main` extension development because a developer can start Lens with `--hidden`.