### PR TITLE
Removes links to ClusterFeature API docs as these no longer exist

### DIFF
--- a/docs/extensions/guides/renderer-extension.md
+++ b/docs/extensions/guides/renderer-extension.md
@@ -10,7 +10,6 @@ The custom Lens UI elements that you can add include:
 * [Cluster page menus](#clusterpagemenus)
 * [Global pages](#globalpages)
 * [Global page menus](#globalpagemenus)
-* [Cluster features](#clusterfeatures)
 * [App preferences](#apppreferences)
 * [Status bar items](#statusbaritems)
 * [KubeObject menu items](#kubeobjectmenuitems)

--- a/docs/extensions/typedoc-readme.md.tpl
+++ b/docs/extensions/typedoc-readme.md.tpl
@@ -3,7 +3,6 @@
 ## Modules
 
 * [App](modules/_core_api_app_.md)
-* [ClusterFeature](modules/_core_api_cluster_feature_.md)
 * [EventBus](modules/_core_api_event_bus_.md)
 * [Store](modules/_core_api_stores_.md)
 * [Util](modules/_core_api_utils_.md)


### PR DESCRIPTION
Removes links to ClusterFeature API docs as these no longer exist >=Lens.5.0.0-beta.5

Signed-off-by: Mario Sarcher <mario@sarcher.de>