### PR TITLE
Catalog render optimizations

### DIFF
--- a/__mocks__/windowMock.ts
+++ b/__mocks__/windowMock.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+Object.defineProperty(window, "requestIdleCallback", {
+  writable: true,
+  value: jest.fn().mockImplementation(callback => callback()),
+});
+
+Object.defineProperty(window, "cancelIdleCallback", {
+  writable: true,
+  value: jest.fn(),
+});
+
+export default {};

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     },
     "moduleNameMapper": {
       "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.ts",
-      "\\.(svg)$": "<rootDir>/__mocks__/imageMock.ts"
+      "\\.(svg)$": "<rootDir>/__mocks__/imageMock.ts",
+      "src/(.*)": "<rootDir>/__mocks__/windowMock.ts"
     },
     "modulePathIgnorePatterns": [
       "<rootDir>/dist",

--- a/src/common/user-store/user-store.ts
+++ b/src/common/user-store/user-store.ts
@@ -137,7 +137,11 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
    * Toggles the hidden configuration of a table's column
    */
   toggleTableColumnVisibility(tableId: string, columnId: string) {
-    this.hiddenTableColumns.get(tableId)?.toggle(columnId);
+    if (!this.hiddenTableColumns.get(tableId)) {
+      this.hiddenTableColumns.set(tableId, new ObservableToggleSet());
+    }
+
+    this.hiddenTableColumns.get(tableId).toggle(columnId);
   }
 
   @action

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -44,6 +44,7 @@ import { CatalogMenu } from "./catalog-menu";
 import { HotbarIcon } from "../hotbar/hotbar-icon";
 import { RenderDelay } from "../render-delay/render-delay";
 import { CatalogTopbar } from "../cluster-manager/catalog-topbar";
+import type { TableSortCallback } from "../table";
 
 export const previousActiveTab = createAppStorage("catalog-previous-active-tab", "");
 
@@ -194,8 +195,17 @@ export class Catalog extends React.Component<Props> {
 
   renderList() {
     const { activeCategory } = this.catalogEntityStore;
+    const tableId = activeCategory ? `catalog-items-${activeCategory.metadata.name.replace(" ", "")}` : "catalog-items";
+    let sortingCallbacks: { [sortBy: string]: TableSortCallback } = {
+      [sortBy.name]: (item: CatalogEntityItem<CatalogEntity>) => item.name,
+      [sortBy.source]: (item: CatalogEntityItem<CatalogEntity>) => item.source,
+      [sortBy.status]: (item: CatalogEntityItem<CatalogEntity>) => item.phase,
+    };
 
-    const tableId = activeCategory ? `catalog-items-${activeCategory?.metadata.name.replace(" ", "")}` : "catalog-items";
+    sortingCallbacks = activeCategory ? sortingCallbacks : {
+      ...sortingCallbacks,
+      [sortBy.kind]: (item: CatalogEntityItem<CatalogEntity>) => item.kind,
+    };
 
     if (this.activeTab === undefined) {
       return null;
@@ -209,12 +219,7 @@ export class Catalog extends React.Component<Props> {
         isConfigurable={true}
         className="CatalogItemList"
         store={this.catalogEntityStore}
-        sortingCallbacks={{
-          [sortBy.name]: (item: CatalogEntityItem<CatalogEntity>) => item.name,
-          [sortBy.kind]: (item: CatalogEntityItem<CatalogEntity>) => item.kind,
-          [sortBy.source]: (item: CatalogEntityItem<CatalogEntity>) => item.source,
-          [sortBy.status]: (item: CatalogEntityItem<CatalogEntity>) => item.phase,
-        }}
+        sortingCallbacks={sortingCallbacks}
         searchFilters={[
           (entity: CatalogEntityItem<CatalogEntity>) => entity.searchFields,
         ]}

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -42,6 +42,8 @@ import { CatalogEntityDetails } from "./catalog-entity-details";
 import { catalogURL, CatalogViewRouteParam } from "../../../common/routes";
 import { CatalogMenu } from "./catalog-menu";
 import { HotbarIcon } from "../hotbar/hotbar-icon";
+import { RenderDelay } from "../render-delay/render-delay";
+import { CatalogTopbar } from "../cluster-manager/catalog-topbar";
 
 export const previousActiveTab = createAppStorage("catalog-previous-active-tab", "");
 
@@ -144,7 +146,11 @@ export class Catalog extends React.Component<Props> {
   };
 
   renderNavigation() {
-    return <CatalogMenu activeItem={this.activeTab} onItemClick={this.onTabChange}/>;
+    return (
+      <RenderDelay>
+        <CatalogMenu activeItem={this.activeTab} onItemClick={this.onTabChange}/>
+      </RenderDelay>
+    );
   }
 
   renderItemMenu = (item: CatalogEntityItem<CatalogEntity>) => {
@@ -172,69 +178,37 @@ export class Catalog extends React.Component<Props> {
 
   renderIcon(item: CatalogEntityItem<CatalogEntity>) {
     return (
-      <HotbarIcon
-        uid={`catalog-icon-${item.getId()}`}
-        title={item.getName()}
-        source={item.source}
-        src={item.entity.spec.icon?.src}
-        material={item.entity.spec.icon?.material}
-        background={item.entity.spec.icon?.background}
-        size={24}
-      />
+      <RenderDelay>
+        <HotbarIcon
+          uid={`catalog-icon-${item.getId()}`}
+          title={item.getName()}
+          source={item.source}
+          src={item.entity.spec.icon?.src}
+          material={item.entity.spec.icon?.material}
+          background={item.entity.spec.icon?.background}
+          size={24}
+        />
+      </RenderDelay>
     );
   }
 
-  renderSingleCategoryList() {
+  renderList() {
+    const { activeCategory } = this.catalogEntityStore;
+
+    const tableId = activeCategory ? `catalog-items-${activeCategory?.metadata.name.replace(" ", "")}` : "catalog-items";
+
+    if (this.activeTab === undefined) {
+      return null;
+    }
+
     return (
       <ItemListLayout
-        key={this.catalogEntityStore.activeCategory.getId()}
-        tableId={`catalog-items-${this.catalogEntityStore.activeCategory?.metadata.name.replace(" ", "")}`}
-        renderHeaderTitle={this.catalogEntityStore.activeCategory?.metadata.name}
+        tableId={tableId}
+        renderHeaderTitle={activeCategory?.metadata.name || "Browse All"}
         isSelectable={false}
         isConfigurable={true}
         className="CatalogItemList"
         store={this.catalogEntityStore}
-        sortingCallbacks={{
-          [sortBy.name]: (item: CatalogEntityItem<CatalogEntity>) => item.name,
-          [sortBy.source]: (item: CatalogEntityItem<CatalogEntity>) => item.source,
-          [sortBy.status]: (item: CatalogEntityItem<CatalogEntity>) => item.phase,
-        }}
-        searchFilters={[
-          (entity: CatalogEntityItem<CatalogEntity>) => entity.searchFields,
-        ]}
-        renderTableHeader={[
-          { title: "", className: css.iconCell, id: "icon" },
-          { title: "Name", className: css.nameCell, sortBy: sortBy.name, id: "name" },
-          { title: "Source", className: css.sourceCell, sortBy: sortBy.source, id: "source" },
-          { title: "Labels", className: css.labelsCell, id: "labels" },
-          { title: "Status", className: css.statusCell, sortBy: sortBy.status, id: "status" },
-        ]}
-        customizeTableRowProps={(item: CatalogEntityItem<CatalogEntity>) => ({
-          disabled: !item.enabled,
-        })}
-        renderTableContents={(item: CatalogEntityItem<CatalogEntity>) => [
-          this.renderIcon(item),
-          item.name,
-          item.source,
-          item.getLabelBadges(),
-          { title: item.phase, className: cssNames(css[item.phase]) }
-        ]}
-        onDetails={this.onDetails}
-        renderItemMenu={this.renderItemMenu}
-      />
-    );
-  }
-
-  renderAllCategoriesList() {
-    return (
-      <ItemListLayout
-        key="all"
-        renderHeaderTitle={"Browse All"}
-        isSelectable={false}
-        isConfigurable={true}
-        className="CatalogItemList"
-        store={this.catalogEntityStore}
-        tableId="catalog-items"
         sortingCallbacks={{
           [sortBy.name]: (item: CatalogEntityItem<CatalogEntity>) => item.name,
           [sortBy.kind]: (item: CatalogEntityItem<CatalogEntity>) => item.kind,
@@ -247,35 +221,26 @@ export class Catalog extends React.Component<Props> {
         renderTableHeader={[
           { title: "", className: css.iconCell, id: "icon" },
           { title: "Name", className: css.nameCell, sortBy: sortBy.name, id: "name" },
-          { title: "Kind", className: css.kindCell, sortBy: sortBy.kind, id: "kind" },
+          !activeCategory && { title: "Kind", className: css.kindCell, sortBy: sortBy.kind, id: "kind" },
           { title: "Source", className: css.sourceCell, sortBy: sortBy.source, id: "source" },
           { title: "Labels", className: css.labelsCell, id: "labels" },
           { title: "Status", className: css.statusCell, sortBy: sortBy.status, id: "status" },
-        ]}
+        ].filter(Boolean)}
         customizeTableRowProps={(item: CatalogEntityItem<CatalogEntity>) => ({
           disabled: !item.enabled,
         })}
         renderTableContents={(item: CatalogEntityItem<CatalogEntity>) => [
           this.renderIcon(item),
           item.name,
-          item.kind,
+          !activeCategory && item.kind,
           item.source,
           item.getLabelBadges(),
           { title: item.phase, className: cssNames(css[item.phase]) }
-        ]}
-        detailsItem={this.catalogEntityStore.selectedItem}
+        ].filter(Boolean)}
         onDetails={this.onDetails}
         renderItemMenu={this.renderItemMenu}
       />
     );
-  }
-
-  renderCategoryList() {
-    if (this.activeTab === undefined) {
-      return null;
-    }
-
-    return this.catalogEntityStore.activeCategory ? this.renderSingleCategoryList() : this.renderAllCategoriesList();
   }
 
   render() {
@@ -284,21 +249,28 @@ export class Catalog extends React.Component<Props> {
     }
 
     return (
-      <MainLayout sidebar={this.renderNavigation()}>
-        <div className="p-6 h-full">
-          { this.renderCategoryList() }
-        </div>
-        {
-          this.catalogEntityStore.selectedItem
-            ? <CatalogEntityDetails
-              item={this.catalogEntityStore.selectedItem}
-              hideDetails={() => this.catalogEntityStore.selectedItemId = null}
-            />
-            : <CatalogAddButton
-              category={this.catalogEntityStore.activeCategory}
-            />
-        }
-      </MainLayout>
+      <>
+        <CatalogTopbar/>
+        <MainLayout sidebar={this.renderNavigation()}>
+          <div className="p-6 h-full">
+            { this.renderList() }
+          </div>
+          {
+            this.catalogEntityStore.selectedItem
+              ? <CatalogEntityDetails
+                item={this.catalogEntityStore.selectedItem}
+                hideDetails={() => this.catalogEntityStore.selectedItemId = null}
+              />
+              : (
+                <RenderDelay>
+                  <CatalogAddButton
+                    category={this.catalogEntityStore.activeCategory}
+                  />
+                </RenderDelay>
+              )
+          }
+        </MainLayout>
+      </>
     );
   }
 }

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -148,9 +148,7 @@ export class Catalog extends React.Component<Props> {
 
   renderNavigation() {
     return (
-      <RenderDelay>
-        <CatalogMenu activeItem={this.activeTab} onItemClick={this.onTabChange}/>
-      </RenderDelay>
+      <CatalogMenu activeItem={this.activeTab} onItemClick={this.onTabChange}/>
     );
   }
 

--- a/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -35,10 +35,6 @@
     position: relative;
     display: flex;
     flex-direction: column;
-
-    > * {
-      z-index: 1;
-    }
   }
 
   .HotbarMenu {
@@ -52,7 +48,7 @@
   #lens-views {
     position: absolute;
     left: 0;
-    top: 0;
+    top: 40px; // Move below top bar
     right: 0;
     bottom: 0;
     display: flex;

--- a/src/renderer/components/cluster-manager/cluster-manager.tsx
+++ b/src/renderer/components/cluster-manager/cluster-manager.tsx
@@ -34,8 +34,6 @@ import { Extensions } from "../+extensions";
 import { HotbarMenu } from "../hotbar/hotbar-menu";
 import { EntitySettings } from "../+entity-settings";
 import { Welcome } from "../+welcome";
-import { ClusterTopbar } from "./cluster-topbar";
-import { CatalogTopbar } from "./catalog-topbar";
 import * as routes from "../../../common/routes";
 
 @observer
@@ -43,8 +41,6 @@ export class ClusterManager extends React.Component {
   render() {
     return (
       <div className="ClusterManager">
-        <Route component={CatalogTopbar} {...routes.catalogRoute} />
-        <Route component={ClusterTopbar} {...routes.clusterViewRoute} />
         <main>
           <div id="lens-views"/>
           <Switch>

--- a/src/renderer/components/cluster-manager/cluster-view.tsx
+++ b/src/renderer/components/cluster-manager/cluster-view.tsx
@@ -34,6 +34,7 @@ import { catalogEntityRegistry } from "../../api/catalog-entity-registry";
 import { navigate } from "../../navigation";
 import { catalogURL, ClusterViewRouteParams } from "../../../common/routes";
 import { previousActiveTab } from "../+catalog";
+import { ClusterTopbar } from "./cluster-topbar";
 
 interface Props extends RouteComponentProps<ClusterViewRouteParams> {
 }
@@ -104,6 +105,7 @@ export class ClusterView extends React.Component<Props> {
   render() {
     return (
       <div className="ClusterView flex column align-center">
+        <ClusterTopbar {...this.props}/>
         {this.renderStatus()}
       </div>
     );

--- a/src/renderer/components/input/input.scss
+++ b/src/renderer/components/input/input.scss
@@ -61,7 +61,6 @@
       width: 0;
       height: 2px;
       background: $primary;
-      transition: width 250ms;
     }
   }
 

--- a/src/renderer/components/menu/menu-actions.tsx
+++ b/src/renderer/components/menu/menu-actions.tsx
@@ -30,6 +30,7 @@ import { Icon, IconProps } from "../icon";
 import { Menu, MenuItem, MenuProps } from "../menu";
 import uniqueId from "lodash/uniqueId";
 import isString from "lodash/isString";
+import { RenderDelay } from "../render-delay/render-delay";
 
 export interface MenuActionsProps extends Partial<MenuProps> {
   className?: string;
@@ -124,30 +125,32 @@ export class MenuActions extends React.Component<MenuActionsProps> {
     return (
       <>
         {this.renderTriggerIcon()}
-        <Menu
-          htmlFor={this.id}
-          isOpen={this.isOpen} open={this.toggle} close={this.toggle}
-          className={menuClassName}
-          usePortal={autoClose}
-          closeOnScroll={autoClose}
-          closeOnClickItem={autoCloseOnSelect ?? autoClose }
-          closeOnClickOutside={autoClose}
-          {...menuProps}
-        >
-          {children}
-          {updateAction && (
-            <MenuItem onClick={updateAction}>
-              <Icon material="edit" interactive={toolbar} tooltip="Edit"/>
-              <span className="title">Edit</span>
-            </MenuItem>
-          )}
-          {removeAction && (
-            <MenuItem onClick={this.remove}>
-              <Icon material="delete" interactive={toolbar} tooltip="Delete"/>
-              <span className="title">Remove</span>
-            </MenuItem>
-          )}
-        </Menu>
+        <RenderDelay>
+          <Menu
+            htmlFor={this.id}
+            isOpen={this.isOpen} open={this.toggle} close={this.toggle}
+            className={menuClassName}
+            usePortal={autoClose}
+            closeOnScroll={autoClose}
+            closeOnClickItem={autoCloseOnSelect ?? autoClose }
+            closeOnClickOutside={autoClose}
+            {...menuProps}
+          >
+            {children}
+            {updateAction && (
+              <MenuItem onClick={updateAction}>
+                <Icon material="edit" interactive={toolbar} tooltip="Edit"/>
+                <span className="title">Edit</span>
+              </MenuItem>
+            )}
+            {removeAction && (
+              <MenuItem onClick={this.remove}>
+                <Icon material="delete" interactive={toolbar} tooltip="Delete"/>
+                <span className="title">Remove</span>
+              </MenuItem>
+            )}
+          </Menu>
+        </RenderDelay>
       </>
     );
   }

--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -260,6 +260,8 @@ export class Menu extends React.Component<MenuProps, State> {
   }
 
   onBlur() {
+    if (!this.isOpen) return;
+
     if (document.activeElement?.tagName == "IFRAME") {
       this.close();
     }

--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -260,7 +260,7 @@ export class Menu extends React.Component<MenuProps, State> {
   }
 
   onBlur() {
-    if (!this.isOpen) return;
+    if (!this.isOpen) return;  // Prevents triggering document.activeElement for each <Menu/> instance
 
     if (document.activeElement?.tagName == "IFRAME") {
       this.close();

--- a/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
+++ b/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+import { RenderDelay } from "../render-delay";
+
+describe("<RenderDelay/>", () => {
+  it("renders w/o errors", () => {
+    const { container } = render(<RenderDelay><button>My button</button></RenderDelay>);
+
+    expect(container).toBeInstanceOf(HTMLElement);
+  });
+
+  it("renders it's child", () => {
+    const { getByText } = render(<RenderDelay><button>My button</button></RenderDelay>);
+
+    expect(getByText("My button")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/render-delay/render-delay.tsx
+++ b/src/renderer/components/render-delay/render-delay.tsx
@@ -19,54 +19,43 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* This file overwrites basic Material UI TreeView styles. Can contain only following
-  classnames: root, expanded, selected, content, iconContainer, label, group
-*/
+import React from "react";
+import { makeObservable, observable } from "mobx";
+import { observer } from "mobx-react";
+import { boundMethod } from "../../utils";
 
-.root {
-  color: var(--textColorTertiary);
-  min-height: 26px;
+interface Props {
+  placeholder?: React.ReactNode;
+  children: unknown;
 }
 
-.label {
-  font-size: var(--font-size);
-  background-color: transparent!important;
-}
+@observer
+export class RenderDelay extends React.Component<Props> {
+  @observable isVisible = false;
 
-.label:hover {
-  background-color: transparent;
-}
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
-.content {
-  min-height: 26px;
-}
+  componentDidMount() {
+    window.requestIdleCallback(this.showContents);
+  }
 
-.content:hover {
-  background-color: var(--sidebarItemHoverBackground);
-  border-radius: 2px;
-}
+  componentWillUnmount() {
+    window.cancelIdleCallback(this.showContents);
+  }
 
-.content:active {
-  color: white;
-  background-color: var(--blue);
-}
+  @boundMethod
+  showContents() {
+    this.isVisible = true;
+  }
 
-.group {
-  margin-left: 0px;
-}
+  render() {
+    if (!this.isVisible) {
+      return this.props.placeholder || null;
+    }
 
-.group .iconContainer {
-  margin-left: 28px;
-}
-
-.selected > *:first-child {
-  background-color: var(--blue);
-  color: white;
-  border-radius: 2px;
-}
-
-.iconContainer {
-  width: 21px;
-  margin-left: 5px;
-  margin-right: 0;
+    return this.props.children;
+  }
 }

--- a/src/renderer/components/render-delay/render-delay.tsx
+++ b/src/renderer/components/render-delay/render-delay.tsx
@@ -39,7 +39,9 @@ export class RenderDelay extends React.Component<Props> {
   }
 
   componentDidMount() {
-    window.requestIdleCallback(this.showContents);
+    const guaranteedFireTime = 1000;
+
+    window.requestIdleCallback(this.showContents, { timeout: guaranteedFireTime });
   }
 
   componentWillUnmount() {

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -24,4 +24,9 @@ declare global {
   interface Element {
     scrollIntoViewIfNeeded(opt_center?: boolean): void;
   }
+
+  interface Window {
+    requestIdleCallback(callback: () => void);
+    cancelIdleCallback(callback: () => void);
+  }
 }

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -26,7 +26,7 @@ declare global {
   }
 
   interface Window {
-    requestIdleCallback(callback: () => void);
+    requestIdleCallback(callback: () => void, options: { timeout: number });
     cancelIdleCallback(callback: () => void);
   }
 }


### PR DESCRIPTION
Optimising Catalog list rendering by:
1. Using same `ItemListLayout` for each section
2. Moving slow components (components which user doesn't need to see instantly, e. g. submenus, add clusters button etc) to newly introduced `<RenderDelay/>`. It renders its own children only when browser goes to idle state (not busy rendering something).

Dev mode:


https://user-images.githubusercontent.com/9607060/126120105-64139e3a-a7c2-4c0a-bdca-2930dfedbd97.mov

Production mode:


https://user-images.githubusercontent.com/9607060/126120154-f1c07862-639b-4dbc-8382-43f22bfba4f8.mov

Fixes #3389 