### PR TITLE
Re-enable strict mode in docs vlidation. Bump mkdocs-material version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,6 @@ repo_name: GitHub
 repo_url: https://github.com/lensapp/lens
 copyright: Copyright &copy; 2021 <a href="https://mirantis.com/">Mirantis Inc.</a> - All rights reserved.
 edit_uri: ""
-google_analytics:
-  - UA-159377374-2
-  - auto
 nav:
   - Overview: README.md
   - Getting Started:
@@ -87,3 +84,6 @@ extra:
       name: Lens Website
   version:
     method: mike
+  analytics:
+    provider: google
+    property: UA-159377374-2

--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -1,8 +1,8 @@
 # Direct dependencies
-mkdocs>=1.1
+mkdocs>=1.2
 Pygments>=2.4
 markdown>=3.2
 pymdown-extensions>=7.0
 mkdocs-material-extensions>=1.0
 mkdocs-git-revision-date-localized-plugin>=0.7.3
-mkdocs-material>=6.1.0
+mkdocs-material>=7.1.8

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint": "yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "yarn run lint --fix",
     "mkdocs-serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
-    "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build",
+    "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",
     "typedocs-extensions-api": "yarn run typedoc src/extensions/extension-api.ts",
     "version-checkout": "cat package.json | jq '.version' -r | xargs printf \"release/v%s\" | xargs git checkout -b",
     "version-commit": "cat package.json | jq '.version' -r | xargs printf \"release v%s\" | git commit --no-edit -s -F -",


### PR DESCRIPTION
- Re-enable strict mode in the verify docs command now that the latest version of mkdocs-material is available and supports the new Google Analytics layout
- Amend mkdocs config to use the new Google Analytics layout
- Bump to use latest 1.2 version of mkdocs

Note - current issue https://github.com/mkdocs/mkdocs/issues/2457 stops live reload from work in mkdocs 1.2 so developers will need to amend the mkdocs.yml to pin mkdocs to version 1.1.2

Signed-off-by: Steve Richards <srichards@mirantis.com>