### PR TITLE
Filtering out clusters by metadata.id in hotbar migrations

### DIFF
--- a/src/migrations/hotbar-store/5.0.0-beta.10.ts
+++ b/src/migrations/hotbar-store/5.0.0-beta.10.ts
@@ -22,7 +22,7 @@
 import { createHash } from "crypto";
 import { app } from "electron";
 import fse from "fs-extra";
-import { isNull } from "lodash";
+import { isNull, uniqBy } from "lodash";
 import path from "path";
 import * as uuid from "uuid";
 import type { ClusterStoreModel } from "../../common/cluster-store";
@@ -47,6 +47,7 @@ export default {
       const workspaceStoreData: Pre500WorkspaceStoreModel = fse.readJsonSync(path.join(userDataPath, "lens-workspace-store.json"));
       const { clusters }: ClusterStoreModel = fse.readJSONSync(path.join(userDataPath, "lens-cluster-store.json"));
       const workspaceHotbars = new Map<string, Hotbar>(); // mapping from WorkspaceId to HotBar
+      const uniqueClusters = uniqBy(clusters, "metadata.id"); // Filtering out duplicated clusters
 
       for (const { id, name } of workspaceStoreData.workspaces) {
         workspaceHotbars.set(id, {
@@ -68,7 +69,7 @@ export default {
         });
       }
 
-      for (const cluster of clusters) {
+      for (const cluster of uniqueClusters) {
         const workspaceHotbar = workspaceHotbars.get(cluster.workspace);
 
         if (workspaceHotbar?.items.length < defaultHotbarCells) {


### PR DESCRIPTION
`cluster.id` doesn't seems to be a good choice for filtering since it is always unique even for same clusters. However, `metadata.id` is same.

Fixes #3126 

![clusters in 4](https://user-images.githubusercontent.com/9607060/123647783-1018f400-d831-11eb-95e6-51921688c165.png)

![clusters in 5](https://user-images.githubusercontent.com/9607060/123647795-127b4e00-d831-11eb-8fee-f05bba2baf35.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>