### PR TITLE
Fix misaligned spinner at cluster load

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-status.scss
+++ b/src/renderer/components/cluster-manager/cluster-status.scss
@@ -33,10 +33,14 @@
     max-width: 70vw;
     max-height: 40vh;
     white-space: pre-line;
+
+    p {
+      margin-bottom: $margin;
+    }
   }
 
   .Spinner {
-    --spinner-size: 48px;
+    --spinner-size: 38px;
     --spinner-border: calc(var(--spinner-size) / 10);
   }
 

--- a/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -102,7 +102,7 @@ export class ClusterStatus extends React.Component<Props> {
         <>
           <Spinner singleColor={false} />
           <pre className="kube-auth-out">
-            <p>{this.isReconnecting ? "Reconnecting..." : "Connecting..."}</p>
+            <p>{this.isReconnecting ? "Reconnecting" : "Connecting"}&hellip;</p>
             {authOutput.map(({ data, error }, index) => {
               return <p key={index} className={cssNames({ error })}>{data}</p>;
             })}


### PR DESCRIPTION
Ellipsis `...` after `Connecting` word creates a visual illusion of misaligned Spinner above. In this PR using the special HTLM `&hellip;` character which is smaller. It makes loading page to look neat.

Fixes #3406 

![loader](https://user-images.githubusercontent.com/9607060/126289185-9b3ae76f-7d8d-46b8-97dc-103182b779f7.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>