### PR TITLE
Fix kube auth proxy race condition

### DIFF
--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -146,8 +146,10 @@ export class ContextHandler {
         proxyEnv.HTTPS_PROXY = this.cluster.preferences.httpsProxy;
       }
       this.kubeAuthProxy = new KubeAuthProxy(this.cluster, proxyEnv);
-      await this.kubeAuthProxy.run();
+      this.kubeAuthProxy.run();
     }
+
+    await this.kubeAuthProxy.whenReady;
   }
 
   stopServer() {

--- a/src/main/kube-auth-proxy.ts
+++ b/src/main/kube-auth-proxy.ts
@@ -27,6 +27,7 @@ import { Kubectl } from "./kubectl";
 import logger from "./logger";
 import * as url from "url";
 import { getPortFrom } from "./utils/get-port";
+import { makeObservable, observable, when } from "mobx";
 
 export interface KubeAuthProxyLog {
   data: string;
@@ -47,8 +48,11 @@ export class KubeAuthProxy {
   protected env: NodeJS.ProcessEnv = null;
   protected proxyProcess: ChildProcess;
   protected kubectl: Kubectl;
+  @observable protected ready: boolean;
 
   constructor(cluster: Cluster, env: NodeJS.ProcessEnv) {
+    makeObservable(this);
+    this.ready = false;
     this.env = env;
     this.cluster = cluster;
     this.kubectl = Kubectl.bundled();
@@ -58,52 +62,58 @@ export class KubeAuthProxy {
     return url.parse(this.cluster.apiUrl).hostname;
   }
 
+  get whenReady() {
+    return when(() => this.ready);
+  }
+
   public async run(): Promise<void> {
-    if (this.proxyProcess) {
-      return;
+    if (!this.proxyProcess) {
+      const proxyBin = await this.kubectl.getPath();
+      const args = [
+        "proxy",
+        "-p", "0",
+        "--kubeconfig", `${this.cluster.kubeConfigPath}`,
+        "--context", `${this.cluster.contextName}`,
+        "--accept-hosts", this.acceptHosts,
+        "--reject-paths", "^[^/]"
+      ];
+
+      if (process.env.DEBUG_PROXY === "true") {
+        args.push("-v", "9");
+      }
+      logger.debug(`spawning kubectl proxy with args: ${args}`);
+
+      this.proxyProcess = spawn(proxyBin, args, { env: this.env, });
+      this.proxyProcess.on("error", (error) => {
+        this.sendIpcLogMessage({ data: error.message, error: true });
+        this.exit();
+      });
+
+      this.proxyProcess.on("exit", (code) => {
+        this.sendIpcLogMessage({ data: `proxy exited with code: ${code}`, error: code > 0 });
+        this.exit();
+      });
+
+      this.proxyProcess.stderr.on("data", (data) => {
+        this.lastError = this.parseError(data.toString());
+        this.sendIpcLogMessage({ data: data.toString(), error: true });
+      });
+
+      this._port = await getPortFrom(this.proxyProcess.stdout, {
+        lineRegex: startingServeRegex,
+        onFind: () => this.sendIpcLogMessage({ data: "Authentication proxy started\n" }),
+      });
+
+      this.proxyProcess.stdout.on("data", (data: any) => {
+        this.sendIpcLogMessage({ data: data.toString() });
+      });
+
+      await waitUntilUsed(this.port, 500, 10000);
+    
+      this.ready = true;
     }
-
-    const proxyBin = await this.kubectl.getPath();
-    const args = [
-      "proxy",
-      "-p", "0",
-      "--kubeconfig", `${this.cluster.kubeConfigPath}`,
-      "--context", `${this.cluster.contextName}`,
-      "--accept-hosts", this.acceptHosts,
-      "--reject-paths", "^[^/]"
-    ];
-
-    if (process.env.DEBUG_PROXY === "true") {
-      args.push("-v", "9");
-    }
-    logger.debug(`spawning kubectl proxy with args: ${args}`);
-
-    this.proxyProcess = spawn(proxyBin, args, { env: this.env, });
-    this.proxyProcess.on("error", (error) => {
-      this.sendIpcLogMessage({ data: error.message, error: true });
-      this.exit();
-    });
-
-    this.proxyProcess.on("exit", (code) => {
-      this.sendIpcLogMessage({ data: `proxy exited with code: ${code}`, error: code > 0 });
-      this.exit();
-    });
-
-    this.proxyProcess.stderr.on("data", (data) => {
-      this.lastError = this.parseError(data.toString());
-      this.sendIpcLogMessage({ data: data.toString(), error: true });
-    });
-
-    this._port = await getPortFrom(this.proxyProcess.stdout, {
-      lineRegex: startingServeRegex,
-      onFind: () => this.sendIpcLogMessage({ data: "Authentication proxy started\n" }),
-    });
-
-    this.proxyProcess.stdout.on("data", (data: any) => {
-      this.sendIpcLogMessage({ data: data.toString() });
-    });
-
-    return waitUntilUsed(this.port, 500, 10000);
+    
+    return this.whenReady;
   }
 
   protected parseError(data: string) {
@@ -132,6 +142,7 @@ export class KubeAuthProxy {
   }
 
   public exit() {
+    this.ready = false;
     if (!this.proxyProcess) return;
     logger.debug("[KUBE-AUTH]: stopping local proxy", this.cluster.getMeta());
     this.proxyProcess.kill();


### PR DESCRIPTION
fix race condition where the first call to `ensureServer()` initiates the kube auth proxy  but a subsequent call to `ensureServer()` does not wait for the initiation to complete. Relying on mobx `when()` to indicate when the kube auth proxy is really ready.

fixes some cluster connection issues, hopefully some reported in #3226 