### PR TITLE
release v5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.1.2

## 🚀 Features

* Turn on tailwind JIT mode, and upgrade to 2.2.4 (#3297) @chenhunghan

## 🐛 Bug Fixes

* Fix kube auth proxy race condition (#3458) @jim-docker
* Fix typings for KubeObjectDetailsRegistration (#3460) @Nokel81
* Catalog render optimizations (#3422) @aleksfront
* Fix onRun not executing everywhere :hover is defined for HotbarIcon (#3316) @Nokel81
* Bundled extensions are always compatible in dev mode (#3459) @Nokel81
* Default to empty array for 500Beta13 migration (#3461) @Nokel81
* Wait for shell to bring up prompt before sending commands (#3337) @Nokel81
* Wait for a file to be stable before computing diff (#3427) @Nokel81
* Add ability to trim the value from <Input> (#3333) @Nokel81
* Fix misaligned spinner at cluster load (#3450) @aleksfront
* When viewing a specific release, select its namespace (#3440) @Nokel81
* Sort cronjob last scheduled time by number (#3430) @Nokel81
* Fix styling on cluster roles and bindings (#3434) @Nokel81
* Fix permissions issue on ServiceDetails under RBAC (#3433) @Nokel81
* Use all namespaces for cluster overview warnings (#3441) @Nokel81

## 🧰 Maintenance

* Bump nodemon from 2.0.4 to 2.0.12 (#3465) @dependabot
* Bump mac-ca from 1.0.4 to 1.0.6 (#3464) @dependabot
* Bump @types/progress-bar-webpack-plugin from 2.1.0 to 2.1.2 (#3342) @dependabot
* Enable codeql analysis (#3455) @jakolehm
* Cleanup <EventEmitter> (#3338) @Nokel81
* Removing dependency @types/shelljs (#3448) @aleksfront
* Bump ts-jest from 26.3.0 to 26.5.6 (#3449) @dependabot
* Bump @types/tar from 4.0.4 to 4.0.5 (#3443) @dependabot
* Failing to loadAll should only warn (#3442) @Nokel81


Signed-off-by: Sebastian Malton <sebastian@malton.name>