### PR TITLE
Add the ability to copy k8s object name

### DIFF
--- a/src/renderer/components/drawer/drawer.scss
+++ b/src/renderer/components/drawer/drawer.scss
@@ -80,6 +80,17 @@
       padding-right: $padding;
     }
 
+    .drawer-title-text .Icon {
+      opacity: 0;
+      font-weight: normal;
+      margin-left: 8px;
+    }
+     
+    .drawer-title-text:hover .Icon {
+      opacity: 1;
+      transition: opacity 250ms;
+    }
+
     .MenuActions.toolbar .Icon {
       color: $drawerTitleText;
     }


### PR DESCRIPTION
This PR makes it easier to copy any of the pod names , configmaps and so on by adding a button to the k8s object menu