### PR TITLE
Fixing CatalogAddButton

### DIFF
--- a/src/renderer/components/+catalog/catalog-add-button.scss
+++ b/src/renderer/components/+catalog/catalog-add-button.scss
@@ -5,5 +5,20 @@
 
   .MuiFab-primary {
     background-color: var(--blue);
+
+    &:hover {
+      background-color: #317bb3;
+    }
  }
+}
+
+.MuiTooltip-popper {
+  .MuiTooltip-tooltip {
+    background-color: #222;
+    font-size: 12px
+  }
+
+  .MuiTooltip-arrow {
+    color: #222;
+  }
 }

--- a/src/renderer/components/+catalog/catalog-add-button.tsx
+++ b/src/renderer/components/+catalog/catalog-add-button.tsx
@@ -45,6 +45,13 @@ export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
     this.isOpen = false;
   }
 
+  @autobind()
+  onButtonClick() {
+    if (this.menuItems.length == 1) {
+      this.menuItems[0].onClick();
+    }
+  }
+
   render() {
     if (this.menuItems.length === 0) {
       return null;
@@ -59,6 +66,7 @@ export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
         onClose={this.onClose}
         icon={<Icon material="add" />}
         direction="up"
+        onClick={this.onButtonClick}
       >
         { this.menuItems.map((menuItem, index) => {
           return <SpeedDialAction


### PR DESCRIPTION
* Fixed bg color on hover
* Fixed tooltip styles (bigger font and black background)
* Start first action on click if only one presented (no need to open icons and click action manually)

![catalog add button](https://user-images.githubusercontent.com/9607060/116216042-dce2b780-a750-11eb-8da2-2ffb99422f1c.png)
