### PR TITLE
Fix KubeApi.watch leak on abort

### DIFF
--- a/src/common/k8s-api/json-api.ts
+++ b/src/common/k8s-api/json-api.ts
@@ -93,12 +93,6 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
       reqUrl += (reqUrl.includes("?") ? "&" : "?") + queryString;
     }
 
-    this.writeLog({
-      method: reqInit.method.toUpperCase(),
-      reqUrl,
-      reqInit,
-    });
-
     return fetch(reqUrl, reqInit);
   }
 

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -131,6 +131,8 @@ export type KubeApiWatchOptions = {
   namespace: string;
   callback?: KubeApiWatchCallback;
   abortController?: AbortController
+  watchId?: string;
+  retry?: boolean;
 };
 
 export class KubeApi<T extends KubeObject> {
@@ -147,6 +149,7 @@ export class KubeApi<T extends KubeObject> {
   protected request: KubeJsonApi;
   protected resourceVersions = new Map<string, string>();
   protected watchDisposer: () => void;
+  private watchId = 1;
 
   constructor(protected options: IKubeApiOptions<T>) {
     const {
@@ -418,31 +421,38 @@ export class KubeApi<T extends KubeObject> {
     });
   }
 
-  watch(opts: KubeApiWatchOptions = { namespace: "" }): () => void {
+  watch(opts: KubeApiWatchOptions = { namespace: "", retry: false }): () => void {
     let errorReceived = false;
     let timedRetry: NodeJS.Timeout;
-    const { abortController: { abort, signal } = new AbortController(), namespace, callback = noop } = opts;
+    const { abortController: { abort, signal } = new AbortController(), namespace, callback = noop, retry } = opts;
+    let { watchId = `${this.kind.toLowerCase()}-${this.watchId++}` } = opts;
 
     signal.addEventListener("abort", () => {
+      logger.info(`[KUBE-API] watch (${watchId}) aborted ${watchUrl}`);
       clearTimeout(timedRetry);
     });
 
     const watchUrl = this.getWatchUrl(namespace);
     const responsePromise = this.request.getResponse(watchUrl, null, { signal, timeout: 600_000 });
+    logger.info(`[KUBE-API] watch (${watchId}) ${ retry === true ? "retried" : "started" } ${watchUrl}`);
 
     responsePromise
       .then(response => {
         if (!response.ok) {
+          logger.warn(`[KUBE-API] watch (${watchId}) error response ${watchUrl}`, { status: response.status })
           return callback(null, response);
         }
 
         ["end", "close", "error"].forEach((eventName) => {
           response.body.on(eventName, () => {
             if (errorReceived) return; // kubernetes errors should be handled in a callback
+            if (signal.aborted) return;
+
+            logger.info(`[KUBE-API] watch (${watchId}) ${eventName} ${watchUrl}`);
 
             clearTimeout(timedRetry);
             timedRetry = setTimeout(() => { // we did not get any kubernetes errors so let's retry
-              this.watch({ ...opts, namespace, callback });
+              this.watch({ ...opts, namespace, callback, watchId, retry: true });
             }, 1000);
           });
         });
@@ -465,7 +475,7 @@ export class KubeApi<T extends KubeObject> {
         });
       })
       .catch(error => {
-        if (error?.type === "aborted") return; // AbortController rejects, we can ignore it
+        logger.error(`[KUBE-API] watch (${watchId}) throwed ${watchUrl}`, error);
 
         callback(null, error);
       });

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -425,7 +425,7 @@ export class KubeApi<T extends KubeObject> {
     let errorReceived = false;
     let timedRetry: NodeJS.Timeout;
     const { abortController: { abort, signal } = new AbortController(), namespace, callback = noop, retry } = opts;
-    let { watchId = `${this.kind.toLowerCase()}-${this.watchId++}` } = opts;
+    const { watchId = `${this.kind.toLowerCase()}-${this.watchId++}` } = opts;
 
     signal.addEventListener("abort", () => {
       logger.info(`[KUBE-API] watch (${watchId}) aborted ${watchUrl}`);
@@ -434,12 +434,14 @@ export class KubeApi<T extends KubeObject> {
 
     const watchUrl = this.getWatchUrl(namespace);
     const responsePromise = this.request.getResponse(watchUrl, null, { signal, timeout: 600_000 });
-    logger.info(`[KUBE-API] watch (${watchId}) ${ retry === true ? "retried" : "started" } ${watchUrl}`);
+
+    logger.info(`[KUBE-API] watch (${watchId}) ${retry === true ? "retried" : "started"} ${watchUrl}`);
 
     responsePromise
       .then(response => {
         if (!response.ok) {
-          logger.warn(`[KUBE-API] watch (${watchId}) error response ${watchUrl}`, { status: response.status })
+          logger.warn(`[KUBE-API] watch (${watchId}) error response ${watchUrl}`, { status: response.status });
+
           return callback(null, response);
         }
 


### PR DESCRIPTION
Noticed this while debugging other issues. AbortController does not throw anymore, it just emits an error via response. (not sure how/when this behaviour did change, most likely somewhere in #3553). Also improves watch logging so that it's easier to spot these kind of bugs.