### PR TITLE
Clean up empty pod log entries

### DIFF
--- a/src/renderer/components/dock/log.store.ts
+++ b/src/renderer/components/dock/log.store.ts
@@ -107,7 +107,7 @@ export class LogStore {
       });
 
       // Add newly received logs to bottom
-      this.podLogs.set(tabId, [...oldLogs, ...logs]);
+      this.podLogs.set(tabId, [...oldLogs, ...logs.filter(Boolean)]);
     } catch (error) {
       this.handlerError(tabId, error);
     }


### PR DESCRIPTION
If empty log entries `[""]` arrived from `/logs` fetch request, it breaks determination of `sinceTime` request parameter. This, in turn, leads to duplicate logs after each fetch.

Fixes #3006 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>