### PR TITLE
Cleanup integration and unit tests 

### DIFF
--- a/__mocks__/windowMock.ts
+++ b/__mocks__/windowMock.ts
@@ -19,14 +19,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-Object.defineProperty(window, "requestIdleCallback", {
-  writable: true,
-  value: jest.fn().mockImplementation(callback => callback()),
-});
+/**
+ * Mock the global window variable
+ */
+export function mockWindow() {
+  Object.defineProperty(window, "requestIdleCallback", {
+    writable: true,
+    value: jest.fn().mockImplementation(callback => callback()),
+  });
 
-Object.defineProperty(window, "cancelIdleCallback", {
-  writable: true,
-  value: jest.fn(),
-});
-
-export default {};
+  Object.defineProperty(window, "cancelIdleCallback", {
+    writable: true,
+    value: jest.fn(),
+  });
+}

--- a/integration/__tests__/app.tests.ts
+++ b/integration/__tests__/app.tests.ts
@@ -30,7 +30,7 @@ import * as utils from "../helpers/utils";
 import { listHelmRepositories } from "../helpers/utils";
 import { fail } from "assert";
 
-jest.setTimeout(60000);
+jest.setTimeout(2 * 60 * 1000); // 2 minutes so that we can get better errors from spectron
 
 // FIXME (!): improve / simplify all css-selectors + use [data-test-id="some-id"] (already used in some tests below)
 describe("Lens integration tests", () => {
@@ -38,14 +38,10 @@ describe("Lens integration tests", () => {
 
   describe("app start", () => {
     utils.beforeAllWrapped(async () => {
-      app = await utils.appStart();
+      app = await utils.setup();
     });
 
-    utils.afterAllWrapped(async () => {
-      if (app?.isRunning()) {
-        await utils.tearDown(app);
-      }
-    });
+    utils.afterAllWrapped(() => utils.tearDown(app));
 
     it('shows "add cluster"', async () => {
       await app.electron.ipcRenderer.send("test-menu-item-click", "File", "Add Cluster");

--- a/integration/__tests__/command-palette.tests.ts
+++ b/integration/__tests__/command-palette.tests.ts
@@ -22,21 +22,17 @@
 import type { Application } from "spectron";
 import * as utils from "../helpers/utils";
 
-jest.setTimeout(60000);
+jest.setTimeout(2 * 60 * 1000); // 2 minutes so that we can get better errors from spectron
 
 describe("Lens command palette", () => {
   let app: Application;
 
   describe("menu", () => {
     utils.beforeAllWrapped(async () => {
-      app = await utils.appStart();
+      app = await utils.setup();
     });
 
-    utils.afterAllWrapped(async () => {
-      if (app?.isRunning()) {
-        await utils.tearDown(app);
-      }
-    });
+    utils.afterAllWrapped(() => utils.tearDown(app));
 
     it("opens command dialog from menu", async () => {
       await app.electron.ipcRenderer.send("test-menu-item-click", "View", "Command Palette...");

--- a/integration/helpers/utils.ts
+++ b/integration/helpers/utils.ts
@@ -69,24 +69,20 @@ export function describeIf(condition: boolean) {
   return condition ? describe : describe.skip;
 }
 
-export function setup(): Application {
-  return new Application({
-    path: AppPaths[process.platform], // path to electron app
-    args: [],
-    startTimeout: 30000,
-    waitTimeout: 60000,
-    env: {
-      CICD: "true"
-    }
-  });
-}
-
 export const keys = {
   backspace: "\uE003"
 };
 
-export async function appStart() {
-  const app = setup();
+export async function setup(): Promise<Application> {
+  const app =  new Application({
+    path: AppPaths[process.platform], // path to electron app
+    args: [],
+    startTimeout: 60000,
+    waitTimeout: 10000,
+    env: {
+      CICD: "true"
+    }
+  });
 
   await app.start();
   // Wait for splash screen to be closed

--- a/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -30,6 +30,9 @@ import { ConfirmDialog } from "../../confirm-dialog";
 import { ExtensionInstallationStateStore } from "../extension-install.store";
 import { Extensions } from "../extensions";
 import mockFs from "mock-fs";
+import { mockWindow } from "../../../../../__mocks__/windowMock";
+
+mockWindow();
 
 jest.setTimeout(30000);
 jest.mock("fs-extra");

--- a/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
+++ b/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
@@ -22,6 +22,9 @@ import React from "react";
 import "@testing-library/jest-dom/extend-expect";
 import { render } from "@testing-library/react";
 import { RenderDelay } from "../render-delay";
+import { mockWindow } from "../../../../../__mocks__/windowMock";
+
+mockWindow();
 
 describe("<RenderDelay/>", () => {
   it("renders w/o errors", () => {


### PR DESCRIPTION
- Make mockWindow a function and call it when needed

- Change timeouts so that better error messages happen more often in
  integration tests

Signed-off-by: Sebastian Malton <sebastian@malton.name>

split out of #3410 