### PR TITLE
Always display a Node's taints' values

### DIFF
--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -134,7 +134,7 @@ export class NodeDetails extends React.Component<Props> {
           <DrawerItem name="Taints" labelsOnly>
             {
               taints.map(({ key, effect, value }) => (
-                <Badge key={key} label={`${key}: ${effect}`} tooltip={value}/>
+                <Badge key={key} label={`${key}=${value}:${effect}`} />
               ))
             }
           </DrawerItem>


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This is more inline with how `kubectl` displays them (and how you set them). Furthermore, it seems strange to display the effect of a taint but not its value.