### PR TITLE
Make customizing ItemListLayout header explicitly reducable 

### DIFF
--- a/src/renderer/components/+apps-helm-charts/helm-charts.tsx
+++ b/src/renderer/components/+apps-helm-charts/helm-charts.tsx
@@ -30,7 +30,6 @@ import type { HelmChart } from "../../api/endpoints/helm-charts.api";
 import { HelmChartDetails } from "./helm-chart-details";
 import { navigation } from "../../navigation";
 import { ItemListLayout } from "../item-object-list/item-list-layout";
-import { SearchInputUrl } from "../input";
 
 enum columnId {
   name = "name",
@@ -92,9 +91,12 @@ export class HelmCharts extends Component<Props> {
             (chart: HelmChart) => chart.getAppVersion(),
             (chart: HelmChart) => chart.getKeywords(),
           ]}
-          customizeHeader={() => (
-            <SearchInputUrl placeholder="Search Helm Charts" />
-          )}
+          customizeHeader={({ searchProps }) => ({
+            searchProps: {
+              ...searchProps,
+              placeholder: "Search Helm Charts...",
+            },
+          })}
           renderTableHeader={[
             { className: "icon", showWithColumn: columnId.name },
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },

--- a/src/renderer/components/+apps-releases/releases.tsx
+++ b/src/renderer/components/+apps-releases/releases.tsx
@@ -117,16 +117,20 @@ export class HelmReleases extends Component<Props> {
             (release: HelmRelease) => release.getStatus(),
             (release: HelmRelease) => release.getVersion(),
           ]}
