### PR TITLE
Wait for LensApp to report that the view has loaded before showing main window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -190,7 +190,7 @@ app.on("ready", async () => {
   installDeveloperTools();
 
   if (!startHidden) {
-    windowManager.initMainWindow();
+    windowManager.ensureMainWindow();
   }
 
   ipcMain.on(IpcRendererNavigationEvents.LOADED, () => {
@@ -238,7 +238,7 @@ app.on("activate", (event, hasVisibleWindows) => {
   logger.info("APP:ACTIVATE", { hasVisibleWindows });
 
   if (!hasVisibleWindows) {
-    WindowManager.getInstance(false)?.initMainWindow(false);
+    WindowManager.getInstance(false)?.ensureMainWindow(false);
   }
 });
 

--- a/src/renderer/lens-app.tsx
+++ b/src/renderer/lens-app.tsx
@@ -49,6 +49,9 @@ export class LensApp extends React.Component {
     window.addEventListener("online", () => broadcastMessage("network:online"));
 
     registerIpcHandlers();
+  }
+
+  componentDidMount() {
     ipcRenderer.send(IpcRendererNavigationEvents.LOADED);
   }
 
@@ -57,11 +60,11 @@ export class LensApp extends React.Component {
       <Router history={history}>
         <ErrorBoundary>
           <Switch>
-            <Route component={ClusterManager}/>
+            <Route component={ClusterManager} />
           </Switch>
         </ErrorBoundary>
-        <Notifications/>
-        <ConfirmDialog/>
+        <Notifications />
+        <ConfirmDialog />
         <CommandContainer />
       </Router>
     );


### PR DESCRIPTION
This prevents showing an empty main window for a few seconds. From a UX perspective it feels more responsive because the user is not greeted with a blank page after the loading window goes away.

Signed-off-by: Sebastian Malton <sebastian@malton.name>