### PR TITLE
Fix main->renderer catalog entity sync issue

### DIFF
--- a/src/main/catalog-pusher.ts
+++ b/src/main/catalog-pusher.ts
@@ -24,10 +24,17 @@ import { broadcastMessage } from "../common/ipc";
 import type { CatalogEntityRegistry } from "./catalog";
 import "../common/catalog-entities/kubernetes-cluster";
 import { toJS } from "../common/utils";
+import { debounce } from "lodash";
+import type { CatalogEntity } from "../common/catalog";
+
+
+const broadcaster = debounce((items: CatalogEntity[]) => {
+  broadcastMessage("catalog:items", items);
+}, 1_000, { trailing: true });
 
 export function pushCatalogToRenderer(catalog: CatalogEntityRegistry) {
   return reaction(() => toJS(catalog.items), (items) => {
-    broadcastMessage("catalog:items", items);
+    broadcaster(items);
   }, {
     fireImmediately: true,
   });

--- a/src/renderer/api/__tests__/catalog-entity-registry.test.ts
+++ b/src/renderer/api/__tests__/catalog-entity-registry.test.ts
@@ -26,7 +26,7 @@ import type { CatalogEntityData, CatalogEntityKindData } from "../catalog-entity
 
 class TestCatalogEntityRegistry extends CatalogEntityRegistry {
   replaceItems(items: Array<CatalogEntityData & CatalogEntityKindData>) {
-    this.rawItems.replace(items);
+    this.updateItems(items);
   }
 }
 
@@ -97,6 +97,32 @@ describe("CatalogEntityRegistry", () => {
       catalog.replaceItems(items);
       expect(catalog.items.length).toEqual(1);
       expect(catalog.items[0].status.phase).toEqual("connected");
+    });
+
+    it("updates activeEntity", () => {
+      const catalog = new TestCatalogEntityRegistry(catalogCategoryRegistry);
+      const items = [{
+        apiVersion: "entity.k8slens.dev/v1alpha1",
+        kind: "KubernetesCluster",
+        metadata: {
+          uid: "123",
+          name: "foobar",
+          source: "test",
+          labels: {}
+        },
+        status: {
+          phase: "disconnected"
+        },
+        spec: {}
+      }];
+
+      catalog.replaceItems(items);
+      catalog.activeEntity = catalog.items[0];
+      expect(catalog.activeEntity.status.phase).toEqual("disconnected");
+
+      items[0].status.phase = "connected";
+      catalog.replaceItems(items);
+      expect(catalog.activeEntity.status.phase).toEqual("connected");
     });
 
     it("removes deleted items", () => {

--- a/src/renderer/api/__tests__/catalog-entity-registry.test.ts
+++ b/src/renderer/api/__tests__/catalog-entity-registry.test.ts
@@ -22,12 +22,34 @@
 import { CatalogEntityRegistry } from "../catalog-entity-registry";
 import "../../../common/catalog-entities";
 import { catalogCategoryRegistry } from "../../../common/catalog/catalog-category-registry";
-import type { CatalogEntityData, CatalogEntityKindData } from "../catalog-entity";
+import { CatalogCategory, CatalogEntityData, CatalogEntityKindData } from "../catalog-entity";
+import { WebLink } from "../../../common/catalog-entities";
 
 class TestCatalogEntityRegistry extends CatalogEntityRegistry {
   replaceItems(items: Array<CatalogEntityData & CatalogEntityKindData>) {
     this.updateItems(items);
   }
+}
+
+class FooBarCategory extends CatalogCategory {
+  public readonly apiVersion = "catalog.k8slens.dev/v1alpha1";
+  public readonly kind = "CatalogCategory";
+  public metadata = {
+    name: "FooBars",
+    icon: "broken"
+  };
+  public spec = {
+    group: "entity.k8slens.dev",
+    versions: [
+      {
+        name: "v1alpha1",
+        entityClass: WebLink
+      }
+    ],
+    names: {
+      kind: "FooBar"
+    }
+  };
 }
 
 describe("CatalogEntityRegistry", () => {
@@ -201,8 +223,31 @@ describe("CatalogEntityRegistry", () => {
       ];
 
       catalog.replaceItems(items);
-
       expect(catalog.items.length).toBe(1);
     });
+  });
+
+  it("does return items after matching category is added", () => {
+    const catalog = new TestCatalogEntityRegistry(catalogCategoryRegistry);
+    const items = [
+      {
+        apiVersion: "entity.k8slens.dev/v1alpha1",
+        kind: "FooBar",
+        metadata: {
+          uid: "456",
+          name: "barbaz",
+          source: "test",
+          labels: {}
+        },
+        status: {
+          phase: "disconnected"
+        },
+        spec: {}
+      }
+    ];
+
+    catalog.replaceItems(items);
+    catalogCategoryRegistry.add(new FooBarCategory());
+    expect(catalog.items.length).toBe(1);
   });
 });


### PR DESCRIPTION
Previously renderer always created a new entity instance when `registry.items` was called. This had side-effects on observability.

## Changes

- update existing entity if found from registry
- debounce catalog broadcast on main, otherwise we trigger a broadcast on every entity update