### PR TITLE
Add ability to configure the locale timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "mobx-react": "^6.2.2",
     "mock-fs": "^4.12.0",
     "moment": "^2.26.0",
+    "moment-timezone": "^0.5.33",
     "node-pty": "^0.9.0",
     "npm": "^6.14.8",
     "openid-client": "^3.15.2",

--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -3,6 +3,7 @@ import { app, remote } from "electron";
 import semver from "semver";
 import { readFile } from "fs-extra";
 import { action, computed, observable, reaction, toJS } from "mobx";
+import moment from "moment-timezone";
 import { BaseStore } from "./base-store";
 import migrations from "../migrations/user-store";
 import { getAppVersion } from "./utils/app-version";
@@ -23,6 +24,7 @@ export interface UserPreferences {
   httpsProxy?: string;
   shell?: string;
   colorTheme?: string;
+  localeTimezone?: string;
   allowUntrustedCAs?: boolean;
   allowTelemetry?: boolean;
   downloadMirror?: string | "default";
@@ -54,6 +56,7 @@ export class UserStore extends BaseStore<UserStoreModel> {
     allowTelemetry: true,
     allowUntrustedCAs: false,
     colorTheme: UserStore.defaultTheme,
+    localeTimezone: moment.tz.guess(true),
     downloadMirror: "default",
     downloadKubectlBinaries: true,  // Download kubectl binaries matching cluster version
     openAtLogin: false,
@@ -75,7 +78,7 @@ export class UserStore extends BaseStore<UserStoreModel> {
 
       // open at system start-up
       reaction(() => this.preferences.openAtLogin, openAtLogin => {
-        app.setLoginItemSettings({ 
+        app.setLoginItemSettings({
           openAtLogin,
           openAsHidden: true,
           args: ["--hidden"]

--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -56,7 +56,7 @@ export class UserStore extends BaseStore<UserStoreModel> {
     allowTelemetry: true,
     allowUntrustedCAs: false,
     colorTheme: UserStore.defaultTheme,
-    localeTimezone: moment.tz.guess(true),
+    localeTimezone: moment.tz.guess(true) || "UTC",
     downloadMirror: "default",
     downloadKubectlBinaries: true,  // Download kubectl binaries matching cluster version
     openAtLogin: false,
@@ -131,6 +131,11 @@ export class UserStore extends BaseStore<UserStoreModel> {
   saveLastSeenAppVersion() {
     appEventBus.emit({ name: "app", action: "whats-new-seen" });
     this.lastSeenAppVersion = getAppVersion();
+  }
+
+  @action
+  setLocaleTimezone(tz: string) {
+    this.preferences.localeTimezone = tz;
   }
 
   protected refreshNewContexts = async () => {

--- a/src/renderer/components/+events/event-details.tsx
+++ b/src/renderer/components/+events/event-details.tsx
@@ -11,6 +11,7 @@ import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 import { lookupApiLink } from "../../api/kube-api";
 import { kubeObjectDetailRegistry } from "../../api/kube-object-detail-registry";
+import { LocaleDate } from "../locale-date";
 
 interface Props extends KubeObjectDetailsProps<KubeEvent> {
 }
@@ -38,10 +39,10 @@ export class EventDetails extends React.Component<Props> {
           {event.getSource()}
         </DrawerItem>
         <DrawerItem name="First seen">
-          {event.getFirstSeenTime()} ago {event.firstTimestamp}
+          {event.getFirstSeenTime()} ago (<LocaleDate date={event.firstTimestamp} />)
         </DrawerItem>
         <DrawerItem name="Last seen">
-          {event.getLastSeenTime()} ago {event.lastTimestamp}
+          {event.getLastSeenTime()} ago (<LocaleDate date={event.lastTimestamp} />)
         </DrawerItem>
         <DrawerItem name="Count">
           {count}

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -41,12 +41,10 @@ export class Preferences extends React.Component {
     }));
   }
 
-  @computed get timezoneOptions(): SelectOption<string>[] {
-    return moment.tz.names().map(zone => ({
-      label: zone,
-      value: zone,
-    }));
-  }
+  timezoneOptions: SelectOption<string>[] = moment.tz.names().map(zone => ({
+    label: zone,
+    value: zone,
+  }));
 
   componentDidMount() {
     disposeOnUnmount(this, [
@@ -169,7 +167,7 @@ export class Preferences extends React.Component {
               <Select
                 options={this.timezoneOptions}
                 value={preferences.localeTimezone}
-                onChange={({ value }: SelectOption) => preferences.localeTimezone = value}
+                onChange={({ value }: SelectOption) => userStore.setLocaleTimezone(value)}
                 themeName="lens"
               />
             </section>

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -1,6 +1,7 @@
 import "./preferences.scss";
 
 import React from "react";
+import moment from "moment-timezone";
 import { computed, observable, reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 
@@ -37,6 +38,13 @@ export class Preferences extends React.Component {
     return themeStore.themes.map(theme => ({
       label: theme.name,
       value: theme.id,
+    }));
+  }
+
+  @computed get timezoneOptions(): SelectOption<string>[] {
+    return moment.tz.names().map(zone => ({
+      label: zone,
+      value: zone,
     }));
   }
 
@@ -95,7 +103,7 @@ export class Preferences extends React.Component {
     const { preferences } = userStore;
     const extensions = appPreferenceRegistry.getItems();
     const telemetryExtensions = extensions.filter(e => e.showInPreferencesTab == Pages.Telemetry);
-    let defaultShell = process.env.SHELL || process.env.PTYSHELL;
+    let defaultShell = process.env.SHELL || process.env.PTYSHELL;
 
     if (!defaultShell) {
       if (isWindows) {
@@ -151,6 +159,18 @@ export class Preferences extends React.Component {
                   />
                 }
                 label="Automatically start Lens on login"
+              />
+            </section>
+
+            <hr />
+
+            <section id="locale">
+              <SubTitle title="Locale Timezone" />
+              <Select
+                options={this.timezoneOptions}
+                value={preferences.localeTimezone}
+                onChange={({ value }: SelectOption) => preferences.localeTimezone = value}
+                themeName="lens"
               />
             </section>
           </section>

--- a/src/renderer/components/+workloads-pods/pod-details-container.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-container.tsx
@@ -13,6 +13,7 @@ import { IMetrics } from "../../api/endpoints/metrics.api";
 import { ContainerCharts } from "./container-charts";
 import { ResourceType } from "../+cluster-settings/components/cluster-metrics-setting";
 import { clusterStore } from "../../../common/cluster-store";
+import { LocaleDate } from '../locale-date';
 
 interface Props {
   pod: Pod;
@@ -39,8 +40,8 @@ export class PodDetailsContainer extends React.Component<Props> {
         <span>
           {lastState}<br/>
           Reason: {status.lastState.terminated.reason} - exit code: {status.lastState.terminated.exitCode}<br/>
-          Started at: {status.lastState.terminated.startedAt}<br/>
-          Finished at: {status.lastState.terminated.finishedAt}<br/>
+          Started at: {<LocaleDate date={status.lastState.terminated.startedAt} />}<br/>
+          Finished at: {<LocaleDate date={status.lastState.terminated.finishedAt} />}<br/>
         </span>
       );
     }

--- a/src/renderer/components/+workloads-pods/pod-details-container.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-container.tsx
@@ -13,7 +13,7 @@ import { IMetrics } from "../../api/endpoints/metrics.api";
 import { ContainerCharts } from "./container-charts";
 import { ResourceType } from "../+cluster-settings/components/cluster-metrics-setting";
 import { clusterStore } from "../../../common/cluster-store";
-import { LocaleDate } from '../locale-date';
+import { LocaleDate } from "../locale-date";
 
 interface Props {
   pod: Pod;

--- a/src/renderer/components/dock/log-list.tsx
+++ b/src/renderer/components/dock/log-list.tsx
@@ -87,9 +87,9 @@ export class LogList extends React.Component<Props> {
       return logStore.logsWithoutTimestamps;
     }
 
-    return this.props.logs.map(log => (
-      `${moment.tz(logStore.getTimestamps(log)[0] || "", preferences.localeTimezone).format()} ${logStore.removeTimestamps(log)}`
-    ));
+    return this.props.logs
+      .map(log => logStore.splitOutTimestamp(log))
+      .map(([logTimestamp, log]) => (`${moment.tz(logTimestamp, preferences.localeTimezone).format()} ${log}`));
   }
 
   /**

--- a/src/renderer/components/dock/log-list.tsx
+++ b/src/renderer/components/dock/log-list.tsx
@@ -6,9 +6,11 @@ import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
 import { action, computed, observable } from "mobx";
 import { observer } from "mobx-react";
+import moment from "moment-timezone";
 import { Align, ListOnScrollProps } from "react-window";
 
 import { SearchStore, searchStore } from "../../../common/search-store";
+import { userStore } from "../../../common/user-store";
 import { cssNames } from "../../utils";
 import { Button } from "../button";
 import { Icon } from "../icon";
@@ -79,12 +81,15 @@ export class LogList extends React.Component<Props> {
   @computed
   get logs() {
     const showTimestamps = logTabStore.getData(this.props.id).showTimestamps;
+    const { preferences } = userStore;
 
     if (!showTimestamps) {
       return logStore.logsWithoutTimestamps;
     }
 
-    return this.props.logs;
+    return this.props.logs.map(log => (
+      `${moment.tz(logStore.getTimestamps(log)[0] || "", preferences.localeTimezone).format()} ${logStore.removeTimestamps(log)}`
+    ));
   }
 
   /**

--- a/src/renderer/components/dock/log-list.tsx
+++ b/src/renderer/components/dock/log-list.tsx
@@ -89,7 +89,7 @@ export class LogList extends React.Component<Props> {
 
     return this.props.logs
       .map(log => logStore.splitOutTimestamp(log))
-      .map(([logTimestamp, log]) => (`${moment.tz(logTimestamp, preferences.localeTimezone).format()} ${log}`));
+      .map(([logTimestamp, log]) => (`${moment.tz(logTimestamp, preferences.localeTimezone).format()}${log}`));
   }
 
   /**

--- a/src/renderer/components/dock/log.store.ts
+++ b/src/renderer/components/dock/log.store.ts
@@ -146,6 +146,16 @@ export class LogStore {
     return stamp.toISOString();
   }
 
+  splitOutTimestamp(logs: string): [string, string] {
+    const extraction = /^(\d+\S+) (.*)/gm.exec(logs);
+
+    if (extraction.length < 3) {
+      return ["", ""];
+    }
+
+    return [extraction[1], extraction[2]];
+  }
+
   getTimestamps(logs: string) {
     return logs.match(/^\d+\S+/gm);
   }

--- a/src/renderer/components/dock/log.store.ts
+++ b/src/renderer/components/dock/log.store.ts
@@ -147,9 +147,9 @@ export class LogStore {
   }
 
   splitOutTimestamp(logs: string): [string, string] {
-    const extraction = /^(\d+\S+) (.*)/gm.exec(logs);
+    const extraction = /^(\d+\S+) (.*)/m.exec(logs);
 
-    if (extraction.length < 3) {
+    if (!extraction || extraction.length < 3) {
       return ["", ""];
     }
 

--- a/src/renderer/components/dock/log.store.ts
+++ b/src/renderer/components/dock/log.store.ts
@@ -147,7 +147,7 @@ export class LogStore {
   }
 
   splitOutTimestamp(logs: string): [string, string] {
-    const extraction = /^(\d+\S+) (.*)/m.exec(logs);
+    const extraction = /^(\d+\S+)(.*)/m.exec(logs);
 
     if (!extraction || extraction.length < 3) {
       return ["", ""];

--- a/src/renderer/components/kube-object/kube-object-meta.tsx
+++ b/src/renderer/components/kube-object/kube-object-meta.tsx
@@ -4,6 +4,7 @@ import { DrawerItem, DrawerItemLabels } from "../drawer";
 import { lookupApiLink } from "../../api/kube-api";
 import { Link } from "react-router-dom";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
+import { LocaleDate } from "../locale-date";
 import { getDetailsUrl } from "./kube-object-details";
 
 export interface KubeObjectMetaProps {
@@ -35,7 +36,7 @@ export class KubeObjectMeta extends React.Component<KubeObjectMetaProps> {
     return (
       <>
         <DrawerItem name="Created" hidden={this.isHidden("creationTimestamp")}>
-          {getAge(true, false)} ago ({creationTimestamp})
+          {getAge(true, false)} ago ({<LocaleDate date={creationTimestamp} />})
         </DrawerItem>
         <DrawerItem name="Name" hidden={this.isHidden("name")}>
           {getName()} <KubeObjectStatusIcon key="icon" object={object} />

--- a/src/renderer/components/locale-date/index.ts
+++ b/src/renderer/components/locale-date/index.ts
@@ -1,0 +1,1 @@
+export * from "./locale-date";

--- a/src/renderer/components/locale-date/locale-date.tsx
+++ b/src/renderer/components/locale-date/locale-date.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { observer } from "mobx-react";
+import moment from "moment-timezone";
+import { userStore } from "../../../common/user-store";
+
+interface Props {
+  date: string
+}
+
+@observer
+export class LocaleDate extends React.Component<Props> {
+  render() {
+    const { preferences } = userStore;
+    const { date } = this.props;
+
+    return <>{moment.tz(date, preferences.localeTimezone).format()}</>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9538,6 +9538,18 @@ mock-fs@^4.12.0:
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.12.0.tgz#a5d50b12d2d75e5bec9dac3b67ffe3c41d31ade4"
   integrity sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==
 
+moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 moment@^2.10.2, moment@^2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"


### PR DESCRIPTION
This PR adds the possibility to configure the locale timezone of the user in the preferences of Lens. Then, all the date displayed in the application (ressources creation, events date, logs, ...) should follow this timezone.
By default, it uses the user's timezone or fallback to UTC if it cannot be determined.

Closes #2397 
Closes #569

As a video is worth a thousand words:

https://user-images.githubusercontent.com/27413532/114598157-dc96e680-9c91-11eb-8155-e930287d4618.mp4

