### PR TITLE
Use env var for registry mirror

### DIFF
--- a/src/main/shell-session/node-shell-session.ts
+++ b/src/main/shell-session/node-shell-session.ts
@@ -77,7 +77,7 @@ export class NodeShellSession extends ShellSession {
           }],
           containers: [{
             name: "shell",
-            image: "docker.io/alpine:3.13",
+            image: (process.env.REGISTRY_MIRROR || "docker.io") + "/alpine:3.13",
             securityContext: {
               privileged: true,
             },


### PR DESCRIPTION
In an offline environment, using docker.io as a hardcoded registry does not work. If there's a better alternative to environment variables, please let me know.