### PR TITLE
release v5.2.0-beta.3

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -107,7 +107,7 @@ jobs:
 
   - job: macOS_arm64
     pool:
-      vmImage: macOS-10.15
+      vmImage: macOS-11
     strategy:
       matrix:
         node_14.x:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -56,56 +56,10 @@ jobs:
           AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
           AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
           BUILD_NUMBER: $(Build.BuildNumber)
+          ELECTRON_BUILDER_EXTRA_ARGS: "--x64 --ia32"
         displayName: Build
 
   - job: macOS
-    pool:
-      vmImage: macOS-10.14
-    strategy:
-      matrix:
-        node_14.x:
-          node_version: 14.x
-    steps:
-      - script: CI_BUILD_TAG=`git describe --tags` && echo "##vso[task.setvariable variable=CI_BUILD_TAG]$CI_BUILD_TAG"
-        condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
-        displayName: Set the tag name as an environment variable
-
-      - task: NodeTool@0
-        inputs:
-          versionSpec: $(node_version)
-        displayName: Install Node.js
-
-      - task: Cache@2
-        inputs:
-          key: 'yarn | "$(Agent.OS)" | yarn.lock'
-          restoreKeys: |
-            yarn | "$(Agent.OS)"
-          path: $(YARN_CACHE_FOLDER)
-        displayName: Cache Yarn packages
-
-      - bash: |
-          set -e
-          git clone "https://${GH_TOKEN}@github.com/lensapp/lens-ide.git" .lens-ide-overlay
-          rm -rf .lens-ide-overlay/.git
-          cp -r .lens-ide-overlay/* ./
-          jq -s '.[0] * .[1]' package.json package.ide.json > package.custom.json && mv package.custom.json package.json
-        env:
-          GH_TOKEN: $(LENS_IDE_GH_TOKEN)
-        displayName: Customize config
-
-      - script: make build
-        condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
-        env:
-          APPLEID: $(APPLEID)
-          APPLEIDPASS: $(APPLEIDPASS)
-          CSC_LINK: $(CSC_LINK)
-          CSC_KEY_PASSWORD: $(CSC_KEY_PASSWORD)
-          AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-          BUILD_NUMBER: $(Build.BuildNumber)
-        displayName: Build
-
-  - job: macOS_arm64
     pool:
       vmImage: macOS-11
     strategy:
@@ -143,7 +97,6 @@ jobs:
       - script: make build
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
         env:
-          BINARY_ARCH: arm64
           APPLEID: $(APPLEID)
           APPLEIDPASS: $(APPLEIDPASS)
           CSC_LINK: $(CSC_LINK)
@@ -151,6 +104,7 @@ jobs:
           AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
           AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
           BUILD_NUMBER: $(Build.BuildNumber)
+          ELECTRON_BUILDER_EXTRA_ARGS: "--x64 --arm64"
         displayName: Build
 
   - job: Linux

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
           BUILD_NUMBER: $(Build.BuildNumber)
         displayName: Build
 
-  - job: macOS-arm64
+  - job: macOS_arm64
     pool:
       vmImage: macOS-10.14
     strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -107,7 +107,7 @@ jobs:
 
   - job: macOS_arm64
     pool:
-      vmImage: macOS-10.14
+      vmImage: macOS-10.15
     strategy:
       matrix:
         node_14.x:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,15 @@ jobs:
         if: runner.os == 'Linux'
 
       - run: make integration
-        name: Run integration tests
+        name: Run macOS integration tests
         shell: bash
-        if: runner.os != 'Linux'
+        env:
+          ELECTRON_BUILDER_EXTRA_ARGS: "--x64 --arm64"
+        if: runner.os == 'macOS'
+
+      - run: make integration
+        name: Run Windows integration tests
+        shell: bash
+        env:
+          ELECTRON_BUILDER_EXTRA_ARGS: "--x64 --ia32"
+        if: runner.os == 'Windows'

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CMD_ARGS = $(filter-out $@,$(MAKECMDGOALS))
 %:
   @:
 
-BINARY_ARCH ?= x64
 NPM_RELEASE_TAG ?= latest
+ELECTRON_BUILDER_EXTRA_ARGS ?=
 EXTENSIONS_DIR = ./extensions
 extensions = $(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), ${dir})
 extension_node_modules = $(foreach dir, $(wildcard $(EXTENSIONS_DIR)/*), ${dir}/node_modules)
@@ -63,10 +63,8 @@ build: node_modules binaries/client
 ifeq "$(DETECTED_OS)" "Windows"
 # https://github.com/ukoloff/win-ca#clear-pem-folder-on-publish
 	rm -rf node_modules/win-ca/pem
-	yarn run electron-builder --publish onTag --x64 --ia32
-else
-	yarn run electron-builder --publish onTag --$(BINARY_ARCH)
 endif
+	yarn run electron-builder --publish onTag $(ELECTRON_BUILDER_EXTRA_ARGS)
 
 $(extension_node_modules): node_modules
 	cd $(@:/node_modules=) && ../../node_modules/.bin/npm install --no-audit --no-fund

--- a/build/download_helm.ts
+++ b/build/download_helm.ts
@@ -18,6 +18,18 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { helmCli } from "../src/main/helm/helm-cli";
+import packageInfo from "../package.json";
+import { isWindows } from "../src/common/vars";
+import { HelmCli } from "../src/main/helm/helm-cli";
+import * as path from "path";
 
-helmCli.ensureBinary();
+const helmVersion = packageInfo.config.bundledHelmVersion;
+
+if (!isWindows) {
+  Promise.all([
+    new HelmCli(path.join(process.cwd(), "binaries", "client", "x64"), helmVersion).ensureBinary(),
+    new HelmCli(path.join(process.cwd(), "binaries", "client", "arm64"), helmVersion).ensureBinary()
+  ]);
+} else {
+  new HelmCli(path.join(process.cwd(), "binaries", "client", "x64"), helmVersion).ensureBinary();
+}

--- a/build/download_kubectl.ts
+++ b/build/download_kubectl.ts
@@ -118,17 +118,17 @@ class KubectlDownloader {
 }
 const downloadVersion = packageInfo.config.bundledKubectlVersion;
 const baseDir = path.join(__dirname, "..", "binaries", "client");
-const binaryArch = process.env.BINARY_ARCH || "amd64";
-const binaryTargetArch = binaryArch === "amd64" ? "x64" : "arm64";
 
 const downloads = [];
 
 if (isMac) {
-  downloads.push({ platform: "darwin", arch: binaryArch, target: path.join(baseDir, "darwin", binaryTargetArch, "kubectl") });
+  downloads.push({ platform: "darwin", arch: "amd64", target: path.join(baseDir, "darwin", "x64", "kubectl") });
+  downloads.push({ platform: "darwin", arch: "arm64", target: path.join(baseDir, "darwin", "arm64", "kubectl") });
 } else if (isLinux) {
-  downloads.push({ platform: "linux", arch: binaryArch, target: path.join(baseDir, "linux", binaryTargetArch, "kubectl") });
+  downloads.push({ platform: "linux", arch: "amd64", target: path.join(baseDir, "linux", "x64", "kubectl") });
+  downloads.push({ platform: "linux", arch: "arm64", target: path.join(baseDir, "linux", "arm64", "kubectl") });
 } else {
-  downloads.push({ platform: "windows", arch: "amd64", target: path.join(baseDir, "windows", binaryTargetArch, "kubectl.exe") });
+  downloads.push({ platform: "windows", arch: "amd64", target: path.join(baseDir, "windows", "x64", "kubectl.exe") });
   downloads.push({ platform: "windows", arch: "386", target: path.join(baseDir, "windows", "ia32", "kubectl.exe") });
 }
 

--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
       ],
       "extraResources": [
         {
-          "from": "binaries/client/linux/x64/kubectl",
-          "to": "./x64/kubectl"
+          "from": "binaries/client/linux/${arch}/kubectl",
+          "to": "./${arch}/kubectl"
         },
         {
           "from": "binaries/client/helm3/helm3",
@@ -137,15 +137,11 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extraResources": [
         {
-          "from": "binaries/client/darwin/x64/kubectl",
-          "to": "./x64/kubectl"
+          "from": "binaries/client/darwin/${arch}/kubectl",
+          "to": "./${arch}/kubectl"
         },
         {
-          "from": "binaries/client/darwin/arm64/kubectl",
-          "to": "./arm64/kubectl"
-        },
-        {
-          "from": "binaries/client/helm3/helm3",
+          "from": "binaries/client/${arch}/helm3/helm3",
           "to": "./helm3/helm3"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.2.0-beta.2",
+  "version": "5.2.0-beta.3",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/src/main/helm/helm-cli.ts
+++ b/src/main/helm/helm-cli.ts
@@ -58,7 +58,7 @@ const helmVersion = packageInfo.config.bundledHelmVersion;
 let baseDir = process.resourcesPath;
 
 if (!isProduction) {
-  baseDir = path.join(process.cwd(), "binaries", "client");
+  baseDir = path.join(process.cwd(), "binaries", "client", process.arch);
 }
 
 export const helmCli = new HelmCli(baseDir, helmVersion);


### PR DESCRIPTION
## Changes since v5.2.0-beta.2

## 🚀 Features

* Upgrade to electron 12 and Node 14 (#3572) @Nokel81
* Add WelcomeBanner.width extension API (#3663) @chenhunghan
* Add 'welcome banner' extension API (#3656) @chenhunghan
* Always display a Node's taints' values (#3646) @Nokel81
* Display top bar in welcome screen (#3643) @panuhorsmalahti

## 🐛 Bug Fixes

* Fixing cropped long namespace names in dropdown (#3678) @aleksfront
* Fix: font-size jumping in Catalog sidebar (#3667) @aleksfront
* Fix filtering deprecated charts (#3635) @Nokel81
* Fix @material-ui/core console errors (#3658) @aleksfront
* Fix name copy on Helm details (#3657) @aleksfront
* Validate and set defaults for HelmChart creation (#3492) @Nokel81
* Fix metrics loading on Ingress, PVC and StatefulSet details (#3632) @nevalla

## 🧰 Maintenance

* Bump postcss-loader from 4.0.3 to 4.3.0 (#3687) @dependabot
* Support MacOS arm64 build (#3682) @jakolehm
* Bump @types/npm from 2.0.31 to 2.0.32 (#3686) @dependabot
* Bump @types/chart.js from 2.9.21 to 2.9.34 (#3662) @dependabot
* Bump @types/node from 12.20.16 to 12.20.21 (#3680) @dependabot
* Bump @types/react-virtualized-auto-sizer from 1.0.0 to 1.0.1 (#3649) @dependabot
* Bump webpack-dev-server from 3.11.0 to 3.11.2 (#3650) @dependabot
* Bump tar from 6.1.4 to 6.1.10 (#3651) @dependabot
* Bump jest-canvas-mock from 2.3.0 to 2.3.1 (#3652) @dependabot
* Fix .eslintrc.js (#3648) @Nokel81
* Bump @kubernetes/client-node from 0.14.3 to 0.15.1 (#3638) @dependabot
* Bump react-virtualized-auto-sizer from 1.0.5 to 1.0.6 (#3636) @dependabot
* Bump @types/react-dom from 17.0.6 to 17.0.9 (#3637) @dependabot
* Remove patch-package (#3640) @jakolehm
* Bump crypto-js from 4.0.0 to 4.1.1 (#3627) @dependabot
