### PR TITLE
Retry yarn/npm install steps on gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: nick-invision/retry@v2
         name: Install dependencies
         with:
+          timeout_minutes: 10
           max_attempts: 3
           retry_on: error
           command: make node_modules
@@ -45,6 +46,7 @@ jobs:
       - uses: nick-invision/retry@v2
         name: Build bundled extensions
         with:
+          timeout_minutes: 15
           max_attempts: 3
           retry_on: error
           command: make -j2 build-extensions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: make node_modules
+      - uses: nick-invision/retry@v2
         name: Install dependencies
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: make node_modules
 
       - run: make build-npm
         name: Generate npm package
 
-      - run: make -j2 build-extensions
+      - uses: nick-invision/retry@v2
         name: Build bundled extensions
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: make -j2 build-extensions
 
       - run: make test
         name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ binaries/client: node_modules
 	yarn download-bins
 
 node_modules: yarn.lock
-	yarn install --frozen-lockfile
+	yarn install --frozen-lockfile --network-timeout=100000
 	yarn check --verify-tree --integrity
 
 static/build/LensDev.html: node_modules


### PR DESCRIPTION
Those seem to error quite often (probably because of slow network).