### PR TITLE
Add React.Fragment with key property to entity settings navigation

### DIFF
--- a/src/renderer/components/+entity-settings/entity-settings.tsx
+++ b/src/renderer/components/+entity-settings/entity-settings.tsx
@@ -85,8 +85,8 @@ export class EntitySettings extends React.Component<Props> {
       <>
         <h2>{this.entity.metadata.name}</h2>
         <Tabs className="flex column" scrollable={false} onChange={this.onTabChange} value={this.activeTab}>
-          { groups.map((group) => (
-            <>
+          { groups.map((group, groupIndex) => (
+            <React.Fragment key={`group-${groupIndex}`}>
               <div className="header">{group[0]}</div>
               { group[1].map((setting, index) => (
                 <Tab
@@ -96,7 +96,7 @@ export class EntitySettings extends React.Component<Props> {
                   data-testid={`${setting.id}-tab`}
                 />
               ))}
-            </>
+            </React.Fragment>
           ))}
         </Tabs>
       </>


### PR DESCRIPTION
`key` property is currently missing from React component on entity settings navigation. Added `React.Fragment` component with `key` property to fix this error.