### PR TITLE
Cherry pick chages from 4.2 branch

### DIFF
--- a/docs/extensions/capabilities/common-capabilities.md
+++ b/docs/extensions/capabilities/common-capabilities.md
@@ -1,10 +1,13 @@
 # Common Capabilities
 
-Here we will discuss common and important building blocks for your extensions, and explain how you can use them. Almost all extensions use some of these functionalities.
+Here we will discuss common and important building blocks for your extensions, and explain how you can use them.
+Almost all extensions use some of these functionalities.
 
 ## Main Extension
 
-The main extension runs in the background. It adds app menu items to the Lens UI. In order to see logs from this extension, you need to start Lens from the command line.
+The main extension runs in the background.
+It adds app menu items to the Lens UI.
+In order to see logs from this extension, you need to start Lens from the command line.
 
 ### Activate
 
@@ -58,7 +61,8 @@ export default class ExampleMainExtension extends LensMainExtension {
 
 ## Renderer Extension
 
-The renderer extension runs in a browser context, and is visible in Lens's main window. In order to see logs from this extension you need to check them via **View** > **Toggle Developer Tools** > **Console**.
+The renderer extension runs in a browser context, and is visible in Lens's main window.
+In order to see logs from this extension you need to check them via **View** > **Toggle Developer Tools** > **Console**.
 
 ### Activate
 
@@ -90,7 +94,8 @@ export default class ExampleMainExtension extends LensRendererExtension {
 
 ### Global Pages
 
-This extension can register custom global pages (views) to Lens's main window. The global page is a full-screen page that hides all other content from a window.
+This extension can register custom global pages (views) to Lens's main window.
+The global page is a full-screen page that hides all other content from a window.
 
 ```typescript
 import React from "react"
@@ -121,7 +126,8 @@ export default class ExampleRendererExtension extends LensRendererExtension {
 
 ### App Preferences
 
-This extension can register custom app preferences. It is responsible for storing a state for custom preferences.
+This extension can register custom app preferences.
+It is responsible for storing a state for custom preferences.
 
 ```typescript
 import React from "react"
@@ -145,7 +151,8 @@ export default class ExampleRendererExtension extends LensRendererExtension {
 
 ### Cluster Pages
 
-This extension can register custom cluster pages. These pages are visible in a cluster menu when a cluster is opened.
+This extension can register custom cluster pages.
+These pages are visible in a cluster menu when a cluster is opened.
 
 ```typescript
 import React from "react"
@@ -178,7 +185,8 @@ export default class ExampleExtension extends LensRendererExtension {
 
 ### Cluster Features
 
-This extension can register installable features for a cluster. These features are visible in the "Cluster Settings" page.
+This extension can register installable features for a cluster.
+These features are visible in the "Cluster Settings" page.
 
 ```typescript
 import React from "react"

--- a/docs/extensions/capabilities/styling.md
+++ b/docs/extensions/capabilities/styling.md
@@ -4,7 +4,8 @@ Lens provides a set of global styles and UI components that can be used by any e
 
 ## Layout
 
-For layout tasks, Lens uses the [flex.box](https://www.npmjs.com/package/flex.box) library which provides helpful class names to specify some of the [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) properties. For example, consider the following HTML and its associated CSS properties:
+For layout tasks, Lens uses the [flex.box](https://www.npmjs.com/package/flex.box) library which provides helpful class names to specify some of the [flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) properties.
+For example, consider the following HTML and its associated CSS properties:
 
 ```html
 <div className="flex column align-center"></div>
@@ -22,7 +23,8 @@ However, you are free to use any styling technique or framework you like, includ
 
 ### Layout Variables
 
-There is a set of CSS variables available for for basic layout needs. They are located inside `:root` and are defined in [app.scss](https://github.com/lensapp/lens/blob/master/src/renderer/components/app.scss):
+There is a set of CSS variables available for for basic layout needs.
+They are located inside `:root` and are defined in [app.scss](https://github.com/lensapp/lens/blob/master/src/renderer/components/app.scss):
 
 ```css
 --unit: 8px;
@@ -31,7 +33,8 @@ There is a set of CSS variables available for for basic layout needs. They are l
 --border-radius: 3px;
 ```
 
-These variables are intended to set consistent margins and paddings across components. For example:
+These variables are intended to set consistent margins and paddings across components.
+For example:
 
 ```css
 .status {
@@ -46,14 +49,16 @@ Lens uses two built-in themes defined in [the themes directory](https://github.c
 
 ### Theme Variables
 
-When Lens is loaded, it transforms the selected theme's `json` file into a list of [CSS Custom Properties (CSS Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties). This list then gets injected into the `:root` element so that any of the down-level components can use them.
+When Lens is loaded, it transforms the selected theme's `json` file into a list of [CSS Custom Properties (CSS Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+This list then gets injected into the `:root` element so that any of the down-level components can use them.
 ![CSS vars listed in devtools](images/css-vars-in-devtools.png)
 
 When the user changes the theme, the above process is repeated, and new CSS variables appear, replacing the previous ones.
 
 If you want to preserve Lens's native look and feel, with respect to the lightness or darkness of your extension, you can use the provided variables and built-in Lens components such as `Button`, `Select`, `Table`, and so on.
 
-There is a set of CSS variables available for extensions to use for theming. They are all located inside `:root` and are defined in [app.scss](https://github.com/lensapp/lens/blob/master/src/renderer/components/app.scss):
+There is a set of CSS variables available for extensions to use for theming.
+They are all located inside `:root` and are defined in [app.scss](https://github.com/lensapp/lens/blob/master/src/renderer/components/app.scss):
 
 ```css
 --font-main: 'Roboto', 'Helvetica', 'Arial', sans-serif;
@@ -88,7 +93,8 @@ as well as in [the theme modules](https://github.com/lensapp/lens/tree/master/sr
 ...
 ```
 
-These variables can be used in the following form: `var(--magenta)`. For example:
+These variables can be used in the following form: `var(--magenta)`.
+For example:
 
 ```css
 .status {
@@ -97,11 +103,12 @@ These variables can be used in the following form: `var(--magenta)`. For example
 }
 ```
 
-A complete list of themable colors can be found in the [Color Reference](../color-reference).
+A complete list of theme colors can be found in the [Color Reference](../color-reference).
 
 ### Theme Switching
 
-When the light theme is active, the `<body>` element gets a "theme-light" class, or: `<body class="theme-light">`. If the class isn't there, the theme defaults to dark. The active theme can be changed in the **Preferences** page:
+When the light theme is active, the `<body>` element gets a "theme-light" class, or: `<body class="theme-light">`.
+If the class isn't there, the theme defaults to dark. The active theme can be changed in the **Preferences** page:
 ![Color Theme](images/theme-selector.png)
 
 There is a way of detect active theme and its changes in JS. [MobX observer function/decorator](https://github.com/mobxjs/mobx-react#observercomponent) can be used for this purpose.

--- a/docs/extensions/get-started/anatomy.md
+++ b/docs/extensions/get-started/anatomy.md
@@ -1,6 +1,7 @@
 # Extension Anatomy
 
-In the [previous section](your-first-extension.md) you learned how to create your first extension. In this section you will learn how this extension works under the hood.
+In the [previous section](your-first-extension.md) you learned how to create your first extension.
+In this section you will learn how this extension works under the hood.
 
 The Hello World sample extension does three things:
 
@@ -26,13 +27,19 @@ Let's take a closer look at our Hello World sample's source code and see how the
 ├── webpack.config.js    // Webpack configuration
 ```
 
-The extension directory contains the extension's entry files and a few configuration files. Three files: `package.json`, `main.ts` and `renderer.tsx` are essential to understanding the Hello World sample extension. We'll look at those first.
+The extension directory contains the extension's entry files and a few configuration files.
+Three files: `package.json`, `main.ts` and `renderer.tsx` are essential to understanding the Hello World sample extension.
+We'll look at those first.
 
 ### Extension Manifest
 
-Each Lens extension must have a `package.json` file. It contains a mix of Node.js fields, including scripts and dependencies, and Lens-specific fields such as `publisher` and `contributes`. Some of the most-important fields include:
+Each Lens extension must have a `package.json` file.
+It contains a mix of Node.js fields, including scripts and dependencies, and Lens-specific fields such as `publisher` and `contributes`.
+Some of the most-important fields include:
 
-- `name` and `publisher`: Lens uses `@<publisher>/<name>` as a unique ID for the extension. For example, the Hello World sample has the ID `@lensapp-samples/helloworld-sample`. Lens uses this ID to uniquely identify your extension.
+- `name` and `publisher`: Lens uses `@<publisher>/<name>` as a unique ID for the extension.
+For example, the Hello World sample has the ID `@lensapp-samples/helloworld-sample`.
+Lens uses this ID to uniquely identify your extension.
 - `main`: the extension's entry point run in `main` process.
 - `renderer`: the extension's entry point run in `renderer` process.
 - `engines.lens`: the minimum version of Lens API that the extension depends upon.
@@ -71,11 +78,22 @@ Each Lens extension must have a `package.json` file. It contains a mix of Node.j
 
 ## Extension Entry Files
 
-Lens extensions can have two separate entry files. One file is used in the `main` process of the Lens application and the other is used in the `renderer` process. The `main` entry file exports the class that extends `LensMainExtension`, and the `renderer` entry file exports the class that extends `LensRendererExtension`.
+Lens extensions can have two separate entry files.
+One file is used in the `main` process of the Lens application and the other is used in the `renderer` process.
+The `main` entry file exports the class that extends `LensMainExtension`, and the `renderer` entry file exports the class that extends `LensRendererExtension`.
 
-Both extension classes have `onActivate` and `onDeactivate` methods. The `onActivate` method is executed when your extension is activated. If you need to initialize something in your extension, this is where such an operation should occur. The `onDeactivate` method gives you a chance to clean up before your extension becomes deactivated. For extensions where explicit cleanup is not required, you don't need to override this method. However, if an extension needs to perform an operation when Lens is shutting down (or if the extension is disabled or uninstalled), this is the method where such an operation should occur.
+Both extension classes have `onActivate` and `onDeactivate` methods.
+The `onActivate` method is executed when your extension is activated.
+If you need to initialize something in your extension, this is where such an operation should occur.
+The `onDeactivate` method gives you a chance to clean up before your extension becomes deactivated.
+For extensions where explicit cleanup is not required, you don't need to override this method.
+However, if an extension needs to perform an operation when Lens is shutting down (or if the extension is disabled or uninstalled), this is the method where such an operation should occur.
 
-The Hello World sample extension does not do anything on the `main` process, so we'll focus on the `renderer` process, instead. On the `renderer` entry point, the Hello World sample extension defines the `Cluster Page` object. The `Cluster Page` object registers the `/extension-example` path, and this path renders the `ExamplePage` React component. It also registers the `MenuItem` component that displays the `ExampleIcon` React component and the "Hello World" text in the left-side menu of the cluster dashboard. These React components are defined in the additional `./src/page.tsx` file.
+The Hello World sample extension does not do anything on the `main` process, so we'll focus on the `renderer` process, instead.
+On the `renderer` entry point, the Hello World sample extension defines the `Cluster Page` object.
+The `Cluster Page` object registers the `/extension-example` path, and this path renders the `ExamplePage` React component.
+It also registers the `MenuItem` component that displays the `ExampleIcon` React component and the "Hello World" text in the left-side menu of the cluster dashboard.
+These React components are defined in the additional `./src/page.tsx` file.
 
 ``` typescript
 import { LensRendererExtension } from "@k8slens/extensions";
@@ -94,4 +112,5 @@ export default class ExampleExtension extends LensRendererExtension {
 }
 ```
 
-The Hello World sample extension uses the `Cluster Page` capability, which is just one of the Lens extension API's capabilities. The [Common Capabilities](../capabilities/common-capabilities.md) page will help you home in on the right capabilities to use with your own extensions.
+The Hello World sample extension uses the `Cluster Page` capability, which is just one of the Lens extension API's capabilities.
+The [Common Capabilities](../capabilities/common-capabilities.md) page will help you home in on the right capabilities to use with your own extensions.

--- a/docs/extensions/get-started/overview.md
+++ b/docs/extensions/get-started/overview.md
@@ -1,19 +1,27 @@
 # Extension Development Overview
 
-This is a general overview to how the development of an extension will procede. For building extensions there will be a few things that you should have installed, and some other things that might be of help.
+This is a general overview to how the development of an extension will proceed.
+For building extensions there will be a few things that you should have installed, and some other things that might be of help.
 
 ### Required:
 - [Node.js](https://www.nodejs.org/en/)
 - [Git](https://www.git-scm.com/)
 - Some sort of text editor – we recommend [VSCode](https://code.visualstudio.com/)
-- We use [Webpack](https://www.webpack.js.org/) for compilation. All extension need to be at least compatable with a webpack system.
+- We use [Webpack](https://www.webpack.js.org/) for compilation.
+All extension need to be at least compatible with a webpack system.
 
 ### Recommended:
 
-All Lens extensions are javascript packages. We recommend that you program in [Typescript](https://www.typescriptlang.org/) because it catches many common errors.
+All Lens extensions are javascript packages.
+We recommend that you program in [Typescript](https://www.typescriptlang.org/) because it catches many common errors.
 
-Lens is a standard [Electron](https://www.electronjs.org/) application with both main and renderer processes. An extension is made up of two parts, one for each of Lens's core processes. When an extension is loaded, each part is first loaded and issues a notification that it has been loaded. From there, the extension can start doing is work.
+Lens is a standard [Electron](https://www.electronjs.org/) application with both main and renderer processes.
+An extension is made up of two parts, one for each of Lens's core processes.
+When an extension is loaded, each part is first loaded and issues a notification that it has been loaded.
+From there, the extension can start doing is work.
 
-Lens uses [React](https://www.reactjs.org/) as its UI framework and provides some of Lens's own components for reuse with extensions. An extension is resonsible for the lifetime of any resources it spins up. If an extension's main part starts new processes they all must be stopped and cleaned up when the extension is deactivated or unloaded.
+Lens uses [React](https://www.reactjs.org/) as its UI framework and provides some of Lens's own components for reuse with extensions.
+An extension is responsible for the lifetime of any resources it spins up.
+If an extension's main part starts new processes they all must be stopped and cleaned up when the extension is deactivated or unloaded.
 
 See [Your First Extension](your-first-extension.md) to get started.

--- a/docs/extensions/get-started/wrapping-up.md
+++ b/docs/extensions/get-started/wrapping-up.md
@@ -1,14 +1,20 @@
 # Wrapping Up
 
-In [Your First Extension](your-first-extension.md), you learned how to create and run an extension. In [Extension Anatomy](anatomy.md), you learned in detail how a basic extension works. This is just a glimpse into what can be created with Lens extensions. Below are some suggested routes for learning more.
+In [Your First Extension](your-first-extension.md), you learned how to create and run an extension.
+In [Extension Anatomy](anatomy.md), you learned in detail how a basic extension works.
+This is just a glimpse into what can be created with Lens extensions.
+Below are some suggested routes for learning more.
 
 ## Extension Capabilities
 
-In this section, you'll find information on common extension capabilities, styling information, and a color reference guide. Determine whether your idea for an extension is doable and get ideas for new extensions by reading through the [Common Capabilities](../capabilities/common-capabilities.md) page.
+In this section, you'll find information on common extension capabilities, styling information, and a color reference guide.
+Determine whether your idea for an extension is doable and get ideas for new extensions by reading through the [Common Capabilities](../capabilities/common-capabilities.md) page.
 
 ## Guides and Samples
 
-Here you'll find a collection of sample extensions that you can use as a base to work from. Some of these samples include a detailed guide that explains the source code. You can find all samples and guides in the [lens-extension-samples](https://github.com/lensapp/lens-extension-samples) repository.
+Here you'll find a collection of sample extensions that you can use as a base to work from.
+Some of these samples include a detailed guide that explains the source code.
+You can find all samples and guides in the [lens-extension-samples](https://github.com/lensapp/lens-extension-samples) repository.
 
 ## Testing and Publishing
 

--- a/docs/extensions/get-started/your-first-extension.md
+++ b/docs/extensions/get-started/your-first-extension.md
@@ -1,6 +1,7 @@
 # Your First Extension
 
-We recommend to always use [Yeoman generator for Lens Extension](https://github.com/lensapp/generator-lens-ext) to start new extension project. [Read the generator guide here](../guides/generator.md).
+We recommend to always use [Yeoman generator for Lens Extension](https://github.com/lensapp/generator-lens-ext) to start new extension project.
+[Read the generator guide here](../guides/generator.md).
 
 If you want to setup the project manually, please continue reading.
 
@@ -16,7 +17,9 @@ To install the extension, clone the [Lens Extension samples](https://github.com/
 git clone https://github.com/lensapp/lens-extension-samples.git
 ```
 
-Next you need to create a symlink. A symlink connects the directory that Lens will monitor for user-installed extensions to the sample extension. In this case the sample extension is `helloworld-sample`.
+Next you need to create a symlink.
+A symlink connects the directory that Lens will monitor for user-installed extensions to the sample extension.
+In this case the sample extension is `helloworld-sample`.
 
 ### Linux & macOS
 
@@ -64,16 +67,19 @@ npm install
 npm run build
 ```
 
-Optionally, automatically rebuild the extension by watching for changes to the source code. To do so, enter:
+Optionally, automatically rebuild the extension by watching for changes to the source code.
+To do so, enter:
 
 ```sh
 cd <lens-extension-samples directory>/helloworld-sample
 npm run dev
 ```
 
-You must restart Lens for the extension to load. After this initial restart, reload Lens and it will automatically pick up changes any time the extension rebuilds. 
+You must restart Lens for the extension to load.
+After this initial restart, reload Lens and it will automatically pick up changes any time the extension rebuilds.
 
-With Lens running, either connect to an existing cluster or [create a new one](../../clusters/adding-clusters.md). You will see the "Hello World" page in the left-side cluster menu.
+With Lens running, either connect to an existing cluster or [create a new one](../../clusters/adding-clusters.md).
+You will see the "Hello World" page in the left-side cluster menu.
 
 ## Develop the Extension
 
@@ -90,4 +96,5 @@ Finally, you'll make a change to the message that our Hello World sample extensi
 
 In the [next topic](anatomy.md), we'll take a closer look at the source code of our Hello World sample.
 
-You can find the source code for this tutorial at: [lensapp/lens-extension-samples](https://github.com/lensapp/lens-extension-samples/tree/master/helloworld-sample). [Extension Guides](../guides/README.md) contains additional samples.
+You can find the source code for this tutorial at: [lensapp/lens-extension-samples](https://github.com/lensapp/lens-extension-samples/tree/master/helloworld-sample).
+[Extension Guides](../guides/README.md) contains additional samples.

--- a/docs/extensions/guides/README.md
+++ b/docs/extensions/guides/README.md
@@ -1,6 +1,8 @@
 # Extension Guides
 
-This section explains how to use specific Lens Extension APIs. It includes detailed guides and code samples. For introductory information about the Lens Extension API, please see [Your First Extension](../get-started/your-first-extension.md).
+This section explains how to use specific Lens Extension APIs.
+It includes detailed guides and code samples.
+For introductory information about the Lens Extension API, please see [Your First Extension](../get-started/your-first-extension.md).
 
 Each guide or code sample includes the following:
 

--- a/docs/extensions/guides/generator.md
+++ b/docs/extensions/guides/generator.md
@@ -25,7 +25,8 @@ Answer the following questions:
 # ? symlink created extension folder to ~/.k8slens/extensions (mac/linux) or :Users\<user>\.k8slens\extensions (windows)? Yes
 ```
 
-Next, you'll need to have webpack watch the `my-first-lens-ext` folder. Start webpack by entering:
+Next, you'll need to have webpack watch the `my-first-lens-ext` folder.
+Start webpack by entering:
 
 ```bash
 cd my-first-lens-ext
@@ -38,7 +39,8 @@ Open Lens and you will see a **Hello World** item in the left-side menu under **
 
 ## Developing the Extension
 
-Next, you'll try changing the way the new menu item appears in the UI. You'll change it from "Hello World" to "Hello Lens".
+Next, you'll try changing the way the new menu item appears in the UI.
+You'll change it from "Hello World" to "Hello Lens".
 
 Open `my-first-lens-ext/renderer.tsx` and change the value of `title` from `"Hello World"` to `"Hello Lens"`:
 
@@ -54,7 +56,8 @@ clusterPageMenus = [
 ]
 ```
 
-Reload Lens and you will see that the menu item text has changed to "Hello Lens." To reload Lens, enter `CMD+R` on Mac and `Ctrl+R` on Windows/Linux.
+Reload Lens and you will see that the menu item text has changed to "Hello Lens".
+To reload Lens, enter `CMD+R` on Mac and `Ctrl+R` on Windows/Linux.
 
 ![Hello World](images/hello-lens.png)
 
@@ -66,6 +69,7 @@ To debug your extension, please see our instructions on [Testing Extensions](../
 
 To dive deeper, consider looking at [Common Capabilities](../capabilities/common-capabilities.md), [Styling](../capabilities/styling.md), or [Extension Anatomy](anatomy.md).
 
-If you find problems with the Lens Extension Generator, or have feature requests, you are welcome to raise an [issue](https://github.com/lensapp/generator-lens-ext/issues). You can find the Lens contribution guidelines [here](../../contributing/README.md).
+If you find problems with the Lens Extension Generator, or have feature requests, you are welcome to raise an [issue](https://github.com/lensapp/generator-lens-ext/issues).
+You can find the Lens contribution guidelines [here](../../contributing/README.md).
 
 The Generator source code is hosted at [Github](https://github.com/lensapp/generator-lens-ext).

--- a/docs/extensions/guides/kube-object-list-layout.md
+++ b/docs/extensions/guides/kube-object-list-layout.md
@@ -1,26 +1,30 @@
 # KubeObjectListLayout Sample
 
-In this guide we will learn how to list Kubernetes CRD objects on the cluster dashboard. You can see the complete source code for this guide [here](https://github.com/lensapp/lens-extension-samples/tree/master/custom-resource-page).
-
+In this guide we will learn how to list Kubernetes CRD objects on the cluster dashboard.
+You can see the complete source code for this guide [here](https://github.com/lensapp/lens-extension-samples/tree/master/custom-resource-page).
 
 ![](./images/certificates-crd-list.png)
 
-Next, we will go the implementation through in steps. To achieve our goal, we need to:
+Next, we will go the implementation through in steps.
+To achieve our goal, we need to:
 
-1. [Register ClustePage and ClusterPageMenu objects](#register-objects-for-clustepages-and-clusterpagemenus)
+1. [Register ClusterPage and ClusterPageMenu objects](#register-objects-for-clustepages-and-clusterpagemenus)
 2. [List Certificate Objects on the Cluster Page](#list-certificate-objects-on-the-cluster-page)
 3. [Customize Details Panel](#customize-details-panel)
 
 ## Register `clusterPage` and `clusterPageMenu` Objects
 
-First thing we need to do with our extension is to register new menu item in the cluster menu and create a cluster page that is opened when clicking the menu item. We will do this in our extension class `CrdSampleExtension` that is derived `LensRendererExtension` class:
+First thing we need to do with our extension is to register new menu item in the cluster menu and create a cluster page that is opened when clicking the menu item.
+We will do this in our extension class `CrdSampleExtension` that is derived `LensRendererExtension` class:
 
 ```typescript
 export default class CrdSampleExtension extends LensRendererExtension {
 }
 ```
 
-To register menu item in the cluster menu we need to register `PageMenuRegistration` object. This object will register a menu item with "Certificates" text. It will also use `CertificateIcon` component to render an icon and navigate to cluster page that is having `certificates` page id.
+To register menu item in the cluster menu we need to register `PageMenuRegistration` object.
+This object will register a menu item with "Certificates" text.
+It will also use `CertificateIcon` component to render an icon and navigate to cluster page that is having `certificates` page id.
 
 ```typescript
 export function CertificateIcon(props: Component.IconProps) {
@@ -59,11 +63,15 @@ export default class CrdSampleExtension extends LensRendererExtension {
 
 ## List Certificate Objects on the Cluster Page
 
-In the previous step we defined `CertificatePage` component to render certificates. In this step we will actually implement that. `CertificatePage` is a React component that will render `Component.KubeObjectListLayout` component to list `Certificate` CRD objects.
+In the previous step we defined `CertificatePage` component to render certificates.
+In this step we will actually implement that.
+`CertificatePage` is a React component that will render `Component.KubeObjectListLayout` component to list `Certificate` CRD objects.
 
 ### Get CRD objects
 
-In order to list CRD objects, we need first fetch those from Kubernetes API. Lens Extensions API provides easy mechanism to do this. We just need to define `Certificate` class derived from `K8sApi.KubeObject`, `CertificatesApi`derived from `K8sApi.KubeApi` and `CertificatesStore` derived from `K8sApi.KubeObjectStore`.
+In order to list CRD objects, we need first fetch those from Kubernetes API.
+Lens Extensions API provides easy mechanism to do this.
+We just need to define `Certificate` class derived from `K8sApi.KubeObject`, `CertificatesApi`derived from `K8sApi.KubeApi` and `CertificatesStore` derived from `K8sApi.KubeObjectStore`.
 
 `Certificate` class defines properties found in the CRD object:
 
@@ -139,7 +147,8 @@ K8sApi.apiManager.registerStore(certificatesStore);
 
 ### Create CertificatePage component
 
-Now we have created mechanism to manage `Certificate` objects in Kubernetes API. Then we need to fetch those and render them in the UI.
+Now we have created mechanism to manage `Certificate` objects in Kubernetes API.
+Then we need to fetch those and render them in the UI.
 
 First we define `CertificatePage` class that extends `React.Component`.
 
@@ -154,7 +163,11 @@ export class CertificatePage extends React.Component<{ extension: LensRendererEx
 }
 ```
 
-Next we will implement `render` method that will display certificates in a list. To do that, we just need to add `Component.KubeObjectListLayout` component inside `Component.TabLayout` component in render method. To define which objects the list is showing, we need to pass `certificateStore` object to `Component.KubeObjectListLayout` in `store` property. `Component.KubeObjectListLayout` will fetch automacially items from the given store when component is mounted. Also, we can define needed sorting callbacks and search filters for the list:
+Next we will implement `render` method that will display certificates in a list.
+To do that, we just need to add `Component.KubeObjectListLayout` component inside `Component.TabLayout` component in render method.
+To define which objects the list is showing, we need to pass `certificateStore` object to `Component.KubeObjectListLayout` in `store` property.
+`Component.KubeObjectListLayout` will fetch automatically items from the given store when component is mounted.
+Also, we can define needed sorting callbacks and search filters for the list:
 
 ```typescript
 enum sortBy {
@@ -199,9 +212,11 @@ export class CertificatePage extends React.Component<{ extension: LensRendererEx
 
 ### Customize Details panel
 
-We have learned now, how to list CRD objects in a list view. Next, we will learn how to customize details panel that will be opened when the object is clicked in the list.
+We have learned now, how to list CRD objects in a list view.
+Next, we will learn how to customize details panel that will be opened when the object is clicked in the list.
 
-First, we need to register our custom component to render details for the specific Kubernetes custom resource, in our case `Certificate`. We will do this again in `CrdSampleExtension` class:
+First, we need to register our custom component to render details for the specific Kubernetes custom resource, in our case `Certificate`.
+We will do this again in `CrdSampleExtension` class:
 
 ```typescript
 export default class CrdSampleExtension extends LensRendererExtension {
@@ -217,7 +232,10 @@ export default class CrdSampleExtension extends LensRendererExtension {
 }
 ```
 
-Here we defined that `CertificateDetails` component will render the resource details. So, next we need to implement that component. Lens will inject `Certificate` object into our component so we just need to render some information out of it. We can use `Component.DrawerItem` component from Lens Extensions API to give the same look and feel as Lens is using elsewhere:
+Here we defined that `CertificateDetails` component will render the resource details.
+So, next we need to implement that component.
+Lens will inject `Certificate` object into our component so we just need to render some information out of it.
+We can use `Component.DrawerItem` component from Lens Extensions API to give the same look and feel as Lens is using elsewhere:
 
 ```typescript
 import { Component, K8sApi } from "@k8slens/extensions";
@@ -265,4 +283,5 @@ export class CertificateDetails extends React.Component<CertificateDetailsProps>
 
 ## Summary
 
-Like we can see above, it's very easy to add custom pages and fetch Kubernetes resources by using Extensions API. Please see the [complete source code](https://github.com/lensapp/lens-extension-samples/tree/master/custom-resource-page) to test it out.
+Like we can see above, it's very easy to add custom pages and fetch Kubernetes resources by using Extensions API.
+Please see the [complete source code](https://github.com/lensapp/lens-extension-samples/tree/master/custom-resource-page) to test it out.

--- a/docs/extensions/guides/main-extension.md
+++ b/docs/extensions/guides/main-extension.md
@@ -1,6 +1,8 @@
 # Main Extension
 
-The Main Extension API is the interface to Lens's main process. Lens runs in both main and renderer processes. The Main Extension API allows you to access, configure, and customize Lens data, add custom application menu items, and run custom code in Lens's main process.
+The Main Extension API is the interface to Lens's main process.
+Lens runs in both main and renderer processes.
+The Main Extension API allows you to access, configure, and customize Lens data, add custom application menu items, and run custom code in Lens's main process.
 
 ## `LensMainExtension` Class
 
@@ -22,16 +24,23 @@ export default class ExampleExtensionMain extends LensMainExtension {
 }
 ```
 
-Two methods enable you to run custom code: `onActivate()` and `onDeactivate()`. Enabling your extension calls `onActivate()` and disabling your extension calls `onDeactivate()`. You can initiate custom code by implementing `onActivate()`. Implementing `onDeactivate()` gives you the opportunity to clean up after your extension.
+Two methods enable you to run custom code: `onActivate()` and `onDeactivate()`.
+Enabling your extension calls `onActivate()` and disabling your extension calls `onDeactivate()`.
+You can initiate custom code by implementing `onActivate()`.
+Implementing `onDeactivate()` gives you the opportunity to clean up after your extension.
 
 Disable extensions from the Lens Extensions page:
 
-1. Navigate to **File** > **Extensions** in the top menu bar. (On Mac, it is **Lens** > **Extensions**.)
+1. Navigate to **File** > **Extensions** in the top menu bar.
+(On Mac, it is **Lens** > **Extensions**.)
 2. Click **Disable** on the extension you want to disable.
 
-The example above logs messages when the extension is enabled and disabled. To see standard output from the main process there must be a console connected to it. Achieve this by starting Lens from the command prompt.
+The example above logs messages when the extension is enabled and disabled.
+To see standard output from the main process there must be a console connected to it.
+Achieve this by starting Lens from the command prompt.
 
-The following example is a little more interesting. It accesses some Lens state data, and it periodically logs the name of the cluster that is currently active in Lens.
+The following example is a little more interesting.
+It accesses some Lens state data, and it periodically logs the name of the cluster that is currently active in Lens.
 
 ```typescript
 import { LensMainExtension, Store } from "@k8slens/extensions";
@@ -64,7 +73,9 @@ For more details on accessing Lens state data, please see the [Stores](../stores
 
 ### `appMenus`
 
-The Main Extension API allows you to customize the UI application menu. Note that this is the only UI feature that the Main Extension API allows you to customize. The following example demonstrates adding an item to the **Help** menu.
+The Main Extension API allows you to customize the UI application menu.
+Note that this is the only UI feature that the Main Extension API allows you to customize.
+The following example demonstrates adding an item to the **Help** menu.
 
 ``` typescript
 import { LensMainExtension } from "@k8slens/extensions";
@@ -82,8 +93,15 @@ export default class SamplePageMainExtension extends LensMainExtension {
 }
 ```
 
-`appMenus` is an array of objects that satisfy the `MenuRegistration` interface. `MenuRegistration` extends React's `MenuItemConstructorOptions` interface. The properties of the appMenus array objects are defined as follows:
+`appMenus` is an array of objects that satisfy the `MenuRegistration` interface.
+`MenuRegistration` extends React's `MenuItemConstructorOptions` interface.
+The properties of the appMenus array objects are defined as follows:
 
-* `parentId` is the name of the menu where your new menu item will be listed. Valid values include: `"file"`, `"edit"`, `"view"`, and `"help"`. `"lens"` is valid on Mac only.
+* `parentId` is the name of the menu where your new menu item will be listed.
+Valid values include: `"file"`, `"edit"`, `"view"`, and `"help"`.
+`"lens"` is valid on Mac only.
 * `label` is the name of your menu item.
-* `click()` is called when the menu item is selected. In this example, we simply log a message. However, you would typically have this navigate to a specific page or perform another operation. Note that pages are associated with the [`LensRendererExtension`](renderer-extension.md) class and can be defined in the process of extending it. 
+* `click()` is called when the menu item is selected.
+In this example, we simply log a message.
+However, you would typically have this navigate to a specific page or perform another operation.
+Note that pages are associated with the [`LensRendererExtension`](renderer-extension.md) class and can be defined in the process of extending it.

--- a/docs/extensions/guides/renderer-extension.md
+++ b/docs/extensions/guides/renderer-extension.md
@@ -1,6 +1,8 @@
 # Renderer Extension
 
-The Renderer Extension API is the interface to Lens's renderer process. Lens runs in both the main and renderer processes. The Renderer Extension API allows you to access, configure, and customize Lens data, add custom Lens UI elements, and run custom code in Lens's renderer process.
+The Renderer Extension API is the interface to Lens's renderer process.
+Lens runs in both the main and renderer processes.
+The Renderer Extension API allows you to access, configure, and customize Lens data, add custom Lens UI elements, and run custom code in Lens's renderer process.
 
 The custom Lens UI elements that you can add include:
 
@@ -36,19 +38,26 @@ export default class ExampleExtensionMain extends LensRendererExtension {
 }
 ```
 
-Two methods enable you to run custom code: `onActivate()` and `onDeactivate()`. Enabling your extension calls `onActivate()` and disabling your extension calls `onDeactivate()`. You can initiate custom code by implementing `onActivate()`. Implementing `onDeactivate()` gives you the opportunity to clean up after your extension.
+Two methods enable you to run custom code: `onActivate()` and `onDeactivate()`.
+Enabling your extension calls `onActivate()` and disabling your extension calls `onDeactivate()`.
+You can initiate custom code by implementing `onActivate()`.
+Implementing `onDeactivate()` gives you the opportunity to clean up after your extension.
 
 !!! info
     Disable extensions from the Lens Extensions page:
 
-    1. Navigate to **File** > **Extensions** in the top menu bar. (On Mac, it is **Lens** > **Extensions**.)
+    1. Navigate to **File** > **Extensions** in the top menu bar.
+    (On Mac, it is **Lens** > **Extensions**.)
     2. Click **Disable** on the extension you want to disable.
 
 The example above logs messages when the extension is enabled and disabled.
 
 ### `clusterPages`
 
-Cluster pages appear in the cluster dashboard. Use cluster pages to display information about or add functionality to the active cluster. It is also possible to include custom details from other clusters. Use your extension to access Kubernetes resources in the active cluster with [`clusterStore`](../stores#clusterstore).
+Cluster pages appear in the cluster dashboard.
+Use cluster pages to display information about or add functionality to the active cluster.
+It is also possible to include custom details from other clusters.
+Use your extension to access Kubernetes resources in the active cluster with [`clusterStore`](../stores#clusterstore).
 
 Add a cluster page definition to a `LensRendererExtension` subclass with the following example:
 
@@ -69,11 +78,13 @@ export default class ExampleExtension extends LensRendererExtension {
 }
 ```
 
-`clusterPages` is an array of objects that satisfy the `PageRegistration` interface. The properties of the `clusterPages` array objects are defined as follows:
+`clusterPages` is an array of objects that satisfy the `PageRegistration` interface.
+The properties of the `clusterPages` array objects are defined as follows:
 
 * `id` is a string that identifies the page.
 * `components` matches the `PageComponents` interface for which there is one field, `Page`.
-* `Page` is of type ` React.ComponentType<any>`. It offers flexibility in defining the appearance and behavior of your page.
+* `Page` is of type ` React.ComponentType<any>`.
+It offers flexibility in defining the appearance and behavior of your page.
 
 `ExamplePage` in the example above can be defined in `page.tsx`:
 
@@ -92,9 +103,12 @@ export class ExamplePage extends React.Component<{ extension: LensRendererExtens
 }
 ```
 
-Note that the `ExamplePage` class defines the `extension` property. This allows the `ExampleExtension` object to be passed in the cluster page definition in the React style. This way, `ExamplePage` can access all `ExampleExtension` subclass data.
+Note that the `ExamplePage` class defines the `extension` property.
+This allows the `ExampleExtension` object to be passed in the cluster page definition in the React style.
+This way, `ExamplePage` can access all `ExampleExtension` subclass data.
 
-The above example shows how to create a cluster page, but not how to make that page available to the Lens user. Use `clusterPageMenus`, covered in the next section, to add cluster pages to the Lens UI.
+The above example shows how to create a cluster page, but not how to make that page available to the Lens user.
+Use `clusterPageMenus`, covered in the next section, to add cluster pages to the Lens UI.
 
 ### `clusterPageMenus`
 
@@ -129,14 +143,17 @@ export default class ExampleExtension extends LensRendererExtension {
 }
 ```
 
-`clusterPageMenus` is an array of objects that satisfy the `ClusterPageMenuRegistration` interface. This element defines how the cluster page menu item will appear and what it will do when you click it. The properties of the `clusterPageMenus` array objects are defined as follows:
+`clusterPageMenus` is an array of objects that satisfy the `ClusterPageMenuRegistration` interface.
+This element defines how the cluster page menu item will appear and what it will do when you click it.
+The properties of the `clusterPageMenus` array objects are defined as follows:
 
 * `target` links to the relevant cluster page using `pageId`.
 * `pageId` takes the value of the relevant cluster page's `id` property.
 * `title` sets the name of the cluster page menu item that will appear in the left side menu.
 * `components` is used to set an icon that appears to the left of the `title` text in the left side menu.
 
-The above example creates a menu item that reads **Hello World**. When users click **Hello World**, the cluster dashboard will show the contents of `Example Page`.
+The above example creates a menu item that reads **Hello World**.
+When users click **Hello World**, the cluster dashboard will show the contents of `Example Page`.
 
 This example requires the definition of another React-based component, `ExampleIcon`, which has been added to `page.tsx`, as follows:
 
@@ -159,12 +176,15 @@ export class ExamplePage extends React.Component<{ extension: LensRendererExtens
 }
 ```
 
-Lens includes various built-in components available for extension developers to use. One of these is the `Component.Icon`, introduced in `ExampleIcon`, which you can use to access any of the [icons](https://material.io/resources/icons/) available at [Material Design](https://material.io). The properties that `Component.Icon` uses are defined as follows:
+Lens includes various built-in components available for extension developers to use.
+One of these is the `Component.Icon`, introduced in `ExampleIcon`, which you can use to access any of the [icons](https://material.io/resources/icons/) available at [Material Design](https://material.io).
+The properties that `Component.Icon` uses are defined as follows:
 
 * `material` takes the name of the icon you want to use.
 * `tooltip` sets the text you want to appear when a user hovers over the icon.
 
-`clusterPageMenus` can also be used to define sub menu items, so that you can create groups of cluster pages. The following example groups two sub menu items under one parent menu item:
+`clusterPageMenus` can also be used to define sub menu items, so that you can create groups of cluster pages.
+The following example groups two sub menu items under one parent menu item:
 
 
 ```typescript
@@ -232,9 +252,12 @@ This is what the example will look like, including how the menu item will appear
 
 ### `globalPages`
 
-Global pages are independent of the cluster dashboard and can fill the entire Lens UI. Their primary use is to display information and provide functionality across clusters, including customized data and functionality unique to your extension.
+Global pages are independent of the cluster dashboard and can fill the entire Lens UI.
+Their primary use is to display information and provide functionality across clusters, including customized data and functionality unique to your extension.
 
-Typically, you would use a [global page menu](#globalpagemenus) located in the left nav to trigger a global page. You can also trigger a global page with a [custom app menu selection](../main-extension#appmenus) from a Main Extension or a [custom status bar item](#statusbaritems). Unlike cluster pages, users can trigger global pages even when there is no active cluster.
+Typically, you would use a [global page menu](#globalpagemenus) located in the left nav to trigger a global page.
+You can also trigger a global page with a [custom app menu selection](../main-extension#appmenus) from a Main Extension or a [custom status bar item](#statusbaritems).
+Unlike cluster pages, users can trigger global pages even when there is no active cluster.
 
 The following example defines a `LensRendererExtension` subclass with a single global page definition:
 
@@ -255,11 +278,13 @@ export default class HelpExtension extends LensRendererExtension {
 }
 ```
 
-`globalPages` is an array of objects that satisfy the `PageRegistration` interface. The properties of the `globalPages` array objects are defined as follows:
+`globalPages` is an array of objects that satisfy the `PageRegistration` interface.
+The properties of the `globalPages` array objects are defined as follows:
 
 * `id` is a string that identifies the page.
 * `components` matches the `PageComponents` interface for which there is one field, `Page`.
-* `Page` is of type `React.ComponentType<any>`. It offers flexibility in defining the appearance and behavior of your page.
+* `Page` is of type `React.ComponentType<any>`.
+It offers flexibility in defining the appearance and behavior of your page.
 
 `HelpPage` in the example above can be defined in `page.tsx`:
 
@@ -278,9 +303,12 @@ export class HelpPage extends React.Component<{ extension: LensRendererExtension
 }
 ```
 
-Note that the `HelpPage` class defines the `extension` property. This allows the `HelpExtension` object to be passed in the global page definition in the React-style. This way, `HelpPage` can access all `HelpExtension` subclass data.
+Note that the `HelpPage` class defines the `extension` property.
+This allows the `HelpExtension` object to be passed in the global page definition in the React-style.
+This way, `HelpPage` can access all `HelpExtension` subclass data.
 
-This example code shows how to create a global page, but not how to make that page available to the Lens user. Global pages can be made available in the following ways:
+This example code shows how to create a global page, but not how to make that page available to the Lens user.
+Global pages can be made available in the following ways:
 
 * To add global pages to the top menu bar, see [`appMenus`](../main-extension#appmenus) in the Main Extension guide.
 * To add global pages as an interactive element in the blue status bar along the bottom of the Lens UI, see [`statusBarItems`](#statusbaritems).
@@ -319,16 +347,20 @@ export default class HelpExtension extends LensRendererExtension {
 }
 ```
 
-`globalPageMenus` is an array of objects that satisfy the `PageMenuRegistration` interface. This element defines how the global page menu item will appear and what it will do when you click it. The properties of the `globalPageMenus` array objects are defined as follows:
+`globalPageMenus` is an array of objects that satisfy the `PageMenuRegistration` interface.
+This element defines how the global page menu item will appear and what it will do when you click it.
+The properties of the `globalPageMenus` array objects are defined as follows:
 
 * `target` links to the relevant global page using `pageId`.
 * `pageId` takes the value of the relevant global page's `id` property.
 * `title` sets the name of the global page menu item that will display as a tooltip in the left nav.
 * `components` is used to set an icon that appears in the left nav.
 
-The above example creates a "Help" icon menu item. When users click the icon, the Lens UI will display the contents of `ExamplePage`.
+The above example creates a "Help" icon menu item.
+When users click the icon, the Lens UI will display the contents of `ExamplePage`.
 
-This example requires the definition of another React-based component, `HelpIcon`. Update `page.tsx` from the example above with the `HelpIcon` definition, as follows:
+This example requires the definition of another React-based component, `HelpIcon`.
+Update `page.tsx` from the example above with the `HelpIcon` definition, as follows:
 
 ```typescript
 import { LensRendererExtension, Component } from "@k8slens/extensions";
@@ -349,7 +381,9 @@ export class HelpPage extends React.Component<{ extension: LensRendererExtension
 }
 ```
 
-Lens includes various built-in components available for extension developers to use. One of these is the `Component.Icon`, introduced in `HelpIcon`, which you can use to access any of the [icons](https://material.io/resources/icons/) available at [Material Design](https://material.io). The property that `Component.Icon` uses is defined as follows:
+Lens includes various built-in components available for extension developers to use.
+One of these is the `Component.Icon`, introduced in `HelpIcon`, which you can use to access any of the [icons](https://material.io/resources/icons/) available at [Material Design](https://material.io).
+The property that `Component.Icon` uses is defined as follows:
 
 * `material` takes the name of the icon you want to use.
 
@@ -423,7 +457,8 @@ Consider using the following properties with `updateStatus()`:
 
     * `status.installed` should be set to `true` if the feature is installed, and `false` otherwise.
 
-    * `status.canUpgrade` is set according to a rule meant to determine whether the feature can be upgraded. This rule can involve `status.currentVersion` and `status.latestVersion`, if desired.
+    * `status.canUpgrade` is set according to a rule meant to determine whether the feature can be upgraded.
+    This rule can involve `status.currentVersion` and `status.latestVersion`, if desired.
 
 The following shows a very simple implementation of a `ClusterFeature`:
 
@@ -489,15 +524,18 @@ spec:
 
 The example above implements the four methods as follows:
 
-* It implements `upgrade()` by invoking the `install()` method. Depending on the feature to be supported by an extension, upgrading may require additional and/or different steps.
+* It implements `upgrade()` by invoking the `install()` method.
+Depending on the feature to be supported by an extension, upgrading may require additional and/or different steps.
 
 * It implements `uninstall()` by utilizing the [Kubernetes API](../api/README.md) which Lens provides to delete the `example-pod` applied by the `install()` method.
 
-* It implements `updateStatus()` by using the [Kubernetes API](../api/README.md) which Lens provides to determine whether the `example-pod` is installed, what version is associated with it, and whether it can be upgraded. The implementation determines what the status is for a specific cluster feature.
+* It implements `updateStatus()` by using the [Kubernetes API](../api/README.md) which Lens provides to determine whether the `example-pod` is installed, what version is associated with it, and whether it can be upgraded.
+The implementation determines what the status is for a specific cluster feature.
 
 ### `appPreferences`
 
-The Lens **Preferences** page is a built-in global page. You can use Lens extensions to add custom preferences to the Preferences page, providing a single location for users to configure global options.
+The Lens **Preferences** page is a built-in global page.
+You can use Lens extensions to add custom preferences to the Preferences page, providing a single location for users to configure global options.
 
 The following example demonstrates adding a custom preference:
 
@@ -523,7 +561,8 @@ export default class ExampleRendererExtension extends LensRendererExtension {
 }
 ```
 
-`appPreferences` is an array of objects that satisfies the `AppPreferenceRegistration` interface. The properties of the `appPreferences` array objects are defined as follows:
+`appPreferences` is an array of objects that satisfies the `AppPreferenceRegistration` interface.
+The properties of the `appPreferences` array objects are defined as follows:
 
 * `title` sets the heading text displayed on the Preferences page.
 * `components` specifies two `React.Component` objects that define the interface for the preference.
@@ -533,7 +572,8 @@ export default class ExampleRendererExtension extends LensRendererExtension {
 !!! note
     Note that the input and the hint can be comprised of more sophisticated elements, according to the needs of the extension.
 
-`ExamplePreferenceInput` expects its React props to be set to an `ExamplePreferenceProps` instance. This is how `ExampleRendererExtension` handles the state of the preference input.
+`ExamplePreferenceInput` expects its React props to be set to an `ExamplePreferenceProps` instance.
+This is how `ExampleRendererExtension` handles the state of the preference input.
 `ExampleRendererExtension` has a `preference` field, which you will add to `ExamplePreferenceInput`.
 
 In this example `ExamplePreferenceInput`, `ExamplePreferenceHint`, and `ExamplePreferenceProps` are defined in `./src/example-preference.tsx` as follows:
@@ -579,20 +619,31 @@ export class ExamplePreferenceHint extends React.Component {
 * `value` is initially set to `preference.enabled`.
 * `onChange` is a function that responds when the state of the checkbox changes.
 
-`ExamplePreferenceInput` is defined with the `ExamplePreferenceProps` React props. This is an object with the single `enabled` property. It is used to indicate the state of the preference, and it is bound to the checkbox state in `onChange`.
+`ExamplePreferenceInput` is defined with the `ExamplePreferenceProps` React props.
+This is an object with the single `enabled` property.
+It is used to indicate the state of the preference, and it is bound to the checkbox state in `onChange`.
 
 `ExamplePreferenceHint` is a simple text span.
 
-The above example introduces the decorators `observable` and `observer` from the [`mobx`](https://mobx.js.org/README.html) and [`mobx-react`](https://github.com/mobxjs/mobx-react#mobx-react) packages. `mobx` simplifies state management. Without it, this example would not visually update the checkbox properly when the user activates it. [Lens uses `mobx`](../working-with-mobx) extensively for state management of its own UI elements. We recommend that extensions rely on it, as well.
+The above example introduces the decorators `observable` and `observer` from the [`mobx`](https://mobx.js.org/README.html) and [`mobx-react`](https://github.com/mobxjs/mobx-react#mobx-react) packages.
+`mobx` simplifies state management.
+Without it, this example would not visually update the checkbox properly when the user activates it.
+[Lens uses `mobx`](../working-with-mobx) extensively for state management of its own UI elements.
+We recommend that extensions rely on it, as well.
 Alternatively, you can use React's state management, though `mobx` is typically simpler to use.
 
-Note that you can manage an extension's state data using an `ExtensionStore` object, which conveniently handles persistence and synchronization. To simplify this guide, the example above defines a `preference` field in the `ExampleRendererExtension` class definition to hold the extension's state. However, we recommend that you manage your extension's state data using [`ExtensionStore`](../stores#extensionstore).
+Note that you can manage an extension's state data using an `ExtensionStore` object, which conveniently handles persistence and synchronization.
+To simplify this guide, the example above defines a `preference` field in the `ExampleRendererExtension` class definition to hold the extension's state.
+However, we recommend that you manage your extension's state data using [`ExtensionStore`](../stores#extensionstore).
 
 ### `statusBarItems`
 
-The status bar is the blue strip along the bottom of the Lens UI. `statusBarItems` are `React.ReactNode` types. They can be used to display status information, or act as links to global pages as well as external pages.
+The status bar is the blue strip along the bottom of the Lens UI.
+`statusBarItems` are `React.ReactNode` types.
+They can be used to display status information, or act as links to global pages as well as external pages.
 
-The following example adds a `statusBarItems` definition and a `globalPages` definition to a `LensRendererExtension` subclass. It configures the status bar item to navigate to the global page upon activation (normally a mouse click):
+The following example adds a `statusBarItems` definition and a `globalPages` definition to a `LensRendererExtension` subclass.
+It configures the status bar item to navigate to the global page upon activation (normally a mouse click):
 
 ```typescript
 import { LensRendererExtension } from '@k8slens/extensions';
@@ -629,8 +680,14 @@ export default class HelpExtension extends LensRendererExtension {
 
 The properties of the `statusBarItems` array objects are defined as follows:
 
-* `Item` specifies the `React.Component` that will be shown on the status bar. By default, items are added starting from the right side of the status bar. Due to limited space in the status bar, `Item` will typically specify only an icon or a short string of text. The example above reuses the `HelpIcon` from the [`globalPageMenus` guide](#globalpagemenus).
-* `onClick` determines what the `statusBarItem` does when it is clicked. In the example, `onClick` is set to a function that calls the `LensRendererExtension` `navigate()` method. `navigate` takes the `id` of the associated global page as a parameter. Thus, clicking the status bar item activates the associated global pages.
+* `Item` specifies the `React.Component` that will be shown on the status bar.
+By default, items are added starting from the right side of the status bar.
+Due to limited space in the status bar, `Item` will typically specify only an icon or a short string of text.
+The example above reuses the `HelpIcon` from the [`globalPageMenus` guide](#globalpagemenus).
+* `onClick` determines what the `statusBarItem` does when it is clicked.
+In the example, `onClick` is set to a function that calls the `LensRendererExtension` `navigate()` method.
+`navigate` takes the `id` of the associated global page as a parameter.
+Thus, clicking the status bar item activates the associated global pages.
 
 ### `kubeObjectMenuItems`
 
@@ -664,12 +721,15 @@ export default class ExampleExtension extends LensRendererExtension {
 
 ```
 
-`kubeObjectMenuItems` is an array of objects matching the `KubeObjectMenuRegistration` interface. The example above adds a menu item for namespaces in the cluster dashboard. The properties of the `kubeObjectMenuItems` array objects are defined as follows:
+`kubeObjectMenuItems` is an array of objects matching the `KubeObjectMenuRegistration` interface.
+The example above adds a menu item for namespaces in the cluster dashboard.
+The properties of the `kubeObjectMenuItems` array objects are defined as follows:
 
 * `kind` specifies the Kubernetes resource type the menu item will apply to.
 * `apiVersion` specifies the Kubernetes API version number to use with the resource type.
 * `components` defines the menu item's appearance and behavior.
-* `MenuItem` provides a function that returns a `React.Component` given a set of menu item properties. In this example a `NamespaceMenuItem` object is returned.
+* `MenuItem` provides a function that returns a `React.Component` given a set of menu item properties.
+In this example a `NamespaceMenuItem` object is returned.
 
 `NamespaceMenuItem` is defined in `./src/namespace-menu-item.tsx`:
 
@@ -705,9 +765,14 @@ export function NamespaceMenuItem(props: Component.KubeObjectMenuProps<K8sApi.Na
 
 ```
 
-`NamespaceMenuItem` returns a `Component.MenuItem` which defines the menu item's appearance and its behavior when activated via the `onClick` property. In the example, `getPods()` opens a terminal tab and runs `kubectl` to get a list of pods running in the current namespace.
+`NamespaceMenuItem` returns a `Component.MenuItem` which defines the menu item's appearance and its behavior when activated via the `onClick` property.
+In the example, `getPods()` opens a terminal tab and runs `kubectl` to get a list of pods running in the current namespace.
 
-The name of the namespace is retrieved from `props` passed into `NamespaceMenuItem()`. `namespace` is the `props.object`, which is of type `K8sApi.Namespace`. `K8sApi.Namespace` is the API for accessing namespaces. The current namespace in this example is simply given by `namespace.getName()`. Thus, `kubeObjectMenuItems` afford convenient access to the specific resource selected by the user.
+The name of the namespace is retrieved from `props` passed into `NamespaceMenuItem()`.
+`namespace` is the `props.object`, which is of type `K8sApi.Namespace`.
+`K8sApi.Namespace` is the API for accessing namespaces.
+The current namespace in this example is simply given by `namespace.getName()`.
+Thus, `kubeObjectMenuItems` afford convenient access to the specific resource selected by the user.
 
 ### `kubeObjectDetailItems`
 
@@ -737,12 +802,15 @@ export default class ExampleExtension extends LensRendererExtension {
 }
 ```
 
-`kubeObjectDetailItems` is an array of objects matching the `KubeObjectDetailRegistration` interface. This example above adds a detail item for namespaces in the cluster dashboard. The properties of the `kubeObjectDetailItems` array objects are defined as follows:
+`kubeObjectDetailItems` is an array of objects matching the `KubeObjectDetailRegistration` interface.
+This example above adds a detail item for namespaces in the cluster dashboard.
+The properties of the `kubeObjectDetailItems` array objects are defined as follows:
 
 * `kind` specifies the Kubernetes resource type the detail item will apply to.
 * `apiVersion` specifies the Kubernetes API version number to use with the resource type.
 * `components` defines the detail item's appearance and behavior.
-* `Details` provides a function that returns a `React.Component` given a set of detail item properties. In this example a `NamespaceDetailsItem` object is returned.
+* `Details` provides a function that returns a `React.Component` given a set of detail item properties.
+In this example a `NamespaceDetailsItem` object is returned.
 
 `NamespaceDetailsItem` is defined in `./src/namespace-details-item.tsx`:
 
@@ -842,8 +910,8 @@ export class PodsDetailsList extends React.Component<Props> {
 
 ![DetailsWithPods](images/kubeobjectdetailitemwithpods.png)
 
-Obtain the name, age, and status for each pod using the `K8sApi.Pod` methods. Construct the table using the `Component.Table` and related elements.
-
+Obtain the name, age, and status for each pod using the `K8sApi.Pod` methods.
+Construct the table using the `Component.Table` and related elements.
 
 For each pod the name, age, and status are obtained using the `K8sApi.Pod` methods.
 The table is constructed using the `Component.Table` and related elements.

--- a/docs/extensions/guides/stores.md
+++ b/docs/extensions/guides/stores.md
@@ -10,7 +10,10 @@ This guide focuses on the `ExtensionStore`.
 
 ## ExtensionStore
 
-Extension developers can create their own store for managing state data by extending the `ExtensionStore` class. This guide shows how to create a store for the [`appPreferences`](../renderer-extension#apppreferences) guide example, which demonstrates how to add a custom preference to the **Preferences** page. The preference is a simple boolean that indicates whether or not something is enabled. However, in the example, the enabled state is not stored anywhere, and it reverts to the default when Lens is restarted.
+Extension developers can create their own store for managing state data by extending the `ExtensionStore` class.
+This guide shows how to create a store for the [`appPreferences`](../renderer-extension#apppreferences) guide example, which demonstrates how to add a custom preference to the **Preferences** page.
+The preference is a simple boolean that indicates whether or not something is enabled.
+However, in the example, the enabled state is not stored anywhere, and it reverts to the default when Lens is restarted.
 
 The following example code creates a store for the `appPreferences` guide example:
 
@@ -34,7 +37,7 @@ export class ExamplePreferencesStore extends Store.ExtensionStore<ExamplePrefere
       }
     });
   }
- 
+
   protected fromStore({ enabled }: ExamplePreferencesModel): void {
     this.enabled = enabled;
   }
@@ -51,14 +54,30 @@ export class ExamplePreferencesStore extends Store.ExtensionStore<ExamplePrefere
 export const examplePreferencesStore = ExamplePreferencesStore.getInstance<ExamplePreferencesStore>();
 ```
 
-First, our example defines the extension's data model using the simple `ExamplePreferencesModel` type. This has a single field, `enabled`, which represents the preference's state. `ExamplePreferencesStore` extends `Store.ExtensionStore`, which is based on the `ExamplePreferencesModel`. The `enabled` field is added to the `ExamplePreferencesStore` class to hold the "live" or current state of the preference. Note the use of the `observable` decorator on the `enabled` field. The [`appPreferences`](../renderer-extension#apppreferences) guide example uses [MobX](https://mobx.js.org/README.html) for the UI state management, ensuring the checkbox updates when it's activated by the user.
+First, our example defines the extension's data model using the simple `ExamplePreferencesModel` type.
+This has a single field, `enabled`, which represents the preference's state.
+`ExamplePreferencesStore` extends `Store.ExtensionStore`, which is based on the `ExamplePreferencesModel`.
+The `enabled` field is added to the `ExamplePreferencesStore` class to hold the "live" or current state of the preference.
+Note the use of the `observable` decorator on the `enabled` field.
+The [`appPreferences`](../renderer-extension#apppreferences) guide example uses [MobX](https://mobx.js.org/README.html) for the UI state management, ensuring the checkbox updates when it's activated by the user.
 
-Next, our example implements the constructor and two abstract methods. The constructor specifies the name of the store (`"example-preferences-store"`) and the default (initial) value for the preference state (`enabled: false`). Lens internals call the `fromStore()` method when the store loads. It gives the extension the opportunity to retrieve the stored state data values based on the defined data model. The `enabled` field of the `ExamplePreferencesStore` is set to the value from the store whenever `fromStore()` is invoked. The `toJSON()` method is complementary to `fromStore()`. It is called when the store is being saved.
-`toJSON()` must provide a JSON serializable object, facilitating its storage in JSON format. The `toJS()` function from [`mobx`](https://mobx.js.org/README.html) is convenient for this purpose, and is used here.
+Next, our example implements the constructor and two abstract methods.
+The constructor specifies the name of the store (`"example-preferences-store"`) and the default (initial) value for the preference state (`enabled: false`).
+Lens internals call the `fromStore()` method when the store loads.
+It gives the extension the opportunity to retrieve the stored state data values based on the defined data model.
+The `enabled` field of the `ExamplePreferencesStore` is set to the value from the store whenever `fromStore()` is invoked.
+The `toJSON()` method is complementary to `fromStore()`.
+It is called when the store is being saved.
+`toJSON()` must provide a JSON serializable object, facilitating its storage in JSON format.
+The `toJS()` function from [`mobx`](https://mobx.js.org/README.html) is convenient for this purpose, and is used here.
 
-Finally, `examplePreferencesStore` is created by calling `ExamplePreferencesStore.getInstance<ExamplePreferencesStore>()`, and exported for use by other parts of the extension. Note that `examplePreferencesStore` is a singleton. Calling this function again will not create a new store.
+Finally, `examplePreferencesStore` is created by calling `ExamplePreferencesStore.getInstance<ExamplePreferencesStore>()`, and exported for use by other parts of the extension.
+Note that `examplePreferencesStore` is a singleton.
+Calling this function again will not create a new store.
 
-The following example code, modified from the [`appPreferences`](../renderer-extension#apppreferences) guide demonstrates how to use the extension store. `examplePreferencesStore` must be loaded in the main process, where loaded stores are automatically saved when exiting Lens. This can be done in `./main.ts`:
+The following example code, modified from the [`appPreferences`](../renderer-extension#apppreferences) guide demonstrates how to use the extension store.
+`examplePreferencesStore` must be loaded in the main process, where loaded stores are automatically saved when exiting Lens.
+This can be done in `./main.ts`:
 
 ``` typescript
 import { LensMainExtension } from "@k8slens/extensions";
@@ -72,7 +91,8 @@ export default class ExampleMainExtension extends LensMainExtension {
 ```
 
 Here, `examplePreferencesStore` loads with `examplePreferencesStore.loadExtension(this)`, which is conveniently called from the `onActivate()` method of `ExampleMainExtension`.
-Similarly, `examplePreferencesStore` must load in the renderer process where the `appPreferences` are handled. This can be done in `./renderer.ts`:
+Similarly, `examplePreferencesStore` must load in the renderer process where the `appPreferences` are handled.
+This can be done in `./renderer.ts`:
 
 ``` typescript
 import { LensRendererExtension } from "@k8slens/extensions";
@@ -98,7 +118,8 @@ export default class ExampleRendererExtension extends LensRendererExtension {
 }
 ```
 
-Again, `examplePreferencesStore.loadExtension(this)` is called to load `examplePreferencesStore`, this time from the `onActivate()` method of `ExampleRendererExtension`. There is no longer the need for the `preference` field in the `ExampleRendererExtension` class because the props for `ExamplePreferenceInput` is now `examplePreferencesStore`.
+Again, `examplePreferencesStore.loadExtension(this)` is called to load `examplePreferencesStore`, this time from the `onActivate()` method of `ExampleRendererExtension`.
+There is no longer the need for the `preference` field in the `ExampleRendererExtension` class because the props for `ExamplePreferenceInput` is now `examplePreferencesStore`.
 `ExamplePreferenceInput` is defined in `./src/example-preference.tsx`:
 
 ``` typescript
@@ -116,7 +137,7 @@ export class ExamplePreferenceInput extends React.Component<ExamplePreferencePro
 
   render() {
     const { preference } = this.props;
-    
+
     return (
       <Component.Checkbox
         label="I understand appPreferences"
@@ -137,5 +158,5 @@ export class ExamplePreferenceHint extends React.Component {
 ```
 
 The only change here is that `ExamplePreferenceProps` defines its `preference` field as an `ExamplePreferencesStore` type.
-Everything else works as before, except that now the `enabled` state persists across Lens restarts because it is managed by the 
+Everything else works as before, except that now the `enabled` state persists across Lens restarts because it is managed by the
 `examplePreferencesStore`.

--- a/docs/extensions/testing-and-publishing/testing.md
+++ b/docs/extensions/testing-and-publishing/testing.md
@@ -2,9 +2,11 @@
 
 ## Renderer Process Unit Testing
 
-UI components in extension renderer process are based on React/ReactDOM. These components can be tested by popular React testing tools like [React Testing Library](https://github.com/testing-library/react-testing-library).
+UI components in the extension's renderer process are based on React/ReactDOM.
+These components can be tested by popular React testing tools like [React Testing Library](https://github.com/testing-library/react-testing-library).
 
-If you are using the [Yeoman Lens Extension Generator](https://github.com/lensapp/generator-lens-ext) to scaffold extension project. The testing environment for render process are already setup for you. Just use `npm start` or `yarn test` to run the tests.
+If you are using the [Yeoman Lens Extension Generator](https://github.com/lensapp/generator-lens-ext) to scaffold extension project then the testing environment for render process is already set up for you.
+Just use `npm start` or `yarn test` to run the tests.
 
 For example, I have a component `GlobalPageMenuIcon` and want to test if `props.navigate` is called when user clicks the icon.
 
@@ -41,19 +43,22 @@ test("click called navigate()", () => {
 
 In the example we used [React Testing Library](https://github.com/testing-library/react-testing-library) but any React testing framework can be used to test renderer process UI components.
 
-There are more example tests in the generator's [template](https://github.com/lensapp/generator-lens-ext/tree/main/generators/app/templates/ext-ts/components). Extend your tests based on the examples.
+There are more example tests in the generator's [template](https://github.com/lensapp/generator-lens-ext/tree/main/generators/app/templates/ext-ts/components).
+Extend your tests based on the examples.
 
 ## Main Process Unit Testing
 
-Code in the extension main process are just normal JavaScript files that has access to extension api, you can write unit tests using any testing framework.
+Code in the extension's main process consists of normal JavaScript files that have access to extension api, you can write unit tests using any testing framework.
 
-If you are using the [Yeoman Lens Extension Generator](https://github.com/lensapp/generator-lens-ext) to scaffold your extension project. The testing environment [Jest](https://jestjs.io/) are setup for you. Just use  `npm start` or `yarn test` to run the tests.
+If you are using the [Yeoman Lens Extension Generator](https://github.com/lensapp/generator-lens-ext) to scaffold your extension project then the [Jest](https://jestjs.io/) testing environment is set up for you.
+Just use  `npm start` or `yarn test` to run the tests.
 
 ## Tips
 
 ### Console.log
 
-Extension developers might find `console.log()` useful for printing out information and errors from extensions. To use `console.log()`, note that Lens is based on Electron, and that Electron has two types of processes: [Main and Renderer](https://www.electronjs.org/docs/tutorial/quick-start#main-and-renderer-processes).
+Extension developers might find `console.log()` useful for printing out information and errors from extensions.
+To use `console.log()`, note that Lens is based on Electron, and that Electron has two types of processes: [Main and Renderer](https://www.electronjs.org/docs/tutorial/quick-start#main-and-renderer-processes).
 
 ### Renderer Process Logs
 
@@ -75,7 +80,8 @@ You can also use [Console.app](https://support.apple.com/en-gb/guide/console/wel
 
 #### Linux
 
-On Linux, you can access the Main process logs using the Lens PID. First get the PID:
+On Linux, you can access the Main process logs using the Lens PID.
+First get the PID:
 
 ```bash
 ps aux | grep Lens | grep -v grep

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -86,7 +86,7 @@ export async function clickWhatsNew(app: Application) {
 export async function clickWelcomeNotification(app: Application) {
   const itemsText = await app.client.$("div.info-panel").getText();
 
-  if (itemsText === "0 item") {
+  if (itemsText === "0 items") {
     // welcome notification should be present, dismiss it
     await app.client.waitUntilTextExists("div.message", "Welcome!");
     await app.client.click(".notification i.Icon.close");

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - Renderer Extension: extensions/guides/renderer-extension.md
       - Stores: extensions/guides/stores.md
       - Working with MobX: extensions/guides/working-with-mobx.md
+      - Protocol Handlers: extensions/guides/protocol-handlers.md
     - Testing and Publishing:
       - Testing Extensions: extensions/testing-and-publishing/testing.md
       - Publishing Extensions: extensions/testing-and-publishing/publishing.md

--- a/src/common/__tests__/kube-helpers.test.ts
+++ b/src/common/__tests__/kube-helpers.test.ts
@@ -1,5 +1,5 @@
 import { KubeConfig } from "@kubernetes/client-node";
-import { validateKubeConfig } from "../kube-helpers";
+import { validateKubeConfig, loadConfig } from "../kube-helpers";
 
 const kubeconfig = `
 apiVersion: v1
@@ -40,61 +40,214 @@ users:
 
 const kc = new KubeConfig();
 
-describe("validateKubeconfig", () => {
-  beforeAll(() => {
-    kc.loadFromString(kubeconfig);
+interface kubeconfig {
+  apiVersion: string,
+  clusters: [{
+    name: string,
+    cluster: {
+      server: string
+    }
+  }],
+  contexts: [{
+    context: {
+      cluster: string,
+      user: string,
+    },
+    name: string
+  }],
+  users: [{
+    name: string
+  }],
+  kind: string,
+  "current-context": string,
+  preferences: {}
+}
+
+let mockKubeConfig: kubeconfig;
+
+describe("kube helpers", () => {
+  describe("validateKubeconfig", () => {
+    beforeAll(() => {
+      kc.loadFromString(kubeconfig);
+    });
+    describe("with default validation options", () => {
+      describe("with valid kubeconfig", () => {
+        it("does not raise exceptions", () => {
+          expect(() => { validateKubeConfig(kc, "valid");}).not.toThrow();
+        });
+      });
+      describe("with invalid context object", () => {
+        it("it raises exception", () => {
+          expect(() => { validateKubeConfig(kc, "invalid");}).toThrow("No valid context object provided in kubeconfig for context 'invalid'");
+        });
+      });
+
+      describe("with invalid cluster object", () => {
+        it("it raises exception", () => {
+          expect(() => { validateKubeConfig(kc, "invalidCluster");}).toThrow("No valid cluster object provided in kubeconfig for context 'invalidCluster'");
+        });
+      });
+
+      describe("with invalid user object", () => {
+        it("it raises exception", () => {
+          expect(() => { validateKubeConfig(kc, "invalidUser");}).toThrow("No valid user object provided in kubeconfig for context 'invalidUser'");
+        });
+      });
+
+      describe("with invalid exec command", () => {
+        it("it raises exception", () => {
+          expect(() => { validateKubeConfig(kc, "invalidExec");}).toThrow("User Exec command \"foo\" not found on host. Please ensure binary is found in PATH or use absolute path to binary in Kubeconfig");
+        });
+      });
+    });
+
+    describe("with validateCluster as false", () => {
+      describe("with invalid cluster object", () => {
+        it("does not raise exception", () => {
+          expect(() => { validateKubeConfig(kc, "invalidCluster", { validateCluster: false });}).not.toThrow();
+        });
+      });
+    });
+
+    describe("with validateUser as false", () => {
+      describe("with invalid user object", () => {
+        it("does not raise exceptions", () => {
+          expect(() => { validateKubeConfig(kc, "invalidUser", { validateUser: false });}).not.toThrow();
+        });
+      });
+    });
+
+    describe("with validateExec as false", () => {
+      describe("with invalid exec object", () => {
+        it("does not raise exceptions", () => {
+          expect(() => { validateKubeConfig(kc, "invalidExec", { validateExec: false });}).not.toThrow();
+        });
+      });
+    });
   });
-  describe("with default validation options", () => {
-    describe("with valid kubeconfig", () => {
-      it("does not raise exceptions", () => {
-        expect(() => { validateKubeConfig(kc, "valid");}).not.toThrow();
-      });
+
+  describe("pre-validate context object in kubeconfig tests", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
-    describe("with invalid context object", () => {
-      it("it raises exception", () => {
-        expect(() => { validateKubeConfig(kc, "invalid");}).toThrow("No valid context object provided in kubeconfig for context 'invalid'");
+
+    describe("Check logger.error() output", () => {
+      it("invalid yaml string", () => {
+        const invalidYAMLString = "fancy foo config";
+
+        expect(() => loadConfig(invalidYAMLString)).toThrowError("must be an object");
+      });
+      it("empty contexts", () => {
+        const emptyContexts = `apiVersion: v1\ncontexts:`;
+
+        expect(() => loadConfig(emptyContexts)).not.toThrow();
       });
     });
 
-    describe("with invalid cluster object", () => {
-      it("it raises exception", () => {
-        expect(() => { validateKubeConfig(kc, "invalidCluster");}).toThrow("No valid cluster object provided in kubeconfig for context 'invalidCluster'");
+    describe("Check valid kubeconfigs", () => {
+      beforeEach(() => {
+        mockKubeConfig = {
+          apiVersion: "v1",
+          clusters: [{
+            name: "minikube",
+            cluster: {
+              server: "https://192.168.64.3:8443",
+            },
+          }],
+          contexts: [{
+            context: {
+              cluster: "minikube",
+              user: "minikube",
+            },
+            name: "minikube",
+          }],
+          users: [{
+            name: "minikube",
+          }],
+          kind: "Config",
+          "current-context": "minikube",
+          preferences: {},
+        };
+      });
+
+      it("single context is ok", async () => {
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+      });
+
+      it("multiple context is ok", async () => {
+        mockKubeConfig.contexts.push({context: {cluster: "cluster-2", user: "cluster-2"}, name: "cluster-2"});
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+        expect(kc.contexts.length).toBe(2);
       });
     });
 
-    describe("with invalid user object", () => {
-      it("it raises exception", () => {
-        expect(() => { validateKubeConfig(kc, "invalidUser");}).toThrow("No valid user object provided in kubeconfig for context 'invalidUser'");
+    describe("Check invalid kubeconfigs", () => {
+      beforeEach(() => {
+        mockKubeConfig = {
+          apiVersion: "v1",
+          clusters: [{
+            name: "minikube",
+            cluster: {
+              server: "https://192.168.64.3:8443",
+            },
+          }],
+          contexts: [{
+            context: {
+              cluster: "minikube",
+              user: "minikube",
+            },
+            name: "minikube",
+          }],
+          users: [{
+            name: "minikube",
+          }],
+          kind: "Config",
+          "current-context": "minikube",
+          preferences: {},
+        };
       });
-    });
 
-    describe("with invalid exec command", () => {
-      it("it raises exception", () => {
-        expect(() => { validateKubeConfig(kc, "invalidExec");}).toThrow("User Exec command \"foo\" not found on host. Please ensure binary is found in PATH or use absolute path to binary in Kubeconfig");
+      it("empty name in context causes it to be removed", async () => {
+        mockKubeConfig.contexts.push({context: {cluster: "cluster-2", user: "cluster-2"}, name: ""});
+        expect(mockKubeConfig.contexts.length).toBe(2);
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+        expect(kc.contexts.length).toBe(1);
       });
-    });
-  });
 
-  describe("with validateCluster as false", () => {
-    describe("with invalid cluster object", () => {
-      it("does not raise exception", () => {
-        expect(() => { validateKubeConfig(kc, "invalidCluster", { validateCluster: false });}).not.toThrow();
+      it("empty cluster in context causes it to be removed", async () => {
+        mockKubeConfig.contexts.push({context: {cluster: "", user: "cluster-2"}, name: "cluster-2"});
+        expect(mockKubeConfig.contexts.length).toBe(2);
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+        expect(kc.contexts.length).toBe(1);
       });
-    });
-  });
 
-  describe("with validateUser as false", () => {
-    describe("with invalid user object", () => {
-      it("does not raise excpetions", () => {
-        expect(() => { validateKubeConfig(kc, "invalidUser", { validateUser: false });}).not.toThrow();
+      it("empty user in context causes it to be removed", async () => {
+        mockKubeConfig.contexts.push({context: {cluster: "cluster-2", user: ""}, name: "cluster-2"});
+        expect(mockKubeConfig.contexts.length).toBe(2);
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+        expect(kc.contexts.length).toBe(1);
       });
-    });
-  });
 
-  describe("with validateExec as false", () => {
-    describe("with invalid exec object", () => {
-      it("does not raise excpetions", () => {
-        expect(() => { validateKubeConfig(kc, "invalidExec", { validateExec: false });}).not.toThrow();
+      it("invalid context in between valid contexts is removed", async () => {
+        mockKubeConfig.contexts.push({context: {cluster: "cluster-2", user: ""}, name: "cluster-2"});
+        mockKubeConfig.contexts.push({context: {cluster: "cluster-3", user: "cluster-3"}, name: "cluster-3"});
+        expect(mockKubeConfig.contexts.length).toBe(3);
+        const kc:KubeConfig = loadConfig(JSON.stringify(mockKubeConfig));
+
+        expect(kc.getCurrentContext()).toBe("minikube");
+        expect(kc.contexts.length).toBe(2);
+        expect(kc.contexts[0].name).toBe("minikube");
+        expect(kc.contexts[1].name).toBe("cluster-3");
       });
     });
   });

--- a/src/common/user-store.ts
+++ b/src/common/user-store.ts
@@ -2,7 +2,7 @@ import type { ThemeId } from "../renderer/theme.store";
 import { app, remote } from "electron";
 import semver from "semver";
 import { readFile } from "fs-extra";
-import { action, observable, reaction, toJS } from "mobx";
+import { action, computed, observable, reaction, toJS } from "mobx";
 import { BaseStore } from "./base-store";
 import migrations from "../migrations/user-store";
 import { getAppVersion } from "./utils/app-version";
@@ -112,6 +112,10 @@ export class UserStore extends BaseStore<UserStoreModel> {
   @action
   resetKubeConfigPath() {
     this.kubeConfigPath = kubeConfigDefaultPath;
+  }
+
+  @computed get isDefaultKubeConfigPath(): boolean {
+    return this.kubeConfigPath === kubeConfigDefaultPath;
   }
 
   @action

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -675,6 +675,8 @@ export class Cluster implements ClusterModel, ClusterState {
     };
   }
 
+  protected getAllowedNamespacesErrorCount = 0;
+
   protected async getAllowedNamespaces() {
     if (this.accessibleNamespaces.length) {
       return this.accessibleNamespaces;
@@ -683,16 +685,27 @@ export class Cluster implements ClusterModel, ClusterState {
     const api = (await this.getProxyKubeconfig()).makeApiClient(CoreV1Api);
 
     try {
-      const namespaceList = await api.listNamespace();
+      const { body: { items }} = await api.listNamespace();
+      const namespaces = items.map(ns => ns.metadata.name);
 
-      return namespaceList.body.items.map(ns => ns.metadata.name);
+      this.getAllowedNamespacesErrorCount = 0; // reset on success
+
+      return namespaces;
     } catch (error) {
       const ctx = (await this.getProxyKubeconfig()).getContextObject(this.contextName);
       const namespaceList = [ctx.namespace].filter(Boolean);
 
       if (namespaceList.length === 0 && error instanceof HttpError && error.statusCode === 403) {
-        logger.info("[CLUSTER]: listing namespaces is forbidden, broadcasting", { clusterId: this.id });
-        broadcastMessage(ClusterListNamespaceForbiddenChannel, this.id);
+        this.getAllowedNamespacesErrorCount += 1;
+
+        if (this.getAllowedNamespacesErrorCount > 3) {
+          // reset on send
+          this.getAllowedNamespacesErrorCount = 0;
+
+          // then broadcast, make sure it is 3 successive attempts
+          logger.info("[CLUSTER]: listing namespaces is forbidden, broadcasting", { clusterId: this.id, error });
+          broadcastMessage(ClusterListNamespaceForbiddenChannel, this.id);
+        }
       }
 
       return namespaceList;

--- a/src/renderer/api/__tests__/crd.test.ts
+++ b/src/renderer/api/__tests__/crd.test.ts
@@ -1,0 +1,91 @@
+import { CustomResourceDefinition } from "../endpoints";
+import { IKubeObjectMetadata } from "../kube-object";
+
+describe("Crds", () => {
+  describe("getVersion", () => {
+    it("should get the first version name from the list of versions", () => {
+      const crd = new CustomResourceDefinition({
+        apiVersion: "foo",
+        kind: "CustomResourceDefinition",
+        metadata: {} as IKubeObjectMetadata,
+      });
+
+      crd.spec = {
+        versions: [
+          {
+            name: "123",
+            served: false,
+            storage: false,
+          }
+        ]
+      } as any;
+
+      expect(crd.getVersion()).toBe("123");
+    });
+
+    it("should get the first version name from the list of versions (length 2)", () => {
+      const crd = new CustomResourceDefinition({
+        apiVersion: "foo",
+        kind: "CustomResourceDefinition",
+        metadata: {} as IKubeObjectMetadata,
+      });
+
+      crd.spec = {
+        versions: [
+          {
+            name: "123",
+            served: false,
+            storage: false,
+          },
+          {
+            name: "1234",
+            served: false,
+            storage: false,
+          }
+        ]
+      } as any;
+
+      expect(crd.getVersion()).toBe("123");
+    });
+
+    it("should get the first version name from the list of versions (length 2) even with version field", () => {
+      const crd = new CustomResourceDefinition({
+        apiVersion: "foo",
+        kind: "CustomResourceDefinition",
+        metadata: {} as IKubeObjectMetadata,
+      });
+
+      crd.spec = {
+        version: "abc",
+        versions: [
+          {
+            name: "123",
+            served: false,
+            storage: false,
+          },
+          {
+            name: "1234",
+            served: false,
+            storage: false,
+          }
+        ]
+      } as any;
+
+      expect(crd.getVersion()).toBe("123");
+    });
+
+    it("should get the first version name from the version field", () => {
+      const crd = new CustomResourceDefinition({
+        apiVersion: "foo",
+        kind: "CustomResourceDefinition",
+        metadata: {} as IKubeObjectMetadata,
+      });
+
+      crd.spec = {
+        version: "abc"
+      } as any;
+
+      expect(crd.getVersion()).toBe("abc");
+    });
+  });
+});

--- a/src/renderer/api/endpoints/crd.api.ts
+++ b/src/renderer/api/endpoints/crd.api.ts
@@ -33,7 +33,7 @@ export class CustomResourceDefinition extends KubeObject {
     };
     scope: "Namespaced" | "Cluster" | string;
     validation?: any;
-    versions: {
+    versions?: {
       name: string;
       served: boolean;
       storage: boolean;
@@ -103,7 +103,7 @@ export class CustomResourceDefinition extends KubeObject {
 
   getVersion() {
     // v1 has removed the spec.version property, if it is present it must match the first version
-    return this.spec.versions[0]?.name ?? this.spec.version;
+    return this.spec.versions?.[0]?.name ?? this.spec.version;
   }
 
   isNamespaced() {
@@ -123,7 +123,7 @@ export class CustomResourceDefinition extends KubeObject {
   }
 
   getPrinterColumns(ignorePriority = true): AdditionalPrinterColumnsV1[] {
-    const columns = this.spec.versions.find(a => this.getVersion() == a.name)?.additionalPrinterColumns
+    const columns = this.spec.versions?.find(a => this.getVersion() == a.name)?.additionalPrinterColumns
       ?? this.spec.additionalPrinterColumns?.map(({ JSONPath, ...rest }) => ({ ...rest, jsonPath: JSONPath })) // map to V1 shape
       ?? [];
 

--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -62,9 +62,11 @@ export class AddCluster extends React.Component {
       this.kubeConfigPath = filePath;
       userStore.kubeConfigPath = filePath; // save to store
     } catch (err) {
-      Notifications.error(
-        <div>Can&apos;t setup <code>{filePath}</code> as kubeconfig: {String(err)}</div>
-      );
+      if (!userStore.isDefaultKubeConfigPath) {
+        Notifications.error(
+          <div>Can&apos;t setup <code>{filePath}</code> as kubeconfig: {String(err)}</div>
+        );
+      }
 
       if (throwError) {
         throw err;

--- a/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
+++ b/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
@@ -14,8 +14,18 @@ export interface IChartVersion {
 export class HelmChartStore extends ItemStore<HelmChart> {
   @observable versions = observable.map<string, IChartVersion[]>();
 
-  loadAll() {
-    return this.loadItems(() => helmChartsApi.list());
+  async loadAll() {
+    try {
+      const res = await this.loadItems(() => helmChartsApi.list());
+
+      this.failedLoading = false;
+
+      return res;
+    } catch (error) {
+      this.failedLoading = true;
+
+      throw error;
+    }
   }
 
   getByName(name: string, repo: string) {

--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -24,6 +24,7 @@ interface IWarning extends ItemObject {
   message: string;
   selfLink: string;
   age: string | number;
+  timeDiffFromNow: number;
 }
 
 enum sortBy {
@@ -37,7 +38,7 @@ export class ClusterIssues extends React.Component<Props> {
   private sortCallbacks = {
     [sortBy.type]: (warning: IWarning) => warning.kind,
     [sortBy.object]: (warning: IWarning) => warning.getName(),
-    [sortBy.age]: (warning: IWarning) => warning.age || "",
+    [sortBy.age]: (warning: IWarning) => warning.timeDiffFromNow,
   };
 
   @computed get warnings() {
@@ -45,13 +46,14 @@ export class ClusterIssues extends React.Component<Props> {
 
     // Node bad conditions
     nodesStore.items.forEach(node => {
-      const { kind, selfLink, getId, getName, getAge } = node;
+      const { kind, selfLink, getId, getName, getAge, getTimeDiffFromNow } = node;
 
       node.getWarningConditions().forEach(({ message }) => {
         warnings.push({
           age: getAge(),
           getId,
           getName,
+          timeDiffFromNow: getTimeDiffFromNow(),
           kind,
           message,
           selfLink,
@@ -63,12 +65,13 @@ export class ClusterIssues extends React.Component<Props> {
     const events = eventStore.getWarnings();
 
     events.forEach(error => {
-      const { message, involvedObject, getAge } = error;
+      const { message, involvedObject, getAge, getTimeDiffFromNow } = error;
       const { uid, name, kind } = involvedObject;
 
       warnings.push({
         getId: () => uid,
         getName: () => name,
+        timeDiffFromNow: getTimeDiffFromNow(),
         age: getAge(),
         message,
         kind,

--- a/src/renderer/components/context.ts
+++ b/src/renderer/components/context.ts
@@ -4,8 +4,8 @@ import { namespaceStore } from "./+namespaces/namespace.store";
 
 export interface ClusterContext {
   cluster?: Cluster;
-  allNamespaces?: string[]; // available / allowed namespaces from cluster.ts
-  contextNamespaces?: string[]; // selected by user (see: namespace-select.tsx)
+  allNamespaces: string[]; // available / allowed namespaces from cluster.ts
+  contextNamespaces: string[]; // selected by user (see: namespace-select.tsx)
 }
 
 export const clusterContext: ClusterContext = {

--- a/src/renderer/item.store.ts
+++ b/src/renderer/item.store.ts
@@ -13,6 +13,7 @@ export abstract class ItemStore<T extends ItemObject = ItemObject> {
 
   protected defaultSorting = (item: T) => item.getName();
 
+  @observable failedLoading = false;
   @observable isLoading = false;
   @observable isLoaded = false;
   @observable items = observable.array<T>([], { deep: false });

--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -146,18 +146,20 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
 
       const items = await this.loadItems({ namespaces, api: this.api });
 
-      this.isLoaded = true;
-
       if (merge) {
         this.mergeItems(items, { replace: false });
       } else {
         this.mergeItems(items, { replace: true });
       }
 
+      this.isLoaded = true;
+      this.failedLoading = false;
+
       return items;
     } catch (error) {
       console.error("Loading store items failed", { error, store: this });
       this.resetOnError(error);
+      this.failedLoading = true;
     } finally {
       this.isLoading = false;
     }

--- a/src/renderer/utils/__tests__/storageHelper.test.ts
+++ b/src/renderer/utils/__tests__/storageHelper.test.ts
@@ -26,7 +26,7 @@ describe("renderer/utils/StorageHelper", () => {
       expect(storageHelper.defaultValue).toBe("test");
       expect(storageHelper.get()).toBe("test");
 
-      await storageHelper.init();
+      storageHelper.init();
 
       expect(storageHelper.key).toBe(storageKey);
       expect(storageHelper.defaultValue).toBe("test");


### PR DESCRIPTION
PRs
---
- Broadcast failure to list namespaces less frequently #2501 
- Fix Extension Docs #2377 
- Fix CRD versions not being provided #2500
- fix: proper sorting resources by age column (#2182 followup) #2414 
- Fix releases not reloading when selecting namespaces #2515
- Refactor StorageHelper to be clearer in its constructor #2417
- Pre-Validate kubeconfig before making available in Lens #1078