### PR TITLE
Formalize the to/from Store rules for UserStore

### DIFF
--- a/src/common/__tests__/user-store.test.ts
+++ b/src/common/__tests__/user-store.test.ts
@@ -41,6 +41,7 @@ import { SemVer } from "semver";
 import electron from "electron";
 import { stdout, stderr } from "process";
 import { beforeEachWrapped } from "../../../integration/helpers/utils";
+import { ThemeStore } from "../../renderer/theme.store";
 
 console = new Console(stdout, stderr);
 
@@ -72,7 +73,7 @@ describe("user store tests", () => {
       us.httpsProxy = "abcd://defg";
 
       expect(us.httpsProxy).toBe("abcd://defg");
-      expect(us.colorTheme).toBe(UserStore.defaultTheme);
+      expect(us.colorTheme).toBe(ThemeStore.defaultTheme);
 
       us.colorTheme = "light";
       expect(us.colorTheme).toBe("light");
@@ -83,7 +84,7 @@ describe("user store tests", () => {
 
       us.colorTheme = "some other theme";
       us.resetTheme();
-      expect(us.colorTheme).toBe(UserStore.defaultTheme);
+      expect(us.colorTheme).toBe(ThemeStore.defaultTheme);
     });
 
     it("correctly calculates if the last seen version is an old release", () => {

--- a/src/common/user-store/index.ts
+++ b/src/common/user-store/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export * from "./user-store";
+export type { KubeconfigSyncEntry, KubeconfigSyncValue } from "./preferences-helpers";

--- a/src/common/user-store/preferences-helpers.ts
+++ b/src/common/user-store/preferences-helpers.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import moment from "moment-timezone";
+import path from "path";
+import os from "os";
+import { ThemeStore } from "../../renderer/theme.store";
+import { ObservableToggleSet } from "../utils";
+
+export interface KubeconfigSyncEntry extends KubeconfigSyncValue {
+  filePath: string;
+}
+
+export interface KubeconfigSyncValue { }
+
+interface PreferenceDescription<T, R = T> {
+  fromStore(val: T | undefined): R;
+  toStore(val: R): T | undefined;
+}
+
+const httpsProxy: PreferenceDescription<string | undefined> = {
+  fromStore(val) {
+    return val;
+  },
+  toStore(val) {
+    return val || undefined;
+  },
+};
+
+const shell: PreferenceDescription<string | undefined> = {
+  fromStore(val) {
+    return val;
+  },
+  toStore(val) {
+    return val || undefined;
+  },
+};
+
+const colorTheme: PreferenceDescription<string> = {
+  fromStore(val) {
+    return val || ThemeStore.defaultTheme;
+  },
+  toStore(val) {
+    if (!val || val === ThemeStore.defaultTheme) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const localeTimezone: PreferenceDescription<string> = {
+  fromStore(val) {
+    return val || moment.tz.guess(true) || "UTC";
+  },
+  toStore(val) {
+    if (!val || val === moment.tz.guess(true) || val === "UTC") {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const allowUntrustedCAs: PreferenceDescription<boolean> = {
+  fromStore(val) {
+    return val ?? false;
+  },
+  toStore(val) {
+    if (!val) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const allowTelemetry: PreferenceDescription<boolean> = {
+  fromStore(val) {
+    return val ?? true;
+  },
+  toStore(val) {
+    if (val === true) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const downloadMirror: PreferenceDescription<string> = {
+  fromStore(val) {
+    return val ?? "default";
+  },
+  toStore(val) {
+    if (!val || val === "default") {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const downloadKubectlBinaries: PreferenceDescription<boolean> = {
+  fromStore(val) {
+    return val ?? true;
+  },
+  toStore(val) {
+    if (val === true) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const downloadBinariesPath: PreferenceDescription<string | undefined> = {
+  fromStore(val) {
+    return val;
+  },
+  toStore(val) {
+    if (!val) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const kubectlBinariesPath: PreferenceDescription<string | undefined> = {
+  fromStore(val) {
+    return val;
+  },
+  toStore(val) {
+    if (!val) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const openAtLogin: PreferenceDescription<boolean> = {
+  fromStore(val) {
+    return val ?? false;
+  },
+  toStore(val) {
+    if (!val) {
+      return undefined;
+    }
+
+    return val;
+  },
+};
+
+const hiddenTableColumns: PreferenceDescription<[string, string[]][], Map<string, ObservableToggleSet<string>>> = {
+  fromStore(val) {
+    return new Map(
+      (val ?? []).map(([tableId, columnIds]) => [tableId, new ObservableToggleSet(columnIds)])
+    );
+  },
+  toStore(val) {
+    const res: [string, string[]][] = [];
+
+    for (const [table, columnes] of val) {
+      if (columnes.size) {
+        res.push([table, Array.from(columnes)]);
+      }
+    }
+
+    return res.length ? res : undefined;
+  },
+};
+
+const mainKubeFolder = path.join(os.homedir(), ".kube");
+
+const syncKubeconfigEntries: PreferenceDescription<KubeconfigSyncEntry[], Map<string, KubeconfigSyncValue>> = {
+  fromStore(val) {
+    return new Map(
+      val
+        ?.map(({ filePath, ...rest }) => [filePath, rest])
+      ?? [[mainKubeFolder, {}]]
+    );
+  },
+  toStore(val) {
+    if (val.size === 1 && val.has(mainKubeFolder)) {
+      return undefined;
+    }
+
+    return Array.from(val, ([filePath, rest]) => ({ filePath, ...rest }));
+  },
+};
+
+type PreferencesModelType<field extends keyof typeof DESCRIPTORS> = typeof DESCRIPTORS[field] extends PreferenceDescription<infer T, any> ? T : never;
+type UserStoreModelType<field extends keyof typeof DESCRIPTORS> = typeof DESCRIPTORS[field] extends PreferenceDescription<any, infer T> ? T : never;
+
+export type UserStoreFlatModel = {
+  [field in keyof typeof DESCRIPTORS]: UserStoreModelType<field>;
+};
+
+export type UserPreferencesModel = {
+  [field in keyof typeof DESCRIPTORS]: PreferencesModelType<field>;
+};
+
+export const DESCRIPTORS = {
+  httpsProxy,
+  shell,
+  colorTheme,
+  localeTimezone,
+  allowUntrustedCAs,
+  allowTelemetry,
+  downloadMirror,
+  downloadKubectlBinaries,
+  downloadBinariesPath,
+  kubectlBinariesPath,
+  openAtLogin,
+  hiddenTableColumns,
+  syncKubeconfigEntries,
+};

--- a/src/renderer/theme.store.ts
+++ b/src/renderer/theme.store.ts
@@ -46,6 +46,7 @@ export interface ThemeItems extends Theme {
 }
 
 export class ThemeStore extends Singleton {
+  static readonly defaultTheme = "lens-dark";
   protected styles: HTMLStyleElement;
 
   // bundled themes from `themes/${themeId}.json`


### PR DESCRIPTION
- Explicitly don't save to disk if the value in the store is the same as
  the default. That way we can change the defaults between versions

- Calculate the PreferencesModel on demand

- In the future, when we turn on strict null checking, we can enforce
  that the UserStore expects the correct types too

Signed-off-by: Sebastian Malton <sebastian@malton.name>