### PR TITLE
release v4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "main": "static/build/main.js",
   "copyright": "© 2021, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,15 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.2.2 (current version)
+## 4.2.3 (current version)
+- Filter out invalid contexts when added clusters to Lens
+- Add notifications when helm actions fail
+- Fix: Extension management page should be more resilient to install errors
+- Fix: Loading spinner for custom resources no longer appears when the menu is minimized
+- Fix: HPA's not sortable by age
+- Fix: Reload pod logs if the values are missing
+
+## 4.2.2
 - Ability to install some extensions by their name only
 - Fix: Extension Docs' spelling in a few places and improve protocol handler docs
 - Fix: CRD display no longer crashes on older versions of kubernetes


### PR DESCRIPTION
## Changes since v4.2.2

## 🚀 Features

- Pre-Validate kubeconfig before making available in Lens (#1078) @stevejr and @Nokel81

## 🐛 Bug Fixes

- Refactor the Extensions settings page (#2221) @Nokel81 
- Fix custom resource loading spinner appears above extensions' cluster menus (#2344) @Nokel81 
- Fix: HPA's not sortable by age (#2565) @Nokel81 
- Refactor helm-chart.api and improve kube validation and error handling (#2265) @Nokel81 
- Fix: logs data disapearing causing crashes (#2566) @Nokel81 

## 🧰 Maintenance

- Lens should point to the release docs (#2268) @Nokel81 
- Conditionally render status icon for kube meta (#2298) @Nokel81 

Signed-off-by: Sebastian Malton <sebastian@malton.name>