### PR TITLE
Fix .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     "**/node_modules/**/*",
     "**/dist/**/*",
     "**/static/**/*",
+    "**/site/**/*",
   ],
   settings: {
     react: {
@@ -114,7 +115,7 @@ module.exports = {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warn",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",
@@ -182,7 +183,7 @@ module.exports = {
         "@typescript-eslint/no-empty-function": "off",
         "react/display-name": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warning",
+        "unused-imports/no-unused-imports-ts": process.env.PROD === "true" ? "error" : "warn",
         "unused-imports/no-unused-vars-ts": [
           "warn", {
             "vars": "all",


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This PR fixes the `.eslintrc.js` file, both by readding in the `sites` folder ignore and by fixing the non-prod level for `no-unused-imports-ts`.