### PR TITLE
release v5.0.0-beta.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ dev: binaries/client build-extensions static/build/LensDev.html
 lint:
 	yarn lint
 
+.PHONY: release-version
+release-version:
+	npm version $(CMD_ARGS) --git-tag-version false
+
 .PHONY: test
 test: binaries/client
 	yarn run jest $(or $(CMD_ARGS), "src")

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-lens",
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",
@@ -39,7 +39,11 @@
     "lint:fix": "yarn run lint --fix",
     "mkdocs-serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
     "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",
-    "typedocs-extensions-api": "yarn run typedoc --ignoreCompilerErrors --readme docs/extensions/typedoc-readme.md.tpl --name @k8slens/extensions --out docs/extensions/api --mode library --excludePrivate --hideBreadcrumbs --includes src/ src/extensions/extension-api.ts"
+    "typedocs-extensions-api": "yarn run typedoc --ignoreCompilerErrors --readme docs/extensions/typedoc-readme.md.tpl --name @k8slens/extensions --out docs/extensions/api --mode library --excludePrivate --hideBreadcrumbs --includes src/ src/extensions/extension-api.ts",
+    "version-checkout": "cat package.json | jq '.version' -r | xargs printf \"release/v%s\" | xargs git checkout -b",
+    "version-commit": "cat package.json | jq '.version' -r | xargs printf \"release v%s\" | git commit --no-edit -s -F -",
+    "version": "yarn run version-checkout && git add package.json && yarn run version-commit",
+    "postversion": "git push --set-upstream origin release/v$npm_package_version"
   },
   "config": {
     "bundledKubectlVersion": "1.18.15",


### PR DESCRIPTION
## Changes since v5.0.0-beta.1

## 🚀 Features

* Show entity source on tooltip + use it for color (#2669) @jakolehm 

## 🐛 Bug Fixes

* Refactor / fix cluster view visibility (#2654) @jakolehm 
* Electron-updater 4.3.8 (#2622) @jakolehm 
* Removing add/delete empty cells feature from hotbar (#2667) @aleksfront 
* Fix hotbar icon kind on light theme (#2668) @jakolehm 
* fix(renderer-log): multiple spaces merge into one (#2655) @BlackHole1 
* fix getNodeWarningConditions (#2644) @Nokel81 
* Fix display name on accessible namespaces notification (#2657) @Nokel81 
* Fix KubeObjectStore not correctly tracking loading of namespaces (#2266) @Nokel81 
* Fix broken link to adding-cluster instruction (#2646) @samundra 

## 🧰 Maintenance

* Ignore failures due to files in bundled folder (#2661) @Nokel81 
* Set product name to window title (#2665) @jakolehm 

Signed-off-by: Sebastian Malton <sebastian@malton.name>

FYI the changes to the `package.json` and `Makefile` are to facilitate an even easier release mechanism. Namely, all you have to do is run `make release-version prerelease` and then open a PR. The branch will be created, commit made, and all pushed for you.

Valid arguments are: 
- `major`
- `minor`
- `patch`
- `premajor`
- `preminor`
- `prepatch`
- `prerelease [--preid=<prerelease-id>]`