### PR TITLE
Make node shell image configurable

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -101,6 +101,8 @@ export interface ClusterPreferences extends ClusterPrometheusPreferences {
   icon?: string;
   httpsProxy?: string;
   hiddenMetrics?: string[];
+  nodeShellImage?: string;
+  imagePullSecret?: string;
 }
 
 export interface ClusterPrometheusPreferences {
@@ -116,6 +118,8 @@ export interface ClusterPrometheusPreferences {
 }
 
 const initialStates = "cluster:states";
+
+export const initialNodeShellImage = "docker.io/alpine:3.13";
 
 export class ClusterStore extends BaseStore<ClusterStoreModel> {
   private static StateChannel = "cluster:state";

--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -34,6 +34,7 @@ import { VersionDetector } from "./cluster-detectors/version-detector";
 import { detectorRegistry } from "./cluster-detectors/detector-registry";
 import plimit from "p-limit";
 import { toJS } from "../common/utils";
+import { initialNodeShellImage } from "../common/cluster-store";
 
 export enum ClusterStatus {
   AccessGranted = 2,
@@ -744,5 +745,13 @@ export class Cluster implements ClusterModel, ClusterState {
 
   isMetricHidden(resource: ClusterMetricsResourceType): boolean {
     return Boolean(this.preferences.hiddenMetrics?.includes(resource));
+  }
+
+  get nodeShellImage(): string {
+    return this.preferences.nodeShellImage || initialNodeShellImage;
+  }
+
+  get imagePullSecret(): string {
+    return this.preferences.imagePullSecret || "";
   }
 }

--- a/src/main/shell-session/node-shell-session.ts
+++ b/src/main/shell-session/node-shell-session.ts
@@ -77,13 +77,16 @@ export class NodeShellSession extends ShellSession {
           }],
           containers: [{
             name: "shell",
-            image: "docker.io/alpine:3.13",
+            image: this.cluster.nodeShellImage,
             securityContext: {
               privileged: true,
             },
             command: ["nsenter"],
             args: ["-t", "1", "-m", "-u", "-i", "-n", "sleep", "14000"]
           }],
+          imagePullSecrets: [{
+            name: this.cluster.imagePullSecret,
+          }]
         }
       });
   }

--- a/src/renderer/components/cluster-settings/cluster-settings.tsx
+++ b/src/renderer/components/cluster-settings/cluster-settings.tsx
@@ -118,3 +118,17 @@ export function MetricsSettings({ entity }: EntitySettingViewProps) {
     </section>
   );
 }
+
+export function NodeShellSettings({entity}: EntitySettingViewProps) {
+  const cluster = getClusterForEntity(entity);
+
+  if(!cluster) {
+    return null;
+  }
+
+  return (
+    <section>
+      <components.ClusterNodeShellSetting cluster={cluster} />
+    </section>
+  );
+}

--- a/src/renderer/components/cluster-settings/components/cluster-node-shell-setting.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-node-shell-setting.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import type { Cluster } from "../../../../main/cluster";
+import { autorun, makeObservable, observable } from "mobx";
+import { SubTitle } from "../../layout/sub-title";
+import React from "react";
+import { Input } from "../../input/input";
+import { disposeOnUnmount, observer } from "mobx-react";
+import { Icon } from "../../icon/icon";
+import { initialNodeShellImage } from "../../../../common/cluster-store";
+
+interface Props {
+  cluster: Cluster;
+}
+
+@observer
+export class ClusterNodeShellSetting extends React.Component<Props> {
+  @observable nodeShellImage = "";
+  @observable imagePullSecret = "";
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
+
+  componentDidMount() {
+    disposeOnUnmount(this,
+      autorun(() => {
+        this.nodeShellImage = this.props.cluster.nodeShellImage;
+        this.imagePullSecret = this.props.cluster.imagePullSecret;
+      })
+    );
+  }
+
+  onImageChange = (value: string) => {
+    this.nodeShellImage = value;
+  };
+
+  onSecretChange = (value: string) => {
+    this.imagePullSecret = value;
+  };
+
+  saveImage = () => {
+    this.props.cluster.preferences.nodeShellImage = this.nodeShellImage;
+  };
+
+  saveSecret = () => {
+    this.props.cluster.preferences.imagePullSecret = this.imagePullSecret;
+  };
+
+  resetImage = () => {
+    this.nodeShellImage = initialNodeShellImage; //revert to default
+  };
+
+  clearSecret = () => {
+    this.imagePullSecret = "";
+  };
+
+  render() {
+
+    return (
+      <>
+        <section>
+          <SubTitle title="Node shell image" id="node-shell-image"/>
+          <Input
+            theme="round-black"
+            value={this.nodeShellImage}
+            onChange={this.onImageChange}
+            onBlur={this.saveImage}
+            iconRight={<Icon small material="close" onClick={this.resetImage} tooltip="Reset"/>}
+          />
+          <small className="hint">
+            Node shell image. Used for creating node shell pod.
+          </small>
+        </section>
+        <section>
+          <SubTitle title="Image pull secret" id="image-pull-secret"/>
+          <Input
+            placeholder={"Add a secret name..."}
+            theme="round-black"
+            value={this.imagePullSecret}
+            onChange={this.onSecretChange}
+            onBlur={this.saveSecret}
+            iconRight={<Icon small material="close" onClick={this.clearSecret} tooltip="Clear"/>}
+          />
+          <small className="hint">
+            Name of a pre-existing secret (optional). Used for pulling image from a private registry.
+          </small>
+        </section>
+      </>
+    );
+  }
+}

--- a/src/renderer/components/cluster-settings/components/index.ts
+++ b/src/renderer/components/cluster-settings/components/index.ts
@@ -28,3 +28,4 @@ export * from "./cluster-prometheus-setting";
 export * from "./cluster-proxy-setting";
 export * from "./cluster-show-metrics";
 export * from "./cluster-icon-settings";
+export * from "./cluster-node-shell-setting";

--- a/src/renderer/initializers/entity-settings-registry.ts
+++ b/src/renderer/initializers/entity-settings-registry.ts
@@ -70,6 +70,15 @@ export function initEntitySettingsRegistry() {
         components: {
           View: clusterSettings.MetricsSettings,
         }
+      },
+      {
+        apiVersions: ["entity.k8slens.dev/v1alpha1"],
+        kind: "KubernetesCluster",
+        title: "Node Shell",
+        group: "Settings",
+        components: {
+          View: clusterSettings.NodeShellSettings,
+        }
       }
     ]);
 }


### PR DESCRIPTION
deploy node shell pod using an image from a private repo
![Screenshot from 2021-07-08 17-01-43](https://user-images.githubusercontent.com/38247153/124931293-1ff3bd80-e013-11eb-88d6-9dae324c6b9b.png)

settings
<img width="1022" alt="Screen Shot 2021-07-12 at 4 45 20 PM" src="https://user-images.githubusercontent.com/38247153/125298726-79bcf600-e339-11eb-890a-21330cee46f6.png">






fixes: https://github.com/lensapp/lens/issues/2007