### PR TITLE
Allow clicking on selector badge to navigate to filtered pods/nodes page

### DIFF
--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -19,6 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { KubeObject } from "../kube-object";
 import { IAffinity, WorkloadKubeObject } from "../workload-kube-object";
 import { autoBind } from "../../utils";
 import { IMetrics, metricsApi } from "./metrics.api";
@@ -409,7 +410,7 @@ export class Pod extends WorkloadKubeObject {
   getNodeSelectors(): string[] {
     const { nodeSelector = {} } = this.spec;
 
-    return Object.entries(nodeSelector).map(values => values.join(": "));
+    return KubeObject.stringifyLabels(nodeSelector);
   }
 
   getTolerations() {

--- a/src/renderer/components/+network-services/service-details.tsx
+++ b/src/renderer/components/+network-services/service-details.tsx
@@ -24,7 +24,7 @@ import "./service-details.scss";
 import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { DrawerItem, DrawerTitle } from "../drawer";
-import { Badge } from "../badge";
+import { Badge, BadgeNavigatable } from "../badge";
 import type { KubeObjectDetailsProps } from "../kube-object";
 import type { Service } from "../../api/endpoints";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
@@ -61,7 +61,7 @@ export class ServiceDetails extends React.Component<Props> {
         <KubeObjectMeta object={service}/>
 
         <DrawerItem name="Selector" labelsOnly>
-          {service.getSelector().map(selector => <Badge key={selector} label={selector}/>)}
+          {service.getSelector().map(selector => <BadgeNavigatable key={selector} searchFilter={selector} resource="pods"/>)}
         </DrawerItem>
 
         <DrawerItem name="Type">

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -24,7 +24,7 @@ import "./daemonset-details.scss";
 import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { DrawerItem } from "../drawer";
-import { Badge } from "../badge";
+import { BadgeNavigatable } from "../badge";
 import { PodDetailsStatuses } from "../+workloads-pods/pod-details-statuses";
 import { PodDetailsTolerations } from "../+workloads-pods/pod-details-tolerations";
 import { PodDetailsAffinities } from "../+workloads-pods/pod-details-affinities";
@@ -83,16 +83,12 @@ export class DaemonSetDetails extends React.Component<Props> {
         <KubeObjectMeta object={daemonSet}/>
         {selectors.length > 0 &&
         <DrawerItem name="Selector" labelsOnly>
-          {
-            selectors.map(label => <Badge key={label} label={label}/>)
-          }
+          {selectors.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="pods"/>)}
         </DrawerItem>
         }
         {nodeSelector.length > 0 &&
         <DrawerItem name="Node Selector" labelsOnly>
-          {
-            nodeSelector.map(label => (<Badge key={label} label={label}/>))
-          }
+          {nodeSelector.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="nodes"/>)}
         </DrawerItem>
         }
         {images.length > 0 &&

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { DrawerItem } from "../drawer";
-import { Badge } from "../badge";
+import { Badge, BadgeNavigatable } from "../badge";
 import type { Deployment } from "../../api/endpoints";
 import { PodDetailsTolerations } from "../+workloads-pods/pod-details-tolerations";
 import { PodDetailsAffinities } from "../+workloads-pods/pod-details-affinities";
@@ -91,18 +91,12 @@ export class DeploymentDetails extends React.Component<Props> {
         </DrawerItem>
         {selectors.length > 0 &&
         <DrawerItem name="Selector" labelsOnly>
-          {
-            selectors.map(label => <Badge key={label} label={label}/>)
-          }
+          {selectors.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="pods"/>)}
         </DrawerItem>
         }
         {nodeSelector.length > 0 &&
         <DrawerItem name="Node Selector">
-          {
-            nodeSelector.map(label => (
-              <Badge key={label} label={label}/>
-            ))
-          }
+          {nodeSelector.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="nodes"/>)}
         </DrawerItem>
         }
         <DrawerItem name="Strategy Type">

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -28,7 +28,7 @@ import { Link } from "react-router-dom";
 import { autorun, observable, reaction, makeObservable } from "mobx";
 import { IPodMetrics, nodesApi, Pod, pvcApi, configMapApi } from "../../api/endpoints";
 import { DrawerItem, DrawerTitle } from "../drawer";
-import { Badge } from "../badge";
+import { Badge, BadgeNavigatable } from "../badge";
 import { boundMethod, cssNames, interval, toJS } from "../../utils";
 import { PodDetailsContainer } from "./pod-details-container";
 import { PodDetailsAffinities } from "./pod-details-affinities";
@@ -152,11 +152,7 @@ export class PodDetails extends React.Component<Props> {
         }
         {nodeSelector.length > 0 &&
         <DrawerItem name="Node Selector">
-          {
-            nodeSelector.map(label => (
-              <Badge key={label} label={label}/>
-            ))
-          }
+          {nodeSelector.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="nodes"/>)}
         </DrawerItem>
         }
         <PodDetailsTolerations workload={pod}/>

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -23,7 +23,7 @@ import "./replicaset-details.scss";
 import React from "react";
 import { reaction } from "mobx";
 import { DrawerItem } from "../drawer";
-import { Badge } from "../badge";
+import { BadgeNavigatable } from "../badge";
 import { replicaSetStore } from "./replicasets.store";
 import { PodDetailsStatuses } from "../+workloads-pods/pod-details-statuses";
 import { PodDetailsTolerations } from "../+workloads-pods/pod-details-tolerations";
@@ -83,16 +83,12 @@ export class ReplicaSetDetails extends React.Component<Props> {
         <KubeObjectMeta object={replicaSet}/>
         {selectors.length > 0 &&
         <DrawerItem name="Selector" labelsOnly>
-          {
-            selectors.map(label => <Badge key={label} label={label}/>)
-          }
+          {selectors.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="pods"/>)}
         </DrawerItem>
         }
         {nodeSelector.length > 0 &&
         <DrawerItem name="Node Selector" labelsOnly>
-          {
-            nodeSelector.map(label => <Badge key={label} label={label}/>)
-          }
+          {nodeSelector.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="nodes"/>)}
         </DrawerItem>
         }
         {images.length > 0 &&

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -24,7 +24,7 @@ import "./statefulset-details.scss";
 import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { reaction } from "mobx";
-import { Badge } from "../badge";
+import { BadgeNavigatable } from "../badge";
 import { DrawerItem } from "../drawer";
 import { PodDetailsStatuses } from "../+workloads-pods/pod-details-statuses";
 import { PodDetailsTolerations } from "../+workloads-pods/pod-details-tolerations";
@@ -82,18 +82,12 @@ export class StatefulSetDetails extends React.Component<Props> {
         <KubeObjectMeta object={statefulSet}/>
         {selectors.length &&
         <DrawerItem name="Selector" labelsOnly>
-          {
-            selectors.map(label => <Badge key={label} label={label}/>)
-          }
+          {selectors.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="pods"/>)}
         </DrawerItem>
         }
         {nodeSelector.length > 0 &&
         <DrawerItem name="Node Selector" labelsOnly>
-          {
-            nodeSelector.map(label => (
-              <Badge key={label} label={label}/>
-            ))
-          }
+          {nodeSelector.map(label => <BadgeNavigatable key={label} searchFilter={label} resource="nodes"/>)}
         </DrawerItem>
         }
         {images.length > 0 &&

--- a/src/renderer/components/badge/badge-navigatable.tsx
+++ b/src/renderer/components/badge/badge-navigatable.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import { observer } from "mobx-react";
+import { Badge } from ".";
+import { navigate } from "../../navigation/helpers";
+import { cssNames } from "../../utils";
+import type { KubeResource } from "../../../common/rbac";
+import { podsURL } from "../../../common/routes/workloads";
+import { nodesURL } from "../../../common/routes/nodes";
+import type { buildURL } from "../../../common/utils/buildUrl";
+
+const navigateURL: Partial<Record<KubeResource, ReturnType<typeof buildURL>>> = {
+  "pods": podsURL,
+  "nodes": nodesURL,
+};
+
+interface Props {
+  className?: string
+  resource: KubeResource
+  searchFilter: string
+}
+
+@observer
+export class BadgeNavigatable extends React.Component<Props> {
+
+  render() {
+    const { className, resource, searchFilter } = this.props;
+
+    return (
+      <Badge
+        className={cssNames("BadgeNavigatable", className)}
+        label={searchFilter}
+        tooltip={`Navigate to ${resource}`}
+        onClick={(event) => {
+          navigate(navigateURL[resource]({ query: { search: searchFilter }}));
+          event.stopPropagation();
+        }}
+      />
+    );
+  }
+}

--- a/src/renderer/components/badge/badge.module.css
+++ b/src/renderer/components/badge/badge.module.css
@@ -34,6 +34,13 @@
   cursor: pointer;
 }
 
+.badge.clickable:hover {
+  background-color: var(--mainBackground);
+  box-shadow: 0 0 0 1pt var(--primary);
+  outline: none;
+  transition: .1s;
+}
+
 .badge:not(.isExpanded) {
   white-space: nowrap;
   overflow: hidden;

--- a/src/renderer/components/badge/index.ts
+++ b/src/renderer/components/badge/index.ts
@@ -20,3 +20,4 @@
  */
 
 export * from "./badge";
+export * from "./Badge-navigatable";


### PR DESCRIPTION
### Description
- Add `BadgeNavigatable` component that navigates to a resource page on click
- Update the `.Badge.clickable:hover` style to now have a primary-colored outline
- Use `stringifyLabels` in `getNodeSelectors` of `WorkloadKubeObject` to align with other `getNodeSelectors` (use `=` separator)

Replaces `Selector` and `Node Selector` badges of: `Services`, `Pods`, `Daemonsets`, `Deployments`, `Replicasets` and `Statefulsets`.

### Screenshots

Service selector on hover

![image](https://user-images.githubusercontent.com/48306674/126048396-19305521-2d56-4d07-a53c-1c44c5bb2a69.png)

Pod node selector on hover

![image](https://user-images.githubusercontent.com/48306674/126048613-7e06fe09-fd9e-4b5e-90ed-bc843263d296.png)

Filtered pods (Pod node selector)

![image](https://user-images.githubusercontent.com/48306674/126048449-ece63c00-166f-4023-b8dc-e5559813f3c5.png)

Service annotations on hover (update to `.Badge.clickable:hover`)

![image](https://user-images.githubusercontent.com/48306674/126048475-b7031565-e377-45d2-be53-cbc55e905b6e.png)

---

Resolves https://github.com/lensapp/lens/issues/41