### PR TITLE
Improving metric queries

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -62,6 +62,8 @@ export enum ClusterMetricsResourceType {
   VolumeClaim = "VolumeClaim",
   ReplicaSet = "ReplicaSet",
   DaemonSet = "DaemonSet",
+  Job = "Job",
+  Namespace = "Namespace"
 }
 
 export type ClusterRefreshOptions = {

--- a/src/renderer/api/endpoints/cluster.api.ts
+++ b/src/renderer/api/endpoints/cluster.api.ts
@@ -52,6 +52,26 @@ export class ClusterApi extends KubeApi<Cluster> {
   }
 }
 
+export function getMetricsByNodeNames(nodeNames: string[], params?: IMetricsReqParams): Promise<IClusterMetrics> {
+  const nodes = nodeNames.join("|");
+  const opts = { category: "cluster", nodes };
+
+  return metricsApi.getMetrics({
+    memoryUsage: opts,
+    memoryRequests: opts,
+    memoryLimits: opts,
+    memoryCapacity: opts,
+    cpuUsage: opts,
+    cpuRequests: opts,
+    cpuLimits: opts,
+    cpuCapacity: opts,
+    podUsage: opts,
+    podCapacity: opts,
+    fsSize: opts,
+    fsUsage: opts
+  }, params);
+}
+
 export enum ClusterStatus {
   ACTIVE = "Active",
   CREATING = "Creating",

--- a/src/renderer/api/endpoints/cluster.api.ts
+++ b/src/renderer/api/endpoints/cluster.api.ts
@@ -26,30 +26,6 @@ import { KubeApi } from "../kube-api";
 export class ClusterApi extends KubeApi<Cluster> {
   static kind = "Cluster";
   static namespaced = true;
-
-  async getMetrics(nodeNames: string[], params?: IMetricsReqParams): Promise<IClusterMetrics> {
-    const nodes = nodeNames.join("|");
-    const opts = { category: "cluster", nodes };
-
-    return metricsApi.getMetrics({
-      memoryUsage: opts,
-      workloadMemoryUsage: opts,
-      memoryRequests: opts,
-      memoryLimits: opts,
-      memoryCapacity: opts,
-      memoryAllocatableCapacity: opts,
-      cpuUsage: opts,
-      cpuRequests: opts,
-      cpuLimits: opts,
-      cpuCapacity: opts,
-      cpuAllocatableCapacity: opts,
-      podUsage: opts,
-      podCapacity: opts,
-      podAllocatableCapacity: opts,
-      fsSize: opts,
-      fsUsage: opts
-    }, params);
-  }
 }
 
 export function getMetricsByNodeNames(nodeNames: string[], params?: IMetricsReqParams): Promise<IClusterMetrics> {
@@ -58,15 +34,19 @@ export function getMetricsByNodeNames(nodeNames: string[], params?: IMetricsReqP
 
   return metricsApi.getMetrics({
     memoryUsage: opts,
+    workloadMemoryUsage: opts,
     memoryRequests: opts,
     memoryLimits: opts,
     memoryCapacity: opts,
+    memoryAllocatableCapacity: opts,
     cpuUsage: opts,
     cpuRequests: opts,
     cpuLimits: opts,
     cpuCapacity: opts,
+    cpuAllocatableCapacity: opts,
     podUsage: opts,
     podCapacity: opts,
+    podAllocatableCapacity: opts,
     fsSize: opts,
     fsUsage: opts
   }, params);

--- a/src/renderer/api/endpoints/deployment.api.ts
+++ b/src/renderer/api/endpoints/deployment.api.ts
@@ -24,6 +24,8 @@ import moment from "moment";
 import { IAffinity, WorkloadKubeObject } from "../workload-kube-object";
 import { autoBind } from "../../utils";
 import { KubeApi } from "../kube-api";
+import { metricsApi } from "./metrics.api";
+import type { IPodMetrics } from "./pods.api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class DeploymentApi extends KubeApi<Deployment> {
@@ -66,6 +68,21 @@ export class DeploymentApi extends KubeApi<Deployment> {
       }
     });
   }
