### PR TITLE
Fix broken link to adding-cluster instruction

### DIFF
--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -204,7 +204,7 @@ export class AddCluster extends React.Component {
         Add clusters by clicking the <span className="text-primary">Add Cluster</span> button.
         You&apos;ll need to obtain a working kubeconfig for the cluster you want to add.
         You can either browse it from the file system or paste it as a text from the clipboard.
-        Read more about adding clusters <a href={`${docsUrl}/latest/clusters/adding-clusters/`} rel="noreferrer" target="_blank">here</a>.
+        Read more about adding clusters <a href={`${docsUrl}/clusters/adding-clusters/`} rel="noreferrer" target="_blank">here</a>.
       </p>
     );
   }


### PR DESCRIPTION
### Problem

In Adding cluster page, there is link with text `here`. Link pointed to by here is broken as it currently returns 404 page not found. The correct link seems to be one starting with `master` taken from doc on live site https://docs.k8slens.dev/master/clusters/adding-clusters/

Screenshot for the reproduction steps:

### Reproduction steps

1) Click Add cluster
![Screen Shot 2021-04-27 at 21 34 40](https://user-images.githubusercontent.com/760855/116260568-fe6b8f80-a7a0-11eb-8b97-f09f2ddba766.png)


2) Click `Here`

![Screen Shot 2021-04-27 at 21 35 29](https://user-images.githubusercontent.com/760855/116260609-088d8e00-a7a1-11eb-9de9-834b9fddb20b.png)


3) it will take to broken link

### Solution

- fix the broken link

Signed-off-by: Samundra Shrestha <samundra.shr@gmail.com>