### PR TITLE
release v5.2.0-beta.1

### DIFF
--- a/.github/workflows/require-type-labels.yml
+++ b/.github/workflows/require-type-labels.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "enhancement, bug, chore, area/ci, area/tests, dependencies, area/documentation"
+          labels: "enhancement, bug, chore, area/ci, area/tests, dependencies, area/documentation, skip-changelog"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.1.4",
+  "version": "5.2.0-beta.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

## Changes since v5.1.3

## 🚀 Features

* Replace Ace editor with Monaco (#2949) @pashevskii
* Expose KubeObjectStore to main extension (#3597) @jakolehm
* Allow to pass KubeObjectStore.api via constructor (#3596) @jakolehm
* Sync kubeconfigs from catalog (#3573) @aleksfront
* Refactor k8s api to common (#3553) @jakolehm
* Notify user of error if confirmation dialog rejects promise (#3179) @Nokel81
* Add ability to rename hotbars (#3469) @vshakirova
* Improve <NamespaceSelectFilter>'s UX (#3490) @Nokel81
* Add accessibleNamespaces to KubernetesClusterModel (#3487) @farodin91
* Improve Table typing and remove annotations on callbacks (#2981) @Nokel81
* Improving metric queries (#3424) @aleksfront

## 🐛 Bug Fixes

* Polishing Kubernetes section view in Preferences (#3603) @aleksfront
* Add back sentry winston logger transport (#3602) @Nokel81
* Fix apiBase initialization on main (#3595) @jakolehm
* Fix k0s distribution detector (#3589) @jakolehm
* Add background-color, box-shadow and padding to .ClusterStatus (#3582) @chenhunghan
* Create c&p folder before starting kube sync (#3428) @Nokel81
* Make sure that there are only ever 12 slots in a hotbar (#3379) @Nokel81
* Fix custom resources not having a fallback details component (#3542) @Nokel81
* Update kubectl to v1.21.2 (#3267) @jakolehm
* Ignore certain file globs when under dir kube sync (#3452) @Nokel81
* Fixing <Tab/> onKeyDown error (#3537) @aleksfront
* Set default type params for KubeObjectDetail related APIs (#3528) @Nokel81
* Fix KubernetesClusters overriding entity names too often (#3524) @Nokel81
* Fix crd resources watch issue (#3520) @jakolehm
* Set defaults for EndpointSubsets (#3454) @Nokel81
* Only stopPropagration in onClick for the itemMenu (#3502) @Nokel81
* Fix workload overview status sorting (#3486) @aleksfront
* increase timeout for getPortFrom() (#3511) @jim-docker
* Fix auto cleanup of Extension's IPC classes (#3505) @Nokel81
* Fix entity accessibleNamespaces (#3507) @Nokel81
* Display hint to user on how to add items in an EditableList (#3475) @Nokel81
* Fix input default value warning (#3497) @aleksfront
* Fix entity settings menu order (#3494) @jakolehm
* Treat default weblinks same as any other weblinks (#3385) @Nokel81
* Filter out undefined values in hotbar-store migration (#3489) @Nokel81

## 🧰 Maintenance

* Bump @types/react-beautiful-dnd from 13.0.0 to 13.1.1 (#3574) @dependabot
* Bump @typescript-eslint/parser from 4.8.2 to 4.29.1 (#3581) @dependabot
* Log lens-metrics status request failures (#3584) @jakolehm
* Bump path-parse from 1.0.6 to 1.0.7 (#3594) @dependabot
* Fix license-header gh action error (#3585) @jakolehm
* Inject handlers into LensProxy to remove circular-deps (#3546) @Nokel81
* Remove circular dependency with isAllowedResource function (#3545) @Nokel81
* Remove circular imports around the command pallet (#3544) @Nokel81
* Move lookupApi into apiManager (#3540) @Nokel81
* Make DetectoryRegistry a Singleton and initialize in a function (#3538) @Nokel81
* Bump tar from 6.1.0 to 6.1.4 (#3567) @dependabot
* PR authors must label their PRs (#2985) @Nokel81
* Split KubeObject related components into seperate folders (#3533) @Nokel81
* Move Hotbar types to seperate file (#3532) @Nokel81
* Move cluster related types and function into seperate files (#3530) @Nokel81
* Update in-tree extensions webpack (#3561) @jakolehm
* Cleanup integration and unit tests  (#3531) @Nokel81
* Simplify most of the KubeObjectDetailRegistry initial values  (#3529) @Nokel81
* Add new SentryTransport to winston (#3432) @Nokel81
* Bump @typescript-eslint/eslint-plugin from 4.14.2 to 4.29.0 (#3562) @dependabot
* Bump @types/color from 3.0.1 to 3.0.2 (#3563) @dependabot
* Bump @material-ui/core from 4.11.4 to 4.12.3 (#3554) @dependabot
* Bump @types/http-proxy from 1.17.5 to 1.17.7 (#3560) @dependabot
* Bump chart.js from 2.9.3 to 2.9.4 (#3556) @dependabot
* Bump postcss from 8.3.5 to 8.3.6 (#3527) @dependabot
* Bump @sentry/integrations from 6.8.0 to 6.10.0 (#3555) @dependabot
* Bump winston from 3.2.1 to 3.3.3 (#3519) @dependabot
* Bump node-pty from 0.9.0 to 0.10.1 (#3478) @dependabot
* Remove package open (#3504) @Nokel81
* Warn if ClusterPageMenuRegistration is a subMenu and has an Icon (#3462) @Nokel81
* Bump react and react-dom (#3508) @dependabot
* Installing tailwindcss/nesting plugin (#3496) @aleksfront
* Bump @types/node from 12.20.11 to 12.20.16 (#3503) @dependabot
* Bump url-loader from 4.1.0 to 4.1.1 (#3501) @dependabot
* Bump @types/hapi from 18.0.5 to 18.0.6 (#3468) @dependabot
