### PR TITLE
Fix global pages z-index order

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -29,7 +29,6 @@
     bottom: 0;
     display: flex;
     background-color: $mainBackground;
-    z-index: 1;
 
     iframe {
       flex: 1;


### PR DESCRIPTION
Removing explicit z-index in `#lens-views` solving the issue.

<img width="909" alt="visible extension" src="https://user-images.githubusercontent.com/9607060/111609781-b180ba80-87eb-11eb-88f9-247a66bd8a4d.png">

Fixes #2357 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>