### PR TITLE
Replace no-unused-imports rule to "warning" in dev environment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.NODE_ENV === "production" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.ENV === "production" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",
@@ -182,7 +182,7 @@ module.exports = {
         "@typescript-eslint/no-empty-function": "off",
         "react/display-name": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.NODE_ENV === "production" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.ENV === "production" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.ENV === "production" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",
@@ -182,7 +182,7 @@ module.exports = {
         "@typescript-eslint/no-empty-function": "off",
         "react/display-name": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.ENV === "production" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": "error",
+        "unused-imports/no-unused-imports-ts": process.env.NODE_ENV === "production" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",
@@ -182,7 +182,7 @@ module.exports = {
         "@typescript-eslint/no-empty-function": "off",
         "react/display-name": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": "error",
+        "unused-imports/no-unused-imports-ts": process.env.NODE_ENV === "production" ? "error" : "warning",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "download:kubectl": "yarn run ts-node build/download_kubectl.ts",
     "download:helm": "yarn run ts-node build/download_helm.ts",
     "build:tray-icons": "yarn run ts-node build/build_tray_icon.ts",
-    "lint": "NODE_ENV=production yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
+    "lint": "ENV=production yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "yarn run lint --fix",
     "mkdocs-serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
     "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "download:kubectl": "yarn run ts-node build/download_kubectl.ts",
     "download:helm": "yarn run ts-node build/download_helm.ts",
     "build:tray-icons": "yarn run ts-node build/build_tray_icon.ts",
-    "lint": "yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
+    "lint": "NODE_ENV=production yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "yarn run lint --fix",
     "mkdocs-serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
     "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "download:kubectl": "yarn run ts-node build/download_kubectl.ts",
     "download:helm": "yarn run ts-node build/download_helm.ts",
     "build:tray-icons": "yarn run ts-node build/build_tray_icon.ts",
-    "lint": "ENV=production yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
+    "lint": "PROD=true yarn run eslint --ext js,ts,tsx --max-warnings=0 .",
     "lint:fix": "yarn run lint --fix",
     "mkdocs-serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
     "verify-docs": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",


### PR DESCRIPTION
Switching from `error` to `warning` for `no-unused-imports` rules to make development process faster. Before this PR, the app can't be recompiled if some imports are left unused, so it's needed to spend some time cleaning imports just to test one thing or another.

Added separation for environments by adding `NODE_ENV=production` rule into `yarn lint` command.

So after the changes this one:
<img width="749" alt="error imports" src="https://user-images.githubusercontent.com/9607060/129161338-30b2e25a-a4fb-4768-89c6-788b9b093fcf.png">

Becomes this in editor:
<img width="801" alt="warning imports" src="https://user-images.githubusercontent.com/9607060/129161360-5003527b-7442-4a57-a5b8-88eeced1070b.png">

`yarn lint:fix` still cleaning imports even if `warning` status provided.
![linter is fixing](https://user-images.githubusercontent.com/9607060/129161558-5baff2d2-f821-4687-99f2-adddaae7d46e.gif)

However, PR request lint process will fail as it will use `NODE_ENV=production`.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>