### PR TITLE
Release v5.2.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0-beta.2",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.2.0-beta.1

## 🚀 Features

* Add the ability to copy k8s object name (#3575) @mostafahussein

## 🐛 Bug Fixes

* Fix nodes view observability (#3630) @jakolehm
* Fix KubeApi.watch leak on abort (#3629) @jakolehm
* Fix StatefulSet.getImages to handle null case (#3619) @Nokel81
* Fixing binaries path Input field (#3616) @aleksfront

## 🧰 Maintenance

* Bump ansi_up from 5.0.0 to 5.0.1 (#3628) @dependabot
* Bump @types/uuid from 8.3.0 to 8.3.1 (#3626) @dependabot
* Bump @types/marked from 2.0.3 to 2.0.4 (#3625) @dependabot
* Bump joi from 17.4.0 to 17.4.2 (#3621) @dependabot
* Bump @types/request from 2.48.5 to 2.48.7 (#3622) @dependabot
* Bump react-select from 3.1.1 to 3.2.0 (#3618) @dependabot
* Bump sharp from 0.26.1 to 0.29.0 (#3620) @dependabot
* Bump electron-updater from 4.3.8 to 4.3.9 (#3612) @dependabot
* Remove @types/circular-dependency-plugin (#3601) @Nokel81
* Bump webpack-cli from 3.3.11 to 3.3.12 (#3613) @dependabot
* Bump @testing-library/jest-dom from 5.13.0 to 5.14.1 (#3599) @dependabot
* Bump path-parse from 1.0.6 to 1.0.7 in /extensions/node-menu (#3606) @dependabot
* Bump path-parse from 1.0.6 to 1.0.7 in /extensions/pod-menu (#3605) @dependabot
* Bump path-parse from 1.0.6 to 1.0.7 in /extensions/metrics-cluster-feature (#3607) @dependabot
* Bump @types/randomcolor from 0.5.5 to 0.5.6 (#3608) @dependabot
* Replace no-unused-imports rule to "warning" in dev environment (#3598) @aleksfront
