### PR TITLE
Allow to pass KubeObjectStore.api via constructor

### DIFF
--- a/src/common/k8s-api/kube-object.store.ts
+++ b/src/common/k8s-api/kube-object.store.ts
@@ -42,7 +42,7 @@ export interface KubeObjectStoreLoadingParams<K extends KubeObject> {
 export abstract class KubeObjectStore<T extends KubeObject> extends ItemStore<T> {
   static defaultContext = observable.box<ClusterContext>(); // TODO: support multiple cluster contexts
 
-  declare public api: KubeApi<T>;
+  public api: KubeApi<T>;
   public readonly limit?: number;
   public readonly bufferSize: number = 50000;
   @observable private loadedNamespaces?: string[];

--- a/src/common/k8s-api/kube-object.store.ts
+++ b/src/common/k8s-api/kube-object.store.ts
@@ -42,7 +42,7 @@ export interface KubeObjectStoreLoadingParams<K extends KubeObject> {
 export abstract class KubeObjectStore<T extends KubeObject> extends ItemStore<T> {
   static defaultContext = observable.box<ClusterContext>(); // TODO: support multiple cluster contexts
 
-  abstract api: KubeApi<T>;
+  declare public api: KubeApi<T>;
   public readonly limit?: number;
   public readonly bufferSize: number = 50000;
   @observable private loadedNamespaces?: string[];
@@ -55,8 +55,14 @@ export abstract class KubeObjectStore<T extends KubeObject> extends ItemStore<T>
     return when(() => Boolean(this.loadedNamespaces));
   }
 
-  constructor() {
+  constructor(api?: KubeApi<T>) {
     super();
+    if (api) this.api = api;
+
+    if (!this.api) {
+      throw new Error("api is not defined");
+    }
+
     makeObservable(this);
     autoBind(this);
     this.bindWatchEventsUpdater();

--- a/src/common/k8s-api/kube-object.store.ts
+++ b/src/common/k8s-api/kube-object.store.ts
@@ -59,10 +59,6 @@ export abstract class KubeObjectStore<T extends KubeObject> extends ItemStore<T>
     super();
     if (api) this.api = api;
 
-    if (!this.api) {
-      throw new Error("api is not defined");
-    }
-
     makeObservable(this);
     autoBind(this);
     this.bindWatchEventsUpdater();

--- a/src/renderer/components/+custom-resources/crd-resource.store.ts
+++ b/src/renderer/components/+custom-resources/crd-resource.store.ts
@@ -24,10 +24,7 @@ import { KubeObjectStore } from "../../../common/k8s-api/kube-object.store";
 import type { KubeObject } from "../../../common/k8s-api/kube-object";
 
 export class CRDResourceStore<K extends KubeObject> extends KubeObjectStore<K> {
-  api: KubeApi<K>;
-
   constructor(api: KubeApi<K>) {
-    super();
-    this.api = api;
+    super(api);
   }
 }


### PR DESCRIPTION
Allows to create a store per api/cluster:

```ts
const api = Main.K8sApi.forCluster(cluster, MyCustomResource);
const store = new MyCustomResourceStore(api);
```