### PR TITLE
Remove `podsStore` as a `dependentStore` in `nodes.tsx`

### DIFF
--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -168,7 +168,6 @@ export class Nodes extends React.Component<Props> {
           className="Nodes"
           store={nodesStore} isClusterScoped
           isReady={nodesStore.isLoaded}
-          dependentStores={[podsStore]}
           isSelectable={false}
           sortingCallbacks={{
             [columnId.name]: (node: Node) => node.getName(),


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

blocked by #2743 

Fixes the `<NamespaceSelectFilter>` being displayed on the `nodes.tsx` page. This should be fine since `node-details.tsx` calls `podsStore.reloadAll()` in `componentDidMount`.