-          renderHeaderTitle="Releases"
-          customizeHeader={({ filters, ...headerPlaceholders }) => ({
+          customizeHeader={({ filters, searchProps, ...headerPlaceholders }) => ({
             filters: (
               <>
                 {filters}
                 <NamespaceSelectFilter />
               </>
             ),
+            searchProps: {
+              ...searchProps,
+              placeholder: "Search Releases...",
+            },
             ...headerPlaceholders,
           })}
+          renderHeaderTitle="Releases"
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
             { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -205,7 +205,6 @@ export class Catalog extends React.Component<Props> {
     return (
       <ItemListLayout
         renderHeaderTitle={this.catalogEntityStore.activeCategory?.metadata.name ?? "Browse All"}
-        isSearchable={true}
         isSelectable={false}
         className="CatalogItemList"
         store={this.catalogEntityStore}
@@ -242,7 +241,6 @@ export class Catalog extends React.Component<Props> {
     return (
       <ItemListLayout
         renderHeaderTitle={this.catalogEntityStore.activeCategory?.metadata.name ?? "Browse All"}
-        isSearchable={true}
         isSelectable={false}
         className="CatalogItemList"
         store={this.catalogEntityStore}

--- a/src/renderer/components/+custom-resources/crd-list.scss
+++ b/src/renderer/components/+custom-resources/crd-list.scss
@@ -42,4 +42,8 @@
       }
     }
   }
+
+  .SearchInput {
+    width: 300px;
+  }
 }

--- a/src/renderer/components/+custom-resources/crd-list.tsx
+++ b/src/renderer/components/+custom-resources/crd-list.tsx
@@ -95,7 +95,7 @@ export class CrdList extends React.Component {
         sortingCallbacks={sortingCallbacks}
         searchFilters={Object.values(sortingCallbacks)}
         renderHeaderTitle="Custom Resources"
-        customizeHeader={() => {
+        customizeHeader={({ filters, ...headerPlaceholders }) => {
           let placeholder = <>All groups</>;
 
           if (selectedGroups.length == 1) placeholder = <>Group: {selectedGroups[0]}</>;
@@ -104,26 +104,30 @@ export class CrdList extends React.Component {
           return {
             // todo: move to global filters
             filters: (
-              <Select
-                className="group-select"
-                placeholder={placeholder}
-                options={Object.keys(crdStore.groups)}
-                onChange={({ value: group }: SelectOption) => this.toggleSelection(group)}
-                closeMenuOnSelect={false}
-                controlShouldRenderValue={false}
-                formatOptionLabel={({ value: group }: SelectOption) => {
-                  const isSelected = selectedGroups.includes(group);
-
-                  return (
-                    <div className="flex gaps align-center">
-                      <Icon small material="folder"/>
-                      <span>{group}</span>
-                      {isSelected && <Icon small material="check" className="box right"/>}
-                    </div>
-                  );
-                }}
-              />
-            )
+              <>
+                {filters}
+                <Select
+                  className="group-select"
+                  placeholder={placeholder}
+                  options={Object.keys(crdStore.groups)}
+                  onChange={({ value: group }: SelectOption) => this.toggleSelection(group)}
+                  closeMenuOnSelect={false}
+                  controlShouldRenderValue={false}
+                  formatOptionLabel={({ value: group }: SelectOption) => {
+                    const isSelected = selectedGroups.includes(group);
+  
+                    return (
+                      <div className="flex gaps align-center">
+                        <Icon small material="folder"/>
+                        <span>{group}</span>
+                        {isSelected && <Icon small material="check" className="box right"/>}
+                      </div>
+                    );
+                  }}
+                />
+              </>
+            ),
+            ...headerPlaceholders,
           };
         }}
         renderTableHeader={[

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -101,6 +101,13 @@ export class CrdResources extends React.Component<Props> {
           (item: KubeObject) => item.getSearchFields(),
         ]}
         renderHeaderTitle={crd.getResourceTitle()}
+        customizeHeader={({ searchProps, ...headerPlaceholders }) => ({
+          searchProps: {
+            ...searchProps,
+            placeholder: `Search ${crd.getResourceTitle()}...`,
+          },
+          ...headerPlaceholders
+        })}
         renderTableHeader={[
           { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
           isNamespaced && { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },

--- a/src/renderer/components/+events/events.tsx
+++ b/src/renderer/components/+events/events.tsx
@@ -30,7 +30,7 @@ import { EventStore, eventStore } from "./event.store";
 import { getDetailsUrl, KubeObjectListLayout, KubeObjectListLayoutProps } from "../kube-object";
 import type { KubeEvent } from "../../api/endpoints/events.api";
 import type { TableSortCallbacks, TableSortParams, TableProps } from "../table";
-import type { IHeaderPlaceholders } from "../item-object-list";
+import type { HeaderCustomizer } from "../item-object-list";
 import { Tooltip } from "../tooltip";
 import { Link } from "react-router-dom";
 import { cssNames, IClassName, stopPropagation } from "../../utils";
@@ -112,19 +112,21 @@ export class Events extends React.Component<Props> {
     return this.items;
   }
 
-  customizeHeader = ({ info, title }: IHeaderPlaceholders) => {
+  customizeHeader: HeaderCustomizer = ({ info, title, ...headerPlaceholders }) => {
     const { compact } = this.props;
     const { store, items, visibleItems } = this;
     const allEventsAreShown = visibleItems.length === items.length;
 
     // handle "compact"-mode header
     if (compact) {
-      if (allEventsAreShown) return title; // title == "Events"
+      if (allEventsAreShown) {
+        return { title };
+      }
 
-      return <>
-        {title}
-        <span> ({visibleItems.length} of <Link to={eventsURL()}>{items.length}</Link>)</span>
-      </>;
+      return {
+        title,
+        info: <span> ({visibleItems.length} of <Link to={eventsURL()}>{items.length}</Link>)</span>,
+      };
     }
 
     return {
@@ -136,7 +138,9 @@ export class Events extends React.Component<Props> {
           className="help-icon"
           tooltip={`Limited to ${store.limit}`}
         />
-      </>
+      </>,
+      title, 
+      ...headerPlaceholders
     };
   };
 

--- a/src/renderer/components/input/search-input-url.tsx
+++ b/src/renderer/components/input/search-input-url.tsx
@@ -32,12 +32,12 @@ export const searchUrlParam = createPageParam({
   defaultValue: "",
 });
 
-interface Props extends InputProps {
+export interface SearchInputUrlProps extends InputProps {
   compact?: boolean; // show only search-icon when not focused
 }
 
 @observer
-export class SearchInputUrl extends React.Component<Props> {
+export class SearchInputUrl extends React.Component<SearchInputUrlProps> {
   @observable inputVal = ""; // fix: use empty string on init to avoid react warnings
 
   @disposeOnUnmount
@@ -62,7 +62,7 @@ export class SearchInputUrl extends React.Component<Props> {
     }
   };
 
-  constructor(props: Props) {
+  constructor(props: SearchInputUrlProps) {
     super(props);
     makeObservable(this);
   }

--- a/src/renderer/components/kube-object/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object/kube-object-list-layout.tsx
@@ -30,6 +30,8 @@ import { KubeObjectMenu } from "./kube-object-menu";
 import { kubeSelectedUrlParam, showDetails } from "./kube-object-details";
 import { kubeWatchApi } from "../../api/kube-watch-api";
 import { clusterContext } from "../context";
+import { NamespaceSelectFilter } from "../+namespaces/namespace-select-filter";
+import { ResourceKindMap, ResourceNames } from "../../utils/rbac";
 
 export interface KubeObjectListLayoutProps extends ItemListLayoutProps {
   store: KubeObjectStore;
@@ -66,7 +68,8 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
   }
 
   render() {
-    const { className, store, items = store.contextItems, ...layoutProps } = this.props;
+    const { className, customizeHeader, store, items = store.contextItems, ...layoutProps } = this.props;
+    const placeholderString = ResourceNames[ResourceKindMap[store.api.kind]] || store.api.kind;
 
     return (
       <ItemListLayout
@@ -76,6 +79,22 @@ export class KubeObjectListLayout extends React.Component<KubeObjectListLayoutPr
         items={items}
         preloadStores={false} // loading handled in kubeWatchApi.subscribeStores()
         detailsItem={this.selectedItem}
+        customizeHeader={[
+          ({ filters, searchProps, ...headerPlaceHolders }) => ({
+            filters: (
+              <>
+                {filters}
+                {store.api.isNamespaced && <NamespaceSelectFilter />}
+              </>
+            ),
+            searchProps: {
+              ...searchProps,
+              placeholder: `Search ${placeholderString}...`,
+            },
+            ...headerPlaceHolders,
+          }),
+          ...[customizeHeader].flat(),
+        ]}
         renderItemMenu={(item: KubeObject) => <KubeObjectMenu object={item} />} // safe because we are dealing with KubeObjects here
       />
     );

--- a/src/renderer/utils/rbac.ts
+++ b/src/renderer/utils/rbac.ts
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type { KubeResource } from "../../common/rbac";
+import { apiResourceRecord, KubeResource } from "../../common/rbac";
 
 export const ResourceNames: Record<KubeResource, string> = {
   "namespaces": "Namespaces",
@@ -53,3 +53,8 @@ export const ResourceNames: Record<KubeResource, string> = {
   "clusterroles": "Cluster Roles",
   "serviceaccounts": "Service Accounts"
 };
+
+export const ResourceKindMap: Record<string, KubeResource> = Object.fromEntries(
+  Object.entries(apiResourceRecord)
+    .map(([resource, { kind }]) => [kind, resource as KubeResource])
+);


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This was inspired by wanting to move `<NamespaceSelectFilter>` into `KubeObjectListLayout` since it really didn't belong in `<ItemListLayout>`. However, to do that effectively and with the least amount of code in the consumers of either of those two components, `<ItemListLayout>` was changed to "reduce" or "fold" over all the customizers.

Video: (only minor visual changes)

https://user-images.githubusercontent.com/8225332/120715486-a3f5db00-c492-11eb-9dcb-a23a1866ce56.mov