### PR TITLE
Selecting one namespace at a time

### DIFF
--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -159,6 +159,12 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
   }
 
   @action
+  toggleSingle(namespace: string){
+    this.clearSelected();
+    this.selectNamespaces(namespace);
+  }
+
+  @action
   toggleAll(showAll?: boolean) {
     if (typeof showAll === "boolean") {
       if (showAll) {


### PR DESCRIPTION
select one namespace by default, using "shift clicking" as a way to select multiple namespaces.
select all namespaces in list when clicked `All namespaces`
duplicate Shift behavior to Cmd (on mac) and Ctrl on windows which is more intuitive on win.

react-select contains "onKeyDown" props, but doesn't contain "onKeyUp" and "onClick". Wdyt? 


fixes: https://github.com/lensapp/lens/issues/2773