### PR TITLE
Fixing visibility of extension global pages

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -35,6 +35,10 @@
     position: relative;
     display: flex;
     flex-direction: column;
+
+    > * {
+      z-index: 1;
+    }
   }
 
   .HotbarMenu {


### PR DESCRIPTION
`#lens-view` element currently placed visually on top of custom global pages causing them to be hidden.

Adding `z-index` property solves the issue and shows any adjacent pages "above" `#lens-view`.

Before:
<img width="1051" alt="invisible global page" src="https://user-images.githubusercontent.com/9607060/122358246-22578000-cf5d-11eb-9a96-97f62dd0ea14.png">


After:
<img width="1051" alt="global page" src="https://user-images.githubusercontent.com/9607060/122358226-1f5c8f80-cf5d-11eb-8f68-bc94fc3f29d4.png">



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>