### PR TITLE
Fix listing charts failing due to bad versions

### DIFF
--- a/src/common/utils/sort-compare.ts
+++ b/src/common/utils/sort-compare.ts
@@ -19,39 +19,37 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
- * A function that does nothing
- */
-export function noop<T extends any[]>(...args: T): void {
-  return void args;
+import semver, { SemVer } from "semver";
+
+export function sortCompare<T>(left: T, right: T): -1 | 0 | 1 {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left === right) {
+    return 0;
+  }
+
+  return 1;
 }
 
-export * from "./app-version";
-export * from "./autobind";
-export * from "./base64";
-export * from "./camelCase";
-export * from "./cloneJson";
-export * from "./debouncePromise";
-export * from "./defineGlobal";
-export * from "./delay";
-export * from "./disposer";
-export * from "./downloadFile";
-export * from "./escapeRegExp";
-export * from "./extended-map";
-export * from "./getRandId";
-export * from "./hash-set";
-export * from "./n-fircate";
-export * from "./openExternal";
-export * from "./paths";
-export * from "./reject-promise";
-export * from "./singleton";
-export * from "./sort-compare";
-export * from "./splitArray";
-export * from "./tar";
-export * from "./toggle-set";
-export * from "./toJS";
-export * from "./type-narrowing";
+interface ChartVersion {
+  version: string;
+  __version?: SemVer;
+}
 
-import * as iter from "./iter";
+export function sortCompareChartVersions(left: ChartVersion, right: ChartVersion): -1 | 0 | 1 {
+  if (left.__version && right.__version) {
+    return semver.compare(right.__version, left.__version);
+  }
 
-export { iter };
+  if (!left.__version && right.__version) {
+    return 1;
+  }
+
+  if (left.__version && !right.__version) {
+    return -1;
+  }
+
+  return sortCompare(left.version, right.version);
+}

--- a/src/main/helm/__mocks__/helm-chart-manager.ts
+++ b/src/main/helm/__mocks__/helm-chart-manager.ts
@@ -34,6 +34,36 @@ export class HelmChartManager {
     switch (this.repo.name) {
       case "stable":
         return Promise.resolve({
+          "invalid-semver": [
+            {
+              apiVersion: "3.0.0",
+              name: "weird-versioning",
+              version: "I am not semver",
+              repo: "stable",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "weird-versioning",
+              version: "v4.3.0",
+              repo: "stable",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "weird-versioning",
+              version: "I am not semver but more",
+              repo: "stable",
+              digest: "test"
+            },
+            {
+              apiVersion: "3.0.0",
+              name: "weird-versioning",
+              version: "v4.4.0",
+              repo: "stable",
+              digest: "test"
+            },
+          ],
           "apm-server": [
             {
               apiVersion: "3.0.0",

--- a/src/main/helm/__tests__/helm-service.test.ts
+++ b/src/main/helm/__tests__/helm-service.test.ts
@@ -62,6 +62,36 @@ describe("Helm Service tests", () => {
             digest: "test"
           }
         ],
+        "invalid-semver": [
+          {
+            apiVersion: "3.0.0",
+            name: "weird-versioning",
+            version: "v4.4.0",
+            repo: "stable",
+            digest: "test"
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "weird-versioning",
+            version: "v4.3.0",
+            repo: "stable",
+            digest: "test"
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "weird-versioning",
+            version: "I am not semver",
+            repo: "stable",
+            digest: "test"
+          },
+          {
+            apiVersion: "3.0.0",
+            name: "weird-versioning",
+            version: "I am not semver but more",
+            repo: "stable",
+            digest: "test"
+          },
+        ],
         "redis": [
           {
             apiVersion: "3.0.0",

--- a/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
+++ b/src/renderer/components/+apps-helm-charts/helm-chart.store.ts
@@ -21,7 +21,7 @@
 
 import semver from "semver";
 import { observable, makeObservable } from "mobx";
-import { autoBind } from "../../utils";
+import { autoBind, sortCompareChartVersions } from "../../utils";
 import { getChartDetails, HelmChart, listCharts } from "../../api/endpoints/helm-charts.api";
 import { ItemStore } from "../../item.store";
 import flatten from "lodash/flatten";
@@ -60,12 +60,10 @@ export class HelmChartStore extends ItemStore<HelmChart> {
   }
 
   protected sortVersions = (versions: IChartVersion[]) => {
-    return versions.sort((first, second) => {
-      const firstVersion = semver.coerce(first.version || 0);
-      const secondVersion = semver.coerce(second.version || 0);
-
-      return semver.compare(secondVersion, firstVersion);
-    });
+    return versions
+      .map(chartVersion => ({ ...chartVersion, __version: semver.coerce(chartVersion.version, { includePrerelease: true, loose: true }), }))
+      .sort(sortCompareChartVersions)
+      .map(({ __version, ...chartVersion }) => chartVersion);
   };
 
   async getVersions(chartName: string, force?: boolean): Promise<IChartVersion[]> {


### PR DESCRIPTION
- Add generic sorting function that uses the comparitors directory

- Because repos are 3rd party managed resources we cannot enforce strict
  semver compatibility. Therefore we should loosely coerce versions to
  semver versions.

- If a version is not even loosely coercable then we should just sort
  alphanumerically.

- Sort semver before non-semver

- Filter out a chart if any of the versions are marked as deprecated

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/3250

---
NOTE: please review each commit separately and do not squash this PR.