### PR TITLE
Do not make watch requests without resourceVersion

### DIFF
--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -332,7 +332,7 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
   }
 
   private watchNamespace(namespace: string, abortController: AbortController) {
-    if (!this.api.getResourceVersion()) {
+    if (!this.api.getResourceVersion(namespace)) {
       return;
     }
 

--- a/src/renderer/kube-object.store.ts
+++ b/src/renderer/kube-object.store.ts
@@ -280,7 +280,7 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
 
   async update(item: T, data: Partial<T>): Promise<T> {
     const newItem = await item.update<T>(data);
-    
+
     ensureObjectSelfLink(this.api, newItem);
 
     const index = this.items.findIndex(item => item.getId() === newItem.getId());
@@ -332,6 +332,10 @@ export abstract class KubeObjectStore<T extends KubeObject = any> extends ItemSt
   }
 
   private watchNamespace(namespace: string, abortController: AbortController) {
+    if (!this.api.getResourceVersion()) {
+      return;
+    }
+
     let timedRetry: NodeJS.Timeout;
     const watch = () => this.api.watch({
       namespace,


### PR DESCRIPTION
Stores should not make watch requests without `resourceVersion`. This PR checks existence of resourceVersion before requesting Kubernetes API.

This PR makes also #3086 obsolete.