### PR TITLE
Relax kube api data type validation (to allow metrics-server resources)

### DIFF
--- a/src/renderer/api/__tests__/kube-object.test.ts
+++ b/src/renderer/api/__tests__/kube-object.test.ts
@@ -110,19 +110,6 @@ describe("KubeObject", () => {
     {
       type TestCase = [string, any];
       const tests: TestCase[] = [
-        ["metadata.uid", { kind: "", apiVersion: "", metadata: {  name: "", resourceVersion: "", selfLink: ""} }],
-        ["metadata.name", { kind: "", apiVersion: "", metadata: { uid: "", resourceVersion: "", selfLink: "" } }],
-        ["metadata.resourceVersion", { kind: "", apiVersion: "", metadata: { uid: "", name: "", selfLink: "" } }],
-      ];
-
-      it.each(tests)("should reject with missing non-top level field: %s", (missingField, input) => {
-        expect(KubeObject.isPartialJsonApiData(input)).toBe(false);
-      });
-    }
-
-    {
-      type TestCase = [string, any];
-      const tests: TestCase[] = [
         ["kind", { kind: 1, apiVersion: "", metadata: { uid: "", name: "", resourceVersion: "", selfLink: "" } }],
         ["apiVersion", { apiVersion: 1, kind: "", metadata: { uid: "", name: "", resourceVersion: "", selfLink: "" } }],
         ["metadata", { kind: "", apiVersion: "", metadata: "" }],
@@ -192,7 +179,6 @@ describe("KubeObject", () => {
         ["kind", { apiVersion: "", items: [], metadata: { resourceVersion: "", selfLink: "" } }],
         ["apiVersion", { kind: "", items: [], metadata: { resourceVersion: "", selfLink: "" } }],
         ["metadata", { kind: "", items: [], apiVersion: "" }],
-        ["metadata.resourceVersion", { kind: "", items: [], apiVersion: "", metadata: { selfLink: "" } }],
       ];
 
       it.each(tests)("should reject with missing: %s", (missingField, input) => {

--- a/src/renderer/api/endpoints/pod-metrics.api.ts
+++ b/src/renderer/api/endpoints/pod-metrics.api.ts
@@ -2,7 +2,7 @@ import { KubeObject } from "../kube-object";
 import { KubeApi } from "../kube-api";
 
 export class PodMetrics extends KubeObject {
-  static kind = "Pod";
+  static kind = "PodMetricsList";
   static namespaced = true;
   static apiBase = "/apis/metrics.k8s.io/v1beta1/pods";
 

--- a/src/renderer/api/endpoints/pod-metrics.api.ts
+++ b/src/renderer/api/endpoints/pod-metrics.api.ts
@@ -2,7 +2,7 @@ import { KubeObject } from "../kube-object";
 import { KubeApi } from "../kube-api";
 
 export class PodMetrics extends KubeObject {
-  static kind = "PodMetricsList";
+  static kind = "PodMetrics";
   static namespaced = true;
   static apiBase = "/apis/metrics.k8s.io/v1beta1/pods";
 

--- a/src/renderer/api/kube-object.ts
+++ b/src/renderer/api/kube-object.ts
@@ -91,7 +91,7 @@ export class KubeObject implements ItemObject {
   static isKubeJsonApiListMetadata(object: unknown): object is KubeJsonApiListMetadata {
     return (
       isObject(object)
-      && hasTypedProperty(object, "resourceVersion", isString)
+      && hasOptionalProperty(object, "resourceVersion", isString)
       && hasOptionalProperty(object, "selfLink", isString)
     );
   }
@@ -112,12 +112,28 @@ export class KubeObject implements ItemObject {
     );
   }
 
+  static isPartialJsonApiMetadata(object: unknown): object is Partial<KubeJsonApiMetadata> {
+    return (
+      isObject(object)
+      && hasOptionalProperty(object, "uid", isString)
+      && hasOptionalProperty(object, "name", isString)
+      && hasOptionalProperty(object, "resourceVersion", isString)
+      && hasOptionalProperty(object, "selfLink", isString)
+      && hasOptionalProperty(object, "namespace", isString)
+      && hasOptionalProperty(object, "creationTimestamp", isString)
+      && hasOptionalProperty(object, "continue", isString)
+      && hasOptionalProperty(object, "finalizers", bindPredicate(isTypedArray, isString))
+      && hasOptionalProperty(object, "labels", bindPredicate(isRecord, isString, isString))
+      && hasOptionalProperty(object, "annotations", bindPredicate(isRecord, isString, isString))
+    );
+  }
+
   static isPartialJsonApiData(object: unknown): object is Partial<KubeJsonApiData> {
     return (
       isObject(object)
       && hasOptionalProperty(object, "kind", isString)
       && hasOptionalProperty(object, "apiVersion", isString)
-      && hasOptionalProperty(object, "metadata", KubeObject.isKubeJsonApiMetadata)
+      && hasOptionalProperty(object, "metadata", KubeObject.isPartialJsonApiMetadata)
     );
   }
 


### PR DESCRIPTION
Data received from the `PodMetricsApi` (metrics.k8s.io for metrics-server) does not contain the `resourceVersion` and `uid` metadata fields expected. This PR relaxes these requirements to optional.

should be cherry-picked to 4.2.x

fixes #2664 