### PR TITLE
Move clearKubeconfigEnvVars to separate file

### DIFF
--- a/src/main/__test__/shell-session.test.ts
+++ b/src/main/__test__/shell-session.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { clearKubeconfigEnvVars } from "../shell-session";
+import { clearKubeconfigEnvVars } from "../utils/clear-kube-env-vars";
 
 describe("clearKubeconfigEnvVars tests", () => {
   it("should not touch non kubeconfig keys", () => {

--- a/src/main/shell-session.ts
+++ b/src/main/shell-session.ts
@@ -11,23 +11,7 @@ import { helmCli } from "./helm/helm-cli";
 import { isWindows } from "../common/vars";
 import { appEventBus } from "../common/event-bus";
 import { userStore } from "../common/user-store";
-
-const anyKubeconfig = /^kubeconfig$/i;
-
-/**
- * This function deletes all keys of the form /^kubeconfig$/i, returning a new
- * object.
- *
- * This is needed because `kubectl` checks for other version of kubeconfig
- * before KUBECONFIG and we only set KUBECONFIG.
- * @param env The current copy of env
- */
-export function clearKubeconfigEnvVars(env: Record<string, any>): Record<string, any> {
-  return Object.fromEntries(
-    Object.entries(env)
-      .filter(([key]) => anyKubeconfig.exec(key) === null)
-  );
-}
+import { clearKubeconfigEnvVars } from "./utils/clear-kube-env-vars";
 
 export class ShellSession extends EventEmitter {
   static shellEnvs: Map<string, any> = new Map();

--- a/src/main/utils/clear-kube-env-vars.ts
+++ b/src/main/utils/clear-kube-env-vars.ts
@@ -1,0 +1,16 @@
+const anyKubeconfig = /^kubeconfig$/i;
+
+/**
+ * This function deletes all keys of the form /^kubeconfig$/i, returning a new
+ * object.
+ *
+ * This is needed because `kubectl` checks for other version of kubeconfig
+ * before KUBECONFIG and we only set KUBECONFIG.
+ * @param env The current copy of env
+ */
+export function clearKubeconfigEnvVars(env: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(env)
+      .filter(([key]) => anyKubeconfig.exec(key) === null)
+  );
+}


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Apparently `jest` doesn't pick the correct node version or something. So I am just going to move this code into a separate module so that the tests don't try an import `node-pty`.