### PR TITLE
Add (optional, enable by env) esbuild-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
     "electron": "^9.4.4",
     "electron-builder": "^22.10.5",
     "electron-notarize": "^0.3.0",
+    "esbuild-loader": "^2.13.1",
     "eslint": "^7.7.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-react": "^7.21.5",

--- a/src/common/getTsLoader.ts
+++ b/src/common/getTsLoader.ts
@@ -22,7 +22,7 @@
 /**
  * A function returning webpack ts/tsx loader
  * 
- * depends on env USE_ESBUILD_LOADER to use esbuild-loader (faster) or good-old ts-loader
+ * depends on env LENS_DEV_USE_ESBUILD_LOADER to use esbuild-loader (faster) or good-old ts-loader
  * 
  * @param testRegExp - the regex for webpack to conditional find the files 
  * @returns ts/tsx webpack loader configuration object
@@ -30,12 +30,13 @@
 const getTsloader = (
   testRegExp: RegExp, transpileOnly = true
 ) => {
-  const useEsbuildLoader = process.env.USE_ESBUILD_LOADER === "true";
+  const useEsbuildLoader = process.env.LENS_DEV_USE_ESBUILD_LOADER === "true";
+
+  useEsbuildLoader && console.info(`\n🚀 using esbuild-loader for ts(x)`);
 
   if (useEsbuildLoader) {
     return {
       test: testRegExp,
-      exclude: /node_modules/,
       loader: "esbuild-loader",
       options: {
         loader: "tsx",

--- a/src/common/getTsLoader.ts
+++ b/src/common/getTsLoader.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * A function returning webpack ts/tsx loader
+ * 
+ * depends on env USE_ESBUILD_LOADER to use esbuild-loader (faster) or good-old ts-loader
+ * 
+ * @param testRegExp - the regex for webpack to conditional find the files 
+ * @returns ts/tsx webpack loader configuration object
+ */
+const getTsloader = (
+  testRegExp: RegExp, transpileOnly = true
+) => {
+  const useEsbuildLoader = process.env.USE_ESBUILD_LOADER === "true";
+
+  if (useEsbuildLoader) {
+    return {
+      test: testRegExp,
+      exclude: /node_modules/,
+      loader: "esbuild-loader",
+      options: {
+        loader: "tsx",
+        target: "es2015"
+      },
+    };
+  }
+
+  return {
+    test: testRegExp,
+    exclude: /node_modules/,
+    use: {
+      loader: "ts-loader",
+      options: {
+        transpileOnly,
+      }
+    }
+  };
+};
+
+export default getTsloader;

--- a/src/common/getTsLoader.ts
+++ b/src/common/getTsLoader.ts
@@ -27,7 +27,7 @@
  * @param testRegExp - the regex for webpack to conditional find the files 
  * @returns ts/tsx webpack loader configuration object
  */
-const getTsloader = (
+const getTsLoader = (
   testRegExp: RegExp, transpileOnly = true
 ) => {
   const useEsbuildLoader = process.env.LENS_DEV_USE_ESBUILD_LOADER === "true";
@@ -57,4 +57,4 @@ const getTsloader = (
   };
 };
 
-export default getTsloader;
+export default getTsLoader;

--- a/webpack.main.ts
+++ b/webpack.main.ts
@@ -61,7 +61,7 @@ export default function (): webpack.Configuration {
     },
     plugins: [
       new ProgressBarPlugin(),
-      new ForkTsCheckerPlugin(),
+      process.env.LENS_DEV_DISABLE_TS_CHECKER === "true" ? undefined : new ForkTsCheckerPlugin(),
     ].filter(Boolean)
   };
 }

--- a/webpack.main.ts
+++ b/webpack.main.ts
@@ -26,7 +26,7 @@ import { isProduction, mainDir, buildDir, isDevelopment } from "./src/common/var
 import nodeExternals from "webpack-node-externals";
 import ProgressBarPlugin from "progress-bar-webpack-plugin";
 import * as vars from "./src/common/vars";
