### PR TITLE
Fix cluster-store and hotbar-store migrations

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -241,8 +241,8 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
           cluster = new Cluster(clusterModel);
         }
         newClusters.set(clusterModel.id, cluster);
-      } catch {
-        // ignore
+      } catch (error) {
+        logger.warn(`[CLUSTER-STORE]: Failed to update/create a cluster: ${error}`);
       }
     }
 

--- a/src/migrations/cluster-store/5.0.0-beta.13.ts
+++ b/src/migrations/cluster-store/5.0.0-beta.13.ts
@@ -70,12 +70,13 @@ function mergeSet(left: Iterable<string>, right: Iterable<string>): string[] {
 function mergeClusterModel(prev: ClusterModel, right: Omit<ClusterModel, "id">): ClusterModel {
   return {
     id: prev.id,
-    kubeConfigPath: prev.id,
+    kubeConfigPath: prev.kubeConfigPath,
     contextName: prev.contextName,
     preferences: mergePreferences(prev.preferences ?? {}, right.preferences ?? {}),
     metadata: prev.metadata,
     labels: mergeLabels(prev.labels ?? {}, right.labels ?? {}),
     accessibleNamespaces: mergeSet(prev.accessibleNamespaces ?? [], right.accessibleNamespaces ?? []),
+    workspace: prev.workspace || right.workspace,
   };
 }
 
@@ -105,8 +106,10 @@ export default {
       const newId = generateNewIdFor(cluster);
 
       if (clusters.has(newId)) {
+        migrationLog(`Duplicate entries for ${newId}`, { oldId });
         clusters.set(newId, mergeClusterModel(clusters.get(newId), cluster));
       } else {
+        migrationLog(`First entry for ${newId}`, { oldId });
         clusters.set(newId, {
           ...cluster,
           id: newId,


### PR DESCRIPTION
- kubeConfigPath was erroniously set to cluster.id
- Skip empty workspace hotbars
- Output a warn if updating or creating a cluster throws in cluster-store

Signed-off-by: Sebastian Malton <sebastian@malton.name>