### PR TITLE
Expose NamespaceSelectFilter component to Extensions API

### DIFF
--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -53,6 +53,7 @@ export * from "../../renderer/components/stepper";
 export * from "../../renderer/components/wizard";
 export * from "../../renderer/components/+workloads-pods/pod-details-list";
 export * from "../../renderer/components/+namespaces/namespace-select";
+export * from "../../renderer/components/+namespaces/namespace-select-filter";
 export * from "../../renderer/components/layout/sub-title";
 export * from "../../renderer/components/input/search-input";
 export * from "../../renderer/components/chart/bar-chart";


### PR DESCRIPTION
This PR exposes `NamespaceSelectFilter` component to extensions API and makes extension developers lives easier if they need to allow user to select namespaces.

**Example**
```html
        <header className="flex gaps align-center">
          <h2 className="flex gaps align-center">
            <span>Resource Map</span>
            <Renderer.Component.Icon material="info" tooltip={<KubeResourceChartLegend/>}/>
          </h2>
          <div className="box right">
            <Renderer.Component.NamespaceSelectFilter />
          </div>
        </header>
 ```

![image](https://user-images.githubusercontent.com/455844/120320958-6acf3680-c2eb-11eb-9861-915f2bc4491b.png)
