### PR TITLE
release v5.0.0-rc.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,7 @@ categories:
   - title: '🧰 Maintenance'
     labels:
       - 'chore'
+      - 'area/documentation'
       - 'area/ci'
       - 'area/tests'
       - 'dependencies'

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release-version:
 
 .PHONY: tag-release
 tag-release:
-	scripts/tag-release.sh
+	scripts/tag-release.sh $(CMD_ARGS)
 
 .PHONY: test
 test: binaries/client

--- a/build/set_build_version.ts
+++ b/build/set_build_version.ts
@@ -33,6 +33,7 @@ function getBuildChannel(): string {
    * Note: it is by design that we don't use `rc` as a build channel for these versions
    */
   switch (versionInfo.prerelease?.[0]) {
+    case "rc":
     case "beta":
       return "beta";
     case undefined:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.0.0-beta.11",
+  "version": "5.0.0-rc.0",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -f|--force)
+      FORCE="--force"
+      shift # past argument
+      ;;
+  esac
+done
+
 if [[ `git branch --show-current` =~ ^release/v ]]
 then
   VERSION_STRING=$(cat package.json | jq '.version' -r | xargs printf "v%s")
-  git tag ${VERSION_STRING}
-  git push ${GIT_REMOTE:-origin} ${VERSION_STRING}
+  git tag ${VERSION_STRING} ${FORCE}
+  git push ${GIT_REMOTE:-origin} ${VERSION_STRING} ${FORCE}
 else
   echo "You must be in a release branch"
 fi


### PR DESCRIPTION
## Changes since v5.0.0-beta.9

## 🚀 Features

* Expose MainLayout to extensions (#3125) @jakolehm
* Transition workspaces to hotbars (#3079) @Nokel81
* Make CatalogEntity labels clickable (#3075) @Nokel81
* Allow to hide/show catalog list columns (#3098) @jakolehm
* Allow to search catalog by source (#3097) @jakolehm
* Implement missing weblink add/remove (#3092) @jakolehm
* Add context menu entry for deleting local clusters (#2923) @Nokel81
* Catalog menu restyling (#3067) @aleksfront
* Bring back support for custom cluster icons (#3066) @jakolehm
* General catalog category (#3106) @aleksfront

## 🐛 Bug Fixes

* Fix set of cluster entity icon src (#3134) @jakolehm
* Always open main window if lens:// are routed (#3130) @Nokel81
* Highlight Welcome page community link (#3127) @aleksfront
* Switch sync buttons on windows (#3110) @Nokel81
* Set grouping on local settings (#3109) @Nokel81
* Rename PageLayout to SettingLayout (#3123) @jakolehm
* Use allocatable instead of capacity for node resources. (#2098) @mcpappas
* lens:// routing shouldn't ignore intree extensions (#3091) @Nokel81
* ClusterStore.storedKubeConfigFolder should be usabled everywhere (#3105) @Nokel81
* Update catalog url params on category change (#3102) @jakolehm
* Fix catalog list icon font size (#3093) @jakolehm
* Set correct namespace for the subject when creating new role binding (#3083) @nevalla
* Fixing visibility of extension global pages (#3085) @aleksfront
* Catch exceptions when trying to load namespaces from api (#3084) @nevalla
* Do not make watch requests without resourceVersion (#3089) @nevalla
* Add React.Fragment with key property to entity settings navigation (#3087) @nevalla
* Send LensMainExtension.nagivate calls to renderer before navigating (#3082) @Nokel81
* Check cluster connected status from cluster.status.phase property (#3078) @nevalla
* Fix height resizing of VirtualList (#3072) @Nokel81
* Rename Kubernetes Clusters in Catalog Menu to "Clusters" (#3099) @msa0311

## 🧰 Maintenance

* Remove login layout (#3122) @jakolehm
* Depedabot config should be in .github/ (#3113) @Nokel81
* Bump typeface-roboto from 0.0.75 to 1.1.13 (#3003) @dependabot
* Bump proper-lockfile from 4.1.1 to 4.1.2 (#3047) @dependabot
* Update `extensions/**/package-lock.json` to v0.0.1 (#3076) @Nokel81
* Fix extensions not having the same version as Lens (#3027) @Nokel81
* renderer extension guide updates for 5.0 (WIP) (#3118) @jim-docker
* Add migration details for extension api docs (#3074) @jim-docker
* Use new config structure for mkdocs versioning feature (#3088) @stevejr
* Re-enable strict mode in docs vlidation. Bump mkdocs-material version (#3073) @stevejr


Signed-off-by: Sebastian Malton <sebastian@malton.name>