### PR TITLE
Refactor CatalogEntityRegistry from common to main

### DIFF
--- a/src/common/catalog/catalog-category-registry.ts
+++ b/src/common/catalog/catalog-category-registry.ts
@@ -25,24 +25,22 @@ import { CatalogCategory, CatalogEntityData, CatalogEntityKindData } from "./cat
 
 export class CatalogCategoryRegistry {
   protected categories = observable.set<CatalogCategory>();
+  protected groupKinds = new ExtendedMap<string, ExtendedMap<string, CatalogCategory>>();
 
   @action add(category: CatalogCategory): Disposer {
     this.categories.add(category);
+    this.updateGroupKinds(category);
 
-    return () => this.categories.delete(category);
+    return () => {
+      this.categories.delete(category);
+      this.groupKinds.clear();
+    };
   }
 
-  @computed private get groupKindLookup(): Map<string, Map<string, CatalogCategory>> {
-    // ExtendedMap has the convenience methods `getOrInsert` and `strictSet`
-    const res = new ExtendedMap<string, ExtendedMap<string, CatalogCategory>>();
-
-    for (const category of this.categories) {
-      res
-        .getOrInsert(category.spec.group, ExtendedMap.new)
-        .strictSet(category.spec.names.kind, category);
-    }
-
-    return res;
+  private updateGroupKinds(category: CatalogCategory) {
+    this.groupKinds
+      .getOrInsert(category.spec.group, ExtendedMap.new)
+      .strictSet(category.spec.names.kind, category);
   }
 
   @computed get items() {
@@ -50,7 +48,7 @@ export class CatalogCategoryRegistry {
   }
 
   getForGroupKind<T extends CatalogCategory>(group: string, kind: string): T | undefined {
-    return this.groupKindLookup.get(group)?.get(kind) as T;
+    return this.groupKinds.get(group)?.get(kind) as T;
   }
 
   getEntityForData(data: CatalogEntityData & CatalogEntityKindData) {

--- a/src/common/catalog/index.ts
+++ b/src/common/catalog/index.ts
@@ -21,4 +21,3 @@
 
 export * from "./catalog-category-registry";
 export * from "./catalog-entity";
-export * from "./catalog-entity-registry";

--- a/src/extensions/core-api/catalog.ts
+++ b/src/extensions/core-api/catalog.ts
@@ -20,7 +20,8 @@
  */
 
 
-import { CatalogEntity, catalogEntityRegistry as registry } from "../../common/catalog";
+import type { CatalogEntity } from "../../common/catalog";
+import { catalogEntityRegistry as registry } from "../../main/catalog";
 
 export { catalogCategoryRegistry as catalogCategories } from "../../common/catalog/catalog-category-registry";
 export * from "../../common/catalog-entities";

--- a/src/extensions/lens-main-extension.ts
+++ b/src/extensions/lens-main-extension.ts
@@ -22,7 +22,8 @@
 import { LensExtension } from "./lens-extension";
 import { WindowManager } from "../main/window-manager";
 import { getExtensionPageUrl } from "./registries/page-registry";
-import { CatalogEntity, catalogEntityRegistry } from "../common/catalog";
+import { catalogEntityRegistry } from "../main/catalog";
+import type { CatalogEntity } from "../common/catalog";
 import type { IObservableArray } from "mobx";
 import type { MenuRegistration } from "./registries";
 

--- a/src/main/catalog-pusher.ts
+++ b/src/main/catalog-pusher.ts
@@ -21,7 +21,7 @@
 
 import { reaction, toJS } from "mobx";
 import { broadcastMessage, subscribeToBroadcast, unsubscribeFromBroadcast } from "../common/ipc";
-import type { CatalogEntityRegistry} from "../common/catalog";
+import type { CatalogEntityRegistry} from "./catalog";
 import "../common/catalog-entities/kubernetes-cluster";
 import type { Disposer } from "../common/utils";
 

--- a/src/main/catalog-sources/kubeconfig-sync.ts
+++ b/src/main/catalog-sources/kubeconfig-sync.ts
@@ -20,7 +20,8 @@
  */
 
 import { action, observable, IComputedValue, computed, ObservableMap, runInAction } from "mobx";
-import { CatalogEntity, catalogEntityRegistry } from "../../common/catalog";
+import type { CatalogEntity } from "../../common/catalog";
+import { catalogEntityRegistry } from "../../main/catalog";
 import { watch } from "chokidar";
 import fs from "fs";
 import fse from "fs-extra";

--- a/src/main/catalog/__tests__/catalog-entity-registry.test.ts
+++ b/src/main/catalog/__tests__/catalog-entity-registry.test.ts
@@ -20,8 +20,30 @@
  */
 
 import { observable, reaction } from "mobx";
-import { WebLink } from "../catalog-entities";
-import { CatalogEntityRegistry } from "../catalog";
+import { WebLink, WebLinkSpec, WebLinkStatus } from "../../../common/catalog-entities";
+import { catalogCategoryRegistry, CatalogEntity, CatalogEntityMetadata } from "../../../common/catalog";
+import { CatalogEntityRegistry } from "../catalog-entity-registry";
+
+class InvalidEntity extends CatalogEntity<CatalogEntityMetadata, WebLinkStatus, WebLinkSpec> {
+  public readonly apiVersion = "entity.k8slens.dev/v1alpha1";
+  public readonly kind = "WebLink";
+
+  async onRun() {
+    return;
+  }
+
+  public onSettingsOpen(): void {
+    return;
+  }
+
+  public onDetailsOpen(): void {
+    return;
+  }
+
+  public onContextMenuOpen(): void {
+    return;
+  }
+}
 
 describe("CatalogEntityRegistry", () => {
   let registry: CatalogEntityRegistry;
@@ -39,9 +61,23 @@ describe("CatalogEntityRegistry", () => {
       phase: "valid"
     }
   });
+  const invalidEntity = new InvalidEntity({
+    metadata: {
+      uid: "invalid",
+      name: "test-link",
+      source: "test",
+      labels: {}
+    },
+    spec: {
+      url: "https://k8slens.dev"
+    },
+    status: {
+      phase: "valid"
+    }
+  });
 
   beforeEach(() => {
-    registry = new CatalogEntityRegistry();
+    registry = new CatalogEntityRegistry(catalogCategoryRegistry);
   });
 
   describe("addSource", () => {
@@ -77,6 +113,24 @@ describe("CatalogEntityRegistry", () => {
       registry.removeSource("test");
 
       expect(registry.items.length).toEqual(0);
+    });
+  });
+
+  describe("items", () => {
+    it("returns added items", () => {
+      expect(registry.items.length).toBe(0);
+
+      const source = observable.array([entity]);
+
+      registry.addObservableSource("test", source);
+      expect(registry.items.length).toBe(1);
+    });
+
+    it("does not return items without matching category", () => {
+      const source = observable.array([invalidEntity]);
+
+      registry.addObservableSource("test", source);
+      expect(registry.items.length).toBe(0);
     });
   });
 });

--- a/src/main/catalog/__tests__/catalog-entity-registry.test.ts
+++ b/src/main/catalog/__tests__/catalog-entity-registry.test.ts
@@ -26,7 +26,7 @@ import { CatalogEntityRegistry } from "../catalog-entity-registry";
 
 class InvalidEntity extends CatalogEntity<CatalogEntityMetadata, WebLinkStatus, WebLinkSpec> {
   public readonly apiVersion = "entity.k8slens.dev/v1alpha1";
-  public readonly kind = "WebLink";
+  public readonly kind = "Invalid";
 
   async onRun() {
     return;

--- a/src/main/catalog/catalog-entity-registry.ts
+++ b/src/main/catalog/catalog-entity-registry.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { action, computed, observable, IComputedValue, IObservableArray } from "mobx";
+import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity } from "../../common/catalog";
+import { iter } from "../../common/utils";
+
+export class CatalogEntityRegistry {
+  protected sources = observable.map<string, IComputedValue<CatalogEntity[]>>([], { deep: true });
+
+  constructor(private categoryRegistry: CatalogCategoryRegistry) {}
+
+  @action addObservableSource(id: string, source: IObservableArray<CatalogEntity>) {
+    this.sources.set(id, computed(() => source));
+  }
+
+  @action addComputedSource(id: string, source: IComputedValue<CatalogEntity[]>) {
+    this.sources.set(id, source);
+  }
+
+  @action removeSource(id: string) {
+    this.sources.delete(id);
+  }
+
+  @computed get items(): CatalogEntity[] {
+    const allItems = Array.from(iter.flatMap(this.sources.values(), source => source.get()));
+
+    return allItems.filter((entity) => this.categoryRegistry.getCategoryForEntity(entity) !== undefined);
+  }
+
+  getItemsForApiKind<T extends CatalogEntity>(apiVersion: string, kind: string): T[] {
+    const items = this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind);
+
+    return items as T[];
+  }
+}
+
+export const catalogEntityRegistry = new CatalogEntityRegistry(catalogCategoryRegistry);

--- a/src/main/catalog/index.ts
+++ b/src/main/catalog/index.ts
@@ -19,34 +19,4 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { action, computed, observable, IComputedValue, IObservableArray } from "mobx";
-import type { CatalogEntity } from "./catalog-entity";
-import { iter } from "../utils";
-
-export class CatalogEntityRegistry {
-  protected sources = observable.map<string, IComputedValue<CatalogEntity[]>>([], { deep: true });
-
-  @action addObservableSource(id: string, source: IObservableArray<CatalogEntity>) {
-    this.sources.set(id, computed(() => source));
-  }
-
-  @action addComputedSource(id: string, source: IComputedValue<CatalogEntity[]>) {
-    this.sources.set(id, source);
-  }
-
-  @action removeSource(id: string) {
-    this.sources.delete(id);
-  }
-
-  @computed get items(): CatalogEntity[] {
-    return Array.from(iter.flatMap(this.sources.values(), source => source.get()));
-  }
-
-  getItemsForApiKind<T extends CatalogEntity>(apiVersion: string, kind: string): T[] {
-    const items = this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind);
-
-    return items as T[];
-  }
-}
-
-export const catalogEntityRegistry = new CatalogEntityRegistry();
+export * from "./catalog-entity-registry";

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -28,7 +28,7 @@ import type { Cluster } from "./cluster";
 import logger from "./logger";
 import { apiKubePrefix } from "../common/vars";
 import { Singleton } from "../common/utils";
-import { catalogEntityRegistry } from "../common/catalog";
+import { catalogEntityRegistry } from "./catalog";
 import { KubernetesCluster, KubernetesClusterPrometheusMetrics } from "../common/catalog-entities/kubernetes-cluster";
 
 export class ClusterManager extends Singleton {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,7 +50,7 @@ import { bindBroadcastHandlers } from "../common/ipc";
 import { startUpdateChecking } from "./app-updater";
 import { IpcRendererNavigationEvents } from "../renderer/navigation/events";
 import { CatalogPusher } from "./catalog-pusher";
-import { catalogEntityRegistry } from "../common/catalog";
+import { catalogEntityRegistry } from "./catalog";
 import { HotbarStore } from "../common/hotbar-store";
 import { HelmRepoManager } from "./helm/helm-repo-manager";
 import { KubeconfigSyncManager } from "./catalog-sources";


### PR DESCRIPTION
Follow-up for #2816.

- moves `CatalogEntityRegistry` from `common` to `main` (it should have been there from the start).
- does `items`  filtering also on `main` (`renderer` already has filtering)
- refactors `groupKindLookup` to use cached `ExtendedMap` (because otherwise we are generating new map for each catalog item).
- more tests