### PR TITLE
Fix how integration tests activate adding a cluster via SpeedDial

### DIFF
--- a/integration/helpers/minikube.ts
+++ b/integration/helpers/minikube.ts
@@ -40,7 +40,7 @@ export function minikubeReady(testNamespace: string): boolean {
 
 export async function addMinikubeCluster(app: Application) {
   await app.client.waitForVisible("button.MuiSpeedDial-fab");
-  await app.client.click("button.MuiSpeedDial-fab");
+  await app.client.moveToObject("button.MuiSpeedDial-fab");
   await app.client.waitForVisible(`button[title="Add from kubeconfig"]`);
   await app.client.click(`button[title="Add from kubeconfig"]`);
   await app.client.waitUntilTextExists("div", "Select kubeconfig file");


### PR DESCRIPTION
In adding minikube cluster, simulate hover on `SpeedDial` to bring up the "Add from kubeconfig" `SpeedDialAction`

Before this fix, the integration tests run on Ubuntu by CI and locally fail most of the time to add a cluster via the `SpeedDial` element.

This fix involves using spectron client's `moveToObject()` method (which appears to rely on the `moveTo()` method, which is deprecated). 

tries to fix #2564