+}
+
+export function getMetricsForDeployments(deployments: Deployment[], namespace: string, selector = ""): Promise<IPodMetrics> {
+  const podSelector = deployments.map(deployment => `${deployment.getName()}-[[:alnum:]]{9,}-[[:alnum:]]{5}`).join("|");
+  const opts = { category: "pods", pods: podSelector, namespace, selector };
+
+  return metricsApi.getMetrics({
+    cpuUsage: opts,
+    memoryUsage: opts,
+    fsUsage: opts,
+    networkReceive: opts,
+    networkTransmit: opts,
+  }, {
+    namespace,
+  });
 }
 
 interface IContainerProbe {

--- a/src/renderer/api/endpoints/ingress.api.ts
+++ b/src/renderer/api/endpoints/ingress.api.ts
@@ -26,18 +26,19 @@ import { KubeApi } from "../kube-api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class IngressApi extends KubeApi<Ingress> {
-  getMetrics(ingress: string, namespace: string): Promise<IIngressMetrics> {
-    const opts = { category: "ingress", ingress, namespace };
+}
 
-    return metricsApi.getMetrics({
-      bytesSentSuccess: opts,
-      bytesSentFailure: opts,
-      requestDurationSeconds: opts,
-      responseDurationSeconds: opts
-    }, {
-      namespace,
-    });
-  }
+export function getMetricsForIngress(ingress: string, namespace: string): Promise<IIngressMetrics> {
+  const opts = { category: "ingress", ingress };
+
+  return metricsApi.getMetrics({
+    bytesSentSuccess: opts,
+    bytesSentFailure: opts,
+    requestDurationSeconds: opts,
+    responseDurationSeconds: opts
+  }, {
+    namespace,
+  });
 }
 
 export interface IIngressMetrics<T = IMetrics> {

--- a/src/renderer/api/endpoints/metrics.api.ts
+++ b/src/renderer/api/endpoints/metrics.api.ts
@@ -60,7 +60,7 @@ export interface IMetricsReqParams {
   namespace?: string;             // rbac-proxy validation param
 }
 
-export interface IResourceMetrics<T = IMetrics> {
+export interface IResourceMetrics<T extends IMetrics> {
   [metric: string]: T;
   cpuUsage: T;
   memoryUsage: T;

--- a/src/renderer/api/endpoints/metrics.api.ts
+++ b/src/renderer/api/endpoints/metrics.api.ts
@@ -60,6 +60,15 @@ export interface IMetricsReqParams {
   namespace?: string;             // rbac-proxy validation param
 }
 
+export interface IResourceMetrics<T = IMetrics> {
+  [metric: string]: T;
+  cpuUsage: T;
+  memoryUsage: T;
+  fsUsage: T;
+  networkReceive: T;
+  networkTransmit: T;
+}
+
 export const metricsApi = {
   async getMetrics<T = IMetricsQuery>(query: T, reqParams: IMetricsReqParams = {}): Promise<T extends object ? { [K in keyof T]: IMetrics } : IMetrics> {
     const { range = 3600, step = 60, namespace } = reqParams;

--- a/src/renderer/api/endpoints/namespaces.api.ts
+++ b/src/renderer/api/endpoints/namespaces.api.ts
@@ -22,6 +22,8 @@
 import { KubeApi } from "../kube-api";
 import { KubeObject } from "../kube-object";
 import { autoBind } from "../../utils";
+import { metricsApi } from "./metrics.api";
+import type { IPodMetrics } from "./pods.api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export enum NamespaceStatus {
@@ -50,6 +52,23 @@ export class Namespace extends KubeObject {
   }
 }
 
-export const namespacesApi = new KubeApi({
+export class NamespaceApi extends KubeApi<Namespace> {
+}
+
+export function getMetricsForNamespace(namespace: string, selector = ""): Promise<IPodMetrics> {
+  const opts = { category: "pods", pods: ".*", namespace, selector };
+
+  return metricsApi.getMetrics({
+    cpuUsage: opts,
+    memoryUsage: opts,
+    fsUsage: opts,
+    networkReceive: opts,
+    networkTransmit: opts,
+  }, {
+    namespace,
+  });
+}
+
+export const namespacesApi = new NamespaceApi({
   objectConstructor: Namespace,
 });

--- a/src/renderer/api/endpoints/nodes.api.ts
+++ b/src/renderer/api/endpoints/nodes.api.ts
@@ -26,20 +26,21 @@ import { KubeApi } from "../kube-api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class NodesApi extends KubeApi<Node> {
-  getMetrics(): Promise<INodeMetrics> {
-    const opts = { category: "nodes" };
+}
 
-    return metricsApi.getMetrics({
-      memoryUsage: opts,
-      workloadMemoryUsage: opts,
-      memoryCapacity: opts,
-      memoryAllocatableCapacity: opts,
-      cpuUsage: opts,
-      cpuCapacity: opts,
-      fsSize: opts,
-      fsUsage: opts
-    });
-  }
+export function getMetricsForAllNodes(): Promise<INodeMetrics> {
+  const opts = { category: "nodes"};
+
+  return metricsApi.getMetrics({
+    memoryUsage: opts,
+    workloadMemoryUsage: opts,
+    memoryCapacity: opts,
+    memoryAllocatableCapacity: opts,
+    cpuUsage: opts,
+    cpuCapacity: opts,
+    fsSize: opts,
+    fsUsage: opts
+  });
 }
 
 export interface INodeMetrics<T = IMetrics> {

--- a/src/renderer/api/endpoints/persistent-volume-claims.api.ts
+++ b/src/renderer/api/endpoints/persistent-volume-claims.api.ts
@@ -27,14 +27,15 @@ import { KubeApi } from "../kube-api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class PersistentVolumeClaimsApi extends KubeApi<PersistentVolumeClaim> {
-  getMetrics(pvcName: string, namespace: string): Promise<IPvcMetrics> {
-    return metricsApi.getMetrics({
-      diskUsage: { category: "pvc", pvc: pvcName, namespace },
-      diskCapacity: { category: "pvc", pvc: pvcName, namespace }
-    }, {
-      namespace
-    });
-  }
+}
+
+export function getMetricsForPvc(pvc: PersistentVolumeClaim): Promise<IPvcMetrics> {
+  return metricsApi.getMetrics({
+    diskUsage: { category: "pvc", pvc: pvc.getName() },
+    diskCapacity: { category: "pvc", pvc: pvc.getName() }
+  }, {
+    namespace: pvc.getNs()
+  });
 }
 
 export interface IPvcMetrics<T = IMetrics> {

--- a/src/renderer/api/endpoints/pods.api.ts
+++ b/src/renderer/api/endpoints/pods.api.ts
@@ -31,38 +31,38 @@ export class PodsApi extends KubeApi<Pod> {
 
     return this.request.get(path, { query });
   }
+}
 
-  getMetrics(pods: Pod[], namespace: string, selector = "pod, namespace"): Promise<IPodMetrics> {
-    const podSelector = pods.map(pod => pod.getName()).join("|");
-    const opts = { category: "pods", pods: podSelector, namespace, selector };
+export function getMetricsForPods(pods: Pod[], namespace: string, selector = "pod, namespace"): Promise<IPodMetrics> {
+  const podSelector = pods.map(pod => pod.getName()).join("|");
+  const opts = { category: "pods", pods: podSelector, namespace, selector };
 
-    return metricsApi.getMetrics({
-      cpuUsage: opts,
-      cpuRequests: opts,
-      cpuLimits: opts,
-      memoryUsage: opts,
-      memoryRequests: opts,
-      memoryLimits: opts,
-      fsUsage: opts,
-      networkReceive: opts,
-      networkTransmit: opts,
-    }, {
-      namespace,
-    });
-  }
+  return metricsApi.getMetrics({
+    cpuUsage: opts,
+    cpuRequests: opts,
+    cpuLimits: opts,
+    memoryUsage: opts,
+    memoryRequests: opts,
+    memoryLimits: opts,
+    fsUsage: opts,
+    networkReceive: opts,
+    networkTransmit: opts,
+  }, {
+    namespace,
+  });
 }
 
 export interface IPodMetrics<T = IMetrics> {
   [metric: string]: T;
   cpuUsage: T;
-  cpuRequests: T;
-  cpuLimits: T;
   memoryUsage: T;
-  memoryRequests: T;
-  memoryLimits: T;
   fsUsage: T;
   networkReceive: T;
   networkTransmit: T;
+  cpuRequests?: T;
+  cpuLimits?: T;
+  memoryRequests?: T;
+  memoryLimits?: T;
 }
 
 // Reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#read-log-pod-v1-core

--- a/src/renderer/api/endpoints/replica-set.api.ts
+++ b/src/renderer/api/endpoints/replica-set.api.ts
@@ -22,8 +22,9 @@
 import get from "lodash/get";
 import { autoBind } from "../../utils";
 import { WorkloadKubeObject } from "../workload-kube-object";
-import type { IPodContainer, Pod } from "./pods.api";
 import { KubeApi } from "../kube-api";
+import { metricsApi } from "./metrics.api";
+import type { IPodContainer, IPodMetrics, Pod } from "./pods.api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class ReplicaSetApi extends KubeApi<ReplicaSet> {
@@ -47,6 +48,21 @@ export class ReplicaSetApi extends KubeApi<ReplicaSet> {
       }
     });
   }
+}
+
+export function getMetricsForReplicaSets(replicasets: ReplicaSet[], namespace: string, selector = ""): Promise<IPodMetrics> {
+  const podSelector = replicasets.map(replicaset => `${replicaset.getName()}-[[:alnum:]]{5}`).join("|");
+  const opts = { category: "pods", pods: podSelector, namespace, selector };
+
+  return metricsApi.getMetrics({
+    cpuUsage: opts,
+    memoryUsage: opts,
+    fsUsage: opts,
+    networkReceive: opts,
+    networkTransmit: opts,
+  }, {
+    namespace,
+  });
 }
 
 export class ReplicaSet extends WorkloadKubeObject {

--- a/src/renderer/api/endpoints/stateful-set.api.ts
+++ b/src/renderer/api/endpoints/stateful-set.api.ts
@@ -20,10 +20,11 @@
  */
 
 import get from "lodash/get";
-import type { IPodContainer } from "./pods.api";
 import { IAffinity, WorkloadKubeObject } from "../workload-kube-object";
 import { autoBind } from "../../utils";
 import { KubeApi } from "../kube-api";
+import { metricsApi } from "./metrics.api";
+import type { IPodContainer, IPodMetrics } from "./pods.api";
 import type { KubeJsonApiData } from "../kube-json-api";
 
 export class StatefulSetApi extends KubeApi<StatefulSet> {
@@ -47,6 +48,21 @@ export class StatefulSetApi extends KubeApi<StatefulSet> {
       }
     });
   }
