### PR TITLE
Fixing <Tab/> onKeyDown error

### DIFF
--- a/src/renderer/components/tabs/tabs.tsx
+++ b/src/renderer/components/tabs/tabs.tsx
@@ -127,7 +127,7 @@ export class Tab extends React.PureComponent<TabProps> {
       this.ref.current?.click();
     }
 
-    this.props?.onKeyDown(evt);
+    this.props.onKeyDown?.(evt);
   }
 
   componentDidMount() {


### PR DESCRIPTION
Fixing annoying bug when any key presses within `<Tab/>` is focused throws an error.

![keydown bug](https://user-images.githubusercontent.com/9607060/127650875-cd56bb08-b8a2-4ce8-9dcc-42b4abb9c06a.gif)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>