### PR TITLE
Fix workspace overview switching and enabled state storage

### DIFF
--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -26,6 +26,8 @@ export interface WorkspaceState {
   enabled: boolean;
 }
 
+const updateFromModel = Symbol("updateFromModel");
+
 /**
  * Workspace
  *
@@ -130,7 +132,7 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
     Object.assign(this, state);
   }
 
-  @action updateModel(model: WorkspaceModel) {
+  @action [updateFromModel](model: WorkspaceModel) {
     Object.assign(this, model);
   }
 
@@ -251,10 +253,9 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
 
   @action
   addWorkspace(workspace: Workspace) {
-    workspace.name = workspace.name.trim();
     const { id, name } = workspace;
 
-    if (!name || this.getByName(name)) {
+    if (!name.trim() || this.getByName(name.trim())) {
       return;
     }
     this.workspaces.set(id, workspace);
@@ -312,7 +313,7 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
       const oldWorkspace = this.workspaces.get(workspaceModel.id);
 
       if (oldWorkspace) {
-        oldWorkspace.updateModel(workspaceModel);
+        oldWorkspace[updateFromModel](workspaceModel);
       } else {
         this.workspaces.set(workspaceModel.id, new Workspace(workspaceModel));
       }

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -310,7 +310,7 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
     }
 
     const currentWorkspaces = this.workspaces.toJS();
-    const newWorkspaceIds = new Set<WorkspaceId>();
+    const newWorkspaceIds = new Set<WorkspaceId>([WorkspaceStore.defaultId]); // never delete default
 
     for (const workspaceModel of workspaces) {
       const oldWorkspace = this.workspaces.get(workspaceModel.id);

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -309,6 +309,9 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
       this.currentWorkspaceId = currentWorkspace;
     }
 
+    const currentWorkspaces = this.workspaces.toJS();
+    const newWorkspaceIds = new Set<WorkspaceId>();
+
     for (const workspaceModel of workspaces) {
       const oldWorkspace = this.workspaces.get(workspaceModel.id);
 
@@ -316,6 +319,15 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
         oldWorkspace[updateFromModel](workspaceModel);
       } else {
         this.workspaces.set(workspaceModel.id, new Workspace(workspaceModel));
+      }
+
+      newWorkspaceIds.add(workspaceModel.id);
+    }
+
+    // remove deleted workspaces
+    for (const workspaceId of currentWorkspaces.keys()) {
+      if (!newWorkspaceIds.has(workspaceId)) {
+        this.workspaces.delete(workspaceId);
       }
     }
   }

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -114,7 +114,7 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
   /**
    * Push state
    *
-   * @interal
+   * @internal
    * @param state workspace state
    */
   pushState(state = this.getState()) {
@@ -128,6 +128,10 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
    */
   @action setState(state: WorkspaceState) {
     Object.assign(this, state);
+  }
+
+  @action updateModel(model: WorkspaceModel) {
+    Object.assign(this, model);
   }
 
   toJSON(): WorkspaceModel {
@@ -247,9 +251,10 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
 
   @action
   addWorkspace(workspace: Workspace) {
+    workspace.name = workspace.name.trim();
     const { id, name } = workspace;
 
-    if (!name.trim() || this.getByName(name.trim())) {
+    if (!name || this.getByName(name)) {
       return;
     }
     this.workspaces.set(id, workspace);
@@ -303,16 +308,14 @@ export class WorkspaceStore extends BaseStore<WorkspaceStoreModel> {
       this.currentWorkspaceId = currentWorkspace;
     }
 
-    if (workspaces.length) {
-      this.workspaces.clear();
-      workspaces.forEach(ws => {
-        const workspace = new Workspace(ws);
+    for (const workspaceModel of workspaces) {
+      const oldWorkspace = this.workspaces.get(workspaceModel.id);
 
-        if (!workspace.isManaged) {
-          workspace.enabled = true;
-        }
-        this.workspaces.set(workspace.id, workspace);
-      });
+      if (oldWorkspace) {
+        oldWorkspace.updateModel(workspaceModel);
+      } else {
+        this.workspaces.set(workspaceModel.id, new Workspace(workspaceModel));
+      }
     }
   }
 

--- a/src/common/workspace-store.ts
+++ b/src/common/workspace-store.ts
@@ -132,9 +132,9 @@ export class Workspace implements WorkspaceModel, WorkspaceState {
     Object.assign(this, state);
   }
 
-  @action [updateFromModel](model: WorkspaceModel) {
+  [updateFromModel] = action((model: WorkspaceModel) => {
     Object.assign(this, model);
-  }
+  });
 
   toJSON(): WorkspaceModel {
     return toJS({

--- a/src/renderer/components/+landing-page/landing-page.tsx
+++ b/src/renderer/components/+landing-page/landing-page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { computed, observable } from "mobx";
 import { observer } from "mobx-react";
 import { clusterStore } from "../../../common/cluster-store";
-import { Workspace, workspaceStore } from "../../../common/workspace-store";
+import { workspaceStore } from "../../../common/workspace-store";
 import { WorkspaceOverview } from "./workspace-overview";
 import { PageLayout } from "../layout/page-layout";
 import { Notifications } from "../notifications";
@@ -13,13 +13,9 @@ import { Icon } from "../icon";
 export class LandingPage extends React.Component {
   @observable showHint = true;
 
-  get workspace(): Workspace {
-    return workspaceStore.currentWorkspace;
-  }
-
   @computed
   get clusters() {
-    return clusterStore.getByWorkspaceId(this.workspace.id);
+    return clusterStore.getByWorkspaceId(workspaceStore.currentWorkspaceId);
   }
 
   componentDidMount() {
@@ -36,11 +32,11 @@ export class LandingPage extends React.Component {
 
   render() {
     const showBackButton = this.clusters.length > 0;
-    const header = <><Icon svg="logo-lens" big /> <h2>{this.workspace.name}</h2></>;
+    const header = <><Icon svg="logo-lens" big /> <h2>{workspaceStore.currentWorkspace.name}</h2></>;
 
     return (
       <PageLayout className="LandingOverview flex" header={header} provideBackButtonNavigation={showBackButton} showOnTop={true}>
-        <WorkspaceOverview workspace={this.workspace}/>
+        <WorkspaceOverview />
       </PageLayout>
     );
   }


### PR DESCRIPTION
- Workspaces that are managed can now be enabled without the store removing that flag unconditionally via a roundtrip to the FS

- Workspace overview should be reactive to its computed prop

Signed-off-by: Sebastian Malton <sebastian@malton.name>