+}
+
+export function getMetricsForStatefulSets(statefulSets: StatefulSet[], namespace: string, selector = ""): Promise<IPodMetrics> {
+  const podSelector = statefulSets.map(statefulset => `${statefulset.getName()}-[[:digit:]]+`).join("|");
+  const opts = { category: "pods", pods: podSelector, namespace, selector };
+
+  return metricsApi.getMetrics({
+    cpuUsage: opts,
+    memoryUsage: opts,
+    fsUsage: opts,
+    networkReceive: opts,
+    networkTransmit: opts,
+  }, {
+    namespace,
+  });
 }
 
 export class StatefulSet extends WorkloadKubeObject {

--- a/src/renderer/components/+cluster/cluster-overview.store.ts
+++ b/src/renderer/components/+cluster/cluster-overview.store.ts
@@ -21,7 +21,7 @@
 
 import { action, observable, reaction, when, makeObservable } from "mobx";
 import { KubeObjectStore } from "../../kube-object.store";
-import { Cluster, clusterApi, IClusterMetrics } from "../../api/endpoints";
+import { Cluster, clusterApi, getMetricsByNodeNames, IClusterMetrics } from "../../api/endpoints";
 import { autoBind, createStorage } from "../../utils";
 import { IMetricsReqParams, normalizeMetrics } from "../../api/endpoints/metrics.api";
 import { nodesStore } from "../+nodes/nodes.store";
@@ -101,7 +101,7 @@ export class ClusterOverviewStore extends KubeObjectStore<Cluster> implements Cl
     const { masterNodes, workerNodes } = nodesStore;
     const nodes = this.metricNodeRole === MetricNodeRole.MASTER && masterNodes.length ? masterNodes : workerNodes;
 
-    this.metrics = await clusterApi.getMetrics(nodes.map(node => node.getName()), params);
+    this.metrics = await getMetricsByNodeNames(nodes.map(node => node.getName()), params);
     this.metricsLoaded = true;
   }
 

