### PR TITLE
Bump prometheus and kube-state-metrics for arm+other arch support

### DIFF
--- a/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
@@ -54,7 +54,7 @@ spec:
               mountPath: /var/lib/prometheus
       containers:
         - name: prometheus
-          image: quay.io/prometheus/prometheus:v2.26.0
+          image: quay.io/prometheus/prometheus:v2.27.1
           args:
             - --web.listen-address=0.0.0.0:9090
             - --config.file=/etc/prometheus/prometheus.yaml

--- a/extensions/metrics-cluster-feature/resources/14-kube-state-metrics-deployment.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/14-kube-state-metrics-deployment.yml.hb
@@ -23,23 +23,15 @@ spec:
                   operator: In
                   values:
                   - linux
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                  - amd64
               - matchExpressions:
                 - key: beta.kubernetes.io/os
                   operator: In
                   values:
                   - linux
-                - key: beta.kubernetes.io/arch
-                  operator: In
-                  values:
-                  - amd64
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.9.8
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
- Support for running kube-state-metrics on all architectures
- Bump prometheus for security vuln. fix 


See [here](https://github.com/prometheus/prometheus/releases/tag/v2.27.1) for prometheus release note about security vulnerability

See [here](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-rc.1) for change to new authoritative source for kube-state-metrics image that supports arm, ppc64, etc...

Signed-off-by: Jon Stelly <967068+jonstelly@users.noreply.github.com>