### PR TITLE
Remove unnecessary 'onlyVisibleForSource'

### DIFF
--- a/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/src/common/catalog-entities/kubernetes-cluster.ts
@@ -101,20 +101,18 @@ export class KubernetesCluster extends CatalogEntity<CatalogEntityMetadata, Kube
   }
 
   async onContextMenuOpen(context: CatalogEntityContextMenuContext) {
-    context.menuItems = [
-      {
+    if (!this.metadata.source || this.metadata.source === "local") {
+      context.menuItems.push({
         title: "Settings",
         icon: "edit",
-        onlyVisibleForSource: "local",
         onClick: async () => context.navigate(`/entity/${this.metadata.uid}/settings`)
-      },
-    ];
+      });
+    }
 
     if (this.metadata.labels["file"]?.startsWith(ClusterStore.storedKubeConfigFolder)) {
       context.menuItems.push({
         title: "Delete",
         icon: "delete",
-        onlyVisibleForSource: "local",
         onClick: async () => ClusterStore.getInstance().removeById(this.metadata.uid),
         confirm: {
           message: `Remove Kubernetes Cluster "${this.metadata.name} from ${productName}?`

--- a/src/common/catalog/catalog-entity.ts
+++ b/src/common/catalog/catalog-entity.ts
@@ -105,10 +105,6 @@ export interface CatalogEntityContextMenu {
    */
   icon?: string;
   /**
-   * Show only if empty or if value matches with entity.metadata.source
-   */
-  onlyVisibleForSource?: string;
-  /**
    * OnClick handler
    */
   onClick: () => void | Promise<void>;

--- a/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
@@ -78,23 +78,24 @@ export class CatalogEntityDrawerMenu<T extends CatalogEntity> extends React.Comp
       return [];
     }
 
-    const menuItems = this.contextMenu.menuItems.filter((menuItem) => {
-      return menuItem.icon && !menuItem.onlyVisibleForSource || menuItem.onlyVisibleForSource === entity.metadata.source;
-    });
+    const items: React.ReactChild[] = [];
 
-    const items = menuItems.map((menuItem, index) => {
-      const props = menuItem.icon.includes("<svg") ? { svg: menuItem.icon } : { material: menuItem.icon };
+    for (const menuItem of this.contextMenu.menuItems) {
+      if (!menuItem.icon) {
+        continue;
+      }
 
-      return (
-        <MenuItem key={index} onClick={() => this.onMenuItemClick(menuItem)}>
+      const key = menuItem.icon.includes("<svg") ? "svg" : "material";
+
+      items.push(
+        <MenuItem key={menuItem.title} onClick={() => this.onMenuItemClick(menuItem)}>
           <Icon
             title={menuItem.title}
-            {...props}
+            {...{ [key]: menuItem.icon }}
           />
         </MenuItem>
       );
-
-    });
+    }
 
     items.unshift(
       <MenuItem key="add-to-hotbar" onClick={() => this.addToHotbar(entity) }>

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -171,12 +171,10 @@ export class Catalog extends React.Component<Props> {
   }
 
   renderItemMenu = (item: CatalogEntityItem) => {
-    const menuItems = this.contextMenu.menuItems.filter((menuItem) => !menuItem.onlyVisibleForSource || menuItem.onlyVisibleForSource === item.entity.metadata.source);
-
     return (
       <MenuActions onOpen={() => item.onContextMenuOpen(this.contextMenu)}>
         {
-          menuItems.map((menuItem, index) => (
+          this.contextMenu.menuItems.map((menuItem, index) => (
             <MenuItem key={index} onClick={() => this.onMenuItemClick(menuItem)}>
               {menuItem.title}
             </MenuItem>

--- a/src/renderer/components/hotbar/hotbar-entity-icon.tsx
+++ b/src/renderer/components/hotbar/hotbar-entity-icon.tsx
@@ -106,7 +106,7 @@ export class HotbarEntityIcon extends React.Component<Props> {
     };
     const isActive = this.isActive(entity);
     const isPersisted = this.isPersisted(entity);
-    const menuItems = this.contextMenu?.menuItems.filter((menuItem) => !menuItem.onlyVisibleForSource || menuItem.onlyVisibleForSource === entity.metadata.source);
+    const menuItems = this.contextMenu?.menuItems ?? [];
 
     if (!isPersisted) {
       menuItems.unshift({


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This is a good change because in every instance the entity is also available when adding to `context.menuItems`, so this code can be done on the user side instead.