### PR TITLE
Release v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.0.0

## 🐛 Bug Fixes

* Allow users to disconnect from clusters that fail to connect (#3231) @Nokel81
* Change tray icon (#3037) @vshakirova
* Don't clear cluster icon on cancel (#3191) @Nokel81
* Don't set prerelease version info when non-prerelease (#3261) @jakolehm
* Set ownerReference to manually triggered cron jobs (#3229) @Nokel81
* Use kubeconfigPath for delete synced clusters confirmation (#3205) @Nokel81
* Cap cpu chart label values to 2 decimal points (#3228) @Nokel81
* Increase shell sync timeout (#3241) @nevalla
* Correctly migrate duplicate clusters in workspaces (#3211) @Nokel81
* Always check if ref is active in virtual-list (#3230) @Nokel81
* Fixing tooltips to use single component (#3194) @aleksfront
* Allow Node panel to open for virtual nodes (#3213) @jonstelly
* Fixing Catalog columns alignment (#3222) @aleksfront
* Fix using default hotbars (#3196) @pashevskii

## 🧰 Maintenance

* Remove rc note because we don't use rc anymore (#3262) @jakolehm
* Add esbuild/esbuild-loader to reduce memory usage when `make dev` (#3220) @chenhunghan
