### PR TITLE
Fix: closing workspace menu after clicking on iframe

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -11,10 +11,6 @@
     grid-area: main;
     position: relative;
     display: flex;
-
-    > * {
-      z-index: 1;
-    }
   }
 
   .ClustersMenu {
@@ -33,6 +29,7 @@
     bottom: 0;
     display: flex;
     background-color: $mainBackground;
+    z-index: 1;
 
     iframe {
       flex: 1;

--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -61,3 +61,7 @@
     }
   }
 }
+
+.Menu.WorkspaceMenu {
+  z-index: 2; // Place behind Preferences, Extension pages etc...
+}

--- a/src/renderer/components/layout/page-layout.scss
+++ b/src/renderer/components/layout/page-layout.scss
@@ -31,7 +31,7 @@
   // covers whole app view area
   &.showOnTop {
     position: fixed !important; // allow to cover ClustersMenu
-    z-index: 1;
+    z-index: 3;
     left: 0;
     top: 0;
     right: 0;

--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -82,6 +82,7 @@ export class Menu extends React.Component<MenuProps, State> {
     window.addEventListener("click", this.onClickOutside, true);
     window.addEventListener("scroll", this.onScrollOutside, true);
     window.addEventListener("contextmenu", this.onContextMenu, true);
+    window.addEventListener("blur", this.onBlur, true);
   }
 
   componentWillUnmount() {
@@ -228,6 +229,12 @@ export class Menu extends React.Component<MenuProps, State> {
     const clickOnOpener = this.opener && this.opener.contains(target);
 
     if (!clickInsideMenu && !clickOnOpener) {
+      this.close();
+    }
+  }
+
+  onBlur() {
+    if (document.activeElement?.tagName == "IFRAME") {
       this.close();
     }
   }


### PR DESCRIPTION
`iframe` doesn't have `onClick` event handler, but it's possible to work with `window.onBlur` and `document.activeElement` to detect such "clicks".

![closing workspace menu](https://user-images.githubusercontent.com/9607060/111444204-2fc15c00-871b-11eb-9b55-19baec17fa24.gif)

Fixes #2317 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>