### PR TITLE
Fix typings for KubeObjectDetailsRegistration

### DIFF
--- a/src/extensions/registries/kube-object-detail-registry.ts
+++ b/src/extensions/registries/kube-object-detail-registry.ts
@@ -24,14 +24,14 @@ import type { KubeObjectDetailsProps } from "../renderer-api/components";
 import type { KubeObject } from "../renderer-api/k8s-api";
 import { BaseRegistry } from "./base-registry";
 
-export interface KubeObjectDetailComponents {
-  Details: React.ComponentType<KubeObjectDetailsProps<KubeObject>>;
+export interface KubeObjectDetailComponents<T extends KubeObject> {
+  Details: React.ComponentType<KubeObjectDetailsProps<T>>;
 }
 
 export interface KubeObjectDetailRegistration {
   kind: string;
   apiVersions: string[];
-  components: KubeObjectDetailComponents;
+  components: KubeObjectDetailComponents<KubeObject>;
   priority?: number;
 }
 

--- a/src/renderer/components/kube-object/kube-object-details.tsx
+++ b/src/renderer/components/kube-object/kube-object-details.tsx
@@ -82,7 +82,7 @@ export function getDetailsUrl(selfLink: string, resetSelected = false, mergeGlob
   return `?${params}`;
 }
 
-export interface KubeObjectDetailsProps<T = KubeObject> {
+export interface KubeObjectDetailsProps<T extends KubeObject> {
   className?: string;
   object: T;
 }


### PR DESCRIPTION
- Allows correct subtyping of component props

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes a type regression from #2779 but was only recently noticed by the community.