### PR TITLE
Fix unhandled exception in visibility handler

### DIFF
--- a/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/src/common/catalog-entities/kubernetes-cluster.ts
@@ -62,8 +62,11 @@ export interface KubernetesClusterStatus extends CatalogEntityStatus {
 }
 
 export class KubernetesCluster extends CatalogEntity<CatalogEntityMetadata, KubernetesClusterStatus, KubernetesClusterSpec> {
-  public readonly apiVersion = "entity.k8slens.dev/v1alpha1";
-  public readonly kind = "KubernetesCluster";
+  public static readonly apiVersion = "entity.k8slens.dev/v1alpha1";
+  public static readonly kind = "KubernetesCluster";
+
+  public readonly apiVersion = KubernetesCluster.apiVersion;
+  public readonly kind = KubernetesCluster.kind;
 
   async connect(): Promise<void> {
     if (app) {

--- a/src/main/catalog/catalog-entity-registry.ts
+++ b/src/main/catalog/catalog-entity-registry.ts
@@ -20,7 +20,7 @@
  */
 
 import { action, computed, IComputedValue, IObservableArray, makeObservable, observable } from "mobx";
-import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity } from "../../common/catalog";
+import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity, CatalogEntityKindData } from "../../common/catalog";
 import { iter } from "../../common/utils";
 
 export class CatalogEntityRegistry {
@@ -61,6 +61,10 @@ export class CatalogEntityRegistry {
     const items = this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind);
 
     return items as T[];
+  }
+
+  getItemsByEntityClass<T extends CatalogEntity>({ apiVersion, kind }: CatalogEntityKindData): T[] {
+    return this.getItemsForApiKind(apiVersion, kind);
   }
 }
 

--- a/src/main/initializers/ipc.ts
+++ b/src/main/initializers/ipc.ts
@@ -20,7 +20,7 @@
  */
 
 import type { IpcMainInvokeEvent } from "electron";
-import type { KubernetesCluster } from "../../common/catalog-entities";
+import { KubernetesCluster } from "../../common/catalog-entities";
 import { clusterFrameMap } from "../../common/cluster-frames";
 import { clusterActivateHandler, clusterSetFrameIdHandler, clusterVisibilityHandler, clusterRefreshHandler, clusterDisconnectHandler, clusterKubectlApplyAllHandler, clusterKubectlDeleteAllHandler, clusterDeleteHandler } from "../../common/cluster-ipc";
 import { ClusterId, ClusterStore } from "../../common/cluster-store";
@@ -50,9 +50,9 @@ export function initIpcMainHandlers() {
   });
 
   ipcMainHandle(clusterVisibilityHandler, (event: IpcMainInvokeEvent, clusterId: ClusterId, visible: boolean) => {
-    const entity = catalogEntityRegistry.getById<KubernetesCluster>(clusterId);
+    const entity = catalogEntityRegistry.getById(clusterId);
 
-    for (const kubeEntity of catalogEntityRegistry.getItemsForApiKind(entity.apiVersion, entity.kind)) {
+    for (const kubeEntity of catalogEntityRegistry.getItemsByEntityClass(KubernetesCluster)) {
       kubeEntity.status.active = false;
     }
 


### PR DESCRIPTION
- If an KubernetesCluster entity is being deleted then the
  catalogEntityRegistry.getById() will return undefined. This leads to
  an unhandled exception in the handler because we tried to read
  apiVersion. This commit changes it so that we get the apiVersion and
  kind from KubernetesCluster class itself

Signed-off-by: Sebastian Malton <sebastian@malton.name>