### PR TITLE
Replacing material <Tooltip/> global styles

### DIFF
--- a/src/renderer/components/+catalog/catalog-add-button.scss
+++ b/src/renderer/components/+catalog/catalog-add-button.scss
@@ -12,7 +12,7 @@
  }
 }
 
-.MuiTooltip-popper {
+.catalogSpeedDialPopper  {
   .MuiTooltip-tooltip {
     background-color: #222;
     font-size: 12px

--- a/src/renderer/components/+catalog/catalog-add-button.tsx
+++ b/src/renderer/components/+catalog/catalog-add-button.tsx
@@ -74,6 +74,9 @@ export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
             icon={<Icon material={menuItem.icon} />}
             tooltipTitle={menuItem.title}
             onClick={() => menuItem.onClick()}
+            TooltipClasses={{
+              popper: "catalogSpeedDialPopper"
+            }}
           />;
         })}
       </SpeedDial>


### PR DESCRIPTION
Narrowing global Tooltip styles with `.catalogSpeedDialPopper` class.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>