### PR TITLE
Fix: font-size jumping in Catalog sidebar

### DIFF
--- a/src/renderer/components/+catalog/catalog-tree.module.css
+++ b/src/renderer/components/+catalog/catalog-tree.module.css
@@ -25,11 +25,10 @@
 
 .root {
   color: var(--textColorTertiary);
-  min-height: 26px;
 }
 
 .label {
-  font-size: var(--font-size);
+  font-size: var(--font-size)!important;
   background-color: transparent!important;
 
   &:hover {


### PR DESCRIPTION
Overriding `font-size` rule fixes the problem illustrated below:

![small font size](https://user-images.githubusercontent.com/9607060/130630071-2da9c642-2687-4334-a922-b9874b8dbba6.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>