### PR TITLE
Fix extensions not having the same version as Lens

### DIFF
--- a/build/set_build_version.ts
+++ b/build/set_build_version.ts
@@ -45,7 +45,7 @@ function getBuildChannel(): string {
 async function writeOutExtensionVersion(manifestPath: string) {
   const extensionPackageJson = await fse.readJson(manifestPath);
 
-  extensionPackageJson.version = `${versionInfo.format()}.${buildNumber}`;
+  extensionPackageJson.version = appInfo.version;
 
   return fse.writeJson(manifestPath, extensionPackageJson, {
     spaces: 2,


### PR DESCRIPTION
Minor cleanup that I noticed. This is a follow up to https://github.com/lensapp/lens/pull/3016

Signed-off-by: Sebastian Malton <sebastian@malton.name>