### PR TITLE
release v5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.1.1

## 🐛 Bug Fixes

* Fix HPA visibility (#3426) @vshakirova
* Skip previously bundled extensions (#3420) @jakolehm
* Fix KubeObjectStore loadAll error message (#3421) @jakolehm
* Check KubeObject.metadata is defined in getOwnerRefs (#3412) @Nokel81
* Check metadata labels is an object in getRoleLabels (#3416) @Nokel81
* Catch Cluster create error in cluster-manager (#3401) @Nokel81

## 🧰 Maintenance

* Log as errors the places where getPortFrom can fail (#3425) @Nokel81
* Bump typescript-plugin-css-modules from 3.2.0 to 3.4.0 (#3382) @dependabot
* Bump webpack from 4.44.2 to 4.46.0 (#3413) @dependabot

Signed-off-by: Sebastian Malton <sebastian@malton.name>