### PR TITLE
Fixing cropped long namespace names in dropdown

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select-filter.scss
+++ b/src/renderer/components/+namespaces/namespace-select-filter.scss
@@ -45,3 +45,22 @@
     }
   }
 }
+
+.NamespaceSelectFilterMenu {
+  right: 0;
+
+  .Select {
+    &__menu-list {
+      max-width: 400px;
+    }
+
+    &__option {
+      white-space: normal;
+      word-break: break-all;
+    }
+  }
+
+  .Icon {
+    margin-right: $margin / 2;
+  }
+}

--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -180,6 +180,7 @@ export class NamespaceSelectFilter extends React.Component<SelectProps> {
           onBlur={this.reset}
           formatOptionLabel={this.formatOptionLabel}
           className="NamespaceSelectFilter"
+          menuClass="NamespaceSelectFilterMenu"
           sort={(left, right) => +this.selected.has(right.value) - +this.selected.has(left.value)}
         />
       </div>


### PR DESCRIPTION
Showing dropdown menu on the left side of selector and limiting it's width.

![ns selector](https://user-images.githubusercontent.com/9607060/130916596-68acb112-7cd1-4618-8a48-1c35f7cb76f4.gif)
![long names](https://user-images.githubusercontent.com/9607060/130916621-eb84477f-3812-4105-b1ec-f36b6a0364ef.png)
![short names](https://user-images.githubusercontent.com/9607060/130916622-74bde377-bb25-4970-a231-2cfefd58827a.png)


Fixes #3000 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>