### PR TITLE
Treat bundled extensions as enabled in protocol router

### DIFF
--- a/src/common/protocol-handler/router.ts
+++ b/src/common/protocol-handler/router.ts
@@ -187,7 +187,7 @@ export abstract class LensProtocolRouter extends Singleton {
       return name;
     }
 
-    if (!ExtensionsStore.getInstance().isEnabled(extension.id)) {
+    if (!extension.isBundled && !ExtensionsStore.getInstance().isEnabled(extension.id)) {
       logger.info(`${LensProtocolRouter.LoggingPrefix}: Extension ${name} matched, but not enabled`);
 
       return name;


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes intree extensions not being able to be routed too.