### PR TITLE
CatalogEnitityDrawerMenu should have actions running left to right

### DIFF
--- a/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
@@ -97,13 +97,11 @@ export class CatalogEntityDrawerMenu<T extends CatalogEntity> extends React.Comp
       );
     }
 
-    items.unshift(
+    items.push(
       <MenuItem key="add-to-hotbar" onClick={() => this.addToHotbar(entity) }>
         <Icon material="playlist_add" small title="Add to Hotbar" />
       </MenuItem>
     );
-
-    items.reverse();
 
     return items;
   }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/3014