### PR TITLE
Rename PageLayout to SettingLayout

### DIFF
--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -20,6 +20,7 @@
  */
 
 // layouts
+export * from "../../renderer/components/layout/setting-layout";
 export * from "../../renderer/components/layout/page-layout";
 export * from "../../renderer/components/layout/wizard-layout";
 export * from "../../renderer/components/layout/tab-layout";

--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -38,8 +38,8 @@ import { navigate } from "../../navigation";
 import { iter } from "../../utils";
 import { AceEditor } from "../ace-editor";
 import { Button } from "../button";
-import { PageLayout } from "../layout/page-layout";
 import { Notifications } from "../notifications";
+import { SettingLayout } from "../layout/setting-layout";
 
 interface Option {
   config: KubeConfig;
@@ -108,7 +108,7 @@ export class AddCluster extends React.Component {
 
   render() {
     return (
-      <PageLayout className="AddClusters" showOnTop={true}>
+      <SettingLayout className="AddClusters">
         <h2>Add Clusters from Kubeconfig</h2>
         <p>
           Clusters added here are <b>not</b> merged into the <code>~/.kube/config</code> file.
@@ -144,7 +144,7 @@ export class AddCluster extends React.Component {
             tooltipOverrideDisabled
           />
         </div>
-      </PageLayout>
+      </SettingLayout>
     );
   }
 }

--- a/src/renderer/components/+entity-settings/entity-settings.tsx
+++ b/src/renderer/components/+entity-settings/entity-settings.tsx
@@ -25,7 +25,6 @@ import React from "react";
 import { observable, makeObservable } from "mobx";
 import type { RouteComponentProps } from "react-router";
 import { observer } from "mobx-react";
-import { PageLayout } from "../layout/page-layout";
 import { navigation } from "../../navigation";
 import { Tabs, Tab } from "../tabs";
 import type { CatalogEntity } from "../../api/catalog-entity";
@@ -33,6 +32,7 @@ import { catalogEntityRegistry } from "../../api/catalog-entity-registry";
 import { EntitySettingRegistry } from "../../../extensions/registries";
 import type { EntitySettingsRouteParams } from "../../../common/routes";
 import { groupBy } from "lodash";
+import { SettingLayout } from "../layout/setting-layout";
 
 interface Props extends RouteComponentProps<EntitySettingsRouteParams> {
 }
@@ -120,10 +120,9 @@ export class EntitySettings extends React.Component<Props> {
     const activeSetting = this.menuItems.find((setting) => setting.id === this.activeTab);
 
     return (
-      <PageLayout
+      <SettingLayout
         className="CatalogEntitySettings"
         navigation={this.renderNavigation()}
-        showOnTop={true}
         contentGaps={false}
       >
         <section>
@@ -132,7 +131,7 @@ export class EntitySettings extends React.Component<Props> {
             <activeSetting.components.View entity={this.entity} key={activeSetting.title} />
           </section>
         </section>
-      </PageLayout>
+      </SettingLayout>
     );
   }
 }

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -39,12 +39,12 @@ import logger from "../../../main/logger";
 import { Button } from "../button";
 import { ConfirmDialog } from "../confirm-dialog";
 import { DropFileInput, InputValidators } from "../input";
-import { PageLayout } from "../layout/page-layout";
 import { Notifications } from "../notifications";
 import { ExtensionInstallationState, ExtensionInstallationStateStore } from "./extension-install.store";
 import { Install } from "./install";
 import { InstalledExtensions } from "./installed-extensions";
 import { Notice } from "./notice";
+import { SettingLayout } from "../layout/setting-layout";
 
 function getMessageFromError(error: any): string {
   if (!error || typeof error !== "object") {
@@ -317,7 +317,7 @@ export async function attemptInstallByInfo({ name, version, requireConfirmation 
         version = json["dist-tags"][version];
       } else {
         Notifications.error(<p>The <em>{name}</em> extension does not have a version or tag <code>{version}</code>.</p>);
-  
+
         return disposer();
       }
     }
@@ -510,7 +510,7 @@ export class Extensions extends React.Component<Props> {
 
     return (
       <DropFileInput onDropFiles={installOnDrop}>
-        <PageLayout showOnTop className="Extensions" contentGaps={false}>
+        <SettingLayout className="Extensions" contentGaps={false}>
           <section>
             <h1>Extensions</h1>
 
@@ -533,7 +533,7 @@ export class Extensions extends React.Component<Props> {
               uninstall={confirmUninstallExtension}
             />
           </section>
-        </PageLayout>
+        </SettingLayout>
       </DropFileInput>
     );
   }

--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -31,7 +31,6 @@ import { AppPreferenceRegistry, RegisteredAppPreference } from "../../../extensi
 import { UserStore } from "../../../common/user-store";
 import { ThemeStore } from "../../theme.store";
 import { Input } from "../input";
-import { PageLayout } from "../layout/page-layout";
 import { SubTitle } from "../layout/sub-title";
 import { Select, SelectOption } from "../select";
 import { HelmCharts } from "./helm-charts";
@@ -40,6 +39,7 @@ import { navigation } from "../../navigation";
 import { Tab, Tabs } from "../tabs";
 import { FormSwitch, Switcher } from "../switch";
 import { KubeconfigSyncs } from "./kubeconfig-syncs";
+import { SettingLayout } from "../layout/setting-layout";
 
 enum Pages {
   Application = "application",
@@ -136,8 +136,7 @@ export class Preferences extends React.Component {
       );
 
     return (
-      <PageLayout
-        showOnTop
+      <SettingLayout
         navigation={this.renderNavigation()}
         className="Preferences"
         contentGaps={false}
@@ -266,7 +265,7 @@ export class Preferences extends React.Component {
             {extensions.filter(e => !e.showInPreferencesTab).map(this.renderExtension)}
           </section>
         )}
-      </PageLayout>
+      </SettingLayout>
     );
   }
 }

--- a/src/renderer/components/layout/page-layout.tsx
+++ b/src/renderer/components/layout/page-layout.tsx
@@ -19,96 +19,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "./page-layout.scss";
+import { SettingLayout } from "./setting-layout";
 
-import React from "react";
-import { observer } from "mobx-react";
-import { boundMethod, cssNames, IClassName } from "../../utils";
-import { navigation } from "../../navigation";
-import { Icon } from "../icon";
-
-export interface PageLayoutProps extends React.DOMAttributes<any> {
-  className?: IClassName;
-  contentClass?: IClassName;
-  provideBackButtonNavigation?: boolean;
-  contentGaps?: boolean;
-  showOnTop?: boolean; // covers whole app view
-  navigation?: React.ReactNode;
-  back?: (evt: React.MouseEvent | KeyboardEvent) => void;
-}
-
-const defaultProps: Partial<PageLayoutProps> = {
-  provideBackButtonNavigation: true,
-  contentGaps: true,
-};
-
-@observer
-export class PageLayout extends React.Component<PageLayoutProps> {
-  static defaultProps = defaultProps as object;
-
-  @boundMethod
-  back(evt?: React.MouseEvent | KeyboardEvent) {
-    if (this.props.back) {
-      this.props.back(evt);
-    } else {
-      navigation.goBack();
-    }
-  }
-
-  async componentDidMount() {
-    window.addEventListener("keydown", this.onEscapeKey);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("keydown", this.onEscapeKey);
-  }
-
-  onEscapeKey = (evt: KeyboardEvent) => {
-    if (!this.props.provideBackButtonNavigation) {
-      return;
-    }
-
-    if (evt.code === "Escape") {
-      evt.stopPropagation();
-      this.back(evt);
-    }
-  };
-
-  render() {
-    const {
-      contentClass, provideBackButtonNavigation,
-      contentGaps, showOnTop, navigation, children, ...elemProps
-    } = this.props;
-    const className = cssNames("PageLayout", { showOnTop, showNavigation: navigation }, this.props.className);
-
-    return (
-      <div {...elemProps} className={className}>
-        { navigation && (
-          <nav className="sidebarRegion">
-            <div className="sidebar">
-              {navigation}
-            </div>
-          </nav>
-        )}
-        <div className="contentRegion" id="ScrollSpyRoot">
-          <div className={cssNames("content", contentClass, contentGaps && "flex column gaps")}>
-            {children}
-          </div>
-          <div className="toolsRegion">
-            { this.props.provideBackButtonNavigation && (
-              <div className="fixedTools">
-                <div className="closeBtn" role="button" aria-label="Close" onClick={this.back}>
-                  <Icon material="close"/>
-                </div>
-
-                <div className="esc" aria-hidden="true">
-                  ESC
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  }
-}
+/**
+ * PageLayout is deprecated. See MainLayout & SettingLayout
+ *
+ * @deprecated
+ */
+export class PageLayout extends SettingLayout {}

--- a/src/renderer/components/layout/setting-layout.scss
+++ b/src/renderer/components/layout/setting-layout.scss
@@ -23,15 +23,6 @@
   --width: 75%;
   --nav-width: 180px;
   --nav-column-width: 30vw;
-
-  position: fixed !important; // allow to cover Hotbar
-  z-index: 13;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  height: unset;
-  background-color: var(--settingsBackground);
   width: 100%;
   height: 100%;
   display: grid !important;
@@ -47,6 +38,18 @@
     > .contentRegion {
       justify-content: flex-start;
     }
+  }
+
+  // covers whole app view area
+  &.showOnTop {
+    position: fixed !important; // allow to cover ClustersMenu
+    z-index: 13;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    height: unset;
+    background-color: var(--settingsBackground);
   }
 
   > .sidebarRegion {

--- a/src/renderer/components/layout/setting-layout.scss
+++ b/src/renderer/components/layout/setting-layout.scss
@@ -19,12 +19,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-.PageLayout {
+.SettingLayout {
   --width: 75%;
   --nav-width: 180px;
   --nav-column-width: 30vw;
 
-  position: relative;
+  position: fixed !important; // allow to cover Hotbar
+  z-index: 13;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  height: unset;
+  background-color: var(--settingsBackground);
   width: 100%;
   height: 100%;
   display: grid !important;
@@ -40,18 +47,6 @@
     > .contentRegion {
       justify-content: flex-start;
     }
-  }
-
-  // covers whole app view area
-  &.showOnTop {
-    position: fixed !important; // allow to cover ClustersMenu
-    z-index: 13;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    height: unset;
-    background-color: var(--settingsBackground);
   }
 
   > .sidebarRegion {

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "./page-layout.scss";
+import "./setting-layout.scss";
 
 import React from "react";
 import { observer } from "mobx-react";

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -81,7 +81,7 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
       contentClass, provideBackButtonNavigation,
       contentGaps, navigation, children, ...elemProps
     } = this.props;
-    const className = cssNames("SettingLayout", { showNavigation: navigation }, this.props.className);
+    const className = cssNames("SettingLayout", "showOnTop", { showNavigation: navigation }, this.props.className);
 
     return (
       <div {...elemProps} className={className}>

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import "./page-layout.scss";
+
+import React from "react";
+import { observer } from "mobx-react";
+import { boundMethod, cssNames, IClassName } from "../../utils";
+import { navigation } from "../../navigation";
+import { Icon } from "../icon";
+
+export interface SettingLayoutProps extends React.DOMAttributes<any> {
+  className?: IClassName;
+  contentClass?: IClassName;
+  provideBackButtonNavigation?: boolean;
+  contentGaps?: boolean;
+  navigation?: React.ReactNode;
+  back?: (evt: React.MouseEvent | KeyboardEvent) => void;
+}
+
+const defaultProps: Partial<SettingLayoutProps> = {
+  provideBackButtonNavigation: true,
+  contentGaps: true,
+};
+
+/**
+ * Layout for settings like pages with navigation
+ */
+@observer
+export class SettingLayout extends React.Component<SettingLayoutProps> {
+  static defaultProps = defaultProps as object;
+
+  @boundMethod
+  back(evt?: React.MouseEvent | KeyboardEvent) {
+    if (this.props.back) {
+      this.props.back(evt);
+    } else {
+      navigation.goBack();
+    }
+  }
+
+  async componentDidMount() {
+    window.addEventListener("keydown", this.onEscapeKey);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("keydown", this.onEscapeKey);
+  }
+
+  onEscapeKey = (evt: KeyboardEvent) => {
+    if (!this.props.provideBackButtonNavigation) {
+      return;
+    }
+
+    if (evt.code === "Escape") {
+      evt.stopPropagation();
+      this.back(evt);
+    }
+  };
+
+  render() {
+    const {
+      contentClass, provideBackButtonNavigation,
+      contentGaps, navigation, children, ...elemProps
+    } = this.props;
+    const className = cssNames("SettingLayout", { showNavigation: navigation }, this.props.className);
+
+    return (
+      <div {...elemProps} className={className}>
+        { navigation && (
+          <nav className="sidebarRegion">
+            <div className="sidebar">
+              {navigation}
+            </div>
+          </nav>
+        )}
+        <div className="contentRegion" id="ScrollSpyRoot">
+          <div className={cssNames("content", contentClass, contentGaps && "flex column gaps")}>
+            {children}
+          </div>
+          <div className="toolsRegion">
+            { this.props.provideBackButtonNavigation && (
+              <div className="fixedTools">
+                <div className="closeBtn" role="button" aria-label="Close" onClick={this.back}>
+                  <Icon material="close"/>
+                </div>
+
+                <div className="esc" aria-hidden="true">
+                  ESC
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
- PageLayout was too generic, it's now only used for settings like pages
- all uses of PageLayout set `showOnTop`, this property is now removed -> `SettingLayout` is always "on top"