### PR TITLE
Release v4.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kontena-lens",
   "productName": "Lens",
   "description": "Lens - The Kubernetes IDE",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "static/build/main.js",
   "copyright": "© 2021, Mirantis, Inc.",
   "license": "MIT",

--- a/static/RELEASE_NOTES.md
+++ b/static/RELEASE_NOTES.md
@@ -2,7 +2,13 @@
 
 Here you can find description of changes we've built into each release. While we try our best to make each upgrade automatic and as smooth as possible, there may be some cases where you might need to do something to ensure the application works smoothly. So please read through the release highlights!
 
-## 4.2.4 (current version)
+## 4.2.5 (current version)
+- Fix: allow metrics-server resources through
+- Revert: point to versioned docs
+- Upgrade to Electron 9.4.4
+- Handle auto-update to Lens 5
+
+## 4.2.4
 - Fix: Not able to install extensions by name
 - Fix: Blank disabled `<Select>` element option (workspace menu)
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes:
- relax kube api data type validation (to allow metrics-server resources) (#2802) @jim-docker 
- Revert point docs to versioned docs (#2918) @Nokel81 
- [v4.2] Electron 9.4.4 (#3154) @jakolehm 
- [v4.2] handle auto-update to Lens 5 (#3155) @jakolehm 