### PR TITLE
Save sorting order when changing view

### DIFF
--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -134,6 +134,7 @@ export class ClusterIssues extends React.Component<Props> {
           <>Warnings: {warnings.length}</>
         </SubHeader>
         <Table
+          tableId="cluster_issues"
           items={warnings}
           virtual
           selectable

--- a/src/renderer/components/+pod-security-policies/pod-security-policies.tsx
+++ b/src/renderer/components/+pod-security-policies/pod-security-policies.tsx
@@ -20,7 +20,7 @@ export class PodSecurityPolicies extends React.Component {
     return (
       <KubeObjectListLayout
         isConfigurable
-        tableId="access_roles"
+        tableId="access_pod_security_policies"
         className="PodSecurityPolicies"
         isClusterScoped={true}
         store={podSecurityPoliciesStore}

--- a/src/renderer/components/+storage-volumes/volume-details-list.tsx
+++ b/src/renderer/components/+storage-volumes/volume-details-list.tsx
@@ -64,6 +64,7 @@ export class VolumeDetailsList extends React.Component<Props> {
       <div className="VolumeDetailsList flex column">
         <DrawerTitle title="Persistent Volumes"/>
         <Table
+          tableId="storage_volume_details_list"
           items={persistentVolumes}
           selectable
           virtual={virtual}

--- a/src/renderer/components/+workloads-pods/pod-details-list.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-list.tsx
@@ -135,6 +135,7 @@ export class PodDetailsList extends React.Component<Props> {
       <div className="PodDetailsList flex column">
         {showTitle && <DrawerTitle title="Pods"/>}
         <Table
+          tableId="workloads_pod_details_list"
           items={pods}
           selectable
           virtual={virtual}

--- a/src/renderer/components/+workloads-pods/pod-tolerations.tsx
+++ b/src/renderer/components/+workloads-pods/pod-tolerations.tsx
@@ -43,6 +43,7 @@ const getTableRow = (toleration: IToleration) => {
 export function PodTolerations({ tolerations }: Props) {
   return (
     <Table
+      tableId="workloads_pod_tolerations"
       selectable
       scrollable={false}
       sortable={sortingCallbacks}

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -413,7 +413,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
   renderList() {
     const {
       store, hasDetailsView, addRemoveButtons = {}, virtual, sortingCallbacks, detailsItem,
-      tableProps = {},
+      tableProps = {}, tableId
     } = this.props;
     const { isReady, removeItemsDialog, items } = this;
     const { selectedItems } = store;
@@ -426,6 +426,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
         )}
         {isReady && (
           <Table
+            tableId={tableId}
             virtual={virtual}
             selectable={hasDetailsView}
             sortable={sortingCallbacks}

--- a/src/renderer/components/table/table.storage.ts
+++ b/src/renderer/components/table/table.storage.ts
@@ -1,0 +1,22 @@
+import { createStorage } from "../../utils";
+import { TableSortParams } from "./table";
+
+export interface TableStorageModel {
+  sortParams: {
+    [tableId: string]: Partial<TableSortParams>;
+  }
+}
+
+export const tableStorage = createStorage<TableStorageModel>("table_settings", {
+  sortParams: {}
+});
+
+export function getSortParams(tableId: string): Partial<TableSortParams> {
+  return tableStorage.get().sortParams[tableId];
+}
+
+export function setSortParams(tableId: string, sortParams: Partial<TableSortParams>) {
+  tableStorage.merge(draft => {
+    draft.sortParams[tableId] = sortParams;
+  });
+}


### PR DESCRIPTION
The commit allows you to keep sorting order. It saves params to local storage 


Fixes: https://github.com/lensapp/lens/issues/763