### PR TITLE
Fix catalog sidebar paddings

### DIFF
--- a/src/renderer/components/+catalog/catalog.scss
+++ b/src/renderer/components/+catalog/catalog.scss
@@ -21,6 +21,7 @@
 
     > .sidebar {
       width: 100%;
+      padding: 0;
 
       .sidebarTabs {
         margin-top: 5px;


### PR DESCRIPTION
Before:
![broken sidebar](https://user-images.githubusercontent.com/9607060/114703616-30570d80-9d2e-11eb-8957-4dad754202be.png)

After:
![fixed sidebar](https://user-images.githubusercontent.com/9607060/114703623-3220d100-9d2e-11eb-807d-a46815be15f0.png)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>