### PR TITLE
Keep filter when changing view

### DIFF
--- a/src/renderer/components/input/search-input.storage.ts
+++ b/src/renderer/components/input/search-input.storage.ts
@@ -1,0 +1,19 @@
+import { createStorage } from "../../utils";
+
+export interface SearchInputState {
+  searchInput: string;
+}
+
+export const searchInputStorage = createStorage<SearchInputState>("search_input", {
+  searchInput: ""
+});
+
+export function setSearchInput(searchInput: string) {
+  searchInputStorage.merge(draft => {
+    draft.searchInput = searchInput;
+  });
+}
+
+export function getSearchInput() {
+  return searchInputStorage.get().searchInput;
+}

--- a/src/renderer/components/item-object-list/item-list-layout.tsx
+++ b/src/renderer/components/item-object-list/item-list-layout.tsx
@@ -344,6 +344,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
 
   renderHeader() {
     const { showHeader, customizeHeader, renderHeaderTitle, headerClassName, isClusterScoped } = this.props;
+    const isSearchEnabled = Boolean(this.filters.find(filter => filter.type === FilterType.SEARCH));
 
     if (!showHeader) return;
     const title = typeof renderHeaderTitle === "function" ? renderHeaderTitle(this) : renderHeaderTitle;
@@ -356,7 +357,7 @@ export class ItemListLayout extends React.Component<ItemListLayoutProps> {
           [FilterType.NAMESPACE]: true, // namespace-select used instead
         }}/>
       </>,
-      search: <SearchInputUrl/>,
+      search: <SearchInputUrl isEnabled={isSearchEnabled}/>,
     };
     let header = this.renderHeaderContent(placeholders);
 


### PR DESCRIPTION
Problem: double click on the same `SidebarItem` clear filter. Not sure, is it expected behavior?
Fix: after clicking `Reset Filters?` search input was not cleared. 
Suggestion: maybe I could do this filter with history? Wdyt? 

close: https://github.com/lensapp/lens/issues/271