### PR TITLE
Remove old extensions on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ $(extension_dists): src/extensions/npm/extensions/dist
 
 .PHONY: clean-old-extensions
 clean-old-extensions:
+ifndef CI
 	find extensions -d 1 -type d '!' -exec test -e '{}/package.json' \; -delete
+endif
 
 .PHONY: build-extensions
 build-extensions: node_modules clean-old-extensions $(extension_node_modules) $(extension_dists)

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(extension_dists): src/extensions/npm/extensions/dist
 
 .PHONY: clean-old-extensions
 clean-old-extensions:
-	find extensions -d 1 -type d '!' -exec test -e "{}/package.json" \; -delete
+	find extensions -d 1 -type d '!' -exec test -e '{}/package.json' \; -delete
 
 .PHONY: build-extensions
 build-extensions: node_modules clean-old-extensions $(extension_node_modules) $(extension_dists)

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,12 @@ $(extension_node_modules): node_modules
 $(extension_dists): src/extensions/npm/extensions/dist
 	cd $(@:/dist=) && ../../node_modules/.bin/npm run build
 
+.PHONY: clean-old-extensions
+clean-old-extensions:
+	find extensions -d 1 -type d '!' -exec test -e "{}/package.json" \; -delete
+
 .PHONY: build-extensions
-build-extensions: node_modules $(extension_node_modules) $(extension_dists)
+build-extensions: node_modules clean-old-extensions $(extension_node_modules) $(extension_dists)
 
 .PHONY: test-extensions
 test-extensions: $(extension_node_modules)

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,7 @@ $(extension_dists): src/extensions/npm/extensions/dist
 
 .PHONY: clean-old-extensions
 clean-old-extensions:
-ifndef CI
-	find extensions -d 1 -type d '!' -exec test -e '{}/package.json' \; -delete
-endif
+	find ./extensions -mindepth 1 -maxdepth 1 -type d '!' -exec test -e '{}/package.json' \; -exec rm -rf {} \;
 
 .PHONY: build-extensions
 build-extensions: node_modules clean-old-extensions $(extension_node_modules) $(extension_dists)


### PR DESCRIPTION
Why is this needed?:
-
This is needed to prevent build error when switching between branch the contain differing sets of in-tree extensions. This removes the folders that no longer include `package.json` files. This is to prevent this step from removing extensions that are currently being worked on.

Signed-off-by: Sebastian Malton <sebastian@malton.name>