### PR TITLE
Add ability to rename hotbars

### DIFF
--- a/src/common/hotbar-store.ts
+++ b/src/common/hotbar-store.ts
@@ -154,6 +154,19 @@ export class HotbarStore extends BaseStore<HotbarStoreModel> {
   }
 
   @action
+  setHotbarName(id: string, name: string) {
+    const index = this.hotbars.findIndex((hotbar) => hotbar.id === id);
+
+    if(index < 0) {
+      console.warn(`[HOTBAR-STORE]: cannot setHotbarName: unknown id`, { id });
+
+      return;
+    }
+
+    this.hotbars[index].name = name;
+  }
+
+  @action
   remove(hotbar: Hotbar) {
     this.hotbars = this.hotbars.filter((h) => h !== hotbar);
 

--- a/src/renderer/components/hotbar/hotbar-selector.tsx
+++ b/src/renderer/components/hotbar/hotbar-selector.tsx
@@ -28,12 +28,13 @@ import { CommandOverlay } from "../command-palette";
 import { HotbarSwitchCommand } from "./hotbar-switch-command";
 import { hotbarDisplayIndex } from "./hotbar-display-label";
 import { TooltipPosition } from "../tooltip";
+import { observer } from "mobx-react";
 
 interface Props {
   hotbar: Hotbar;
 }
 
-export function HotbarSelector({ hotbar }: Props) {
+export const HotbarSelector = observer(({ hotbar }: Props) => {
   const store = HotbarStore.getInstance();
 
   return (
@@ -55,4 +56,4 @@ export function HotbarSelector({ hotbar }: Props) {
       <Icon material="play_arrow" className="next box" onClick={() => store.switchToNext()} />
     </div>
   );
-}
+});

--- a/src/renderer/components/hotbar/hotbar-switch-command.tsx
+++ b/src/renderer/components/hotbar/hotbar-switch-command.tsx
@@ -28,11 +28,13 @@ import { CommandOverlay } from "../command-palette";
 import { HotbarAddCommand } from "./hotbar-add-command";
 import { HotbarRemoveCommand } from "./hotbar-remove-command";
 import { hotbarDisplayLabel } from "./hotbar-display-label";
+import { HotbarRenameCommand } from "./hotbar-rename-command";
 
 @observer
 export class HotbarSwitchCommand extends React.Component {
   private static addActionId = "__add__";
   private static removeActionId = "__remove__";
+  private static renameActionId = "__rename__";
 
   constructor(props: {}) {
     super(props);
@@ -51,17 +53,23 @@ export class HotbarSwitchCommand extends React.Component {
       options.push({ value: HotbarSwitchCommand.removeActionId, label: "Remove hotbar ..." });
     }
 
+    options.push({ value: HotbarSwitchCommand.renameActionId, label: "Rename hotbar ..." });
+
     return options;
   }
 
   onChange(idOrAction: string): void {
-    switch(idOrAction) {
+    switch (idOrAction) {
       case HotbarSwitchCommand.addActionId:
         CommandOverlay.open(<HotbarAddCommand />);
 
         return;
       case HotbarSwitchCommand.removeActionId:
         CommandOverlay.open(<HotbarRemoveCommand />);
+
+        return;
+      case HotbarSwitchCommand.renameActionId:
+        CommandOverlay.open(<HotbarRenameCommand />);
 
         return;
       default:

--- a/src/renderer/initializers/command-registry.tsx
+++ b/src/renderer/initializers/command-registry.tsx
@@ -29,6 +29,7 @@ import { HotbarAddCommand } from "../components/hotbar/hotbar-add-command";
 import { HotbarRemoveCommand } from "../components/hotbar/hotbar-remove-command";
 import { HotbarSwitchCommand } from "../components/hotbar/hotbar-switch-command";
 import { navigate } from "../navigation";
+import { HotbarRenameCommand } from "../components/hotbar/hotbar-rename-command";
 
 export function initCommandRegistry() {
   CommandRegistry.getInstance()
@@ -188,6 +189,12 @@ export function initCommandRegistry() {
         title: "Hotbar: Remove Hotbar ...",
         scope: "global",
         action: () => CommandOverlay.open(<HotbarRemoveCommand />)
+      },
+      {
+        id: "hotbar.renameHotbar",
+        title: "Hotbar: Rename Hotbar ...",
+        scope: "global",
+        action: () => CommandOverlay.open(<HotbarRenameCommand />)
       },
     ]);
 }


### PR DESCRIPTION
Suggestion: Maybe we could use `value.trim()` in `uniqueHotbarName()` func, line:
`  validate: value => !HotbarStore.getInstance().getByName(value))`? To avoid "name" and "name         " case. Wdyt? 

https://user-images.githubusercontent.com/38247153/126641485-3380b847-d849-4bc5-9d81-4a9ec708a507.mp4


fixes: https://github.com/lensapp/lens/issues/2731