### PR TITLE
Restore telemetry tab to Preferences page

### DIFF
--- a/src/renderer/components/+preferences/preferences.tsx
+++ b/src/renderer/components/+preferences/preferences.tsx
@@ -75,7 +75,7 @@ export class Preferences extends React.Component {
         <Tab value={proxyURL()} label="Proxy" data-testid="proxy-tab" active={isActive(proxyRoute)}/>
         <Tab value={kubernetesURL()} label="Kubernetes" data-testid="kubernetes-tab" active={isActive(kubernetesRoute)}/>
         <Tab value={editorURL()} label="Editor" data-testid="editor-tab" active={isActive(editorRoute)}/>
-        {telemetryExtensions.length > 0 || !!sentryDsn &&
+        {(telemetryExtensions.length > 0 || !!sentryDsn) &&
           <Tab value={telemetryURL()} label="Telemetry" data-testid="telemetry-tab" active={isActive(telemetryRoute)}/>
         }
         {extensions.filter(e => !e.showInPreferencesTab).length > 0 &&


### PR DESCRIPTION
fix logic to determine if the telemetry tab should be rendered on the preferences page

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

fixes #3713 

<img width="823" alt="Screen Shot 2021-09-01 at 12 23 47 PM" src="https://user-images.githubusercontent.com/40840436/131707966-c56eecf4-14e7-401b-ac06-28c1c44407ba.png">
