### PR TITLE
Set default type params for KubeObjectDetail related APIs

### DIFF
--- a/src/extensions/registries/kube-object-detail-registry.ts
+++ b/src/extensions/registries/kube-object-detail-registry.ts
@@ -24,7 +24,7 @@ import type { KubeObjectDetailsProps } from "../renderer-api/components";
 import type { KubeObject } from "../renderer-api/k8s-api";
 import { BaseRegistry } from "./base-registry";
 
-export interface KubeObjectDetailComponents<T extends KubeObject> {
+export interface KubeObjectDetailComponents<T extends KubeObject = KubeObject> {
   Details: React.ComponentType<KubeObjectDetailsProps<T>>;
 }
 

--- a/src/renderer/components/kube-object/kube-object-details.tsx
+++ b/src/renderer/components/kube-object/kube-object-details.tsx
@@ -80,7 +80,7 @@ export function getDetailsUrl(selfLink: string, resetSelected = false, mergeGlob
   return `?${params}`;
 }
 
-export interface KubeObjectDetailsProps<T extends KubeObject> {
+export interface KubeObjectDetailsProps<T extends KubeObject = KubeObject> {
   className?: string;
   object: T;
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes regression from https://github.com/lensapp/lens/pull/3460 by adding default type params.