--- a/src/renderer/components/+network-ingresses/ingress.store.ts
+++ b/src/renderer/components/+network-ingresses/ingress.store.ts
@@ -18,31 +18,12 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
-import { observable, makeObservable } from "mobx";
-import { KubeObjectStore } from "../../kube-object.store";
-import { autoBind } from "../../utils";
-import { IIngressMetrics, Ingress, ingressApi } from "../../api/endpoints";
 import { apiManager } from "../../api/api-manager";
+import { Ingress, ingressApi } from "../../api/endpoints";
+import { KubeObjectStore } from "../../kube-object.store";
 
 export class IngressStore extends KubeObjectStore<Ingress> {
   api = ingressApi;
-  @observable metrics: IIngressMetrics = null;
-
-  constructor() {
-    super();
-
-    makeObservable(this);
-    autoBind(this);
-  }
-
-  async loadMetrics(ingress: Ingress) {
-    this.metrics = await this.api.getMetrics(ingress.getName(), ingress.getNs());
-  }
-
-  reset() {
-    this.metrics = null;
-  }
 }
 
 export const ingressStore = new IngressStore();

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -32,7 +32,7 @@ import { podsStore } from "../+workloads-pods/pods.store";
 import type { KubeObjectDetailsProps } from "../kube-object";
 import { getMetricsByNodeNames, IClusterMetrics, Node } from "../../api/endpoints";
 import { NodeCharts } from "./node-charts";
