### PR TITLE
Restrict what vesions of node-pty can be downloaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "mobx-react": "^6.2.2",
     "mock-fs": "^4.12.0",
     "moment": "^2.26.0",
-    "node-pty": "^0.9.0",
+    "node-pty": "~0.9.0",
     "npm": "^6.14.8",
     "openid-client": "^3.15.2",
     "p-limit": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9571,7 +9571,7 @@ node-notifier@^7.0.0:
     uuid "^7.0.3"
     which "^2.0.2"
 
-node-pty@^0.9.0:
+node-pty@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
   integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This is needed because `0.10.0` is for a newer version of node. And CI is currently broken.