### PR TITLE
Prefer SHELL over PTYSHELL

### DIFF
--- a/src/main/shell-session/local-shell-session.ts
+++ b/src/main/shell-session/local-shell-session.ts
@@ -32,12 +32,11 @@ export class LocalShellSession extends ShellSession {
   }
 
   public async open() {
-
     const env = await this.getCachedShellEnv();
-    const shell = env.PTYSHELL;
+    const shell = env.SHELL || env.PTYSHELL;
     const args = await this.getShellArgs(shell);
 
-    super.open(env.PTYSHELL, args, env);
+    super.open(shell, args, env);
   }
 
   protected async getShellArgs(shell: string): Promise<string[]> {


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

At least on macOS the SHELL env var is set instead of the PTYSHELL env var if you change your default shell.