### PR TITLE
Fix extension enabled status after installation

### DIFF
--- a/src/extensions/extension-loader.ts
+++ b/src/extensions/extension-loader.ts
@@ -192,6 +192,10 @@ export class ExtensionLoader extends Singleton {
     }
   }
 
+  setIsEnabled(lensExtensionId: LensExtensionId, isEnabled: boolean) {
+    this.extensions.get(lensExtensionId).isEnabled = isEnabled;
+  }
+
   protected async initMain() {
     this.isLoaded = true;
     this.loadOnMain();

--- a/src/renderer/components/+extensions/extensions.tsx
+++ b/src/renderer/components/+extensions/extensions.tsx
@@ -278,7 +278,7 @@ async function unpackExtension(request: InstallRequestValidated, disposeDownload
     await when(() => ExtensionLoader.getInstance().userExtensions.has(id));
 
     // Enable installed extensions by default.
-    ExtensionLoader.getInstance().userExtensions.get(id).isEnabled = true;
+    ExtensionLoader.getInstance().setIsEnabled(id, true);
 
     Notifications.ok(
       <p>Extension <b>{displayName}</b> successfully installed!</p>


### PR DESCRIPTION
* Fixes https://github.com/lensapp/lens/issues/3198
* The cause of the bug: the `reaction()` was not triggered after `isEnabled = true` because we edited the computed `userExtensions` instead of the original extension object. This made the UI and the store to be not in sync.
* Thanks for @nevalla for debugging help
* Not extensively tested yet..