### PR TITLE
Allow having table columns hidden by default

### DIFF
--- a/src/common/user-store/preferences-helpers.ts
+++ b/src/common/user-store/preferences-helpers.ts
@@ -23,7 +23,7 @@ import moment from "moment-timezone";
 import path from "path";
 import os from "os";
 import { ThemeStore } from "../../renderer/theme.store";
-import { ObservableToggleSet } from "../utils";
+import { observable, ObservableMap } from "mobx";
 
 export interface KubeconfigSyncEntry extends KubeconfigSyncValue {
   filePath: string;
@@ -184,14 +184,14 @@ const openAtLogin: PreferenceDescription<boolean> = {
   },
 };
 
-const hiddenTableColumns: PreferenceDescription<[string, string[]][], Map<string, ObservableToggleSet<string>>> = {
+const hiddenTableColumns: PreferenceDescription<[string, [string, boolean][]][], Map<string, ObservableMap<string, boolean>>> = {
   fromStore(val) {
     return new Map(
-      (val ?? []).map(([tableId, columnIds]) => [tableId, new ObservableToggleSet(columnIds)])
+      (val ?? []).map(([tableId, columns]) => [tableId, observable.map(columns)])
     );
   },
   toStore(val) {
-    const res: [string, string[]][] = [];
+    const res: [string, [string, boolean][]][] = [];
 
     for (const [table, columns] of val) {
       if (columns.size) {

--- a/src/common/user-store/user-store.ts
+++ b/src/common/user-store/user-store.ts
@@ -21,7 +21,7 @@
 
 import { app, remote } from "electron";
 import semver from "semver";
-import { action, computed, observable, reaction, makeObservable } from "mobx";
+import { action, computed, observable, reaction, makeObservable, ObservableMap } from "mobx";
 import { BaseStore } from "../base-store";
 import migrations from "../../migrations/user-store";
 import { getAppVersion } from "../utils/app-version";
@@ -29,7 +29,7 @@ import { kubeConfigDefaultPath } from "../kube-helpers";
 import { appEventBus } from "../event-bus";
 import path from "path";
 import { fileNameMigration } from "../../migrations/user-store";
-import { ObservableToggleSet, toJS } from "../../renderer/utils";
+import { toJS } from "../../renderer/utils";
 import { DESCRIPTORS, KubeconfigSyncValue, UserPreferencesModel } from "./preferences-helpers";
 import logger from "../../main/logger";
 
@@ -79,7 +79,7 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
    * The column IDs under each configurable table ID that have been configured
    * to not be shown
    */
-  hiddenTableColumns = observable.map<string, ObservableToggleSet<string>>();
+  hiddenTableColumns = observable.map<string, ObservableMap<string, boolean>>();
 
   /**
    * The set of file/folder paths to be synced
@@ -136,12 +136,12 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
   /**
    * Toggles the hidden configuration of a table's column
    */
-  toggleTableColumnVisibility(tableId: string, columnId: string) {
-    if (!this.hiddenTableColumns.get(tableId)) {
-      this.hiddenTableColumns.set(tableId, new ObservableToggleSet());
+  toggleTableColumnVisibility(tableId: string, columnId: string, defaultHidden: boolean) {
+    if (this.hiddenTableColumns.get(tableId)?.get(columnId) === undefined){
+      this.hiddenTableColumns.get(tableId)?.set(columnId, !defaultHidden);
+    } else if (!!this.hiddenTableColumns.get(tableId)?.get(columnId) !== defaultHidden) {
+      this.hiddenTableColumns.get(tableId)?.delete(columnId);
     }
-
-    this.hiddenTableColumns.get(tableId).toggle(columnId);
   }
 
   @action

--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -494,6 +494,10 @@ export class Pod extends WorkloadKubeObject {
     return this.spec.nodeSelector?.["kubernetes.io/os"] || this.spec.nodeSelector?.["beta.kubernetes.io/os"];
   }
 
+  getIP(): string | undefined {
+    return this.status?.podIP;
+  }
+
   getIPs(): string[] {
     if(!this.status.podIPs) return [];
     const podIPs = this.status.podIPs;

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -45,10 +45,11 @@ enum columnId {
   namespace = "namespace",
   containers = "containers",
   restarts = "restarts",
-  age = "age",
-  qos = "qos",
-  node = "node",
   owners = "owners",
+  node = "node",
+  qos = "qos",
+  ip = "ip",
+  age = "age",
   status = "status",
 }
 
@@ -102,15 +103,16 @@ export class Pods extends React.Component<Props> {
           [columnId.containers]: pod => pod.getContainers().length,
           [columnId.restarts]: pod => pod.getRestartsCount(),
           [columnId.owners]: pod => pod.getOwnerRefs().map(ref => ref.kind),
-          [columnId.qos]: pod => pod.getQosClass(),
           [columnId.node]: pod => pod.getNodeName(),
+          [columnId.ip]: pod => pod.getIP(),
+          [columnId.qos]: pod => pod.getQosClass(),
           [columnId.age]: pod => pod.getTimeDiffFromNow(),
           [columnId.status]: pod => pod.getStatusMessage(),
         }}
         searchFilters={[
           pod => pod.getSearchFields(),
           pod => pod.getStatusMessage(),
-          pod => pod.status.podIP,
+          pod => pod.getIP(),
           pod => pod.getNodeName(),
         ]}
         renderHeaderTitle="Pods"
@@ -122,6 +124,7 @@ export class Pods extends React.Component<Props> {
           { title: "Restarts", className: "restarts", sortBy: columnId.restarts, id: columnId.restarts },
           { title: "Controlled By", className: "owners", sortBy: columnId.owners, id: columnId.owners },
           { title: "Node", className: "node", sortBy: columnId.node, id: columnId.node },
+          { title: "Pod IP", className: "ip", sortBy: columnId.ip, id: columnId.ip },
           { title: "QoS", className: "qos", sortBy: columnId.qos, id: columnId.qos },
           { title: "Age", className: "age", sortBy: columnId.age, id: columnId.age },
           { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
@@ -151,6 +154,7 @@ export class Pods extends React.Component<Props> {
               </Link>
             </Badge>
             : "",
+          pod.getIP(),
           pod.getQosClass(),
           pod.getAge(),
           { title: pod.getStatusMessage(), className: kebabCase(pod.getStatusMessage()) }

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -97,6 +97,7 @@ export class Pods extends React.Component<Props> {
         dependentStores={[volumeClaimStore, eventStore]}
         tableId = "workloads_pods"
         isConfigurable
+        hiddenColumns={[columnId.qos]}
         sortingCallbacks={{
           [columnId.name]: pod => pod.getName(),
           [columnId.namespace]: pod => pod.getNs(),


### PR DESCRIPTION
Based on https://github.com/lensapp/lens/pull/3418

- Introduces `hiddenColumns` attribute in `ItemListLayoutProps`
- Make `QoS` column in pods table hidden by default (effectively replaces `QoS` with `Pod IP`)

Breaking change: Format of `hiddenTableColumns` in user-store updated from `Map<string, Set<string>>` to `Map<string, Map<string, boolean>>`

![table-columns-hidden-by-default](https://user-images.githubusercontent.com/48306674/126429386-96a1bef7-0900-46d1-acb0-0cb01dd9fab1.gif)

Signed-off-by: devodev abalexandrebarone@gmail.com