### PR TITLE
Fix node shell secret pulling

### DIFF
--- a/src/main/cluster.ts
+++ b/src/main/cluster.ts
@@ -705,10 +705,10 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   get nodeShellImage(): string {
-    return this.preferences.nodeShellImage || initialNodeShellImage;
+    return this.preferences?.nodeShellImage || initialNodeShellImage;
   }
 
-  get imagePullSecret(): string {
-    return this.preferences.imagePullSecret || "";
+  get imagePullSecret(): string | undefined {
+    return this.preferences?.imagePullSecret;
   }
 }


### PR DESCRIPTION
- On some KE errors are thrown if trying to get a secret with an empty
  name, instead of just ignoring the entry

- Clean up the node shell settings

Signed-off-by: Sebastian Malton <sebastian@malton.name>

Once this is merged, I will start a quick 5.1.4 release. And merge it there too.