### PR TITLE
Transparent background for custom icons

### DIFF
--- a/src/renderer/components/avatar/avatar.tsx
+++ b/src/renderer/components/avatar/avatar.tsx
@@ -72,9 +72,21 @@ function getIconString(title: string) {
 export function Avatar(props: Props) {
   const { title, width = 32, height = 32, colorHash, children, background, ...settings } = props;
 
+  const getBackgroundColor = () => {
+    if (background) {
+      return background;
+    }
+
+    if (settings.src) {
+      return "transparent";
+    }
+
+    return randomColor({ seed: colorHash, luminosity: "dark" });
+  };
+
   const generateAvatarStyle = (): React.CSSProperties => {
     return {
-      backgroundColor: background || randomColor({ seed: colorHash, luminosity: "dark" }),
+      backgroundColor: getBackgroundColor(),
       width,
       height,
       textTransform: "uppercase"


### PR DESCRIPTION
This PR fixes background color for `HotBarIcon` component. Icons with custom uploaded image will have transparent background from now on.

![transparent background](https://user-images.githubusercontent.com/9607060/122920363-fe83a800-d369-11eb-91fc-3431df53c68b.png)

Fixes #3135 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>