### PR TITLE
when checking extension compatibility, ignore the 'latest' tag on appSemVer

### DIFF
--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -366,6 +366,7 @@ export class ExtensionDiscovery extends Singleton {
 
       if (manifest.engines?.lens) {
         const appSemVerLatestImplied = appSemVer;
+
         if (appSemVerLatestImplied.prerelease?.[0] === "latest") {
           /* remove the "latest" prerelease tag so as not to require the extension to specify it */
           appSemVerLatestImplied.prerelease = [];

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -365,7 +365,12 @@ export class ExtensionDiscovery extends Singleton {
       let isCompatible = isBundled;
 
       if (manifest.engines?.lens) {
-        isCompatible = semver.satisfies(appSemVer, manifest.engines.lens);
+        const appSemVerLatestImplied = appSemVer;
+        if (appSemVerLatestImplied.prerelease?.[0] === "latest") {
+          /* remove the "latest" prerelease tag so as not to require the extension to specify it */
+          appSemVerLatestImplied.prerelease = [];
+        }
+        isCompatible = semver.satisfies(appSemVerLatestImplied, manifest.engines.lens);
       }
 
       return {


### PR DESCRIPTION
fixes #3212 

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>