### PR TITLE
Switch to more specific IPC helpers

### DIFF
--- a/src/common/ipc/type-enforced-ipc.ts
+++ b/src/common/ipc/type-enforced-ipc.ts
@@ -23,6 +23,7 @@ import type { EventEmitter } from "events";
 import { ipcMain } from "electron";
 import logger from "../../main/logger";
 import type { Disposer } from "../utils";
+import { ipcMainHandle } from "./ipc";
 
 export type ListenerEvent<EM extends EventEmitter> = Parameters<Parameters<EM["on"]>[1]>[0];
 export type ListVerifier<T extends any[]> = (args: unknown[]) => args is T;
@@ -116,7 +117,7 @@ export function handleCorrect<
     throw new TypeError(`Invalid args for invoke on channel: ${channel}`);
   }
 
-  ipcMain.handle(channel, wrappedHandler);
+  ipcMainHandle(channel, wrappedHandler);
 
   return () => ipcMain.removeHandler(channel);
 }

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -26,7 +26,7 @@ import fse from "fs-extra";
 import { observable, reaction, when, makeObservable } from "mobx";
 import os from "os";
 import path from "path";
-import { broadcastMessage, handleRequest, requestMain, subscribeToBroadcast } from "../common/ipc";
+import { broadcastMessage, ipcMainHandle, ipcRendererOn, requestMain } from "../common/ipc";
 import { Singleton, toJS } from "../common/utils";
 import logger from "../main/logger";
 import { ExtensionInstallationStateStore } from "../renderer/components/+extensions/extension-install.store";
@@ -34,7 +34,6 @@ import { extensionInstaller } from "./extension-installer";
 import { ExtensionsStore } from "./extensions-store";
 import { ExtensionLoader } from "./extension-loader";
 import type { LensExtensionId, LensExtensionManifest } from "./lens-extension";
-import type { PackageJson } from "type-fest";
 import semver from "semver";
 import { appSemVer } from "../common/vars";
 import { isProduction } from "../common/vars";
@@ -144,13 +143,13 @@ export class ExtensionDiscovery extends Singleton {
     };
 
     requestMain(ExtensionDiscovery.extensionDiscoveryChannel).then(onMessage);
