### PR TITLE
Failing to load chart releases should only warn

### DIFF
--- a/src/renderer/components/+apps-releases/release.store.ts
+++ b/src/renderer/components/+apps-releases/release.store.ts
@@ -91,7 +91,7 @@ export class ReleaseStore extends ItemStore<HelmRelease> {
       this.failedLoading = false;
     } catch (error) {
       this.failedLoading = true;
-      console.error("Loading Helm Chart releases has failed", error);
+      console.warn("Loading Helm Chart releases has failed", error);
 
       if (error.error) {
         Notifications.error(error.error);


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/3398