### PR TITLE
ignore Lens's prerelease tag when checking extension compatibility

### DIFF
--- a/src/extensions/__tests__/extension-compatibility.test.ts
+++ b/src/extensions/__tests__/extension-compatibility.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { isCompatibleExtension } from "../extension-compatibility";
+import { Console } from "console";
+import { stdout, stderr } from "process";
+import type { LensExtensionManifest } from "../lens-extension";
+import { appSemVer } from "../../common/vars";
+
+console = new Console(stdout, stderr);
+
+describe("extension compatibility", () => {
+  describe("appSemVer with no prerelease tag", () => {
+    beforeAll(() => {
+      appSemVer.major = 5;
+      appSemVer.minor = 0;
+      appSemVer.patch = 3;
+      appSemVer.prerelease = [];
+    });
+
+    it("has no extension comparator", () => {
+      const manifest = { name: "extensionName", version: "0.0.1"};
+
+      expect(isCompatibleExtension(manifest,)).toBe(false);
+    });
+    
+    it.each([
+      {
+        comparator: "",
+        expected: false,
+      },
+      {
+        comparator: "bad comparator",
+        expected: false,
+      },
+      {
+        comparator: "^4.0.0",
+        expected: false,
+      },
+      {
+        comparator: "^5.0.0",
+        expected: true,
+      },
+      {
+        comparator: "^6.0.0",
+        expected: false,
+      },
+      {
+        comparator: "^4.0.0-alpha.1",
+        expected: false,
+      },
+      {
+        comparator: "^5.0.0-alpha.1",
+        expected: true,
+      },
+      {
+        comparator: "^6.0.0-alpha.1",
+        expected: false,
+      },
+    ])("extension comparator test: %p", ({ comparator, expected }) => {
+      const manifest: LensExtensionManifest = { name: "extensionName", version: "0.0.1", engines: { lens: comparator}};
+
+      expect(isCompatibleExtension(manifest,)).toBe(expected);
+    });
+  });
+
+  describe("appSemVer with prerelease tag", () => {
+    beforeAll(() => {
+      appSemVer.major = 5;
+      appSemVer.minor = 0;
+      appSemVer.patch = 3;
+      appSemVer.prerelease = ["beta", 3];
+    });
+    
+    it("has no extension comparator", () => {
+      const manifest = { name: "extensionName", version: "0.0.1"};
+
+      expect(isCompatibleExtension(manifest,)).toBe(false);
+    });
+    
+    it.each([
+      {
+        comparator: "",
+        expected: false,
+      },
+      {
+        comparator: "bad comparator",
+        expected: false,
+      },
+      {
+        comparator: "^4.0.0",
+        expected: false,
+      },
+      {
+        comparator: "^5.0.0",
+        expected: true,
+      },
+      {
+        comparator: "^6.0.0",
+        expected: false,
+      },
+      {
+        comparator: "^4.0.0-alpha.1",
+        expected: false,
+      },
+      {
+        comparator: "^5.0.0-alpha.1",
+        expected: true,
+      },
+      {
+        comparator: "^6.0.0-alpha.1",
+        expected: false,
+      },
+    ])("extension comparator test: %p", ({ comparator, expected }) => {
+      const manifest: LensExtensionManifest = { name: "extensionName", version: "0.0.1", engines: { lens: comparator}};
+
+      expect(isCompatibleExtension(manifest,)).toBe(expected);
+    });
+  });
+});

--- a/src/extensions/extension-compatibility.ts
+++ b/src/extensions/extension-compatibility.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import semver from "semver";
+import { appSemVer } from "../common/vars";
+import type { LensExtensionManifest } from "./lens-extension";
+
+export function isCompatibleExtension(manifest: LensExtensionManifest): boolean {
+  if (manifest.engines?.lens) {
+    /* include Lens's prerelease tag in the matching so the extension's compatibility is not limited by it */
+    return semver.satisfies(appSemVer, manifest.engines.lens, { includePrerelease: true });
+  }
+
+  return false;
+}

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -34,9 +34,8 @@ import { extensionInstaller } from "./extension-installer";
 import { ExtensionsStore } from "./extensions-store";
 import { ExtensionLoader } from "./extension-loader";
 import type { LensExtensionId, LensExtensionManifest } from "./lens-extension";
-import semver from "semver";
-import { appSemVer } from "../common/vars";
 import { isProduction } from "../common/vars";
+import { isCompatibleExtension } from "./extension-compatibility";
 
 export interface InstalledExtension {
   id: LensExtensionId;
@@ -362,13 +361,7 @@ export class ExtensionDiscovery extends Singleton {
       const extensionDir = path.dirname(manifestPath);
       const npmPackage = path.join(extensionDir, `${manifest.name}-${manifest.version}.tgz`);
       const absolutePath = (isProduction && await fse.pathExists(npmPackage)) ? npmPackage : extensionDir;
-      let isCompatible = isBundled;
-
-      /* assume bundled extensions are compatibile */
-      if (!isBundled && manifest.engines?.lens) {
-        /* include Lens's prerelease tag in the matching so the extension's compatibility is not limited by it */
-        isCompatible = semver.satisfies(appSemVer, manifest.engines.lens, { includePrerelease: true });
-      }
+      const isCompatible = isBundled || isCompatibleExtension(manifest);
 
       return {
         id,

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -364,13 +364,12 @@ export class ExtensionDiscovery extends Singleton {
       const absolutePath = (isProduction && await fse.pathExists(npmPackage)) ? npmPackage : extensionDir;
       let isCompatible = isBundled;
 
-      if (manifest.engines?.lens) {
+      /* assume bundled extensions are compatibile */
+      if (!isBundled && manifest.engines?.lens) {
         const appSemVerLatestImplied = appSemVer;
 
-        if (appSemVerLatestImplied.prerelease?.[0] === "latest") {
-          /* remove the "latest" prerelease tag so as not to require the extension to specify it */
-          appSemVerLatestImplied.prerelease = [];
-        }
+        /* remove any prerelease tag so the extension's compatibility is not limited by it */
+        appSemVerLatestImplied.prerelease = [];
         isCompatible = semver.satisfies(appSemVerLatestImplied, manifest.engines.lens);
       }
 

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -366,11 +366,8 @@ export class ExtensionDiscovery extends Singleton {
 
       /* assume bundled extensions are compatibile */
       if (!isBundled && manifest.engines?.lens) {
-        const appSemVerLatestImplied = appSemVer;
-
-        /* remove any prerelease tag so the extension's compatibility is not limited by it */
-        appSemVerLatestImplied.prerelease = [];
-        isCompatible = semver.satisfies(appSemVerLatestImplied, manifest.engines.lens);
+        /* include Lens's prerelease tag in the matching so the extension's compatibility is not limited by it */
+        isCompatible = semver.satisfies(appSemVer, manifest.engines.lens, { includePrerelease: true });
       }
 
       return {


### PR DESCRIPTION
- ignore Lens's prerelease tag when checking extension compatibility
- assume bundled extensions are compatible

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>