### PR TITLE
Fix app crash when logTabData does not exist in store

### DIFF
--- a/src/renderer/components/dock/log-list.tsx
+++ b/src/renderer/components/dock/log-list.tsx
@@ -106,7 +106,7 @@ export class LogList extends React.Component<Props> {
    */
   @computed
   get logs() {
-    const showTimestamps = logTabStore.getData(this.props.id).showTimestamps;
+    const showTimestamps = logTabStore.getData(this.props.id)?.showTimestamps;
 
     if (!showTimestamps) {
       return logStore.logsWithoutTimestamps;


### PR DESCRIPTION
Fixes #2652