### PR TITLE
Fix the wrong color of welcome banner carousel indicator

### DIFF
--- a/src/renderer/components/+welcome/welcome.tsx
+++ b/src/renderer/components/+welcome/welcome.tsx
@@ -58,6 +58,16 @@ export class Welcome extends React.Component {
                 indicators={welcomeBanner.length > 1}
                 autoPlay={true}
                 navButtonsAlwaysInvisible={true}
+                indicatorIconButtonProps={{
+                  style: {
+                    color: "var(--iconActiveBackground)"
+                  }
+                }}
+                activeIndicatorIconButtonProps={{
+                  style: {
+                    color: "var(--iconActiveColor)"
+                  }
+                }}
               >
                 {welcomeBanner.map((item, index) =>
                   <item.Banner key={index} />


### PR DESCRIPTION
Use `--iconActiveBackground`/`--iconActiveColor` for welcome banner indicator

See video for the result

https://user-images.githubusercontent.com/1474479/131685005-d542ad78-ba8f-4971-8e11-1bc221e115ed.mov

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>