### PR TITLE
Fix network:services clusterIP column sort

### DIFF
--- a/src/renderer/components/+network-services/services.tsx
+++ b/src/renderer/components/+network-services/services.tsx
@@ -30,6 +30,7 @@ import { Badge } from "../badge";
 import { serviceStore } from "./services.store";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
 import type { ServicesRouteParams } from "../../../common/routes";
+import { ipAddressStringToBigInt } from "../../utils";
 
 enum columnId {
   name = "name",
@@ -57,10 +58,10 @@ export class Services extends React.Component<Props> {
         sortingCallbacks={{
           [columnId.name]: (service: Service) => service.getName(),
           [columnId.namespace]: (service: Service) => service.getNs(),
-          [columnId.selector]: (service: Service) => service.getSelector(),
-          [columnId.ports]: (service: Service) => (service.spec.ports || []).map(({ port }) => port)[0],
-          [columnId.clusterIp]: (service: Service) => service.getClusterIp(),
           [columnId.type]: (service: Service) => service.getType(),
+          [columnId.clusterIp]: (service: Service) => ipAddressStringToBigInt(service.getClusterIp()).toString(),
+          [columnId.ports]: (service: Service) => (service.spec.ports || []).map(({ port }) => port)[0],
+          [columnId.selector]: (service: Service) => service.getSelector(),
           [columnId.age]: (service: Service) => service.getTimeDiffFromNow(),
           [columnId.status]: (service: Service) => service.getStatus(),
         }}

--- a/src/renderer/utils/__tests__/convertIPAddress.test.ts
+++ b/src/renderer/utils/__tests__/convertIPAddress.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { ipAddressStringToBigInt } from "../convertIPAddress";
+
+describe("ipAddressStringToBigInt tests", () => {
+  test("Empty string", () => {
+    expect(ipAddressStringToBigInt("")).toStrictEqual(BigInt(0));
+  });
+
+  test("None value", () => {
+    expect(ipAddressStringToBigInt("None")).toStrictEqual(BigInt(0));
+  });
+
+  test("Invalid IPV4", () => {
+    expect(ipAddressStringToBigInt("256.0.0.0")).toStrictEqual(BigInt(0));
+  });
+
+  test("Invalid IPV6", () => {
+    expect(ipAddressStringToBigInt("fffg:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).toStrictEqual(BigInt(0));
+  });
+
+  test("Min IPV4", () => {
+    expect(ipAddressStringToBigInt("0.0.0.0")).toStrictEqual(BigInt(0));
+  });
+
+  test("Min IPV6", () => {
+    expect(ipAddressStringToBigInt("::")).toStrictEqual(BigInt(0));
+  });
+
+  test("Random IPV4", () => {
+    expect(ipAddressStringToBigInt("10.10.10.10")).toStrictEqual(BigInt("168430090"));
+  });
+
+  test("Random IPV4 2", () => {
+    expect(ipAddressStringToBigInt("172.16.1.1")).toStrictEqual(BigInt("2886729985"));
+  });
+
+  test("Random IPV6", () => {
+    expect(ipAddressStringToBigInt("2001:0db8:85a3::8a2e:0370:7334")).toStrictEqual(BigInt("42540766452641154071740215577757643572"));
+  });
+
+
+  test("Max IPV4", () => {
+    expect(ipAddressStringToBigInt("255.255.255.255")).toStrictEqual(BigInt("4294967295"));
+  });
+
+  test("Max IPV6", () => {
+    expect(ipAddressStringToBigInt("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).toStrictEqual(BigInt("340282366920938463463374607431768211455"));
+  });
+});

--- a/src/renderer/utils/convertIPAddress.ts
+++ b/src/renderer/utils/convertIPAddress.ts
@@ -19,23 +19,26 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// Common usage utils & helpers
+import ipaddr from "ipaddr.js";
 
-export * from "../../common/event-emitter";
-export * from "../../common/utils";
-export * from "./convertCpu";
-export * from "./convertIPAddress";
-export * from "./convertMemory";
-export * from "./copyToClipboard";
-export * from "./createStorage";
-export * from "./cssNames";
-export * from "./cssVar";
-export * from "./display-booleans";
-export * from "./formatDuration";
-export * from "./interval";
-export * from "./isMiddleClick";
-export * from "./isReactNode";
-export * from "./metricUnitsToNumber";
-export * from "./prevDefault";
-export * from "./saveFile";
-export * from "./storageHelper";
+export function ipAddressStringToBigInt(value: string): BigInt {
+  let result = BigInt(0);
+
+  if (!ipaddr.isValid(value)) {
+    return result;
+  }
+
+  const byteArr = ipaddr.parse(value).toByteArray();
+  let multiplier = byteArr.length;
+
+  byteArr.forEach(byte => {
+    if (byte !== 0) {
+      const value = BigInt(byte) << BigInt(8*(multiplier-1));
+
+      result += value;
+    }
+    multiplier -= 1;
+  });
+
+  return result;
+}


### PR DESCRIPTION
### Description
This PR updates the sortingCallback of the `clusterIP` table column in the `network-services` component. More specifically, it uses a newly introduced helper function: `ipAddressStringToBigInt()` to convert the IP Address string to a BigInt, and then back to a string (BigInt is not a supported type for `TableSortCallback`).

Resolves: https://github.com/lensapp/lens/issues/3344

### Tests
Added unit tests under `src/renderer/utils/__test__/convertIPAddress.test.ts`:

```
 PASS  src/renderer/utils/__tests__/convertIPAddress.test.ts
  ipAddressStringToBigInt tests
    ✓ Empty string (2 ms)
    ✓ None value (1 ms)
    ✓ Invalid IPV4
    ✓ Invalid IPV6
    ✓ Min IPV4 (1 ms)
    ✓ Min IPV6
    ✓ Random IPV4 (1 ms)
    ✓ Random IPV4 2
    ✓ Random IPV6
    ✓ Max IPV4
    ✓ Max IPV6

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        0.821 s, estimated 7 s
Ran all test suites matching /src\/renderer\/utils\/__tests__\/convertIPAddress.test.ts/i.
Done in 3.83s.
```

Signed-off-by: devodev abalexandrebarone@gmail.com