### PR TITLE
Make Sentry captures Winston based logger message

### DIFF
--- a/src/common/sentry.ts
+++ b/src/common/sentry.ts
@@ -28,7 +28,7 @@ import logger from "../main/logger";
 /**
  * "Translate" 'browser' to 'main' as Lens developer more familiar with the term 'main'
  */
-export function mapProcessName(processType: string) {
+function mapProcessName(processType: string) {
   if (processType === "browser") {
     return "main";
   }

--- a/src/common/sentry.ts
+++ b/src/common/sentry.ts
@@ -28,7 +28,7 @@ import logger from "../main/logger";
 /**
  * "Translate" 'browser' to 'main' as Lens developer more familiar with the term 'main'
  */
-function mapProcessName(processType: string) {
+export function mapProcessName(processType: string) {
   if (processType === "browser") {
     return "main";
   }

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -23,6 +23,7 @@ import { app, remote } from "electron";
 import winston from "winston";
 import * as Sentry from "@sentry/electron";
 import { isDebugging, isTestEnv } from "../common/vars";
+import { mapProcessName } from "../common/sentry";
 
 const logLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : isDebugging ? "debug" : "info";
 const consoleOptions: winston.transports.ConsoleTransportOptions = {
@@ -74,7 +75,7 @@ const proxiedLogger: Logger = new Proxy(logger, {
         property(...params);
 
         const tags = {
-          process: process.type,
+          process: mapProcessName(process.type),
           logger: "winston"
         };
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -23,7 +23,6 @@ import { app, remote } from "electron";
 import winston from "winston";
 import * as Sentry from "@sentry/electron";
 import { isDebugging, isTestEnv } from "../common/vars";
-import { mapProcessName } from "../common/sentry";
 
 const logLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : isDebugging ? "debug" : "info";
 const consoleOptions: winston.transports.ConsoleTransportOptions = {
@@ -75,7 +74,7 @@ const proxiedLogger: Logger = new Proxy(logger, {
         property(...params);
 
         const tags = {
-          process: mapProcessName(process.type),
+          process: process.type,
           logger: "winston"
         };
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -63,7 +63,7 @@ const isLoggerError = (unknown: unknown, key: LoggerKeys): unknown is LoggerErro
 /**
  * Proxied version of logger
  * 
- * Captures error message using Sentry.captureException(...params) when logger.error(...params)
+ * Captures error message using Sentry.captureMessage(...params) when logger.error(...params)
  */
 const proxiedLogger: Logger = new Proxy(logger, {
   get(target: Logger, key: LoggerKeys) {
@@ -91,7 +91,7 @@ const proxiedLogger: Logger = new Proxy(logger, {
             extra: extra ? { ...extra } : null
           });
         } catch {
-          // fallback to just captureException(params) (issue will have 'unknown' title in Sentry dashbaird)
+          // fallback to just captureException(params) (issue will have 'unknown' title in Sentry dashboard)
           Sentry.captureException(params, { tags });
         }
       };

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -51,8 +51,8 @@ const logger = winston.createLogger({
 });
 
 type Logger = ReturnType<typeof winston.createLogger>;
-type LoggerKeys = keyof typeof logger;
-type LoggerError = typeof logger.error;
+type LoggerKeys = keyof Logger;
+type LoggerError = Logger["error"];
 
 /**
  * Type guard to ensure unknown is logger.error function


### PR DESCRIPTION
In addition to `console.error` and `exception`, this PR allows Sentry to capture `logger.error` error messages.

To verify it works as expected, please try `logger.error(any string or object)` in both renderer process and main process.

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>