### PR TITLE
Fix chart upgrade screen by coercing the chart version to semver

### DIFF
--- a/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
+++ b/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
@@ -34,7 +34,10 @@ export class HelmChartStore extends ItemStore<HelmChart> {
 
   protected sortVersions = (versions: IChartVersion[]) => {
     return versions.sort((first, second) => {
-      return semver.compare(second.version, first.version);
+      const firstVersion = semver.coerce(first.version || 0);
+      const secondVersion = semver.coerce(second.version || 0);
+
+      return semver.compare(secondVersion, firstVersion);
     });
   };
 


### PR DESCRIPTION
Without that fix, I'm seeing such an errors when upgrading a chart:
```
semver.js:41 Uncaught (in promise) TypeError: Invalid Version: 1.9-dev
    at new A (semver.js:41)
    at Object.e.exports [as compare] (compare.js:3)
    at helm-chart.store.ts:37
    at Array.sort (<anonymous>)
    at QR.sortVersions (helm-chart.store.ts:36)
    at async QR.getVersions (helm-chart.store.ts:64)
    at async XD.loadVersions (upgrade-chart.tsx:57)
```

![image](https://user-images.githubusercontent.com/431376/115556769-4b3afc00-a2b1-11eb-84c8-6995e89bb72f.png)
