### PR TITLE
Mark typed-emitter as a dependency for @k8slens/extensions

### DIFF
--- a/src/extensions/npm/extensions/package.json
+++ b/src/extensions/npm/extensions/package.json
@@ -19,6 +19,7 @@
     "@types/node": "*",
     "@types/react-select": "*",
     "@material-ui/core": "*",
-    "conf": "^7.0.1"
+    "conf": "^7.0.1",
+    "typed-emitter": "^1.3.1"
   }
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Without this `tsc` complains that `T extends CatalogCategory` doesn't have `.on()` as a method because `CatalogCategory extends (EventEmitter as new => TypedEmitter<CatalogCategoryEvents>)` now correctly is exposed to the extension API. But if it is not installed then it resolves to type `any`.