### PR TITLE
release v5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.1.0

## 🐛 Bug Fixes

* Fix broken shell when workdir not exists (#3349) @devodev
* Display toleration's value in pod-details (#3384) @Nokel81
* Failing to load chart releases should only warn (#3399) @Nokel81
* Failing to load KubeStateMetrics should only warn (#3394) @Nokel81
* Fix clusters not being defined  (#3392) @Nokel81
* Stringify errors that get sent to notifications (#3393) @Nokel81

## 🧰 Maintenance

* Bump mock-fs from 4.12.0 to 4.14.0 (#3117) @dependabot
* Fix spelling (#3181) @jsoref
* getPortFrom should log the lines it retrived if it fails to get a port (#3395) @Nokel81


Signed-off-by: Sebastian Malton <sebastian@malton.name>