### PR TITLE
Fix: don't assign to priority in getItemsForKind

### DIFF
--- a/src/extensions/registries/entity-setting-registry.ts
+++ b/src/extensions/registries/entity-setting-registry.ts
@@ -35,10 +35,6 @@ export class EntitySettingRegistry extends BaseRegistry<EntitySettingRegistratio
   getItemsForKind(kind: string, apiVersion: string, source?: string) {
     let items = this.getItems().filter((item) => {
       return item.kind === kind && item.apiVersions.includes(apiVersion);
-    }).map((item) => {
-      item.priority = item.priority ?? 50;
-
-      return item;
     });
 
     if (source) {
@@ -47,7 +43,7 @@ export class EntitySettingRegistry extends BaseRegistry<EntitySettingRegistratio
       });
     }
 
-    return items.sort((a, b) => b.priority - a.priority);
+    return items.sort((a, b) => (b.priority ?? 50) - (a.priority ?? 50));
   }
 }
 

--- a/src/extensions/registries/kube-object-detail-registry.ts
+++ b/src/extensions/registries/kube-object-detail-registry.ts
@@ -16,15 +16,9 @@ export class KubeObjectDetailRegistry extends BaseRegistry<KubeObjectDetailRegis
   getItemsForKind(kind: string, apiVersion: string) {
     const items = this.getItems().filter((item) => {
       return item.kind === kind && item.apiVersions.includes(apiVersion);
-    }).map((item) => {
-      if (item.priority === null) {
-        item.priority = 50;
-      }
-
-      return item;
     });
 
-    return items.sort((a, b) => b.priority - a.priority);
+    return items.sort((a, b) => (b.priority ?? 50) - (a.priority ?? 50));
   }
 }
 


### PR DESCRIPTION
Otherwise `mobx` throws a modification error (if getItemsForKind is within an observable)

Signed-off-by: Sebastian Malton <sebastian@malton.name>