-import getTsloader from "./src/common/getTsloader";
+import getTsLoader from "./src/common/getTsLoader";
 
 export default function (): webpack.Configuration {
   console.info("WEBPACK:main", vars);
@@ -56,7 +56,7 @@ export default function (): webpack.Configuration {
           test: /\.node$/,
           use: "node-loader"
         },
-        getTsloader(/\.ts$/)
+        getTsLoader(/\.ts$/)
       ]
     },
     plugins: [

--- a/webpack.main.ts
+++ b/webpack.main.ts
@@ -26,6 +26,7 @@ import { isProduction, mainDir, buildDir, isDevelopment } from "./src/common/var
 import nodeExternals from "webpack-node-externals";
 import ProgressBarPlugin from "progress-bar-webpack-plugin";
 import * as vars from "./src/common/vars";
+import getTsloader from "./src/common/getTsloader";
 
 export default function (): webpack.Configuration {
   console.info("WEBPACK:main", vars);
@@ -55,16 +56,7 @@ export default function (): webpack.Configuration {
           test: /\.node$/,
           use: "node-loader"
         },
-        {
-          test: /\.ts$/,
-          exclude: /node_modules/,
-          use: {
-            loader: "ts-loader",
-            options: {
-              transpileOnly: true,
-            }
-          }
-        },
+        getTsloader(/\.ts$/)
       ]
     },
     plugins: [

--- a/webpack.renderer.ts
+++ b/webpack.renderer.ts
@@ -28,7 +28,7 @@ import ForkTsCheckerPlugin from "fork-ts-checker-webpack-plugin";
 import ProgressBarPlugin from "progress-bar-webpack-plugin";
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import * as vars from "./src/common/vars";
-import getTsloader from "./src/common/getTsloader";
+import getTsLoader from "./src/common/getTsLoader";
 
 export default [
   webpackLensRenderer
@@ -89,7 +89,7 @@ export function webpackLensRenderer({ showVars = true } = {}): webpack.Configura
           test: /\.node$/,
           use: "node-loader"
         },
-        getTsloader(/\.tsx?$/),
+        getTsLoader(/\.tsx?$/),
         {
           test: /\.(jpg|png|svg|map|ico)$/,
           use: {

--- a/webpack.renderer.ts
+++ b/webpack.renderer.ts
@@ -139,7 +139,7 @@ export function webpackLensRenderer({ showVars = true } = {}): webpack.Configura
 
     plugins: [
       new ProgressBarPlugin(),
-      new ForkTsCheckerPlugin(),
+      process.env.LENS_DEV_DISABLE_TS_CHECKER === "true" ? undefined : new ForkTsCheckerPlugin(),
 
       // todo: fix remain warnings about circular dependencies
       // new CircularDependencyPlugin({

--- a/webpack.renderer.ts
+++ b/webpack.renderer.ts
@@ -28,6 +28,7 @@ import ForkTsCheckerPlugin from "fork-ts-checker-webpack-plugin";
 import ProgressBarPlugin from "progress-bar-webpack-plugin";
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import * as vars from "./src/common/vars";
+import getTsloader from "./src/common/getTsloader";
 
 export default [
   webpackLensRenderer
@@ -88,16 +89,7 @@ export function webpackLensRenderer({ showVars = true } = {}): webpack.Configura
           test: /\.node$/,
           use: "node-loader"
         },
-        {
-          test: /\.tsx?$/,
-          exclude: /node_modules/,
-          use: {
-            loader: "ts-loader",
-            options: {
-              transpileOnly: true, // ForkTsCheckerPlugin does type-checking
-            }
-          }
-        },
+        getTsloader(/\.tsx?$/),
         {
           test: /\.(jpg|png|svg|map|ico)$/,
           use: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,6 +5231,24 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+esbuild-loader@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/esbuild-loader/-/esbuild-loader-2.13.1.tgz#9c89e654390a9a25d99b2f6d803ade30f4335418"
+  integrity sha512-Tzc5nB5tVUmigXz6m4j1OYozJCjdix7E9vtd5RaE54fqz2Rz34Is9S8FbAf8uqR4xvQUBAXIi6Jkn1OeMxw2aQ==
+  dependencies:
+    esbuild "^0.11.19"
+    joycon "^3.0.1"
+    json5 "^2.2.0"
+    loader-utils "^2.0.0"
+    tapable "^2.2.0"
+    type-fest "^1.0.1"
+    webpack-sources "^2.2.0"
+
+esbuild@^0.11.19:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.23.tgz#c42534f632e165120671d64db67883634333b4b8"
+  integrity sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -8204,6 +8222,11 @@ jose@^1.27.1:
   dependencies:
     "@panva/asn1.js" "^1.0.0"
 
+joycon@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.0.1.tgz#9074c9b08ccf37a6726ff74a18485f85efcaddaf"
+  integrity sha512-SJcJNBg32dGgxhPtM0wQqxqV0ax9k/9TaUskGDSJkSFSQOEWWvQ3zzWdGQRIUry2j1zA5+ReH13t0Mf3StuVZA==
+
 jquery@^3.4.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
@@ -8379,6 +8402,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -12727,7 +12757,7 @@ sorted-union-stream@~2.1.3:
     from2 "^1.3.0"
     stream-iterate "^1.1.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -13309,6 +13339,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar-fs@^2.0.0, tar-fs@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.0.tgz#d1cdd121ab465ee0eb9ccde2d35049d3f3daf0d5"
@@ -13793,6 +13828,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.3.tgz#ea1a602e98e5a968a56a289886a52f04c686fc81"
+  integrity sha512-CsiQeFMR1jZEq8R+H59qe+bBevnjoV5N2WZTTdlyqxeoODQOOepN2+msQOywcieDq5sBjabKzTn3U+sfHZlMdw==
 
 type-fest@^1.0.2:
   version "1.0.2"
@@ -14442,6 +14482,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@^4.44.2:
   version "4.44.2"


### PR DESCRIPTION
For faster build in dev mode.

- Add env `LENS_DEV_DISABLE_TS_CHECKER `, to disable type checking (as most editor already have it), default is on (as before)
- Add env `LENS_DEV_USE_ESBUILD_LOADER `, to enable `esbuild-loader`, default is off as before.