### PR TITLE
Fix broken shell when workdir not exists

### DIFF
--- a/src/main/shell-session/local-shell-session.ts
+++ b/src/main/shell-session/local-shell-session.ts
@@ -31,8 +31,11 @@ export class LocalShellSession extends ShellSession {
     return [helmCli.getBinaryDir()];
   }
 
-  public async open() {
+  protected get cwd(): string | undefined {
+    return this.cluster.preferences?.terminalCWD;
+  }
 
+  public async open() {
     const env = await this.getCachedShellEnv();
     const shell = env.PTYSHELL;
     const args = await this.getShellArgs(shell);

--- a/src/main/shell-session/node-shell-session.ts
+++ b/src/main/shell-session/node-shell-session.ts
@@ -32,6 +32,10 @@ export class NodeShellSession extends ShellSession {
   protected podId = `node-shell-${uuid()}`;
   protected kc: KubeConfig;
 
+  protected get cwd(): string | undefined {
+    return undefined;
+  }
+
   constructor(socket: WebSocket, cluster: Cluster, protected nodeName: string) {
     super(socket, cluster);
   }


### PR DESCRIPTION
- validate shell session cwd exists, otherwise use default: `env.HOME`.

Resolves: https://github.com/lensapp/lens/issues/125