### PR TITLE
Show led only for clusters

### DIFF
--- a/src/renderer/components/hotbar/hotbar-entity-icon.tsx
+++ b/src/renderer/components/hotbar/hotbar-entity-icon.tsx
@@ -74,6 +74,10 @@ export class HotbarEntityIcon extends React.Component<Props> {
   }
 
   get ledIcon() {
+    if (this.props.entity.kind !== "KubernetesCluster") {
+      return null;
+    }
+
     const className = cssNames("led", { online: this.props.entity.status.phase == "connected"}); // TODO: make it more generic
 
     return <div className={className} />;


### PR DESCRIPTION
Led on hotbar icon does not really make sense to any other entities. We need to provide proper API for enabling this in future versions.