### PR TITLE
Fix manage cluster proxy settings

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-status.scss
+++ b/src/renderer/components/cluster-manager/cluster-status.scss
@@ -39,4 +39,8 @@
     --size: 70px;
     margin: auto;
   }
+
+  a.interactive {
+    cursor: pointer
+  }
 }

--- a/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -89,7 +89,7 @@ export class ClusterStatus extends React.Component<Props> {
       params: {
         entityId: this.props.clusterId,
       },
-      fragment: "http-proxy",
+      fragment: "Proxy",
     }));
   };
 
@@ -132,12 +132,11 @@ export class ClusterStatus extends React.Component<Props> {
           onClick={this.reconnect}
           waiting={this.isReconnecting}
         />
-        <Button
-          primary
-          label="Manage Proxy Settings"
-          className="box center"
-          onClick={this.manageProxySettings}
-        />
+        <a
+          className="box center interactive"
+          onClick={this.manageProxySettings}>
+          Manage Proxy Settings
+        </a>
       </>
     );
   }


### PR DESCRIPTION
- Click did go to "General" settings, not "Proxy" settings
- Changed button to link so that UI stays more calm (button was way too big compared to primary action, "Reconnect")

![image](https://user-images.githubusercontent.com/1446224/121844222-511aef80-ccec-11eb-8428-72a93e2214e7.png)
