### PR TITLE
fix: proper sorting resources by age column (#2182 followup)

### DIFF
--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -71,7 +71,7 @@ export class ClusterIssues extends React.Component<Props> {
       warnings.push({
         getId: () => uid,
         getName: () => name,
-          timeDiffFromNow: getTimeDiffFromNow(),
+        timeDiffFromNow: getTimeDiffFromNow(),
         age: getAge(),
         message,
         kind,

--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -24,6 +24,7 @@ interface IWarning extends ItemObject {
   message: string;
   selfLink: string;
   age: string | number;
+  getTimeDiffFromNow(): number;
 }
 
 enum sortBy {
@@ -37,7 +38,7 @@ export class ClusterIssues extends React.Component<Props> {
   private sortCallbacks = {
     [sortBy.type]: (warning: IWarning) => warning.kind,
     [sortBy.object]: (warning: IWarning) => warning.getName(),
-    [sortBy.age]: (warning: IWarning) => warning.age || "",
+    [sortBy.age]: (warning: IWarning) => warning.getTimeDiffFromNow(),
   };
 
   @computed get warnings() {
@@ -45,13 +46,14 @@ export class ClusterIssues extends React.Component<Props> {
 
     // Node bad conditions
     nodesStore.items.forEach(node => {
-      const { kind, selfLink, getId, getName, getAge } = node;
+      const { kind, selfLink, getId, getName, getAge, getTimeDiffFromNow } = node;
 
       node.getWarningConditions().forEach(({ message }) => {
         warnings.push({
           age: getAge(),
           getId,
           getName,
+          getTimeDiffFromNow,
           kind,
           message,
           selfLink,
@@ -63,12 +65,13 @@ export class ClusterIssues extends React.Component<Props> {
     const events = eventStore.getWarnings();
 
     events.forEach(error => {
-      const { message, involvedObject, getAge } = error;
+      const { message, involvedObject, getAge, getTimeDiffFromNow } = error;
       const { uid, name, kind } = involvedObject;
 
       warnings.push({
         getId: () => uid,
         getName: () => name,
+        getTimeDiffFromNow,
         age: getAge(),
         message,
         kind,

--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -24,7 +24,7 @@ interface IWarning extends ItemObject {
   message: string;
   selfLink: string;
   age: string | number;
-  getTimeDiffFromNow(): number;
+  timeDiffFromNow: number;
 }
 
 enum sortBy {
@@ -38,7 +38,7 @@ export class ClusterIssues extends React.Component<Props> {
   private sortCallbacks = {
     [sortBy.type]: (warning: IWarning) => warning.kind,
     [sortBy.object]: (warning: IWarning) => warning.getName(),
-    [sortBy.age]: (warning: IWarning) => warning.getTimeDiffFromNow(),
+    [sortBy.age]: (warning: IWarning) => warning.timeDiffFromNow,
   };
 
   @computed get warnings() {
@@ -53,7 +53,7 @@ export class ClusterIssues extends React.Component<Props> {
           age: getAge(),
           getId,
           getName,
-          getTimeDiffFromNow,
+          timeDiffFromNow: getTimeDiffFromNow(),
           kind,
           message,
           selfLink,
@@ -71,7 +71,7 @@ export class ClusterIssues extends React.Component<Props> {
       warnings.push({
         getId: () => uid,
         getName: () => name,
-        getTimeDiffFromNow,
+          timeDiffFromNow: getTimeDiffFromNow(),
         age: getAge(),
         message,
         kind,


### PR DESCRIPTION
Hello guys, thank you for the awesome project! I'm actively using lens in production.
I recently encountered this bug and searched #2182 PR was merged but omitted this part.
So, As followup, I added this PR.
If you have question, feel free to comment. Thanks.

**Fixes:**
sorting resources by age is broken (previously sorted by iso-string timestamp) in cluster-issues

**AS-IS**
<img width="645" alt="Screen Shot 2021-03-30 at 8 04 31 PM" src="https://user-images.githubusercontent.com/10170144/112981717-8b1d3080-9196-11eb-9f38-5350977a6981.png">

**TO-BE**
<img width="636" alt="Screen Shot 2021-03-30 at 8 00 41 PM" src="https://user-images.githubusercontent.com/10170144/112981707-8789a980-9196-11eb-9ee8-f287e72b8641.png">

