### PR TITLE
Fixing binaries path Input field

### DIFF
--- a/src/renderer/components/+preferences/kubectl-binaries.tsx
+++ b/src/renderer/components/+preferences/kubectl-binaries.tsx
@@ -76,7 +76,7 @@ export const KubectlBinaries = observer(() => {
         <SubTitle title="Directory for binaries" />
         <Input
           theme="round-black"
-          value={userStore.downloadBinariesPath}
+          value={downloadPath}
           placeholder={getDefaultKubectlDownloadPath()}
           validators={pathValidator}
           onChange={setDownloadPath}


### PR DESCRIPTION
Using variable from component's state as an Input value fixes the issue.

Fixes #3568 

![directory for binaries](https://user-images.githubusercontent.com/9607060/129716637-7832bd95-7b16-4ac3-9070-9087c597489c.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>