-    subscribeToBroadcast(ExtensionDiscovery.extensionDiscoveryChannel, (_event, message: ExtensionDiscoveryChannelMessage) => {
+    ipcRendererOn(ExtensionDiscovery.extensionDiscoveryChannel, (_event, message: ExtensionDiscoveryChannelMessage) => {
       onMessage(message);
     });
   }
 
   async initMain(): Promise<void> {
-    handleRequest(ExtensionDiscovery.extensionDiscoveryChannel, () => this.toJSON());
+    ipcMainHandle(ExtensionDiscovery.extensionDiscoveryChannel, () => this.toJSON());
 
     reaction(() => this.toJSON(), () => {
       this.broadcast();

--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -25,7 +25,7 @@ import { isEqual } from "lodash";
 import { action, computed, makeObservable, observable, reaction, when } from "mobx";
 import path from "path";
 import { getHostedCluster } from "../common/cluster-store";
-import { broadcastMessage, handleRequest, requestMain, subscribeToBroadcast } from "../common/ipc";
+import { broadcastMessage, ipcMainOn, ipcRendererOn, requestMain, ipcMainHandle } from "../common/ipc";
 import { Disposer, Singleton, toJS } from "../common/utils";
 import logger from "../main/logger";
 import type { InstalledExtension } from "./extension-discovery";
@@ -174,11 +174,11 @@ export class ExtensionLoader extends Singleton {
     this.isLoaded = true;
     this.loadOnMain();
 
-    handleRequest(ExtensionLoader.extensionsMainChannel, () => {
+    ipcMainHandle(ExtensionLoader.extensionsMainChannel, () => {
       return Array.from(this.toJSON());
     });
 
-    subscribeToBroadcast(ExtensionLoader.extensionsRendererChannel, (_event, extensions: [LensExtensionId, InstalledExtension][]) => {
+    ipcMainOn(ExtensionLoader.extensionsRendererChannel, (event, extensions: [LensExtensionId, InstalledExtension][]) => {
       this.syncExtensions(extensions);
     });
   }
@@ -199,7 +199,7 @@ export class ExtensionLoader extends Singleton {
     };
 
     requestMain(ExtensionLoader.extensionsMainChannel).then(extensionListHandler);
-    subscribeToBroadcast(ExtensionLoader.extensionsMainChannel, (_event, extensions: [LensExtensionId, InstalledExtension][]) => {
+    ipcRendererOn(ExtensionLoader.extensionsMainChannel, (event, extensions: [LensExtensionId, InstalledExtension][]) => {
       extensionListHandler(extensions);
     });
   }

--- a/src/extensions/ipc/ipc-main.ts
+++ b/src/extensions/ipc/ipc-main.ts
@@ -24,6 +24,7 @@ import { Disposers } from "../lens-extension";
 import type { LensMainExtension } from "../lens-main-extension";
 import type { Disposer } from "../../common/utils";
 import { once } from "lodash";
+import { ipcMainHandle } from "../../common/ipc";
 
 export abstract class IpcMain extends IpcRegistrar {
   constructor(extension: LensMainExtension) {
@@ -55,7 +56,7 @@ export abstract class IpcMain extends IpcRegistrar {
   handle(channel: string, handler: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any): void {
     const prefixedChannel = `extensions@${this[IpcPrefix]}:${channel}`;
 
-    ipcMain.handle(prefixedChannel, handler);
+    ipcMainHandle(prefixedChannel, handler);
     this.extension[Disposers].push(() => ipcMain.removeHandler(prefixedChannel));
   }
 }

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -21,7 +21,6 @@
 
 import "../common/cluster-ipc";
 import type http from "http";
-import { ipcMain } from "electron";
 import { action, autorun, makeObservable, reaction } from "mobx";
 import { ClusterStore, getClusterIdFromHost } from "../common/cluster-store";
 import type { Cluster } from "./cluster";
@@ -30,6 +29,7 @@ import { apiKubePrefix } from "../common/vars";
 import { Singleton } from "../common/utils";
 import { catalogEntityRegistry } from "./catalog";
 import { KubernetesCluster, KubernetesClusterPrometheusMetrics } from "../common/catalog-entities/kubernetes-cluster";
+import { ipcMainOn } from "../common/ipc";
 
 export class ClusterManager extends Singleton {
   private store = ClusterStore.getInstance();
@@ -67,8 +67,8 @@ export class ClusterManager extends Singleton {
       delay: 250
     });
 
-    ipcMain.on("network:offline", this.onNetworkOffline);
-    ipcMain.on("network:online", this.onNetworkOnline);
+    ipcMainOn("network:offline", this.onNetworkOffline);
+    ipcMainOn("network:online", this.onNetworkOnline);
   }
 
   @action

--- a/src/main/initializers/index.ts
+++ b/src/main/initializers/index.ts
@@ -21,3 +21,4 @@
 
 export * from "./registries";
 export * from "./metrics-providers";
+export * from "./ipc";

--- a/src/main/initializers/ipc.ts
+++ b/src/main/initializers/ipc.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type { IpcMainInvokeEvent } from "electron";
+import type { KubernetesCluster } from "../../common/catalog-entities";
+import { clusterFrameMap } from "../../common/cluster-frames";
+import { clusterActivateHandler, clusterSetFrameIdHandler, clusterVisibilityHandler, clusterRefreshHandler, clusterDisconnectHandler, clusterKubectlApplyAllHandler, clusterKubectlDeleteAllHandler } from "../../common/cluster-ipc";
+import { ClusterId, ClusterStore } from "../../common/cluster-store";
+import { appEventBus } from "../../common/event-bus";
+import { ipcMainHandle } from "../../common/ipc";
+import { catalogEntityRegistry } from "../catalog";
+import { ResourceApplier } from "../resource-applier";
+
+export function initIpcMainHandlers() {
+  ipcMainHandle(clusterActivateHandler, (event, clusterId: ClusterId, force = false) => {
+    return ClusterStore.getInstance()
+      .getById(clusterId)
+      ?.activate(force);
+  });
+
+  ipcMainHandle(clusterSetFrameIdHandler, (event: IpcMainInvokeEvent, clusterId: ClusterId) => {
+    const cluster = ClusterStore.getInstance().getById(clusterId);
+
+    if (cluster) {
+      clusterFrameMap.set(cluster.id, { frameId: event.frameId, processId: event.processId });
+      cluster.pushState();
+    }
+  });
+
+  ipcMainHandle(clusterVisibilityHandler, (event: IpcMainInvokeEvent, clusterId: ClusterId, visible: boolean) => {
+    const entity = catalogEntityRegistry.getById<KubernetesCluster>(clusterId);
+
+    for (const kubeEntity of catalogEntityRegistry.getItemsForApiKind(entity.apiVersion, entity.kind)) {
+      kubeEntity.status.active = false;
+    }
+
+    if (entity) {
+      entity.status.active = visible;
+    }
+  });
+
+  ipcMainHandle(clusterRefreshHandler, (event, clusterId: ClusterId) => {
+    return ClusterStore.getInstance()
+      .getById(clusterId)
+      ?.refresh({ refreshMetadata: true });
+  });
+
+  ipcMainHandle(clusterDisconnectHandler, (event, clusterId: ClusterId) => {
+    appEventBus.emit({ name: "cluster", action: "stop" });
+    const cluster = ClusterStore.getInstance().getById(clusterId);
+
+    if (cluster) {
+      cluster.disconnect();
+      clusterFrameMap.delete(cluster.id);
+    }
+  });
+
+  ipcMainHandle(clusterKubectlApplyAllHandler, async (event, clusterId: ClusterId, resources: string[], extraArgs: string[]) => {
+    appEventBus.emit({ name: "cluster", action: "kubectl-apply-all" });
+    const cluster = ClusterStore.getInstance().getById(clusterId);
+
+    if (cluster) {
+      const applier = new ResourceApplier(cluster);
+
+      try {
+        const stdout = await applier.kubectlApplyAll(resources, extraArgs);
+
+        return { stdout };
+      } catch (error: any) {
+        return { stderr: error };
+      }
+    } else {
+      throw `${clusterId} is not a valid cluster id`;
+    }
+  });
+
+  ipcMainHandle(clusterKubectlDeleteAllHandler, async (event, clusterId: ClusterId, resources: string[], extraArgs: string[]) => {
+    appEventBus.emit({ name: "cluster", action: "kubectl-delete-all" });
+    const cluster = ClusterStore.getInstance().getById(clusterId);
+
+    if (cluster) {
+      const applier = new ResourceApplier(cluster);
+
+      try {
+        const stdout = await applier.kubectlDeleteAll(resources, extraArgs);
+
+        return { stdout };
+      } catch (error: any) {
+        return { stderr: error };
+      }
+    } else {
+      throw `${clusterId} is not a valid cluster id`;
+    }
+  });
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -19,14 +19,14 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { app, BrowserWindow, dialog, ipcMain, IpcMainEvent, Menu, MenuItem, MenuItemConstructorOptions, webContents, shell } from "electron";
+import { app, BrowserWindow, dialog, IpcMainEvent, Menu, MenuItem, MenuItemConstructorOptions, webContents, shell } from "electron";
 import { autorun } from "mobx";
 import type { WindowManager } from "./window-manager";
 import { appName, isMac, isWindows, isTestEnv, docsUrl, supportUrl, productName } from "../common/vars";
 import { MenuRegistry } from "../extensions/registries/menu-registry";
 import logger from "./logger";
 import { exitApp } from "./exit-app";
-import { broadcastMessage } from "../common/ipc";
+import { broadcastMessage, ipcMainOn } from "../common/ipc";
 import * as packageJson from "../../package.json";
 import { preferencesURL, extensionsURL, addClusterURL, catalogURL, welcomeURL } from "../common/routes";
 
@@ -276,7 +276,7 @@ export function buildMenu(windowManager: WindowManager) {
   if (isTestEnv) {
     // this is a workaround for the test environment (spectron) not being able to directly access
     // the application menus (https://github.com/electron-userland/spectron/issues/21)
-    ipcMain.on("test-menu-item-click", (event: IpcMainEvent, ...names: string[]) => {
+    ipcMainOn("test-menu-item-click", (event: IpcMainEvent, ...names: string[]) => {
       let menu: Menu = Menu.getApplicationMenu();
       const parentLabels: string[] = [];
       let menuItem: MenuItem;

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -24,7 +24,7 @@ import { makeObservable, observable } from "mobx";
 import { app, BrowserWindow, dialog, ipcMain, shell, webContents } from "electron";
 import windowStateKeeper from "electron-window-state";
 import { appEventBus } from "../common/event-bus";
-import { subscribeToBroadcast } from "../common/ipc";
+import { ipcMainOn } from "../common/ipc";
 import { initMenu } from "./menu";
 import { initTray } from "./tray";
 import { delay, Singleton } from "../common/utils";
@@ -140,7 +140,7 @@ export class WindowManager extends Singleton {
 
   protected bindEvents() {
     // track visible cluster from ui
-    subscribeToBroadcast(IpcRendererNavigationEvents.CLUSTER_VIEW_CURRENT_ID, (event, clusterId: ClusterId) => {
+    ipcMainOn(IpcRendererNavigationEvents.CLUSTER_VIEW_CURRENT_ID, (event, clusterId: ClusterId) => {
       this.activeClusterId = clusterId;
     });
   }

--- a/src/renderer/api/catalog-entity-registry.ts
+++ b/src/renderer/api/catalog-entity-registry.ts
@@ -20,8 +20,8 @@
  */
 
 import { computed, observable, makeObservable, action } from "mobx";
-import { subscribeToBroadcast } from "../../common/ipc";
-import { CatalogCategory, catalogCategoryRegistry, CatalogCategoryRegistry, CatalogEntity, CatalogEntityData, CatalogEntityKindData } from "../../common/catalog";
+import { ipcRendererOn } from "../../common/ipc";
+import { CatalogCategory, CatalogEntity, CatalogEntityData, catalogCategoryRegistry, CatalogCategoryRegistry, CatalogEntityKindData } from "../../common/catalog";
 import "../../common/catalog-entities";
 import type { Cluster } from "../../main/cluster";
 import { ClusterStore } from "../../common/cluster-store";
@@ -40,7 +40,7 @@ export class CatalogEntityRegistry {
   }
 
   init() {
-    subscribeToBroadcast("catalog:items", (ev, items: (CatalogEntityData & CatalogEntityKindData)[]) => {
+    ipcRendererOn("catalog:items", (event, items: (CatalogEntityData & CatalogEntityKindData)[]) => {
       this.updateItems(items);
     });
   }

--- a/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -27,7 +27,7 @@ import { observer } from "mobx-react";
 import React from "react";
 import { clusterActivateHandler } from "../../../common/cluster-ipc";
 import { ClusterId, ClusterStore } from "../../../common/cluster-store";
-import { requestMain, subscribeToBroadcast } from "../../../common/ipc";
+import { ipcRendererOn, requestMain } from "../../../common/ipc";
 import type { Cluster } from "../../../main/cluster";
 import { cssNames, IClassName } from "../../utils";
 import { Button } from "../button";
@@ -61,7 +61,7 @@ export class ClusterStatus extends React.Component<Props> {
   }
 
   async componentDidMount() {
-    subscribeToBroadcast(`kube-auth:${this.cluster.id}`, (evt, res: KubeAuthProxyLog) => {
+    ipcRendererOn(`kube-auth:${this.cluster.id}`, (evt, res: KubeAuthProxyLog) => {
       this.authOutput.push({
         data: res.data.trimRight(),
         error: res.error,

--- a/src/renderer/components/command-palette/command-container.tsx
+++ b/src/renderer/components/command-palette/command-container.tsx
@@ -26,7 +26,7 @@ import { observer } from "mobx-react";
 import React from "react";
 import { Dialog } from "../dialog";
 import { EventEmitter } from "../../../common/event-emitter";
-import { subscribeToBroadcast } from "../../../common/ipc";
+import { ipcRendererOn } from "../../../common/ipc";
 import { CommandDialog } from "./command-dialog";
 import type { ClusterId } from "../../../common/cluster-store";
 import { catalogEntityRegistry } from "../../api/catalog-entity-registry";
@@ -85,7 +85,7 @@ export class CommandContainer extends React.Component<CommandContainerProps> {
 
   componentDidMount() {
     if (this.props.clusterId) {
-      subscribeToBroadcast(`command-palette:run-action:${this.props.clusterId}`, (event, commandId: string) => {
+      ipcRendererOn(`command-palette:run-action:${this.props.clusterId}`, (event, commandId: string) => {
         const command = this.findCommandById(commandId);
 
         if (command) {
@@ -93,8 +93,8 @@ export class CommandContainer extends React.Component<CommandContainerProps> {
         }
       });
     } else {
-      subscribeToBroadcast("command-palette:open", () => {
-        this.commandComponent = <CommandDialog />;
+      ipcRendererOn("command-palette:open", () => {
+        CommandOverlay.open(<CommandDialog />);
       });
     }
     window.addEventListener("keyup", (e) => this.escHandler(e), true);

--- a/src/renderer/navigation/events.ts
+++ b/src/renderer/navigation/events.ts
@@ -22,7 +22,7 @@
 import { ipcRenderer } from "electron";
 import { reaction } from "mobx";
 import { getMatchedClusterId, navigate } from "./helpers";
-import { broadcastMessage, subscribeToBroadcast } from "../../common/ipc";
+import { broadcastMessage, ipcRendererOn } from "../../common/ipc";
 import logger from "../../main/logger";
 
 export const enum IpcRendererNavigationEvents {
@@ -45,7 +45,7 @@ export function bindEvents() {
   }
 
   // Reload dashboard window
-  subscribeToBroadcast(IpcRendererNavigationEvents.RELOAD_PAGE, () => {
+  ipcRendererOn(IpcRendererNavigationEvents.RELOAD_PAGE, () => {
     location.reload();
   });
 }
@@ -60,7 +60,7 @@ function bindClusterManagerRouteEvents() {
   });
 
   // Handle navigation via IPC
-  subscribeToBroadcast(IpcRendererNavigationEvents.NAVIGATE_IN_APP, (event, url: string) => {
+  ipcRendererOn(IpcRendererNavigationEvents.NAVIGATE_IN_APP, (event, url: string) => {
     logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
     navigate(url);
   });
@@ -68,7 +68,7 @@ function bindClusterManagerRouteEvents() {
 
 // Handle cluster-view renderer process events within iframes
 function bindClusterFrameRouteEvents() {
-  subscribeToBroadcast(IpcRendererNavigationEvents.NAVIGATE_IN_CLUSTER, (event, url: string) => {
+  ipcRendererOn(IpcRendererNavigationEvents.NAVIGATE_IN_CLUSTER, (event, url: string) => {
     logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
     navigate(url);
   });


### PR DESCRIPTION
Namely we should now have:

- `ipcMainOn` which is `ipcMain.on` + return disposer of `ipcMain.off`
- `ipcRendererOn` which is `ipcRenderer.on` + return disposer of `ipcRenderer.off`
- `ipcMain.handle` instead of `handleMain`

Signed-off-by: Sebastian Malton <sebastian@malton.name>