### PR TITLE
Ingress and PersistentVolumeClaim metrics need to also be filtered and grouped by namespace

### DIFF
--- a/src/main/prometheus/lens.ts
+++ b/src/main/prometheus/lens.ts
@@ -67,18 +67,18 @@ export class PrometheusLens implements PrometheusProvider {
         };
       case "pvc":
         return {
-          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`,
-          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`
+          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`,
+          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`
         };
       case "ingress":
-        const bytesSent = (ingress: string, statuses: string) =>
-          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
+        const bytesSent = (ingress: string, namespace: string, statuses: string) =>
+          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}",namespace="${namespace}",status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
-          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
-          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
+          bytesSentSuccess: bytesSent(opts.ingress, opts.namespace, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, opts.namespace, "^5\\\\d*"),
+          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`,
+          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`
         };
     }
   }

--- a/src/main/prometheus/operator.ts
+++ b/src/main/prometheus/operator.ts
@@ -77,18 +77,18 @@ export class PrometheusOperator implements PrometheusProvider {
         };
       case "pvc":
         return {
-          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`,
-          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`
+          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`,
+          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`
         };
       case "ingress":
-        const bytesSent = (ingress: string, statuses: string) =>
-          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
+        const bytesSent = (ingress: string, namespace: string, statuses: string) =>
+          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}",namespace="${namespace}",status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
-          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
-          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
+          bytesSentSuccess: bytesSent(opts.ingress, opts.namespace, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, opts.namespace, "^5\\\\d*"),
+          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`,
+          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`
         };
     }
   }

--- a/src/main/prometheus/stacklight.ts
+++ b/src/main/prometheus/stacklight.ts
@@ -67,18 +67,18 @@ export class PrometheusStacklight implements PrometheusProvider {
         };
       case "pvc":
         return {
-          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`,
-          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}"}) by (persistentvolumeclaim, namespace)`
+          diskUsage: `sum(kubelet_volume_stats_used_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`,
+          diskCapacity: `sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="${opts.pvc}",namespace="${opts.namespace}"}) by (persistentvolumeclaim, namespace)`
         };
       case "ingress":
-        const bytesSent = (ingress: string, statuses: string) =>
-          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}", status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress)`;
+        const bytesSent = (ingress: string, namespace: string, statuses: string) =>
+          `sum(rate(nginx_ingress_controller_bytes_sent_sum{ingress="${ingress}",namespace="${namespace}",status=~"${statuses}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
 
         return {
-          bytesSentSuccess: bytesSent(opts.ingress, "^2\\\\d*"),
-          bytesSentFailure: bytesSent(opts.ingress, "^5\\\\d*"),
-          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`,
-          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}"}[${this.rateAccuracy}])) by (ingress)`
+          bytesSentSuccess: bytesSent(opts.ingress, opts.namespace, "^2\\\\d*"),
+          bytesSentFailure: bytesSent(opts.ingress, opts.namespace, "^5\\\\d*"),
+          requestDurationSeconds: `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`,
+          responseDurationSeconds: `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`
         };
     }
   }

--- a/src/renderer/api/endpoints/ingress.api.ts
+++ b/src/renderer/api/endpoints/ingress.api.ts
@@ -5,7 +5,7 @@ import { KubeApi } from "../kube-api";
 
 export class IngressApi extends KubeApi<Ingress> {
   getMetrics(ingress: string, namespace: string): Promise<IIngressMetrics> {
-    const opts = { category: "ingress", ingress };
+    const opts = { category: "ingress", ingress, namespace };
 
     return metricsApi.getMetrics({
       bytesSentSuccess: opts,

--- a/src/renderer/api/endpoints/persistent-volume-claims.api.ts
+++ b/src/renderer/api/endpoints/persistent-volume-claims.api.ts
@@ -7,8 +7,8 @@ import { KubeApi } from "../kube-api";
 export class PersistentVolumeClaimsApi extends KubeApi<PersistentVolumeClaim> {
   getMetrics(pvcName: string, namespace: string): Promise<IPvcMetrics> {
     return metricsApi.getMetrics({
-      diskUsage: { category: "pvc", pvc: pvcName },
-      diskCapacity: { category: "pvc", pvc: pvcName }
+      diskUsage: { category: "pvc", pvc: pvcName, namespace },
+      diskCapacity: { category: "pvc", pvc: pvcName, namespace }
     }, {
       namespace
     });


### PR DESCRIPTION
Ingress and PersistentVolumeClaim metrics need to also be filtered and grouped by namespace, in addition to ingress or persistentvolumeclaim.

I have a cluster where there is a `testing` and a `production` namespace with identical Kubernetes resources, including identically named Ingresses. Lens was showing the same metrics for these Ingresses, which was the sum of both Ingresses.