### PR TITLE
Ignore clusters without kubeconfigPath on kubeconfig sync migration

### DIFF
--- a/src/migrations/user-store/5.0.3-beta.1.ts
+++ b/src/migrations/user-store/5.0.3-beta.1.ts
@@ -40,6 +40,9 @@ export default {
       syncPaths.add(path.join(os.homedir(), ".kube"));
 
       for (const cluster of clusters) {
+        if (!cluster.kubeConfigPath) {
+          continue;
+        }
         const dirOfKubeconfig = path.dirname(cluster.kubeConfigPath);
 
         if (dirOfKubeconfig === storedKubeConfigFolder()) {


### PR DESCRIPTION
Faced this when having one cluster in cluster store without `kubeconfigPath` property. We can ignore these clusters on migration.