### PR TITLE
Fix auto cleanup of Extension's IPC classes

### DIFF
--- a/src/extensions/ipc/ipc-main.ts
+++ b/src/extensions/ipc/ipc-main.ts
@@ -30,6 +30,8 @@ import logger from "../../main/logger";
 export abstract class IpcMain extends IpcRegistrar {
   constructor(extension: LensMainExtension) {
     super(extension);
+
+    // Call the static method on the bottom child class.
     extension[Disposers].push(() => (this.constructor as typeof IpcMain).resetInstance());
   }
 

--- a/src/extensions/ipc/ipc-main.ts
+++ b/src/extensions/ipc/ipc-main.ts
@@ -25,11 +25,12 @@ import type { LensMainExtension } from "../lens-main-extension";
 import type { Disposer } from "../../common/utils";
 import { once } from "lodash";
 import { ipcMainHandle } from "../../common/ipc";
+import logger from "../../main/logger";
 
 export abstract class IpcMain extends IpcRegistrar {
   constructor(extension: LensMainExtension) {
     super(extension);
-    extension[Disposers].push(() => IpcMain.resetInstance());
+    extension[Disposers].push(() => (this.constructor as typeof IpcMain).resetInstance());
   }
 
   /**
@@ -40,8 +41,13 @@ export abstract class IpcMain extends IpcRegistrar {
    */
   listen(channel: string, listener: (event: Electron.IpcRendererEvent, ...args: any[]) => any): Disposer {
     const prefixedChannel = `extensions@${this[IpcPrefix]}:${channel}`;
-    const cleanup = once(() => ipcMain.removeListener(prefixedChannel, listener));
+    const cleanup = once(() => {
+      logger.info(`[IPC-RENDERER]: removing extension listener`, { channel, extension: { name: this.extension.name, version: this.extension.version } });
 
+      return ipcMain.removeListener(prefixedChannel, listener);
+    });
+
+    logger.info(`[IPC-RENDERER]: adding extension listener`, { channel, extension: { name: this.extension.name, version: this.extension.version } });
     ipcMain.addListener(prefixedChannel, listener);
     this.extension[Disposers].push(cleanup);
 
@@ -56,7 +62,12 @@ export abstract class IpcMain extends IpcRegistrar {
   handle(channel: string, handler: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => any): void {
     const prefixedChannel = `extensions@${this[IpcPrefix]}:${channel}`;
 
+    logger.info(`[IPC-RENDERER]: adding extension handler`, { channel, extension: { name: this.extension.name, version: this.extension.version } });
     ipcMainHandle(prefixedChannel, handler);
-    this.extension[Disposers].push(() => ipcMain.removeHandler(prefixedChannel));
+    this.extension[Disposers].push(() => {
+      logger.info(`[IPC-RENDERER]: removing extension handler`, { channel, extension: { name: this.extension.name, version: this.extension.version } });
+
+      return ipcMain.removeHandler(prefixedChannel);
+    });
   }
 }

--- a/src/extensions/ipc/ipc-renderer.ts
+++ b/src/extensions/ipc/ipc-renderer.ts
@@ -28,6 +28,8 @@ import { once } from "lodash";
 export abstract class IpcRenderer extends IpcRegistrar {
   constructor(extension: LensRendererExtension) {
     super(extension);
+
+    // Call the static method on the bottom child class.
     extension[Disposers].push(() => (this.constructor as typeof IpcRenderer).resetInstance());
   }
 

--- a/src/renderer/navigation/events.ts
+++ b/src/renderer/navigation/events.ts
@@ -61,7 +61,7 @@ function bindClusterManagerRouteEvents() {
 
   // Handle navigation via IPC
   ipcRendererOn(IpcRendererNavigationEvents.NAVIGATE_IN_APP, (event, url: string) => {
-    logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
+    logger.info(`[IPC]: navigate to ${url}`, { currentLocation: location.href });
     navigate(url);
   });
 }
@@ -69,7 +69,7 @@ function bindClusterManagerRouteEvents() {
 // Handle cluster-view renderer process events within iframes
 function bindClusterFrameRouteEvents() {
   ipcRendererOn(IpcRendererNavigationEvents.NAVIGATE_IN_CLUSTER, (event, url: string) => {
-    logger.info(`[IPC]: ${event.type}: ${url}`, { currentLocation: location.href });
+    logger.info(`[IPC]: navigate to ${url}`, { currentLocation: location.href });
     navigate(url);
   });
 }


### PR DESCRIPTION
- Add logging for registering/removing IPC handlers & listeners

- Fix navigation logs

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes a bug where uninstalling and then reinstalling the same extension removes but then doesn't add IPC handlers.