### PR TITLE
Fixing hotbar drag-n-drop animation issues

### DIFF
--- a/src/common/__tests__/hotbar-store.test.ts
+++ b/src/common/__tests__/hotbar-store.test.ts
@@ -207,6 +207,21 @@ describe("HotbarStore", () => {
       expect(hotbarStore.getActive().items[0].entity.uid).toEqual("test");
     });
 
+    it("new items takes first empty cell", () => {
+      const hotbarStore = HotbarStore.createInstance();
+      const test = new CatalogEntityItem(testCluster);
+      const minikube = new CatalogEntityItem(minikubeCluster);
+      const aws = new CatalogEntityItem(awsCluster);
+
+      hotbarStore.load();
+      hotbarStore.addToHotbar(test);
+      hotbarStore.addToHotbar(aws);
+      hotbarStore.restackItems(0, 3);
+      hotbarStore.addToHotbar(minikube);
+
+      expect(hotbarStore.getActive().items[0].entity.uid).toEqual("minikube");
+    });
+
     it("throws if invalid arguments provided", () => {
       // Prevent writing to stderr during this render.
       const err = console.error;

--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -7,6 +7,7 @@
     cursor: pointer;
     transition: none;
     text-shadow: 0 0 4px #0000008f;
+    position: relative;
 
     div.MuiAvatar-colorDefault {
       font-weight:500;

--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -27,7 +27,9 @@
     }
 
     &:hover {
-      box-shadow: 0 0 0px 3px var(--clusterMenuBackground), 0 0 0px 6px #ffffff30;
+      &:not(.active) {
+        box-shadow: 0 0 0px 3px var(--clusterMenuBackground), 0 0 0px 6px #ffffff30;
+      }
     }
 
     &.isDragging {

--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -6,6 +6,7 @@
     user-select: none;
     cursor: pointer;
     transition: none;
+    text-shadow: 0 0 4px #0000008f;
 
     div.MuiAvatar-colorDefault {
       font-weight:500;

--- a/src/renderer/components/hotbar/hotbar-menu.scss
+++ b/src/renderer/components/hotbar/hotbar-menu.scss
@@ -46,7 +46,7 @@
       position: relative;
 
       &.isDraggingOver {
-        box-shadow: 0 0 0px 3px $clusterMenuBackground, 0 0 0px 6px #fff;
+        background-color: #3e4148;
 
         &:not(.isDraggingOwner) {
           z-index: 50;
@@ -61,12 +61,16 @@
               transform: translate(0px, -40px)!important;
             }
           }
+
+          &.animateDown {
+            > div {
+              transform: translate(0px, 40px);
+            }
+          }
         }
       }
 
       &.animating {
-        transform: translateZ(0); // Remove flickering artifacts
-
         &:empty {
           animation: shake .6s cubic-bezier(.36,.07,.19,.97) both;
           transform: translate3d(0, 0, 0);
@@ -75,7 +79,9 @@
         }
 
         &:not(:empty) {
-          animation: outline 1s cubic-bezier(0.19, 1, 0.22, 1);
+          .HotbarIcon {
+            animation: click .1s;
+          }
         }
       }
     }
@@ -100,13 +106,12 @@
   }
 }
 
