### PR TITLE
Include all files as resources from extension dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules/
 yarn-error.log
 coverage/
 tmp/
-locales/**/**.js
 lens.log
 static/build
 static/types

--- a/package.json
+++ b/package.json
@@ -80,11 +80,6 @@
     "afterSign": "build/notarize.js",
     "extraResources": [
       {
-        "from": "locales/",
-        "to": "locales/",
-        "filter": "**/*.js"
-      },
-      {
         "from": "static/",
         "to": "static/",
         "filter": "!**/main.js"
@@ -98,6 +93,7 @@
         "from": "extensions/",
         "to": "./extensions/",
         "filter": [
+          "**/dist/**",
           "**/*.js*",
           "**/*.yml*",
           "!**/node_modules"


### PR DESCRIPTION
An extension might have other build artifacts than just yml/js.

Also removes legacy "locales" configuration from `build.extraResources`.