### PR TITLE
Implement extensions API for workloads overview details

### DIFF
--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -279,6 +279,7 @@ export class ExtensionLoader extends Singleton {
         registries.kubeObjectMenuRegistry.add(extension.kubeObjectMenuItems),
         registries.kubeObjectDetailRegistry.add(extension.kubeObjectDetailItems),
         registries.kubeObjectStatusRegistry.add(extension.kubeObjectStatusTexts),
+        registries.workloadsOverviewDetailRegistry.add(extension.workloadsOverviewDetailItems),
         registries.commandRegistry.add(extension.commands),
       ];
 

--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -279,7 +279,7 @@ export class ExtensionLoader extends Singleton {
         registries.kubeObjectMenuRegistry.add(extension.kubeObjectMenuItems),
         registries.kubeObjectDetailRegistry.add(extension.kubeObjectDetailItems),
         registries.kubeObjectStatusRegistry.add(extension.kubeObjectStatusTexts),
-        registries.workloadsOverviewDetailRegistry.add(extension.workloadsOverviewDetailItems),
+        registries.workloadsOverviewDetailRegistry.add(extension.kubeWorkloadsOverviewItems),
         registries.commandRegistry.add(extension.commands),
       ];
 

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -40,9 +40,9 @@ export class LensRendererExtension extends LensExtension {
   statusBarItems: StatusBarRegistration[] = [];
   kubeObjectDetailItems: KubeObjectDetailRegistration[] = [];
   kubeObjectMenuItems: KubeObjectMenuRegistration[] = [];
+  kubeWorkloadsOverviewDetailItems: WorkloadsOverviewDetailRegistration[] = [];
   commands: CommandRegistration[] = [];
   welcomeMenus: WelcomeMenuRegistration[] = [];
-  workloadsOverviewDetailItems: WorkloadsOverviewDetailRegistration[] = [];
 
   async navigate<P extends object>(pageId?: string, params?: P) {
     const { navigate } = await import("../renderer/navigation");

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -21,7 +21,7 @@
 
 import type {
   AppPreferenceRegistration, ClusterPageMenuRegistration, KubeObjectDetailRegistration, KubeObjectMenuRegistration,
-  KubeObjectStatusRegistration, PageMenuRegistration, PageRegistration, StatusBarRegistration, WelcomeMenuRegistration,
+  KubeObjectStatusRegistration, PageMenuRegistration, PageRegistration, StatusBarRegistration, WelcomeMenuRegistration, WorkloadsOverviewDetailRegistration,
 } from "./registries";
 import type { Cluster } from "../main/cluster";
 import { LensExtension } from "./lens-extension";
@@ -42,6 +42,7 @@ export class LensRendererExtension extends LensExtension {
   kubeObjectMenuItems: KubeObjectMenuRegistration[] = [];
   commands: CommandRegistration[] = [];
   welcomeMenus: WelcomeMenuRegistration[] = [];
+  workloadsOverviewDetailItems: WorkloadsOverviewDetailRegistration[] = [];
 
   async navigate<P extends object>(pageId?: string, params?: P) {
     const { navigate } = await import("../renderer/navigation");

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -40,7 +40,7 @@ export class LensRendererExtension extends LensExtension {
   statusBarItems: StatusBarRegistration[] = [];
   kubeObjectDetailItems: KubeObjectDetailRegistration[] = [];
   kubeObjectMenuItems: KubeObjectMenuRegistration[] = [];
-  kubeWorkloadsOverviewDetailItems: WorkloadsOverviewDetailRegistration[] = [];
+  kubeWorkloadsOverviewItems: WorkloadsOverviewDetailRegistration[] = [];
   commands: CommandRegistration[] = [];
   welcomeMenus: WelcomeMenuRegistration[] = [];
 

--- a/src/extensions/registries/index.ts
+++ b/src/extensions/registries/index.ts
@@ -33,3 +33,4 @@ export * from "./command-registry";
 export * from "./entity-setting-registry";
 export * from "./welcome-menu-registry";
 export * from "./protocol-handler-registry";
+export * from "./workloads-overview-detail-registry";

--- a/src/extensions/registries/workloads-overview-detail-registry.ts
+++ b/src/extensions/registries/workloads-overview-detail-registry.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type React from "react";
+import { BaseRegistry } from "./base-registry";
+
+export interface WorkloadsOverviewDetailComponents {
+  Details: React.ComponentType<any>;
+}
+
+export interface WorkloadsOverviewDetailRegistration {
+  components: WorkloadsOverviewDetailComponents;
+  priority?: number;
+}
+
+export class WorkloadsOverviewDetailRegistry extends BaseRegistry<WorkloadsOverviewDetailRegistration> {
+  getItems() {
+    const items = super.getItems();
+
+    return items.sort((a, b) => (b.priority ?? 50) - (a.priority ?? 50));
+  }
+}
+
+export const workloadsOverviewDetailRegistry = new WorkloadsOverviewDetailRegistry();

--- a/src/renderer/components/+workloads-overview/overview.tsx
+++ b/src/renderer/components/+workloads-overview/overview.tsx
@@ -38,6 +38,7 @@ import { Events } from "../+events";
 import { isAllowedResource } from "../../../common/rbac";
 import { kubeWatchApi } from "../../api/kube-watch-api";
 import { clusterContext } from "../context";
+import { workloadsOverviewDetailRegistry } from "../../../extensions/registries";
 
 interface Props extends RouteComponentProps<IWorkloadsOverviewRouteParams> {
 }
@@ -57,11 +58,34 @@ export class WorkloadsOverview extends React.Component<Props> {
   }
 
   render() {
+    const items = workloadsOverviewDetailRegistry.getItems().map((item, index) => {
+      return (
+        <item.components.Details key={`workload-overview-${index}`}/>
+      );
+    });
+
     return (
       <div className="WorkloadsOverview flex column gaps">
-        <OverviewStatuses/>
-        {isAllowedResource("events") && <Events compact hideFilters className="box grow"/>}
+        {items}
       </div>
     );
   }
 }
+
+workloadsOverviewDetailRegistry.add([
+  {
+    components: {
+      Details: (props: any) => <OverviewStatuses {...props} />,
+    }
+  },
+  {
+    priority: 5,
+    components: {
+      Details: () => {
+        return (
+          isAllowedResource("events") && <Events compact hideFilters className="box grow"/>
+        );
+      }
+    }
+  }
+]);


### PR DESCRIPTION
This PR will add `workloadsOverviewDetailItems` property to `LensRendererExtension` and it allows extension developers to register items to Workload Overview page.

**Usage Example**

```typescript
export default class KubeResorceMapRenderer extends Renderer.LensExtension {
  kubeWorkloadsOverviewItems = [
    {
      priority: 25,
      components : {
        Details: () => { return (
          <div className="ResourceMapOverviewDetail">
            <div className="header flex gaps align-center">
              <h5 className="box grow">Resources</h5>
            </div>
            <div className="content">
              <KubeForceChart height={480} />
            </div>
          </div>
        )}
      }
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/455844/120640625-6043a700-c47b-11eb-95d8-6efa272cafd9.png)

