### PR TITLE
Await `onActivate`/`onDeactive` of extensions

### DIFF
--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -26,7 +26,7 @@ import { action, computed, makeObservable, observable, reaction, when } from "mo
 import path from "path";
 import { getHostedCluster } from "../common/cluster-store";
 import { broadcastMessage, handleRequest, requestMain, subscribeToBroadcast } from "../common/ipc";
-import { Singleton, toJS } from "../common/utils";
+import { Disposer, Singleton, toJS } from "../common/utils";
 import logger from "../main/logger";
 import type { InstalledExtension } from "./extension-discovery";
 import { ExtensionsStore } from "./extensions-store";
@@ -295,7 +295,7 @@ export class ExtensionLoader extends Singleton {
     });
   }
 
-  protected autoInitExtensions(register: (ext: LensExtension) => Promise<Function[]>) {
+  protected autoInitExtensions(register: (ext: LensExtension) => Promise<Disposer[]>) {
     return reaction(() => this.toJSON(), installedExtensions => {
       for (const [extId, extension] of installedExtensions) {
         const alreadyInit = this.instances.has(extId);
@@ -310,8 +310,7 @@ export class ExtensionLoader extends Singleton {
 
             const instance = new LensExtensionClass(extension);
 
-            instance.whenEnabled(() => register(instance));
-            instance.enable();
+            instance.enable(register);
             this.instances.set(extId, instance);
           } catch (err) {
             logger.error(`${logModule}: activation extension error`, { ext: extension, err });


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

We currently document these two handlers as being able to be `async`. However, in the code we do not treat them as such.

Furthermore there wasn't any defence against these functions throwing. Finally, since `LensExtension` has a list of disposers itself, we can just hook into that for the registering.