-// TODO: Use theme-aware colors
-@keyframes outline {
+@keyframes click {
   0% {
-    box-shadow: 0 0 0px 11px $clusterMenuBackground, 0 0 0px 15px #ffffff00;
+    margin-top: 0;
   }
 
   100% {
-    box-shadow: 0 0 0px 3px $clusterMenuBackground, 0 0 0px 6px #ffffff;
+    margin-top: 2px;
   }
 }

--- a/src/renderer/components/hotbar/hotbar-menu.scss
+++ b/src/renderer/components/hotbar/hotbar-menu.scss
@@ -47,6 +47,21 @@
 
       &.isDraggingOver {
         box-shadow: 0 0 0px 3px $clusterMenuBackground, 0 0 0px 6px #fff;
+
+        &:not(.isDraggingOwner) {
+          z-index: 50;
+
+          > div:not(:empty) {
+            border-radius: 6px;
+            box-shadow: 0 0 9px #00000042;
+          }
+
+          &.animateUp {
+            > div {
+              transform: translate(0px, -40px)!important;
+            }
+          }
+        }
       }
 
       &.animating {

--- a/src/renderer/components/hotbar/hotbar-menu.scss
+++ b/src/renderer/components/hotbar/hotbar-menu.scss
@@ -47,6 +47,7 @@
 
       &.isDraggingOver {
         background-color: #3e4148;
+        box-shadow: 0 0 0px 3px var(--clusterMenuBackground), 0 0 0px 6px #ffffff30;
 
         &:not(.isDraggingOwner) {
           z-index: 50;

--- a/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -57,6 +57,7 @@ export class HotbarMenu extends React.Component<Props> {
   renderGrid() {
     return this.hotbar.items.map((item, index) => {
       const entity = this.getEntity(item);
+      const isActive = !entity ? false : this.isActive(entity);
 
       return (
         <Droppable droppableId={`${index}`} key={index}>
@@ -92,7 +93,7 @@ export class HotbarMenu extends React.Component<Props> {
                           key={index}
                           index={index}
                           entity={entity}
-                          isActive={this.isActive(entity)}
+                          isActive={isActive}
                           onClick={() => entity.onRun(catalogEntityRunContext)}
                           className={cssNames({ isDragging: snapshot.isDragging })}
                         />

--- a/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -48,6 +48,12 @@ export class HotbarMenu extends React.Component<Props> {
     HotbarStore.getInstance().restackItems(from, to);
   }
 
+  getMoveAwayDirection(entityId: string, cellIndex: number) {
+    const draggableItemIndex = this.hotbar.items.findIndex(item => item?.entity.uid == entityId);
+
+    return draggableItemIndex > cellIndex ? "animateDown" : "animateUp";
+  }
+
   renderGrid() {
     return this.hotbar.items.map((item, index) => {
       const entity = this.getEntity(item);
@@ -59,11 +65,14 @@ export class HotbarMenu extends React.Component<Props> {
               index={index}
               key={entity ? entity.getId() : `cell${index}`}
               innerRef={provided.innerRef}
-              className={cssNames({ isDraggingOver: snapshot.isDraggingOver })}
+              className={cssNames({
+                isDraggingOver: snapshot.isDraggingOver,
+                isDraggingOwner: snapshot.draggingOverWith == entity?.getId(),
+              }, this.getMoveAwayDirection(snapshot.draggingOverWith, index))}
               {...provided.droppableProps}
             >
               {entity && (
-                <Draggable draggableId={item.entity.uid} key={item.entity.uid} index={0}>
+                <Draggable draggableId={item.entity.uid} key={item.entity.uid} index={0} >
                   {(provided, snapshot) => {
                     const style = {
                       zIndex: defaultHotbarCells - index,


### PR DESCRIPTION
* Fixing animation direction mentioned in https://github.com/lensapp/lens/pull/2691#issuecomment-831482235
* Calmed down `isDraggableOver` style (removed white borders)
* Calmed down cluster click animation (replaced faded borders with "click down" effect)
* Added `text-shadow` for icon text (for better readability on bright backgrounds)
* Fixed jumping cluster issue
![jumping cluster](https://user-images.githubusercontent.com/9607060/117119187-5fdfbf80-ad9a-11eb-9fd2-e682372b458f.gif)


Text shadow
![text-shadow](https://user-images.githubusercontent.com/9607060/117119068-3a52b600-ad9a-11eb-83e5-77b02513b1ad.png)

End-result

https://user-images.githubusercontent.com/9607060/117119265-79810700-ad9a-11eb-8fab-a22d26f13e56.mp4



