### PR TITLE
Use user configured kubectl path in node and pod menu items

### DIFF
--- a/extensions/node-menu/src/node-menu.tsx
+++ b/extensions/node-menu/src/node-menu.tsx
@@ -21,7 +21,6 @@
 
 import React from "react";
 import { Common, Renderer } from "@k8slens/extensions";
-import { inspect } from "util";
 
 type Node = Renderer.K8sApi.Node;
 
@@ -48,7 +47,7 @@ export function NodeMenu(props: NodeMenuProps) {
 
   if (!node) return null;
   const nodeName = node.getName();
-  const kubectlPath = inspect(UserPreferences.getKubectlPath(), false, null, false);
+  const kubectlPath = JSON.stringify(UserPreferences.getKubectlPath()); // this call escapes spaces and quotes
 
   const sendToTerminal = (command: string) => {
     terminalStore.sendCommand(command, {

--- a/extensions/node-menu/src/node-menu.tsx
+++ b/extensions/node-menu/src/node-menu.tsx
@@ -45,9 +45,12 @@ export interface NodeMenuProps extends Renderer.Component.KubeObjectMenuProps<No
 export function NodeMenu(props: NodeMenuProps) {
   const { object: node, toolbar } = props;
 
-  if (!node) return null;
+  if (!node) {
+    return null;
+  }
+
   const nodeName = node.getName();
-  const kubectlPath = JSON.stringify(App.Preferences.getKubectlPath()); // this call escapes spaces and quotes
+  const kubectlPath = App.Preferences.getKubectlPath() || "kubectl";
 
   const sendToTerminal = (command: string) => {
     terminalStore.sendCommand(command, {

--- a/extensions/node-menu/src/node-menu.tsx
+++ b/extensions/node-menu/src/node-menu.tsx
@@ -20,7 +20,8 @@
  */
 
 import React from "react";
-import { Renderer } from "@k8slens/extensions";
+import { Common, Renderer } from "@k8slens/extensions";
+import { inspect } from "util";
 
 type Node = Renderer.K8sApi.Node;
 
@@ -34,6 +35,9 @@ const {
   },
   Navigation
 } = Renderer;
+const {
+  UserPreferences,
+} = Common;
 
 
 export interface NodeMenuProps extends Renderer.Component.KubeObjectMenuProps<Node> {
@@ -44,6 +48,7 @@ export function NodeMenu(props: NodeMenuProps) {
 
   if (!node) return null;
   const nodeName = node.getName();
+  const kubectlPath = inspect(UserPreferences.getKubectlPath(), false, null, false);
 
   const sendToTerminal = (command: string) => {
     terminalStore.sendCommand(command, {
@@ -62,15 +67,15 @@ export function NodeMenu(props: NodeMenuProps) {
   };
 
   const cordon = () => {
-    sendToTerminal(`kubectl cordon ${nodeName}`);
+    sendToTerminal(`${kubectlPath} cordon ${nodeName}`);
   };
 
   const unCordon = () => {
-    sendToTerminal(`kubectl uncordon ${nodeName}`);
+    sendToTerminal(`${kubectlPath} uncordon ${nodeName}`);
   };
 
   const drain = () => {
-    const command = `kubectl drain ${nodeName} --delete-local-data --ignore-daemonsets --force`;
+    const command = `${kubectlPath} drain ${nodeName} --delete-local-data --ignore-daemonsets --force`;
 
     ConfirmDialog.open({
       ok: () => sendToTerminal(command),

--- a/extensions/node-menu/src/node-menu.tsx
+++ b/extensions/node-menu/src/node-menu.tsx
@@ -35,7 +35,7 @@ const {
   Navigation
 } = Renderer;
 const {
-  UserPreferences,
+  App,
 } = Common;
 
 
@@ -47,7 +47,7 @@ export function NodeMenu(props: NodeMenuProps) {
 
   if (!node) return null;
   const nodeName = node.getName();
-  const kubectlPath = JSON.stringify(UserPreferences.getKubectlPath()); // this call escapes spaces and quotes
+  const kubectlPath = JSON.stringify(App.Preferences.getKubectlPath()); // this call escapes spaces and quotes
 
   const sendToTerminal = (command: string) => {
     terminalStore.sendCommand(command, {

--- a/extensions/pod-menu/src/attach-menu.tsx
+++ b/extensions/pod-menu/src/attach-menu.tsx
@@ -49,8 +49,9 @@ export class PodAttachMenu extends React.Component<PodAttachMenuProps> {
   async attachToPod(container?: string) {
     const { object: pod } = this.props;
 
+    const kubectlPath = App.Preferences.getKubectlPath() || "kubectl";
     const commandParts = [
-      JSON.stringify(App.Preferences.getKubectlPath()), // this call escapes spaces and quotes
+      kubectlPath,
       "attach",
       "-i",
       "-t",

--- a/extensions/pod-menu/src/attach-menu.tsx
+++ b/extensions/pod-menu/src/attach-menu.tsx
@@ -39,7 +39,7 @@ const {
 } = Renderer;
 const {
   Util,
-  UserPreferences,
+  App,
 } = Common;
 
 export interface PodAttachMenuProps extends Renderer.Component.KubeObjectMenuProps<Pod> {
@@ -50,7 +50,7 @@ export class PodAttachMenu extends React.Component<PodAttachMenuProps> {
     const { object: pod } = this.props;
 
     const commandParts = [
-      JSON.stringify(UserPreferences.getKubectlPath()), // this call escapes spaces and quotes
+      JSON.stringify(App.Preferences.getKubectlPath()), // this call escapes spaces and quotes
       "attach",
       "-i",
       "-t",

--- a/extensions/pod-menu/src/attach-menu.tsx
+++ b/extensions/pod-menu/src/attach-menu.tsx
@@ -23,7 +23,6 @@
 
 import React from "react";
 import { Renderer, Common } from "@k8slens/extensions";
-import { inspect } from "util";
 
 type Pod = Renderer.K8sApi.Pod;
 
@@ -51,7 +50,7 @@ export class PodAttachMenu extends React.Component<PodAttachMenuProps> {
     const { object: pod } = this.props;
 
     const commandParts = [
-      inspect(UserPreferences.getKubectlPath(), false, null, false),
+      JSON.stringify(UserPreferences.getKubectlPath()), // this call escapes spaces and quotes
       "attach",
       "-i",
       "-t",

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -23,7 +23,6 @@
 
 import React from "react";
 import { Renderer, Common } from "@k8slens/extensions";
-import { inspect } from "util";
 
 type Pod = Renderer.K8sApi.Pod;
 
@@ -51,7 +50,7 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
     const { object: pod } = this.props;
 
     const commandParts = [
-      inspect(UserPreferences.getKubectlPath(), false, null, false),
+      JSON.stringify(UserPreferences.getKubectlPath()), // this call escapes spaces and quotes
       "exec",
       "-i",
       "-t",

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -49,8 +49,9 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
   async execShell(container?: string) {
     const { object: pod } = this.props;
 
+    const kubectlPath = App.Preferences.getKubectlPath() || "kubectl";
     const commandParts = [
-      JSON.stringify(App.Preferences.getKubectlPath()), // this call escapes spaces and quotes
+      kubectlPath,
       "exec",
       "-i",
       "-t",

--- a/extensions/pod-menu/src/shell-menu.tsx
+++ b/extensions/pod-menu/src/shell-menu.tsx
@@ -39,7 +39,7 @@ const {
 } = Renderer;
 const {
   Util,
-  UserPreferences,
+  App,
 } = Common;
 
 export interface PodShellMenuProps extends Renderer.Component.KubeObjectMenuProps<Pod> {
@@ -50,7 +50,7 @@ export class PodShellMenu extends React.Component<PodShellMenuProps> {
     const { object: pod } = this.props;
 
     const commandParts = [
-      JSON.stringify(UserPreferences.getKubectlPath()), // this call escapes spaces and quotes
+      JSON.stringify(App.Preferences.getKubectlPath()), // this call escapes spaces and quotes
       "exec",
       "-i",
       "-t",

--- a/src/extensions/common-api/app.ts
+++ b/src/extensions/common-api/app.ts
@@ -21,6 +21,7 @@
 
 import { getAppVersion } from "../../common/utils";
 import { ExtensionsStore } from "../extensions-store";
+import * as Preferences from "./user-preferences";
 
 export const version = getAppVersion();
 export { isSnap, isWindows, isMac, isLinux, appName, slackUrl, issuesTrackerUrl } from "../../common/vars";
@@ -28,3 +29,5 @@ export { isSnap, isWindows, isMac, isLinux, appName, slackUrl, issuesTrackerUrl 
 export function getEnabledExtensions(): string[] {
   return ExtensionsStore.getInstance().enabledExtensions;
 }
+
+export { Preferences };

--- a/src/extensions/common-api/user-preferences.ts
+++ b/src/extensions/common-api/user-preferences.ts
@@ -20,8 +20,10 @@
  */
 
 import { UserStore } from "../../common/user-store";
-import { bundledKubectlPath } from "../../main/kubectl";
 
-export function getKubectlPath(): string {
-  return UserStore.getInstance().kubectlBinariesPath || bundledKubectlPath();
+/**
+ * Get the configured kubectl binaries path.
+ */
+export function getKubectlPath(): string | undefined {
+  return UserStore.getInstance().kubectlBinariesPath;
 }

--- a/src/extensions/common-api/user-preferences.ts
+++ b/src/extensions/common-api/user-preferences.ts
@@ -19,21 +19,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// APIs
-import * as App from "./app";
-import * as EventBus from "./event-bus";
-import * as Store from "./stores";
-import * as Util from "./utils";
-import * as Catalog from "./catalog";
-import * as Types from "./types";
-import logger from "../../common/logger";
+import { UserStore } from "../../common/user-store";
+import { bundledKubectlPath } from "../../main/kubectl";
 
-export {
-  App,
-  EventBus,
-  Catalog,
-  Store,
-  Types,
-  Util,
-  logger,
-};
+export function getKubectlPath(): string {
+  return UserStore.getInstance().kubectlBinariesPath || bundledKubectlPath();
+}


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #2948 

Note:
- This PR adds to the extension API so that extensions can have a read-only view of user settings.