### PR TITLE
HotbarIcon's refering to unknown entities should be removalable

### DIFF
--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -49,6 +49,10 @@
     cursor: default;
     filter: grayscale(0.7);
 
+    &.contextMenuAvailable {
+      cursor: context-menu;
+    }
+
     &:hover {
       &:not(.active) {
         box-shadow: none;

--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -44,8 +44,9 @@
     border-radius: 6px;
   }
 
-  &.disabled,&.inactive {
+  &.disabled {
     opacity: 0.4;
+    cursor: default;
     filter: grayscale(0.7);
 
     &:hover {
@@ -53,14 +54,6 @@
         box-shadow: none;
       }
     }
-  }
-
-  &.disabled {
-    cursor: default;
-  }
-
-  &.inactive {
-    cursor: context-menu;
   }
 
   &.isDragging {

--- a/src/renderer/components/hotbar/hotbar-icon.scss
+++ b/src/renderer/components/hotbar/hotbar-icon.scss
@@ -44,9 +44,8 @@
     border-radius: 6px;
   }
 
-  &.disabled {
+  &.disabled,&.inactive {
     opacity: 0.4;
-    cursor: default;
     filter: grayscale(0.7);
 
     &:hover {
@@ -54,6 +53,14 @@
         box-shadow: none;
       }
     }
+  }
+
+  &.disabled {
+    cursor: default;
+  }
+
+  &.inactive {
+    cursor: context-menu;
   }
 
   &.isDragging {

--- a/src/renderer/components/hotbar/hotbar-icon.tsx
+++ b/src/renderer/components/hotbar/hotbar-icon.tsx
@@ -43,7 +43,6 @@ export interface HotbarIconProps extends DOMAttributes<HTMLElement> {
   active?: boolean;
   menuItems?: CatalogEntityContextMenu[];
   disabled?: boolean;
-  inactive?: boolean;
   size?: number;
   background?: string;
 }
@@ -66,7 +65,7 @@ function onMenuItemClick(menuItem: CatalogEntityContextMenu) {
 }
 
 export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: HotbarIconProps) => {
-  const { uid, title, src, material, active, className, source, disabled, onMenuOpen, onClick, inactive, children, ...rest } = props;
+  const { uid, title, src, material, active, className, source, disabled, onMenuOpen, onClick, children, ...rest } = props;
   const id = `hotbarIcon-${uid}`;
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -96,7 +95,7 @@ export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: Hotba
   };
 
   return (
-    <div className={cssNames("HotbarIcon flex", className, { disabled, inactive })}>
+    <div className={cssNames("HotbarIcon flex", className, { disabled })}>
       <MaterialTooltip title={`${title || "unknown"} (${source || "unknown"})`} placement="right">
         <div id={id}>
           {renderIcon()}
@@ -111,10 +110,8 @@ export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: Hotba
         toggleEvent="contextmenu"
         position={{right: true, bottom: true }} // FIXME: position does not work
         open={() => {
-          if (!disabled) {
-            onMenuOpen?.();
-            toggleMenu();
-          }
+          onMenuOpen?.();
+          toggleMenu();
         }}
         close={() => toggleMenu()}>
         {

--- a/src/renderer/components/hotbar/hotbar-icon.tsx
+++ b/src/renderer/components/hotbar/hotbar-icon.tsx
@@ -43,6 +43,7 @@ export interface HotbarIconProps extends DOMAttributes<HTMLElement> {
   active?: boolean;
   menuItems?: CatalogEntityContextMenu[];
   disabled?: boolean;
+  inactive?: boolean;
   size?: number;
   background?: string;
 }
@@ -65,7 +66,7 @@ function onMenuItemClick(menuItem: CatalogEntityContextMenu) {
 }
 
 export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: HotbarIconProps) => {
-  const { uid, title, src, material, active, className, source, disabled, onMenuOpen, onClick, children, ...rest } = props;
+  const { uid, title, src, material, active, className, source, disabled, onMenuOpen, onClick, inactive, children, ...rest } = props;
   const id = `hotbarIcon-${uid}`;
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -95,7 +96,7 @@ export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: Hotba
   };
 
   return (
-    <div className={cssNames("HotbarIcon flex", className, { disabled })}>
+    <div className={cssNames("HotbarIcon flex", className, { disabled, inactive })}>
       <MaterialTooltip title={`${title || "unknown"} (${source || "unknown"})`} placement="right">
         <div id={id}>
           {renderIcon()}
@@ -116,13 +117,13 @@ export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: Hotba
           }
         }}
         close={() => toggleMenu()}>
