### PR TITLE
Remove custom GA Tags script. Use built in GA.

### DIFF
--- a/docs/custom_theme/main.html
+++ b/docs/custom_theme/main.html
@@ -1,12 +1,1 @@
 {% extends "base.html" %}
-
-{% block analytics %}
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-90E1JB4HW4"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-90E1JB4HW4');
-  </script>
-{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,9 @@ repo_name: GitHub
 repo_url: https://github.com/lensapp/lens
 copyright: Copyright &copy; 2021 <a href="https://mirantis.com/">Mirantis Inc.</a> - All rights reserved.
 edit_uri: ""
+google_analytics:
+  - UA-159377374-2
+  - auto
 nav:
   - Overview: README.md
   - Getting Started: getting-started/README.md


### PR DESCRIPTION
Remove the custom GA Tags script implemented last year as it is no longer needed and replace with the built in GA function.

Signed-off-by: Steve Richards <srichards@mirantis.com>