### PR TITLE
Fix input default value warning

### DIFF
--- a/src/renderer/components/+namespaces/namespace-details.tsx
+++ b/src/renderer/components/+namespaces/namespace-details.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { computed, makeObservable, observable, reaction } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { DrawerItem } from "../drawer";
-import { cssNames } from "../../utils";
+import { boundMethod, cssNames } from "../../utils";
 import { getMetricsForNamespace, IPodMetrics, Namespace } from "../../api/endpoints";
 import { getDetailsUrl, KubeObjectDetailsProps } from "../kube-object";
 import { Link } from "react-router-dom";
@@ -72,6 +72,7 @@ export class NamespaceDetails extends React.Component<Props> {
     return limitRangeStore.getAllByNs(namespace);
   }
 
+  @boundMethod
   async loadMetrics() {
     this.metrics = await getMetricsForNamespace(this.props.object.getName(), "");
   }

--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -328,6 +328,8 @@ export class Input extends React.Component<InputProps, State> {
       multiLine, showValidationLine, validators, theme, maxRows, children, showErrorsAsTooltip,
       maxLength, rows, disabled, autoSelectOnFocus, iconLeft, iconRight, contentRight, id,
       dirty: _dirty, // excluded from passing to input-element
+      defaultValue,
+      trim,
       ...inputProps
     } = this.props;
     const { focused, dirty, valid, validating, errors } = this.state;


### PR DESCRIPTION
Fixing error when both `value` and `defaultValue` were specified for `<Input/>` component making it uncertain which model to use - controlled or uncontrolled one.

Extra fix: bounding `loadMetrics()` method in namespace details.

![uncontrolled input](https://user-images.githubusercontent.com/9607060/126750759-cc65d9f4-a5d9-41d0-b746-df97bb235dd5.png)
![passing trim](https://user-images.githubusercontent.com/9607060/126750767-00f73f1e-55b1-4bd0-ac97-602e646fb72b.png)
