### PR TITLE
Fix tag-release script

### DIFF
--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ${git branch --show-current} =~ ^release/v ]]
+if [[ `git branch --show-current` =~ ^release/v ]]
 then
   VERSION_STRING=$(cat package.json | jq '.version' -r | xargs printf "v%s")
   git tag ${VERSION_STRING}


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

The old script failed (for zsh at least) with `zsh: bad substitution`