-        { menuItems.map((menuItem) => {
-          return (
-            <MenuItem key={menuItem.title} onClick={() => onMenuItemClick(menuItem) }>
+        {
+          menuItems.map((menuItem) => (
+            <MenuItem key={menuItem.title} onClick={() => onMenuItemClick(menuItem)}>
               {menuItem.title}
             </MenuItem>
-          );
-        })}
+          ))
+        }
       </Menu>
     </div>
   );

--- a/src/renderer/components/hotbar/hotbar-icon.tsx
+++ b/src/renderer/components/hotbar/hotbar-icon.tsx
@@ -95,7 +95,7 @@ export const HotbarIcon = observer(({menuItems = [], size = 40, ...props}: Hotba
   };
 
   return (
-    <div className={cssNames("HotbarIcon flex", className, { disabled })}>
+    <div className={cssNames("HotbarIcon flex", className, { disabled, contextMenuAvailable: menuItems.length > 0 })}>
       <MaterialTooltip title={`${title || "unknown"} (${source || "unknown"})`} placement="right">
         <div id={id}>
           {renderIcon()}

--- a/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -163,7 +163,7 @@ export class HotbarMenu extends React.Component<Props> {
                                 onClick: () => this.removeItem(item.entity.uid)
                               }
                             ]}
-                            inactive
+                            disabled
                             size={40}
                           />
                         )}

--- a/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -27,7 +27,7 @@ import { HotbarEntityIcon } from "./hotbar-entity-icon";
 import { cssNames, IClassName } from "../../utils";
 import { catalogEntityRegistry } from "../../api/catalog-entity-registry";
 import { defaultHotbarCells, HotbarItem, HotbarStore } from "../../../common/hotbar-store";
-import { CatalogEntity, CatalogEntityContextMenu, catalogEntityRunContext } from "../../api/catalog-entity";
+import { CatalogEntity, catalogEntityRunContext } from "../../api/catalog-entity";
 import { DragDropContext, Draggable, Droppable, DropResult } from "react-beautiful-dnd";
 import { HotbarSelector } from "./hotbar-selector";
 import { HotbarCell } from "./hotbar-cell";
@@ -110,12 +110,6 @@ export class HotbarMenu extends React.Component<Props> {
   renderGrid() {
     return this.items.map((item, index) => {
       const entity = this.getEntity(item);
-      const disabledMenuItems: CatalogEntityContextMenu[] = [
-        {
-          title: "Unpin from Hotbar",
-          onClick: () => this.removeItem(item.entity.uid)
-        }
-      ];
 
       return (
         <Droppable droppableId={`${index}`} key={index}>
@@ -163,8 +157,13 @@ export class HotbarMenu extends React.Component<Props> {
                             uid={`hotbar-icon-${item.entity.uid}`}
                             title={item.entity.name}
                             source={item.entity.source}
-                            menuItems={disabledMenuItems}
-                            disabled
+                            menuItems={[
+                              {
+                                title: "Unpin from Hotbar",
+                                onClick: () => this.removeItem(item.entity.uid)
+                              }
+                            ]}
+                            inactive
                             size={40}
                           />
                         )}


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes regression from #2923 

This PR creates a new type of hotbar icon prop called `inactive` (because the hotbar icon is used in several different places with different needs). 

When `inactive` is true the icon looks like it is disabled but still allows menu actions and run actions to be done.