### PR TITLE
Set initial cursor position for the editor to beginning

### DIFF
--- a/src/renderer/components/ace-editor/ace-editor.tsx
+++ b/src/renderer/components/ace-editor/ace-editor.tsx
@@ -32,6 +32,7 @@ const defaultProps: Partial<Props> = {
   useWorker: false,
   onBlur: noop,
   onFocus: noop,
+  cursorPos: { row: 0, column: 0 },
 };
 
 @observer


### PR DESCRIPTION
Fixes the issue of jumping cursor from start to the end for newly created tabs for editing resources.

close #2376

https://user-images.githubusercontent.com/6377066/112337118-50168b00-8cc6-11eb-8b9a-ce0059158659.mov
