### PR TITLE
Prevent dependabot from introducing bump PRs for major versions

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,3 +15,7 @@ updates:
     versioning-strategy:
       lockfile-only: false
       increase: true
+    ignore:
+      - dependency-name: *
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

docs: https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/