### PR TITLE
Fix custom resource loading spinner appears above extensions' cluster menus

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -271,7 +271,7 @@ export class Sidebar extends React.Component<Props> {
             icon={<Icon material="extension"/>}
           >
             {this.renderTreeFromTabRoutes(CustomResources.tabRoutes)}
-            {this.crdSubMenus}
+            {this.renderCustomResources()}
           </SidebarItem>
           {this.renderRegisteredMenus()}
         </div>

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -2,7 +2,6 @@ import "./sidebar.scss";
 import type { TabLayoutRoute } from "./tab-layout";
 
 import React from "react";
-import { computed } from "mobx";
 import { observer } from "mobx-react";
 import { NavLink } from "react-router-dom";
 import { cssNames } from "../../utils";
@@ -45,9 +44,9 @@ export class Sidebar extends React.Component<Props> {
     crdStore.reloadAll();
   }
 
-  @computed get crdSubMenus(): React.ReactNode {
-    if (!crdStore.isLoaded && crdStore.isLoading) {
-      return <Spinner centerHorizontal/>;
+  renderCustomResources() {
+    if (crdStore.isLoading) {
+      return <Spinner centerHorizontal />;
     }
 
     return Object.entries(crdStore.groups).map(([group, crds]) => {

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -46,7 +46,11 @@ export class Sidebar extends React.Component<Props> {
 
   renderCustomResources() {
     if (crdStore.isLoading) {
-      return <Spinner centerHorizontal />;
+      return (
+        <div className="flex justify-center">
+          <Spinner />
+        </div>
+      );
     }
 
     return Object.entries(crdStore.groups).map(([group, crds]) => {

--- a/src/renderer/components/spinner/spinner.scss
+++ b/src/renderer/components/spinner/spinner.scss
@@ -34,10 +34,6 @@
     margin-top: calc(var(--spinner-size) / -2);
   }
 
-  &.centerHorizontal {
-    margin-left: 50%;
-  }
-
   @keyframes rotate {
     0% {
       transform: rotate(0deg);

--- a/src/renderer/components/spinner/spinner.scss
+++ b/src/renderer/components/spinner/spinner.scss
@@ -35,9 +35,7 @@
   }
 
   &.centerHorizontal {
-    position: absolute;
-    left: 50%;
-    margin-left: calc(var(--spinner-size) / -2);
+    margin-left: 50%;
   }
 
   @keyframes rotate {

--- a/src/renderer/components/spinner/spinner.tsx
+++ b/src/renderer/components/spinner/spinner.tsx
@@ -6,19 +6,17 @@ import { cssNames } from "../../utils";
 export interface SpinnerProps extends React.HTMLProps<any> {
   singleColor?: boolean;
   center?: boolean;
-  centerHorizontal?: boolean;
 }
 
 export class Spinner extends React.Component<SpinnerProps, {}> {
   static defaultProps = {
     singleColor: true,
     center: false,
-    centerHorizontal: false,
   };
 
   render() {
-    const { center, singleColor, centerHorizontal, className, ...props } = this.props;
-    const classNames = cssNames("Spinner", className, { singleColor, center, centerHorizontal });
+    const { center, singleColor, className, ...props } = this.props;
+    const classNames = cssNames("Spinner", className, { singleColor, center });
 
     return <div {...props} className={classNames} />;
   }

--- a/src/renderer/components/spinner/spinner.tsx
+++ b/src/renderer/components/spinner/spinner.tsx
@@ -13,6 +13,7 @@ export class Spinner extends React.Component<SpinnerProps, {}> {
   static defaultProps = {
     singleColor: true,
     center: false,
+    centerHorizontal: false,
   };
 
   render() {


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Before:
---
https://user-images.githubusercontent.com/8225332/111351143-3f786c00-8659-11eb-9d05-54a9fd610a1b.mov

After:
---
https://user-images.githubusercontent.com/8225332/111350879-f3c5c280-8658-11eb-9a0c-d75ff54a0f5d.mov

