### PR TITLE
Readd NamespaceSelectFilter to releases.tsx

### DIFF
--- a/src/renderer/components/+apps-releases/releases.tsx
+++ b/src/renderer/components/+apps-releases/releases.tsx
@@ -34,6 +34,7 @@ import { navigation } from "../../navigation";
 import { ItemListLayout } from "../item-object-list/item-list-layout";
 import { HelmReleaseMenu } from "./release-menu";
 import { secretsStore } from "../+config-secrets/secrets.store";
+import { NamespaceSelectFilter } from "../+namespaces/namespace-select-filter";
 
 enum columnId {
   name = "name",
@@ -117,6 +118,15 @@ export class HelmReleases extends Component<Props> {
             (release: HelmRelease) => release.getVersion(),
           ]}
           renderHeaderTitle="Releases"
+          customizeHeader={({ filters, ...headerPlaceholders }) => ({
+            filters: (
+              <>
+                {filters}
+                <NamespaceSelectFilter />
+              </>
+            ),
+            ...headerPlaceholders,
+          })}
           renderTableHeader={[
             { title: "Name", className: "name", sortBy: columnId.name, id: columnId.name },
             { title: "Namespace", className: "namespace", sortBy: columnId.namespace, id: columnId.namespace },


### PR DESCRIPTION
Follow up from #2743 

Releases isn't a `<KubeObjectListLayout>` so it needs to add it itself. This is still preferable to having `<ItemListLayout>` add it since `<ItemListLayout>` should be generic.

Signed-off-by: Sebastian Malton <sebastian@malton.name>