### PR TITLE
Release v5.0.0-alpha.1

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -52,6 +52,8 @@ jobs:
           WIN_CSC_LINK: $(WIN_CSC_LINK)
           WIN_CSC_KEY_PASSWORD: $(WIN_CSC_KEY_PASSWORD)
           GH_TOKEN: $(GH_TOKEN)
+          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
   - job: macOS
     pool:
       vmImage: macOS-10.14
@@ -93,6 +95,8 @@ jobs:
           CSC_LINK: $(CSC_LINK)
           CSC_KEY_PASSWORD: $(CSC_KEY_PASSWORD)
           GH_TOKEN: $(GH_TOKEN)
+          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
   - job: Linux
     pool:
       vmImage: ubuntu-16.04
@@ -140,6 +144,8 @@ jobs:
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
         env:
           GH_TOKEN: $(GH_TOKEN)
+          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
       - script: make publish-npm
         displayName: Publish npm package
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "5.0.0-alpha.0",
+  "version": "5.0.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2021, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,21 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.2.0-rc.3 (current version)
+## 5.0.0-alpha.0 (current version)
+
+- Workspaces are replaced by Catalog & Hotbar
+
+## 4.2.1
+
+- User is now notified if helm list fails
+- Sorting order is now saved when switching views
+- Fix: Node shells failing to open
+- Fix: Tray icon is now reactive to changes
+- Fix: Whole window is used for displaying workspace overview
+- Fix: Workspace overview is now reactive to cluster changes
+- Fix: Exported ClusterStore now enforces more invariants
+
+## 4.2.0
 
 - Add lens:// protocol handling with a routing mechanism
 - Add common app routes to the protocol renderer router from the documentation
@@ -37,6 +51,12 @@ Here you can find description of changes we've built into each release. While we
 - Fix: Block global path traversal in router
 - Fix: Set initial cursor position for the editor to beginning
 - Fix: Highlight sidebar's active section
+
+## 4.1.5
+
+- Proxy should listen only on loopback device
+- Fix extension command palette loading
+- Fix Lens not clearing other KUBECONFIG env vars
 
 ## 4.1.4
 

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 5.0.0-alpha.0 (current version)
+## 5.0.0-alpha.1 (current version)
 
 - Workspaces are replaced by Catalog & Hotbar
 


### PR DESCRIPTION
## Changes since v4.2.1

## 🚀 Features

* Style Catalog sidebar to look similar as dashboard one (#2496) @aleksfront
* Catalog & Hotbar - initial groundwork (#2418) @jakolehm
* Export sub-title component to extensions API (#2471) @Nachasic

## 🐛 Bug Fixes

* Electron 9.4.4 (#2472) @jakolehm

## 🧰 Maintenance

* Publish binaries to s3 bucket (#2513) @jakolehm
* Bump electron-builder from 22.7.0 to 22.10.5 (#2480) @dependabot
* Test using GH Actions (#2509) @jakolehm
* Cleanup shell sessions (#2469) @Nokel81
* Improve CatalogEntityRegistry types & add tests (#2495) @jakolehm
* Bump ansi_up from 4.0.4 to 5.0.0 (#2323) @dependabot