### PR TITLE
Temporary add manual update notification to Lens 5 users

### DIFF
--- a/src/common/ipc/update-available.ipc.ts
+++ b/src/common/ipc/update-available.ipc.ts
@@ -22,6 +22,7 @@
 import type { UpdateInfo } from "electron-updater";
 
 export const UpdateAvailableChannel = "update-available";
+export const ManualUpdateAvailableChannel = "manual-update-available";
 export const AutoUpdateLogPrefix = "[UPDATE-CHECKER]";
 
 export type UpdateAvailableFromMain = [backChannel: string, updateInfo: UpdateInfo];

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -23,7 +23,7 @@ import { autoUpdater, UpdateInfo } from "electron-updater";
 import logger from "./logger";
 import { isDevelopment, isPublishConfigured, isTestEnv } from "../common/vars";
 import { delay } from "../common/utils";
-import { areArgsUpdateAvailableToBackchannel, AutoUpdateLogPrefix, broadcastMessage, onceCorrect, UpdateAvailableChannel, UpdateAvailableToBackchannel } from "../common/ipc";
+import { areArgsUpdateAvailableToBackchannel, AutoUpdateLogPrefix, broadcastMessage, ManualUpdateAvailableChannel, onceCorrect, UpdateAvailableChannel, UpdateAvailableToBackchannel } from "../common/ipc";
 import { once } from "lodash";
 import { ipcMain } from "electron";
 
@@ -62,6 +62,11 @@ export const startUpdateChecking = once(function (interval = 1000 * 60 * 60 * 24
 
   autoUpdater
     .on("update-available", (info: UpdateInfo) => {
+      // TODO remove this line and return on next version
+      broadcastMessage(ManualUpdateAvailableChannel, "", info);
+
+      return;
+
       if (autoUpdater.autoInstallOnAppQuit) {
         // a previous auto-update loop was completed with YES+LATER, check if same version
         if (installVersion === info.version) {


### PR DESCRIPTION
Lens 5 uses different `appId` than Lens 4.x and currently Lens 4.x users cannot auto update to Lens 5.

This PR will add notification to Lens 5 users to manually update to the next version that will use the old appId.

When we have released this fix, we can revert Lens to use `electron.com.kontena-lens` as appId so 4.x users can install the  automatic update.

![image](https://user-images.githubusercontent.com/455844/123929342-6acc6000-d997-11eb-93a2-903290e61430.png)


To test this on dev env, please modify `app-updater.ts`:

```
export const startUpdateChecking = once(function (interval = 1000 * 60 * 60 * 24): void {
  if (isDevelopment || isTestEnv) {
    broadcastMessage(ManualUpdateAvailableChannel, "", {version: "5.0.0"});

    return;
  }
```