### PR TITLE
Allow to close tabs using middle-clicks

### DIFF
--- a/src/renderer/components/dock/dock-tab.tsx
+++ b/src/renderer/components/dock/dock-tab.tsx
@@ -23,7 +23,7 @@ import "./dock-tab.scss";
 
 import React from "react";
 import { observer } from "mobx-react";
-import { boundMethod, cssNames, prevDefault } from "../../utils";
+import { boundMethod, cssNames, prevDefault, isMiddleClick } from "../../utils";
 import { dockStore, IDockTab } from "./dock.store";
 import { Tab, TabProps } from "../tabs";
 import { Icon } from "../icon";
@@ -88,13 +88,13 @@ export class DockTab extends React.Component<DockTabProps> {
     const { className, moreActions, ...tabProps } = this.props;
     const { title, pinned } = tabProps.value;
     const label = (
-      <div className="flex gaps align-center">
+      <div className="flex gaps align-center" onAuxClick={isMiddleClick(prevDefault(this.close))}>
         <span className="title" title={title}>{title}</span>
         {moreActions}
         {!pinned && (
           <Icon
             small material="close"
-            title="Close (Ctrl+W)"
+            title="Close (Ctrl+Shift+W)"
             onClick={prevDefault(this.close)}
           />
         )}

--- a/src/renderer/utils/isMiddleClick.ts
+++ b/src/renderer/utils/isMiddleClick.ts
@@ -19,23 +19,18 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// Common usage utils & helpers
+import type React from "react";
 
-export * from "../../common/utils";
+// Helper for inlining middleClick checks 
+// <form onAuxClick={isMiddleClick(() => console.log('do some action'))}>
+//    <input name="text"/>
+//    <button type="submit">Action</button>
+// </form>
 
-export * from "./cssVar";
-export * from "./cssNames";
-export * from "../../common/event-emitter";
-export * from "./saveFile";
-export * from "./prevDefault";
-export * from "./storageHelper";
-export * from "./createStorage";
-export * from "./interval";
-export * from "./copyToClipboard";
-export * from "./formatDuration";
-export * from "./isReactNode";
-export * from "./convertMemory";
-export * from "./convertCpu";
-export * from "./metricUnitsToNumber";
-export * from "./display-booleans";
-export * from "./isMiddleClick";
+export function isMiddleClick<E extends React.MouseEvent>(callback: (evt: E) => any) {
+  return function (evt: E) {
+    if(evt.button === 1) {
+      return callback(evt);
+    }
+  };
+}


### PR DESCRIPTION
Most Browsers allow closing tabs by using the middle mouse button (usually pushing in on the scroll wheel) when hovering over a tab. I think the Labs in Lens should behave the same to make it even more intuitive.

Additionally, I explicitly added the Shift Key to the "Ctrl + W" label(to close a tab) to make it easier to understand