### PR TITLE
fix(renderer-log): multiple spaces merge into one

### DIFF
--- a/src/renderer/components/dock/log-list.scss
+++ b/src/renderer/components/dock/log-list.scss
@@ -30,6 +30,7 @@
 
         span {
           -webkit-font-smoothing: auto; // Better readability on non-retina screens
+          white-space: pre;
         }
 
         span.overlay {


### PR DESCRIPTION
before:
<img width="393" alt="图片" src="https://user-images.githubusercontent.com/8198408/116361929-1b9d6e00-a834-11eb-977f-a9b43f1c5073.png">


after:
<img width="419" alt="图片" src="https://user-images.githubusercontent.com/8198408/116362037-353eb580-a834-11eb-8157-07967cc8496c.png">