-import { observable, reaction } from "mobx";
+import { makeObservable, observable, reaction } from "mobx";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
@@ -47,6 +47,11 @@ interface Props extends KubeObjectDetailsProps<Node> {
 @observer
 export class NodeDetails extends React.Component<Props> {
   @observable metrics: Partial<IClusterMetrics>;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   @disposeOnUnmount
   clean = reaction(() => this.props.object.getName(), () => {

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -32,13 +32,14 @@ import { podsStore } from "../+workloads-pods/pods.store";
 import type { KubeObjectDetailsProps } from "../kube-object";
 import { getMetricsByNodeNames, IClusterMetrics, Node } from "../../api/endpoints";
 import { NodeCharts } from "./node-charts";
-import { action, observable, reaction } from "mobx";
+import { observable, reaction } from "mobx";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
 import { NodeDetailsResources } from "./node-details-resources";
 import { DrawerTitle } from "../drawer/drawer-title";
+import { boundMethod } from "../../utils";
 
 interface Props extends KubeObjectDetailsProps<Node> {
 }
@@ -56,7 +57,7 @@ export class NodeDetails extends React.Component<Props> {
     podsStore.reloadAll();
   }
 
-  @action
+  @boundMethod
   async loadMetrics() {
     const { object: node } = this.props;
 

--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -61,7 +61,7 @@ interface Props extends RouteComponentProps<NodesRouteParams> {
 @observer
 export class Nodes extends React.Component<Props> {
   @observable metrics: Partial<INodeMetrics> = {};
-  private metricsWatcher = interval(30, async () => await getMetricsForAllNodes());
+  private metricsWatcher = interval(30, async () => this.metrics = await getMetricsForAllNodes());
 
   componentDidMount() {
     this.metricsWatcher.start(true);

--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -28,7 +28,7 @@ import { TabLayout } from "../layout/tab-layout";
 import { nodesStore } from "./nodes.store";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { KubeObjectListLayout } from "../kube-object";
-import type { Node } from "../../api/endpoints/nodes.api";
+import { getMetricsForAllNodes, INodeMetrics, Node } from "../../api/endpoints/nodes.api";
 import { LineProgress } from "../line-progress";
 import { bytesToUnits } from "../../utils/convertMemory";
 import { Tooltip, TooltipPosition } from "../tooltip";
@@ -39,6 +39,8 @@ import { Badge } from "../badge/badge";
 import { kubeWatchApi } from "../../api/kube-watch-api";
 import { eventStore } from "../+events/event.store";
 import type { NodesRouteParams } from "../../../common/routes";
+import { observable } from "mobx";
+import isEmpty from "lodash/isEmpty";
 
 enum columnId {
   name = "name",
@@ -58,7 +60,8 @@ interface Props extends RouteComponentProps<NodesRouteParams> {
 
 @observer
 export class Nodes extends React.Component<Props> {
-  private metricsWatcher = interval(30, () => nodesStore.loadUsageMetrics());
+  @observable metrics: Partial<INodeMetrics> = {};
+  private metricsWatcher = interval(30, async () => await getMetricsForAllNodes());
 
   componentDidMount() {
     this.metricsWatcher.start(true);
@@ -73,8 +76,32 @@ export class Nodes extends React.Component<Props> {
     this.metricsWatcher.stop();
   }
 
+  getLastMetricValues(node: Node, metricNames: string[]): number[] {
+    if (isEmpty(this.metrics)) {
+      return [];
+    }
+    const nodeName = node.getName();
+
+    return metricNames.map(metricName => {
+      try {
+        const metric = this.metrics[metricName];
+        const result = metric.data.result.find(result => {
+          return [
+            result.metric.node,
+            result.metric.instance,
+            result.metric.kubernetes_node,
+          ].includes(nodeName);
+        });
+
+        return result ? parseFloat(result.values.slice(-1)[0][1]) : 0;
+      } catch (e) {
+        return 0;
+      }
+    });
+  }
+
   renderCpuUsage(node: Node) {
-    const metrics = nodesStore.getLastMetricValues(node, ["cpuUsage", "cpuCapacity"]);
+    const metrics = this.getLastMetricValues(node, ["cpuUsage", "cpuCapacity"]);
 
     if (!metrics || !metrics[1]) return <LineProgress value={0}/>;
     const usage = metrics[0];
@@ -97,7 +124,7 @@ export class Nodes extends React.Component<Props> {
   }
 
   renderMemoryUsage(node: Node) {
-    const metrics = nodesStore.getLastMetricValues(node, ["workloadMemoryUsage", "memoryAllocatableCapacity"]);
+    const metrics = this.getLastMetricValues(node, ["workloadMemoryUsage", "memoryAllocatableCapacity"]);
 
     if (!metrics || !metrics[1]) return <LineProgress value={0}/>;
     const usage = metrics[0];
@@ -116,7 +143,7 @@ export class Nodes extends React.Component<Props> {
   }
 
   renderDiskUsage(node: Node): any {
-    const metrics = nodesStore.getLastMetricValues(node, ["fsUsage", "fsSize"]);
+    const metrics = this.getLastMetricValues(node, ["fsUsage", "fsSize"]);
 
     if (!metrics || !metrics[1]) return <LineProgress value={0}/>;
     const usage = metrics[0];
@@ -172,9 +199,9 @@ export class Nodes extends React.Component<Props> {
           isSelectable={false}
           sortingCallbacks={{
             [columnId.name]: (node: Node) => node.getName(),
-            [columnId.cpu]: (node: Node) => nodesStore.getLastMetricValues(node, ["cpuUsage"]),
-            [columnId.memory]: (node: Node) => nodesStore.getLastMetricValues(node, ["memoryUsage"]),
-            [columnId.disk]: (node: Node) => nodesStore.getLastMetricValues(node, ["fsUsage"]),
+            [columnId.cpu]: (node: Node) => this.getLastMetricValues(node, ["cpuUsage"]),
+            [columnId.memory]: (node: Node) => this.getLastMetricValues(node, ["memoryUsage"]),
+            [columnId.disk]: (node: Node) => this.getLastMetricValues(node, ["fsUsage"]),
             [columnId.conditions]: (node: Node) => node.getNodeConditionText(),
             [columnId.taints]: (node: Node) => node.getTaints().length,
             [columnId.roles]: (node: Node) => node.getRoleLabels(),

--- a/src/renderer/components/+storage-volume-claims/volume-claim.store.ts
+++ b/src/renderer/components/+storage-volume-claims/volume-claim.store.ts
@@ -18,32 +18,12 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
-import { action, observable, makeObservable } from "mobx";
-import { KubeObjectStore } from "../../kube-object.store";
-import { autoBind } from "../../utils";
-import { IPvcMetrics, PersistentVolumeClaim, pvcApi } from "../../api/endpoints";
 import { apiManager } from "../../api/api-manager";
+import { PersistentVolumeClaim, pvcApi } from "../../api/endpoints";
+import { KubeObjectStore } from "../../kube-object.store";
 
 export class VolumeClaimStore extends KubeObjectStore<PersistentVolumeClaim> {
   api = pvcApi;
-  @observable metrics: IPvcMetrics = null;
-
-  constructor() {
-    super();
-
-    makeObservable(this);
-    autoBind(this);
-  }
-
-  @action
-  async loadMetrics(pvc: PersistentVolumeClaim) {
-    this.metrics = await pvcApi.getMetrics(pvc.getName(), pvc.getNs());
-  }
-
-  reset() {
-    this.metrics = null;
-  }
 }
 
 export const volumeClaimStore = new VolumeClaimStore();

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -39,6 +39,7 @@ import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
+import { boundMethod } from "../../utils";
 
 interface Props extends KubeObjectDetailsProps<DaemonSet> {
 }
@@ -56,6 +57,7 @@ export class DaemonSetDetails extends React.Component<Props> {
     podsStore.reloadAll();
   }
 
+  @boundMethod
   async loadMetrics() {
     const { object: daemonSet } = this.props;
 

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -34,7 +34,7 @@ import type { KubeObjectDetailsProps } from "../kube-object";
 import { DaemonSet, getMetricsForDaemonSets, IPodMetrics } from "../../api/endpoints";
 import { ResourceMetrics, ResourceMetricsText } from "../resource-metrics";
 import { PodCharts, podMetricTabs } from "../+workloads-pods/pod-charts";
-import { observable, reaction } from "mobx";
+import { makeObservable, observable, reaction } from "mobx";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
@@ -47,6 +47,11 @@ interface Props extends KubeObjectDetailsProps<DaemonSet> {
 @observer
 export class DaemonSetDetails extends React.Component<Props> {
   @observable metrics: IPodMetrics = null;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   @disposeOnUnmount
   clean = reaction(() => this.props.object, () => {

--- a/src/renderer/components/+workloads-daemonsets/daemonsets.store.ts
+++ b/src/renderer/components/+workloads-daemonsets/daemonsets.store.ts
@@ -18,30 +18,22 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { makeObservable } from "mobx";
 
-import { observable, makeObservable } from "mobx";
-import { KubeObjectStore } from "../../kube-object.store";
-import { autoBind } from "../../utils";
-import { DaemonSet, daemonSetApi, IPodMetrics, Pod, podsApi, PodStatus } from "../../api/endpoints";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { apiManager } from "../../api/api-manager";
+import { DaemonSet, daemonSetApi, Pod, PodStatus } from "../../api/endpoints";
+import { KubeObjectStore } from "../../kube-object.store";
+import { autoBind } from "../../utils";
 
 export class DaemonSetStore extends KubeObjectStore<DaemonSet> {
   api = daemonSetApi;
-
-  @observable metrics: IPodMetrics = null;
 
   constructor() {
     super();
 
     makeObservable(this);
     autoBind(this);
-  }
-
-  async loadMetrics(daemonSet: DaemonSet) {
-    const pods = this.getChildPods(daemonSet);
-
-    this.metrics = await podsApi.getMetrics(pods, daemonSet.getNs(), "");
   }
 
   getChildPods(daemonSet: DaemonSet): Pod[] {
@@ -66,10 +58,6 @@ export class DaemonSetStore extends KubeObjectStore<DaemonSet> {
     });
 
     return status;
-  }
-
-  reset() {
-    this.metrics = null;
   }
 }
 

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -41,6 +41,7 @@ import { replicaSetStore } from "../+workloads-replicasets/replicasets.store";
 import { DeploymentReplicaSets } from "./deployment-replicasets";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
+import { boundMethod } from "../../utils";
 
 interface Props extends KubeObjectDetailsProps<Deployment> {
 }
@@ -59,6 +60,7 @@ export class DeploymentDetails extends React.Component<Props> {
     replicaSetStore.reloadAll();
   }
 
+  @boundMethod
   async loadMetrics() {
     const { object: deployment } = this.props;
 

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -34,7 +34,7 @@ import type { KubeObjectDetailsProps } from "../kube-object";
 import { ResourceMetrics, ResourceMetricsText } from "../resource-metrics";
 import { deploymentStore } from "./deployments.store";
 import { PodCharts, podMetricTabs } from "../+workloads-pods/pod-charts";
-import { observable, reaction } from "mobx";
+import { makeObservable, observable, reaction } from "mobx";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { replicaSetStore } from "../+workloads-replicasets/replicasets.store";
@@ -49,6 +49,11 @@ interface Props extends KubeObjectDetailsProps<Deployment> {
 @observer
 export class DeploymentDetails extends React.Component<Props> {
   @observable metrics: IPodMetrics = null;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   @disposeOnUnmount
   clean = reaction(() => this.props.object, () => {

--- a/src/renderer/components/+workloads-deployments/deployments.store.ts
+++ b/src/renderer/components/+workloads-deployments/deployments.store.ts
@@ -18,17 +18,16 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { makeObservable } from "mobx";
 
-import { observable, makeObservable } from "mobx";
-import { Deployment, deploymentApi, IPodMetrics, podsApi, PodStatus } from "../../api/endpoints";
-import { KubeObjectStore } from "../../kube-object.store";
-import { autoBind } from "../../utils";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { apiManager } from "../../api/api-manager";
+import { Deployment, deploymentApi, PodStatus } from "../../api/endpoints";
+import { KubeObjectStore } from "../../kube-object.store";
+import { autoBind } from "../../utils";
 
 export class DeploymentStore extends KubeObjectStore<Deployment> {
   api = deploymentApi;
-  @observable metrics: IPodMetrics = null;
 
   constructor() {
     super();
@@ -41,12 +40,6 @@ export class DeploymentStore extends KubeObjectStore<Deployment> {
     return super.sortItems(items, [
       item => item.getReplicas(),
     ], "desc");
-  }
-
-  async loadMetrics(deployment: Deployment) {
-    const pods = this.getChildPods(deployment);
-
-    this.metrics = await podsApi.getMetrics(pods, deployment.getNs(), "");
   }
 
   getStatuses(deployments?: Deployment[]) {
@@ -73,10 +66,6 @@ export class DeploymentStore extends KubeObjectStore<Deployment> {
     return podsStore
       .getByLabel(deployment.getTemplateLabels())
       .filter(pod => pod.getNs() === deployment.getNs());
-  }
-
-  reset() {
-    this.metrics = null;
   }
 }
 

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -42,6 +42,7 @@ import { podMetricTabs, PodCharts } from "../+workloads-pods/pod-charts";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ResourceMetrics } from "../resource-metrics";
+import { boundMethod } from "autobind-decorator";
 
 interface Props extends KubeObjectDetailsProps<Job> {
 }
@@ -54,6 +55,7 @@ export class JobDetails extends React.Component<Props> {
     podsStore.reloadAll();
   }
 
+  @boundMethod
   async loadMetrics() {
     const { object: job } = this.props;
 

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -37,7 +37,7 @@ import { getMetricsForJobs, IPodMetrics, Job } from "../../api/endpoints";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { lookupApiLink } from "../../api/kube-api";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
-import { observable } from "mobx";
+import { makeObservable, observable } from "mobx";
 import { podMetricTabs, PodCharts } from "../+workloads-pods/pod-charts";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
@@ -50,6 +50,11 @@ interface Props extends KubeObjectDetailsProps<Job> {
 @observer
 export class JobDetails extends React.Component<Props> {
   @observable metrics: IPodMetrics = null;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   async componentDidMount() {
     podsStore.reloadAll();

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -33,18 +33,31 @@ import { PodDetailsAffinities } from "../+workloads-pods/pod-details-affinities"
 import { podsStore } from "../+workloads-pods/pods.store";
 import { jobStore } from "./job.store";
 import { getDetailsUrl, KubeObjectDetailsProps } from "../kube-object";
-import type { Job } from "../../api/endpoints";
+import { getMetricsForJobs, IPodMetrics, Job } from "../../api/endpoints";
 import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { lookupApiLink } from "../../api/kube-api";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
+import { observable } from "mobx";
+import { podMetricTabs, PodCharts } from "../+workloads-pods/pod-charts";
+import { ClusterMetricsResourceType } from "../../../main/cluster";
+import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
+import { ResourceMetrics } from "../resource-metrics";
 
 interface Props extends KubeObjectDetailsProps<Job> {
 }
 
 @observer
 export class JobDetails extends React.Component<Props> {
+  @observable metrics: IPodMetrics = null;
+
   async componentDidMount() {
     podsStore.reloadAll();
+  }
+
+  async loadMetrics() {
+    const { object: job } = this.props;
+
+    this.metrics = await getMetricsForJobs([job], job.getNs(), "");
   }
 
   render() {
@@ -57,9 +70,18 @@ export class JobDetails extends React.Component<Props> {
     const childPods = jobStore.getChildPods(job);
     const ownerRefs = job.getOwnerRefs();
     const condition = job.getCondition();
+    const isMetricHidden = getActiveClusterEntity()?.isMetricHidden(ClusterMetricsResourceType.Job);
 
     return (
       <div className="JobDetails">
+        {!isMetricHidden && (
+          <ResourceMetrics
+            loader={this.loadMetrics}
+            tabs={podMetricTabs} object={job} params={{ metrics: this.metrics }}
+          >
+            <PodCharts />
+          </ResourceMetrics>
+        )}
         <KubeObjectMeta object={job}/>
         <DrawerItem name="Selector" labelsOnly>
           {

--- a/src/renderer/components/+workloads-pods/pods.store.ts
+++ b/src/renderer/components/+workloads-pods/pods.store.ts
@@ -20,17 +20,16 @@
  */
 
 import countBy from "lodash/countBy";
-import { action, observable, makeObservable } from "mobx";
+import { observable, makeObservable } from "mobx";
 import { KubeObjectStore } from "../../kube-object.store";
 import { autoBind, cpuUnitsToNumber, unitsToBytes } from "../../utils";
-import { IPodMetrics, Pod, PodMetrics, podMetricsApi, podsApi } from "../../api/endpoints";
+import { Pod, PodMetrics, podMetricsApi, podsApi } from "../../api/endpoints";
 import { apiManager } from "../../api/api-manager";
 import type { WorkloadKubeObject } from "../../api/workload-kube-object";
 
 export class PodsStore extends KubeObjectStore<Pod> {
   api = podsApi;
 
-  @observable metrics: IPodMetrics = null;
   @observable kubeMetrics = observable.array<PodMetrics>([]);
 
   constructor() {
@@ -38,15 +37,6 @@ export class PodsStore extends KubeObjectStore<Pod> {
 
     makeObservable(this);
     autoBind(this);
-  }
-
-  @action
-  async loadMetrics(pod: Pod) {
-    this.metrics = await podsApi.getMetrics([pod], pod.getNs());
-  }
-
-  loadContainerMetrics(pod: Pod) {
-    return podsApi.getMetrics([pod], pod.getNs(), "container, namespace");
   }
 
   async loadKubeMetrics(namespace?: string) {
@@ -112,10 +102,6 @@ export class PodsStore extends KubeObjectStore<Pod> {
         memory: total.memory + unitsToBytes(memory)
       };
     }, empty);
-  }
-
-  reset() {
-    this.metrics = null;
   }
 }
 

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -21,7 +21,7 @@
 
 import "./replicaset-details.scss";
 import React from "react";
-import { observable, reaction } from "mobx";
+import { makeObservable, observable, reaction } from "mobx";
 import { DrawerItem } from "../drawer";
 import { Badge } from "../badge";
 import { replicaSetStore } from "./replicasets.store";
@@ -46,6 +46,11 @@ interface Props extends KubeObjectDetailsProps<ReplicaSet> {
 @observer
 export class ReplicaSetDetails extends React.Component<Props> {
   @observable metrics: IPodMetrics = null;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   @disposeOnUnmount
   clean = reaction(() => this.props.object, () => {

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -38,6 +38,7 @@ import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
+import { boundMethod } from "../../utils";
 
 interface Props extends KubeObjectDetailsProps<ReplicaSet> {
 }
@@ -55,6 +56,7 @@ export class ReplicaSetDetails extends React.Component<Props> {
     podsStore.reloadAll();
   }
 
+  @boundMethod
   async loadMetrics() {
     const { object: replicaSet } = this.props;
 

--- a/src/renderer/components/+workloads-replicasets/replicasets.store.ts
+++ b/src/renderer/components/+workloads-replicasets/replicasets.store.ts
@@ -18,30 +18,23 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { makeObservable } from "mobx";
 
-import { observable, makeObservable } from "mobx";
-import { autoBind } from "../../utils";
-import { KubeObjectStore } from "../../kube-object.store";
-import { Deployment, IPodMetrics, podsApi, ReplicaSet, replicaSetApi } from "../../api/endpoints";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { apiManager } from "../../api/api-manager";
+import { Deployment, ReplicaSet, replicaSetApi } from "../../api/endpoints";
 import { PodStatus } from "../../api/endpoints/pods.api";
+import { KubeObjectStore } from "../../kube-object.store";
+import { autoBind } from "../../utils";
 
 export class ReplicaSetStore extends KubeObjectStore<ReplicaSet> {
   api = replicaSetApi;
-  @observable metrics: IPodMetrics = null;
 
   constructor() {
     super();
 
     makeObservable(this);
     autoBind(this);
-  }
-
-  async loadMetrics(replicaSet: ReplicaSet) {
-    const pods = this.getChildPods(replicaSet);
-
-    this.metrics = await podsApi.getMetrics(pods, replicaSet.getNs(), "");
   }
 
   getChildPods(replicaSet: ReplicaSet) {
@@ -72,10 +65,6 @@ export class ReplicaSetStore extends KubeObjectStore<ReplicaSet> {
     return this.items.filter(replicaSet =>
       !!replicaSet.getOwnerRefs().find(owner => owner.uid === deployment.getId())
     );
-  }
-
-  reset() {
-    this.metrics = null;
   }
 }
 

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -39,6 +39,7 @@ import { PodDetailsList } from "../+workloads-pods/pod-details-list";
 import { KubeObjectMeta } from "../kube-object/kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../main/cluster";
+import { boundMethod } from "../../utils";
 
 interface Props extends KubeObjectDetailsProps<StatefulSet> {
 }
@@ -56,6 +57,7 @@ export class StatefulSetDetails extends React.Component<Props> {
     podsStore.reloadAll();
   }
 
+  @boundMethod
   async loadMetrics() {
     const { object: statefulSet } = this.props;
 

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -23,7 +23,7 @@ import "./statefulset-details.scss";
 
 import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
-import { observable, reaction } from "mobx";
+import { makeObservable, observable, reaction } from "mobx";
 import { Badge } from "../badge";
 import { DrawerItem } from "../drawer";
 import { PodDetailsStatuses } from "../+workloads-pods/pod-details-statuses";
@@ -47,6 +47,11 @@ interface Props extends KubeObjectDetailsProps<StatefulSet> {
 @observer
 export class StatefulSetDetails extends React.Component<Props> {
   @observable metrics: IPodMetrics = null;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
 
   @disposeOnUnmount
   clean = reaction(() => this.props.object, () => {

--- a/src/renderer/components/+workloads-statefulsets/statefulset.store.ts
+++ b/src/renderer/components/+workloads-statefulsets/statefulset.store.ts
@@ -18,30 +18,22 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { makeObservable } from "mobx";
 
-import { observable, makeObservable } from "mobx";
-import { autoBind } from "../../utils";
-import { KubeObjectStore } from "../../kube-object.store";
-import { IPodMetrics, podsApi, PodStatus, StatefulSet, statefulSetApi } from "../../api/endpoints";
 import { podsStore } from "../+workloads-pods/pods.store";
 import { apiManager } from "../../api/api-manager";
+import { PodStatus, StatefulSet, statefulSetApi } from "../../api/endpoints";
+import { KubeObjectStore } from "../../kube-object.store";
+import { autoBind } from "../../utils";
 
 export class StatefulSetStore extends KubeObjectStore<StatefulSet> {
   api = statefulSetApi;
-  @observable metrics: IPodMetrics = null;
 
   constructor() {
     super();
 
     makeObservable(this);
     autoBind(this);
-  }
-
-
-  async loadMetrics(statefulSet: StatefulSet) {
-    const pods = this.getChildPods(statefulSet);
-
-    this.metrics = await podsApi.getMetrics(pods, statefulSet.getNs(), "");
   }
 
   getChildPods(statefulSet: StatefulSet) {
@@ -66,10 +58,6 @@ export class StatefulSetStore extends KubeObjectStore<StatefulSet> {
     });
 
     return status;
-  }
-
-  reset() {
-    this.metrics = null;
   }
 }
 


### PR DESCRIPTION
* Metric query improvements extracted from #1944
* Metrics added to namespaces and jobs
* Metric loaders are moved from stores to React components. The reason here because metrics doesn't really relate to stores. See this comment https://github.com/lensapp/lens/pull/1944#discussion_r556622245

![node metrics](https://user-images.githubusercontent.com/9607060/126163915-7f3117b9-c6c1-4c58-9c3a-c4ce6d59f287.png)
