### PR TITLE
Failing to load KubeStateMetrics should only warn

### DIFF
--- a/src/renderer/components/+workloads-pods/pods.store.ts
+++ b/src/renderer/components/+workloads-pods/pods.store.ts
@@ -51,11 +51,9 @@ export class PodsStore extends KubeObjectStore<Pod> {
 
   async loadKubeMetrics(namespace?: string) {
     try {
-      const metrics = await podMetricsApi.list({ namespace });
-
-      this.kubeMetrics.replace(metrics);
+      this.kubeMetrics.replace(await podMetricsApi.list({ namespace }));
     } catch (error) {
-      console.error("loadKubeMetrics failed", error);
+      console.warn("loadKubeMetrics failed", error);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://sentry.io/organizations/k8slens/issues/2514308208/?project=5753768