### PR TITLE
Fix resource links on Release details

### DIFF
--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -208,7 +208,7 @@ export class ReleaseDetails extends Component<Props> {
             {items.map(item => {
               const name = item.getName();
               const namespace = item.getNs();
-              const api = apiManager.getApi(item.metadata.selfLink);
+              const api = apiManager.getApi(api => api.kind === kind && api.apiVersionWithGroup == item.apiVersion);
               const detailsUrl = api ? getDetailsUrl(api.getUrl({ name, namespace })) : "";
 
               return (


### PR DESCRIPTION
It turned out that `item.metadata.selfLink` is not present so we need to resolve api different way.

Fixes #3120 