### PR TITLE
Refactor <Input> to be clearer. Add namespace name validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ types/extension-renderer-api.d.ts
 extensions/*/dist
 docs/extensions/api
 site/
+logs/

--- a/Makefile
+++ b/Makefile
@@ -53,18 +53,24 @@ integration-linux: binaries/client build-extension-types build-extensions
 # 	rm -rf ${HOME}/.config/Lens
 # endif
 	yarn build:linux
+	mkdir -p logs
+	rm -r ./logs/*
 	yarn integration
 
 .PHONY: integration-mac
 integration-mac: binaries/client build-extension-types build-extensions
 	# rm ${HOME}/Library/Application\ Support/Lens
 	yarn build:mac
+	mkdir -p logs
+	rm -r ./logs/*
 	yarn integration
 
 .PHONY: integration-win
 integration-win: binaries/client build-extension-types build-extensions
 	# rm %APPDATA%/Lens
 	yarn build:win
+	mkdir -p logs
+	rm -r ./logs/*
 	yarn integration
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -53,24 +53,30 @@ integration-linux: binaries/client build-extension-types build-extensions
 # 	rm -rf ${HOME}/.config/Lens
 # endif
 	yarn build:linux
+ifndef CI
 	mkdir -p logs
-	rm -r ./logs/*
+	rm -r logs
+endif
 	yarn integration
 
 .PHONY: integration-mac
 integration-mac: binaries/client build-extension-types build-extensions
 	# rm ${HOME}/Library/Application\ Support/Lens
 	yarn build:mac
+ifndef CI
 	mkdir -p logs
-	rm -r ./logs/*
+	rm -r logs
+endif
 	yarn integration
 
 .PHONY: integration-win
 integration-win: binaries/client build-extension-types build-extensions
 	# rm %APPDATA%/Lens
 	yarn build:win
+ifndef CI
 	mkdir -p logs
-	rm -r ./logs/*
+	rm -r logs
+endif
 	yarn integration
 
 .PHONY: build

--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -13,7 +13,7 @@ import * as utils from "../helpers/utils";
 import { listHelmRepositories } from "../helpers/utils";
 import { fail } from "assert";
 
-jest.setTimeout(60000);
+jest.setTimeout(60 * 1000 * 10); // 10m
 
 // FIXME (!): improve / simplify all css-selectors + use [data-test-id="some-id"] (already used in some tests below)
 describe("Lens integration tests", () => {

--- a/integration/__tests__/cluster-pages.tests.ts
+++ b/integration/__tests__/cluster-pages.tests.ts
@@ -12,7 +12,7 @@ import * as util from "util";
 
 export const promiseExec = util.promisify(exec);
 
-jest.setTimeout(60000);
+jest.setTimeout(60 * 1000 * 10); // 10m
 
 // FIXME (!): improve / simplify all css-selectors + use [data-test-id="some-id"] (already used in some tests below)
 describe("Lens cluster pages", () => {

--- a/integration/__tests__/command-palette.tests.ts
+++ b/integration/__tests__/command-palette.tests.ts
@@ -1,7 +1,7 @@
 import { Application } from "spectron";
 import * as utils from "../helpers/utils";
 
-jest.setTimeout(60000);
+jest.setTimeout(60 * 1000 * 10); // 10m
 
 describe("Lens command palette", () => {
   let app: Application;

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -1,6 +1,7 @@
+import { exec } from "child_process";
 import { AppConstructorOptions, Application } from "spectron";
 import * as util from "util";
-import { exec } from "child_process";
+
 import { isCI } from "../../src/common/vars";
 
 const AppPaths: Partial<Record<NodeJS.Platform, string>> = {
@@ -59,8 +60,6 @@ export function setup(): Application {
     env: {
       CICD: "true",
     },
-    chromeDriverLogPath: "./logs/chromeDriver",
-    webdriverLogPath: "./logs/webdriver",
   };
 
   if (!isCI) {

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -1,6 +1,7 @@
-import { Application } from "spectron";
+import { AppConstructorOptions, Application } from "spectron";
 import * as util from "util";
 import { exec } from "child_process";
+import { isCI } from "../../src/common/vars";
 
 const AppPaths: Partial<Record<NodeJS.Platform, string>> = {
   "win32": "./dist/win-unpacked/OpenLens.exe",
@@ -50,15 +51,24 @@ export function describeIf(condition: boolean) {
 }
 
 export function setup(): Application {
-  return new Application({
+  const args: AppConstructorOptions = {
     path: AppPaths[process.platform], // path to electron app
     args: [],
-    startTimeout: 30000,
-    waitTimeout: 60000,
+    startTimeout: 60000,
+    waitTimeout: 30000,
     env: {
-      CICD: "true"
-    }
-  });
+      CICD: "true",
+    },
+    chromeDriverLogPath: "./logs/chromeDriver",
+    webdriverLogPath: "./logs/webdriver",
+  };
+
+  if (!isCI) {
+    args.chromeDriverLogPath = "./logs/chromeDriver";
+    args.webdriverLogPath = "./logs/webdriver";
+  }
+
+  return new Application(args);
 }
 
 export const keys = {

--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -13,6 +13,7 @@ export const isProduction = process.env.NODE_ENV === "production";
 export const isTestEnv = !!process.env.JEST_WORKER_ID;
 export const isDevelopment = !isTestEnv && !isProduction;
 export const isPublishConfigured = Object.keys(packageInfo.build).includes("publish");
+export const isCI = Boolean(process.env.CI);
 
 export const productName = packageInfo.productName;
 export const appName = `${packageInfo.productName}${isDevelopment ? "Dev" : ""}`;

--- a/src/renderer/components/+namespaces/add-namespace-dialog.tsx
+++ b/src/renderer/components/+namespaces/add-namespace-dialog.tsx
@@ -8,7 +8,7 @@ import { Wizard, WizardStep } from "../wizard";
 import { namespaceStore } from "./namespace.store";
 import { Namespace } from "../../api/endpoints";
 import { Input } from "../input";
-import { systemName } from "../input/input_validators";
+import { namespaceValue } from "../input/input_validators";
 import { Notifications } from "../notifications";
 
 interface Props extends DialogProps {
@@ -49,19 +49,15 @@ export class AddNamespaceDialog extends React.Component<Props> {
   };
 
   render() {
-    const { ...dialogProps } = this.props;
-    const { namespace } = this;
-    const header = <h5>Create Namespace</h5>;
-
     return (
       <Dialog
-        {...dialogProps}
+        {...this.props}
         className="AddNamespaceDialog"
         isOpen={AddNamespaceDialog.isOpen}
         onOpen={this.reset}
         close={AddNamespaceDialog.close}
       >
-        <Wizard header={header} done={AddNamespaceDialog.close}>
+        <Wizard header={<h5>Create Namespace</h5>} done={AddNamespaceDialog.close}>
           <WizardStep
             contentClass="flex gaps column"
             nextLabel="Create"
@@ -71,8 +67,9 @@ export class AddNamespaceDialog extends React.Component<Props> {
               required autoFocus
               iconLeft="layers"
               placeholder="Namespace"
-              validators={systemName}
-              value={namespace} onChange={v => this.namespace = v.toLowerCase()}
+              validators={namespaceValue}
+              value={this.namespace}
+              onChange={v => this.namespace = v.toLowerCase()}
             />
           </WizardStep>
         </Wizard>

--- a/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
+++ b/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
@@ -93,7 +93,7 @@ export class AddHelmRepoDialog extends React.Component<Props> {
       <div className="flex gaps align-center">
         <Input
           placeholder={placeholder}
-          validators = {isPath}
+          asyncValidators={isPath}
           className="box grow"
           value={this.getFilePath(fileType)}
           onChange={v => this.setFilepath(fileType, v)}

--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -61,7 +61,7 @@ export const KubectlBinaries = observer(() => {
           theme="round-black"
           value={userStore.downloadBinariesPath}
           placeholder={getDefaultKubectlPath()}
-          validators={pathValidator}
+          asyncValidators={pathValidator}
           onChange={setDownloadPath}
           onBlur={save}
           disabled={!userStore.downloadKubectlBinaries}
@@ -79,7 +79,7 @@ export const KubectlBinaries = observer(() => {
           theme="round-black"
           placeholder={bundledKubectlPath()}
           value={binariesPath}
-          validators={pathValidator}
+          asyncValidators={pathValidator}
           onChange={setBinariesPath}
           onBlur={save}
           disabled={userStore.downloadKubectlBinaries}

--- a/src/renderer/components/cluster-settings/components/cluster-accessible-namespaces.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-accessible-namespaces.tsx
@@ -4,6 +4,7 @@ import { Cluster } from "../../../../main/cluster";
 import { SubTitle } from "../../layout/sub-title";
 import { EditableList } from "../../editable-list";
 import { observable } from "mobx";
+import { namespaceValue } from "../../input/input_validators";
 
 interface Props {
   cluster: Cluster;
@@ -19,6 +20,7 @@ export class ClusterAccessibleNamespaces extends React.Component<Props> {
         <SubTitle title="Accessible Namespaces" id="accessible-namespaces" />
         <EditableList
           placeholder="Add new namespace..."
+          validator={namespaceValue}
           add={(newNamespace) => {
             this.namespaces.add(newNamespace);
             this.props.cluster.accessibleNamespaces = Array.from(this.namespaces);

--- a/src/renderer/components/cluster-settings/components/cluster-accessible-namespaces.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-accessible-namespaces.tsx
@@ -20,7 +20,7 @@ export class ClusterAccessibleNamespaces extends React.Component<Props> {
         <SubTitle title="Accessible Namespaces" id="accessible-namespaces" />
         <EditableList
           placeholder="Add new namespace..."
-          validator={namespaceValue}
+          validators={namespaceValue}
           add={(newNamespace) => {
             this.namespaces.add(newNamespace);
             this.props.cluster.accessibleNamespaces = Array.from(this.namespaces);
@@ -32,7 +32,7 @@ export class ClusterAccessibleNamespaces extends React.Component<Props> {
           }}
         />
         <small className="hint">
-        This setting is useful for manually specifying which namespaces you have access to. This is useful when you do not have permissions to list namespaces.
+          This setting is useful for manually specifying which namespaces you have access to. This is useful when you do not have permissions to list namespaces.
         </small>
       </>
     );

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -2,7 +2,7 @@ import "./editable-list.scss";
 
 import React from "react";
 import { Icon } from "../icon";
-import { Input, InputValidator } from "../input";
+import { Input, InputValidator, AsyncInputValidator } from "../input";
 import { observable } from "mobx";
 import { observer } from "mobx-react";
 import { autobind } from "../../utils";
@@ -12,7 +12,8 @@ export interface Props<T> {
   add: (newItem: string) => void,
   remove: (info: { oldItem: T, index: number }) => void,
   placeholder?: string,
-  validator?: InputValidator,
+  validators?: InputValidator | InputValidator[],
+  asyncValidators?: AsyncInputValidator | AsyncInputValidator[];
 
   // An optional prop used to convert T to a displayable string
   // defaults to `String`
@@ -40,7 +41,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
   }
 
   render() {
-    const { items, remove, renderItem, placeholder, validator } = this.props;
+    const { items, remove, renderItem, placeholder, validators, asyncValidators } = this.props;
 
     return (
       <div className="EditableList">
@@ -48,7 +49,8 @@ export class EditableList<T> extends React.Component<Props<T>> {
           <Input
             theme="round-black"
             value={this.currentNewItem}
-            validators={validator}
+            validators={validators}
+            asyncValidators={asyncValidators}
             onSubmit={this.onSubmit}
             placeholder={placeholder}
             onChange={val => this.currentNewItem = val}

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -2,7 +2,7 @@ import "./editable-list.scss";
 
 import React from "react";
 import { Icon } from "../icon";
-import { Input } from "../input";
+import { Input, InputValidator } from "../input";
 import { observable } from "mobx";
 import { observer } from "mobx-react";
 import { autobind } from "../../utils";
@@ -12,6 +12,7 @@ export interface Props<T> {
   add: (newItem: string) => void,
   remove: (info: { oldItem: T, index: number }) => void,
   placeholder?: string,
+  validator?: InputValidator,
 
   // An optional prop used to convert T to a displayable string
   // defaults to `String`
@@ -39,7 +40,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
   }
 
   render() {
-    const { items, remove, renderItem, placeholder } = this.props;
+    const { items, remove, renderItem, placeholder, validator } = this.props;
 
     return (
       <div className="EditableList">
@@ -47,6 +48,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
           <Input
             theme="round-black"
             value={this.currentNewItem}
+            validators={validator}
             onSubmit={this.onSubmit}
             placeholder={placeholder}
             onChange={val => this.currentNewItem = val}

--- a/src/renderer/components/hotbar/hotbar-add-command.tsx
+++ b/src/renderer/components/hotbar/hotbar-add-command.tsx
@@ -39,8 +39,8 @@ export class HotbarAddCommand extends React.Component {
           data-test-id="command-palette-hotbar-add-name"
           validators={[uniqueHotbarName]}
           onSubmit={(v) => this.onSubmit(v)}
-          dirty={true}
-          showValidationLine={true} />
+          showErrorInitially={true}
+        />
         <small className="hint">
           Please provide a new hotbar name (Press &quot;Enter&quot; to confirm or &quot;Escape&quot; to cancel)
         </small>

--- a/src/renderer/components/input/input.scss
+++ b/src/renderer/components/input/input.scss
@@ -23,6 +23,20 @@
     }
   }
 
+  &.waiting {
+    pointer-events: none;
+    &:after {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 0;
+      height: 100%;
+      background: transparentize(white, .85);
+      animation: waiting 1.5s infinite linear;
+    }
+  }
+
   label {
     --flex-gap: #{$padding / 1.5};
 
@@ -122,4 +136,19 @@
   --bgc: #{$colorError};
   --border: none;
   --color: white;
+}
+
+@keyframes waiting {
+  0% {
+    left: 0;
+    width: 0;
+  }
+  50% {
+    left: 25%;
+    width: 75%;
+  }
+  75% {
+    left: 100%;
+    width: 0;
+  }
 }

--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -47,9 +47,18 @@ const defaultProps: Partial<InputProps> = {
 export class Input extends React.Component<InputProps> {
   static defaultProps = defaultProps as object;
 
-  public inputRef = React.createRef<InputElement>();
-  public validators: InputValidator[] = [];
-  public asyncValidators: AsyncInputValidator[] = [];
+  inputRef = React.createRef<InputElement>();
+  validators = [
+    ...conditionalValidators.filter(({ condition }) => condition(this.props)),
+    ...[this.props.validators],
+  ]
+    .flat()
+    .filter(Boolean);
+  asyncValidators = [
+    this.props.asyncValidators
+  ]
+    .flat()
+    .filter(Boolean);
 
   @observable errors: React.ReactNode[] = [];
   @observable dirty = Boolean(this.props.showErrorInitially);
@@ -62,17 +71,7 @@ export class Input extends React.Component<InputProps> {
   }
 
   componentDidMount() {
-    const { validators, asyncValidators, showErrorInitially } = this.props;
-
-    this.validators = conditionalValidators
-      // add conditional validators if matches input props
-      .filter(validator => validator.condition(this.props))
-      // add custom validators
-      .concat(validators);
-
-    this.asyncValidators = [asyncValidators].flat();
-
-    if (showErrorInitially) {
+    if (this.props.showErrorInitially) {
       this.runValidatorsRaw(this.getValue());
     }
 

--- a/src/renderer/components/input/input_validators.ts
+++ b/src/renderer/components/input/input_validators.ts
@@ -3,27 +3,26 @@ import { ReactNode } from "react";
 import fse from "fs-extra";
 
 export interface InputValidator {
-  debounce?: number; // debounce for async validators in ms
   condition?(props: InputProps): boolean; // auto-bind condition depending on input props
-  message?: ReactNode | ((value: string, props?: InputProps) => ReactNode | string);
-  validate(value: string, props?: InputProps): boolean | Promise<any>; // promise can throw error message
+  message: ReactNode | ((value: string, props?: InputProps) => ReactNode | string);
+  validate(value: string, props?: InputProps): boolean;
 }
 
 export const isRequired: InputValidator = {
   condition: ({ required }) => required,
-  message: () => `This field is required`,
+  message: "This field is required",
   validate: value => !!value.trim(),
 };
 
 export const isEmail: InputValidator = {
   condition: ({ type }) => type === "email",
-  message: () => `Wrong email format`,
+  message: "Must be an email",
   validate: value => !!value.match(/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/),
 };
 
 export const isNumber: InputValidator = {
   condition: ({ type }) => type === "number",
-  message: () => `Invalid number`,
+  message: "Must be a number",
   validate: (value, { min, max }) => {
     const numVal = +value;
 
@@ -37,7 +36,7 @@ export const isNumber: InputValidator = {
 
 export const isUrl: InputValidator = {
   condition: ({ type }) => type === "url",
-  message: () => `Wrong url format`,
+  message: "Must be a valid URL",
   validate: value => {
     try {
       return Boolean(new URL(value));
@@ -51,13 +50,13 @@ export const isExtensionNameInstallRegex = /^(?<name>(@[-\w]+\/)?[-\w]+)(@(?<ver
 
 export const isExtensionNameInstall: InputValidator = {
   condition: ({ type }) => type === "text",
-  message: () => "Not an extension name with optional version",
+  message: "Not an extension name with optional version",
   validate: value => value.match(isExtensionNameInstallRegex) !== null,
 };
 
 export const isPath: InputValidator = {
   condition: ({ type }) => type === "text",
-  message: () => `This field must be a valid path`,
+  message: "This field must be a path to an existing file.",
   validate: value => value && fse.pathExistsSync(value),
 };
 
@@ -76,12 +75,17 @@ export const maxLength: InputValidator = {
 const systemNameMatcher = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 export const systemName: InputValidator = {
-  message: () => `A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.`,
+  message: "A System Name must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.",
+  validate: value => !!value.match(systemNameMatcher),
+};
+
+export const namespaceValue: InputValidator = {
+  message: "A Namespace must be lowercase DNS labels separated by dots. DNS labels are alphanumerics and dashes enclosed by alphanumerics.",
   validate: value => !!value.match(systemNameMatcher),
 };
 
 export const accountId: InputValidator = {
-  message: () => `Invalid account ID`,
+  message: "Invalid account ID",
   validate: value => (isEmail.validate(value) || systemName.validate(value))
 };
 

--- a/src/renderer/components/input/input_validators.ts
+++ b/src/renderer/components/input/input_validators.ts
@@ -4,6 +4,10 @@ import fse from "fs-extra";
 
 export type ValidatorMessage = ReactNode | ((value: string, props?: InputProps) => ReactNode | string);
 
+export interface ConditionalInputValidator extends InputValidator {
+  condition(props: InputProps): boolean; // auto-bind condition depending on input props
+}
+
 export interface InputValidator {
   condition?(props: InputProps): boolean; // auto-bind condition depending on input props
   message: ValidatorMessage;
@@ -16,19 +20,19 @@ export interface AsyncInputValidator {
   validate(value: string, props?: InputProps): Promise<boolean>;
 }
 
-export const isRequired: InputValidator = {
+export const isRequired: ConditionalInputValidator = {
   condition: ({ required }) => required,
   message: "This field is required",
   validate: value => !!value.trim(),
 };
 
-export const isEmail: InputValidator = {
+export const isEmail: ConditionalInputValidator = {
   condition: ({ type }) => type === "email",
   message: "Must be an email",
   validate: value => !!value.match(/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/),
 };
 
-export const isNumber: InputValidator = {
+export const isNumber: ConditionalInputValidator = {
   condition: ({ type }) => type === "number",
   message: "Must be a number",
   validate: (value, { min, max }) => {
@@ -42,7 +46,7 @@ export const isNumber: InputValidator = {
   },
 };
 
-export const isUrl: InputValidator = {
+export const isUrl: ConditionalInputValidator = {
   condition: ({ type }) => type === "url",
   message: "Must be a valid URL",
   validate: value => {
@@ -56,7 +60,7 @@ export const isUrl: InputValidator = {
 
 export const isExtensionNameInstallRegex = /^(?<name>(@[-\w]+\/)?[-\w]+)(@(?<version>\d\.\d\.\d(-\w+)?))?$/gi;
 
-export const isExtensionNameInstall: InputValidator = {
+export const isExtensionNameInstall: ConditionalInputValidator = {
   condition: ({ type }) => type === "text",
   message: "Not an extension name with optional version",
   validate: value => value.match(isExtensionNameInstallRegex) !== null,
@@ -76,13 +80,13 @@ export const isPath: AsyncInputValidator = {
   },
 };
 
-export const minLength: InputValidator = {
+export const minLength: ConditionalInputValidator = {
   condition: ({ minLength }) => !!minLength,
   message: (value, { minLength }) => `Minimum length is ${minLength}`,
   validate: (value, { minLength }) => value.length >= minLength,
 };
 
-export const maxLength: InputValidator = {
+export const maxLength: ConditionalInputValidator = {
   condition: ({ maxLength }) => !!maxLength,
   message: (value, { maxLength }) => `Maximum length is ${maxLength}`,
   validate: (value, { maxLength }) => value.length <= maxLength,
@@ -105,6 +109,6 @@ export const accountId: InputValidator = {
   validate: value => (isEmail.validate(value) || systemName.validate(value))
 };
 
-export const conditionalValidators = [
+export const conditionalValidators: ConditionalInputValidator[] = [
   isRequired, isEmail, isNumber, isUrl, minLength, maxLength
 ];

--- a/webpack.extensions.ts
+++ b/webpack.extensions.ts
@@ -26,6 +26,7 @@ export default function generateExtensionTypes(): webpack.Configuration {
     optimization: {
       minimize: false, // speed up types compilation
     },
+    stats: "errors-warnings",
     module: {
       rules: [
         {


### PR DESCRIPTION
- Changes support of async validators to only run on submit
- Debounces validation to only run 500ms after the last edit.

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #2727 

Videos:

https://user-images.githubusercontent.com/8225332/117486490-b7fff880-af37-11eb-802c-a3f4c30d7257.mov

Note: that validator at the end is purely for the demo and is not in this PR.