### PR TITLE
Correctly migrate duplicate clusters in workspaces

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -71,6 +71,11 @@ export interface ClusterModel {
    */
   workspace?: string;
 
+  /**
+   * @deprecated this is used only for hotbar migrations from 4.2.X
+   */
+  workspaces?: string[];
+
   /** User context in kubeconfig  */
   contextName: string;
 

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -121,6 +121,10 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @observable workspace: string;
   /**
+   * @deprecated
+   */
+  @observable workspaces: string[];
+  /**
    * Kubernetes API server URL
    *
    * @observable
@@ -292,6 +296,10 @@ export class Cluster implements ClusterModel, ClusterState {
 
     if (model.workspace) {
       this.workspace = model.workspace;
+    }
+
+    if (model.workspaces) {
+      this.workspaces = model.workspaces;
     }
 
     if (model.contextName) {
@@ -589,6 +597,7 @@ export class Cluster implements ClusterModel, ClusterState {
       contextName: this.contextName,
       kubeConfigPath: this.kubeConfigPath,
       workspace: this.workspace,
+      workspaces: this.workspaces,
       preferences: this.preferences,
       metadata: this.metadata,
       accessibleNamespaces: this.accessibleNamespaces,

--- a/src/migrations/cluster-store/5.0.0-beta.13.ts
+++ b/src/migrations/cluster-store/5.0.0-beta.13.ts
@@ -63,8 +63,16 @@ function mergeLabels(left: Record<string, string>, right: Record<string, string>
   };
 }
 
-function mergeSet(left: Iterable<string>, right: Iterable<string>): string[] {
-  return [...new Set([...left, ...right])];
+function mergeSet(...iterables: Iterable<string>[]): string[] {
+  const res = new Set<string>();
+
+  for (const iterable of iterables) {
+    for (const val of iterable) {
+      res.add(val);
+    }
+  }
+
+  return [...res];
 }
 
 function mergeClusterModel(prev: ClusterModel, right: Omit<ClusterModel, "id">): ClusterModel {
@@ -77,6 +85,7 @@ function mergeClusterModel(prev: ClusterModel, right: Omit<ClusterModel, "id">):
     labels: mergeLabels(prev.labels ?? {}, right.labels ?? {}),
     accessibleNamespaces: mergeSet(prev.accessibleNamespaces ?? [], right.accessibleNamespaces ?? []),
     workspace: prev.workspace || right.workspace,
+    workspaces: mergeSet([prev.workspace, right.workspace], prev.workspaces ?? [], right.workspaces ?? []),
   };
 }
 
@@ -113,6 +122,7 @@ export default {
         clusters.set(newId, {
           ...cluster,
           id: newId,
+          workspaces: [cluster.workspace].filter(Boolean),
         });
         moveStorageFolder({ folder, newId, oldId });
       }

--- a/src/migrations/hotbar-store/5.0.0-beta.10.ts
+++ b/src/migrations/hotbar-store/5.0.0-beta.10.ts
@@ -71,17 +71,20 @@ export default {
 
       for (const cluster of clusters) {
         const uid = generateNewIdFor(cluster);
-        const workspaceHotbar = workspaceHotbars.get(cluster.workspace);
 
-        migrationLog(`Adding cluster ${uid} to ${workspaceHotbar.name}`);
+        for (const workspaceId of cluster.workspaces ?? [cluster.workspace].filter(Boolean)) {
+          const workspaceHotbar = workspaceHotbars.get(workspaceId);
 
-        if (workspaceHotbar?.items.length < defaultHotbarCells) {
-          workspaceHotbar.items.push({
-            entity: {
-              uid: generateNewIdFor(cluster),
-              name: cluster.preferences.clusterName || cluster.contextName,
-            }
-          });
+          migrationLog(`Adding cluster ${uid} to ${workspaceHotbar.name}`);
+
+          if (workspaceHotbar?.items.length < defaultHotbarCells) {
+            workspaceHotbar.items.push({
+              entity: {
+                uid: generateNewIdFor(cluster),
+                name: cluster.preferences.clusterName || cluster.contextName,
+              }
+            });
+          }
         }
       }
 


### PR DESCRIPTION
- Keep track of the set of all workspaces that each duplicated entry was a part of

This correctly migrates users' workspaces to hotbars, for users that don't immediately upgrade to `5.0.0` from `4.2.5` (but do upgrade to a version that includes this). Previously duplicated clusters would "forget" all workspaces except for the first one.

Note: this won't fix users that already upgraded to `5.0.0` because the previous version of this migration was destructive of this data.

Signed-off-by: Sebastian Malton <sebastian@malton.name>