### PR TITLE
Set res.statusCode before flushing headers

### DIFF
--- a/src/main/proxy/lens-proxy.ts
+++ b/src/main/proxy/lens-proxy.ts
@@ -168,7 +168,10 @@ export class LensProxy extends Singleton {
       if (!res.headersSent && req.url) {
         const url = new URL(req.url, "http://localhost");
 
-        if (url.searchParams.has("watch")) res.flushHeaders();
+        if (url.searchParams.has("watch")) {
+          res.statusCode = proxyRes.statusCode;
+          res.flushHeaders();
+        }
       }
     });
 


### PR DESCRIPTION
Otherwise in some cases we return `200` (which is default) for error responses.