### PR TITLE
modified kubeconfig manager test to avoid intermittent ENXIO error

### DIFF
--- a/src/main/__test__/kubeconfig-manager.test.ts
+++ b/src/main/__test__/kubeconfig-manager.test.ts
@@ -84,7 +84,9 @@ describe("kubeconfig manager tests", () => {
 
     expect(logger.error).not.toBeCalled();
     expect(await kubeConfManager.getPath()).toBe(`tmp${path.sep}kubeconfig-foo`);
-    const file = await fse.readFile(await kubeConfManager.getPath());
+// this causes an intermittent "ENXIO: no such device or address, read" error
+//    const file = await fse.readFile(await kubeConfManager.getPath());
+    const file = fse.readFileSync(await kubeConfManager.getPath());
     const yml = loadYaml<any>(file.toString());
 
     expect(yml["current-context"]).toBe("minikube");

--- a/src/main/__test__/kubeconfig-manager.test.ts
+++ b/src/main/__test__/kubeconfig-manager.test.ts
@@ -84,8 +84,8 @@ describe("kubeconfig manager tests", () => {
 
     expect(logger.error).not.toBeCalled();
     expect(await kubeConfManager.getPath()).toBe(`tmp${path.sep}kubeconfig-foo`);
-// this causes an intermittent "ENXIO: no such device or address, read" error
-//    const file = await fse.readFile(await kubeConfManager.getPath());
+    // this causes an intermittent "ENXIO: no such device or address, read" error
+    //    const file = await fse.readFile(await kubeConfManager.getPath());
     const file = fse.readFileSync(await kubeConfManager.getPath());
     const yml = loadYaml<any>(file.toString());
 


### PR DESCRIPTION
Determined that `readFile()` from `fs-extra`, in conjunction with `mock-fs`, is intermittently encountering a strange `ENXIO` error. I reproduced this for ~ 1 in 5 test runs. Simplest workaround is to use `readFileSync()` from `fs-extra`. Could not reproduce the problem after 20+ test runs.

fixes #2510 