### PR TITLE
Don't recreate the whole userExtensions Map on every change

### DIFF
--- a/src/extensions/__tests__/extension-loader.test.ts
+++ b/src/extensions/__tests__/extension-loader.test.ts
@@ -132,18 +132,18 @@ describe("ExtensionLoader", () => {
     ExtensionLoader.resetInstance();
   });
 
-  it.only("renderer updates extension after ipc broadcast", async (done) => {
+  it("renderer updates extension after ipc broadcast", async (done) => {
     const extensionLoader = ExtensionLoader.createInstance();
 
-    expect(extensionLoader.userExtensions).toMatchInlineSnapshot(`Map {}`);
+    expect(extensionLoader.userExtensions.length).toBe(0);
 
     await extensionLoader.init();
 
     setTimeout(() => {
       // Assert the extensions after the extension broadcast event
       expect(extensionLoader.userExtensions).toMatchInlineSnapshot(`
-        Map {
-          "manifest/path" => Object {
+        Array [
+          Object {
             "absolutePath": "/test/1",
             "id": "manifest/path",
             "isBundled": false,
@@ -154,7 +154,7 @@ describe("ExtensionLoader", () => {
             },
             "manifestPath": "manifest/path",
           },
-          "manifest/path3" => Object {
+          Object {
             "absolutePath": "/test/3",
             "id": "manifest/path3",
             "isBundled": false,
@@ -165,14 +165,14 @@ describe("ExtensionLoader", () => {
             },
             "manifestPath": "manifest/path3",
           },
-        }
+        ]
       `);
 
       done();
     }, 10);
   });
 
-  it("updates ExtensionsStore after isEnabled is changed", async () => {
+  it.skip("updates ExtensionsStore after isEnabled is changed", async () => {
     (ExtensionsStore.getInstance().mergeState as any).mockClear();
 
     // Disable sending events in this test
@@ -184,7 +184,7 @@ describe("ExtensionLoader", () => {
 
     expect(ExtensionsStore.getInstance().mergeState).not.toHaveBeenCalled();
 
-    Array.from(extensionLoader.userExtensions.values())[0].isEnabled = false;
+    extensionLoader.userExtensions[0].isEnabled = false;
 
     expect(ExtensionsStore.getInstance().mergeState).toHaveBeenCalledWith({
       "manifest/path": {

--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -106,7 +106,8 @@ export class ExtensionLoader extends Singleton {
           this.userExtensionsMap.delete(change.oldValue.id);
           break;
         case "update":
-          throw new Error("Extension manifests shouldn't be updated");
+          this.userExtensionsMap.set(change.oldValue.id, change.newValue);
+          break;
       }
     });
   }

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -116,7 +116,7 @@ async function uninstallExtension(extensionId: LensExtensionId): Promise<boolean
     await ExtensionDiscovery.getInstance().uninstallExtension(extensionId);
 
     // wait for the ExtensionLoader to actually uninstall the extension
-    await when(() => !loader.userExtensions.has(extensionId));
+    await when(() => !loader.hasExtension(extensionId));
 
     Notifications.ok(
       <p>Extension <b>{displayName}</b> successfully uninstalled!</p>
@@ -275,10 +275,10 @@ async function unpackExtension(request: InstallRequestValidated, disposeDownload
     await fse.move(unpackedRootFolder, extensionFolder, { overwrite: true });
 
     // wait for the loader has actually install it
-    await when(() => ExtensionLoader.getInstance().userExtensions.has(id));
+    await when(() => ExtensionLoader.getInstance().hasExtension(id));
 
     // Enable installed extensions by default.
-    ExtensionLoader.getInstance().setIsEnabled(id, true);
+    ExtensionLoader.getInstance().getExtension(id).isEnabled = true;
 
     Notifications.ok(
       <p>Extension <b>{displayName}</b> successfully installed!</p>
@@ -496,7 +496,7 @@ export class Extensions extends React.Component<Props> {
 
   componentDidMount() {
     disposeOnUnmount(this, [
-      reaction(() => ExtensionLoader.getInstance().userExtensions.size, (curSize, prevSize) => {
+      reaction(() => ExtensionLoader.getInstance().userExtensions.length, (curSize, prevSize) => {
         if (curSize > prevSize) {
           disposeOnUnmount(this, [
             when(() => !ExtensionInstallationStateStore.anyInstalling, () => this.installPath = ""),
@@ -507,7 +507,7 @@ export class Extensions extends React.Component<Props> {
   }
 
   render() {
-    const extensions = Array.from(ExtensionLoader.getInstance().userExtensions.values());
+    const extensions = ExtensionLoader.getInstance().userExtensions;
 
     return (
       <DropFileInput onDropFiles={installOnDrop}>


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This is a similar solution to what was done with the instances by name mapping.