### PR TITLE
Check are resources allowed before subscribing stores

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -107,8 +107,22 @@ export class App extends React.Component {
   }
 
   componentDidMount() {
+    const stores: Array<KubeObjectStore> = [namespaceStore];
+
+    if (isAllowedResource("nodes")) {
+      stores.push(nodesStore);
+    }
+
+    if (isAllowedResource("pods")) {
+      stores.push(podsStore);
+    }
+
+    if (isAllowedResource("events")) {
+      stores.push(eventStore);
+    }
+
     disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([podsStore, nodesStore, eventStore, namespaceStore], {
+      kubeWatchApi.subscribeStores(stores, {
         preload: true,
       })
     ]);


### PR DESCRIPTION
Cluster dashboard start watching pods, events, nodes and namespace apis and that is causing issues if user does not have access to those resources. This PR will check are those resources allowed before subscribing related stores.