### PR TITLE
increase timeout for getPortFrom()

### DIFF
--- a/src/main/utils/get-port.ts
+++ b/src/main/utils/get-port.ts
@@ -71,7 +71,7 @@ export function getPortFrom(stream: Readable, args: GetPortArgs): Promise<number
       stream.off("data", handler);
       logger.warn(`[getPortFrom]: failed to retrieve port via ${args.lineRegex.toString()}: ${logLines}`);
       reject(new Error("failed to retrieve port from stream"));
-    }, args.timeout ?? 5000);
+    }, args.timeout ?? 15000);
 
     stream.on("data", handler);
   });


### PR DESCRIPTION
5s may not be enough time to get a port through `kubectl proxy`, particularly on Windows, where a number of "failed to retrieve port from stream" Sentry events are occurring. Since it has been hard to reproduce the issue this is a first attempt at a solution.