### PR TITLE
Menu: more ways to position menu

### DIFF
--- a/src/renderer/components/cluster-manager/clusters-menu.scss
+++ b/src/renderer/components/cluster-manager/clusters-menu.scss
@@ -32,7 +32,6 @@
     margin-bottom: $margin;
 
     .Icon {
-      margin-bottom: $margin * 1.5;
       border-radius: $radius;
       padding: $padding / 3;
       color: var(--textColorPrimary);

--- a/src/renderer/components/cluster-manager/clusters-menu.tsx
+++ b/src/renderer/components/cluster-manager/clusters-menu.tsx
@@ -118,13 +118,13 @@ export class ClustersMenu extends React.Component<Props> {
         <div className="WorkspaceMenu">
           <Icon big material="menu" id="workspace-menu-icon" data-test-id="workspace-menu" />
           <Menu
-            usePortal
             htmlFor="workspace-menu-icon"
             className="WorkspaceMenu"
             isOpen={this.workspaceMenuVisible}
             open={() => this.workspaceMenuVisible = true}
             close={() => this.workspaceMenuVisible = false}
             toggleEvent="click"
+            position={{right: "outside", top: "inside"}}
           >
             <MenuItem onClick={() => navigate(addClusterURL())} data-test-id="add-cluster-menu-item">
               <Icon small material="add" /> Add Cluster

--- a/src/renderer/components/menu/menu.scss
+++ b/src/renderer/components/menu/menu.scss
@@ -9,6 +9,8 @@
   border: 1px solid $borderColor;
   z-index: 101;
 
+  // TODO: support predefined positions setup when rendered in document.body
+  // auto-positioning currently applied inside component on menu open
   &.portal {
     left: -1000px;
     top: -1000px;
@@ -22,23 +24,46 @@
     }
   }
 
+  // predefined positions without `usePortal` (default) where menu is rendered inside it's parent dom tree.
   &:not(.portal) {
-    margin: $margin 0;
-
     &.left {
-      left: 0;
+      &-inside {
+        left: 0;
+      }
+
+      &-outside {
+        right: 100%;
+      }
     }
 
     &.right {
-      right: 0;
+      &-inside {
+        right: 0;
+      }
+
+      &-outside {
+        left: 100%;
+      }
     }
 
     &.top {
-      bottom: 100%;
+      &-inside {
+        top: 0;
+      }
+
+      &-outside {
+        bottom: 100%;
+      }
     }
 
     &.bottom {
-      top: 100%;
+      &-inside {
+        bottom: 0;
+      }
+
+      &-outside {
+        top: 100%;
+      }
     }
   }
 

--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -9,7 +9,13 @@ import debounce from "lodash/debounce";
 
 export const MenuContext = React.createContext<MenuContextValue>(null);
 export type MenuContextValue = Menu;
-export type MenuPositionSide = "inside" | "outside";
+
+/**
+ * Positioning menu relative to parent's element box-area.
+ * In that case menu is rendered in parent's element DOM-tree.
+ * Applicable only when usePortal={false} (default)
+ */
+export type MenuPositionSide = "inside" | "outside"; // of parent element boundaries
 
 export interface MenuPosition {
   left?: MenuPositionSide;
@@ -36,6 +42,7 @@ export interface MenuProps {
 }
 
 interface State {
+  // Auto-positioning menu in <body> in case of `usePortal={true}`
   position?: {
     left?: boolean;
     top?: boolean;


### PR DESCRIPTION
Allows more fine-grained positioning for `<Menu usePortal={false}>` with following `props.position={{...}}` interface:

```ts
export type MenuPositionSide = "inside" | "outside"; // of parent's box area

export interface MenuPosition {
  left?: MenuPositionSide;
  top?: MenuPositionSide;
  right?: MenuPositionSide;
  bottom?: MenuPositionSide;
}
```

_As an example, workspace-menu moved right to the icon (previously at the bottom):_

<img width="446" alt="Screenshot 2021-04-06 at 14 59 51" src="https://user-images.githubusercontent.com/6377066/113708060-74705f80-96e9-11eb-8940-2a3ae3ae905e.png">
