### PR TITLE
Fix @material-ui/core console errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "@emeraldpay/hashicon-react": "^0.4.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.57",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@sentry/react": "^6.8.0",
     "@sentry/types": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,10 +857,10 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/lab@^4.0.0-alpha.57":
-  version "4.0.0-alpha.57"
-  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz#e8961bcf6449e8a8dabe84f2700daacfcafbf83a"
-  integrity sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==
+"@material-ui/lab@^4.0.0-alpha.60":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"


### PR DESCRIPTION
@material-ui/lab dependency should be bumped after https://github.com/lensapp/lens/pull/3554 to avoid some warnings.

![image](https://user-images.githubusercontent.com/9607060/130442540-dc72aa17-dd8f-4ebd-a12f-9deb304ce098.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>