### PR TITLE
Make ipc.boradcast not stopping at uncaught exceptions, improve typing, improve error logs

### DIFF
--- a/src/common/ipc/ipc.ts
+++ b/src/common/ipc/ipc.ts
@@ -78,7 +78,6 @@ export function broadcastMessage(channel: string, ...args: any[]) {
           logger.silly(`[IPC]: broadcasting "${channel}" to ${viewType}=${view.id}`, { args });
           view.send(channel, ...args);
         } catch (error) {
-          console.log(view);
           logger.error(`[IPC]: failed to send IPC message "${channel}" to view "${viewType}=${view.id}"`, { error: String(error) });
         }
 

--- a/src/common/ipc/ipc.ts
+++ b/src/common/ipc/ipc.ts
@@ -82,7 +82,6 @@ export function broadcastMessage(channel: string, ...args: any[]) {
         }
 
         // Send message to subFrames of views.
-
         for (const frameInfo of subFrames) {
           logger.silly(`[IPC]: broadcasting "${channel}" to subframe "frameInfo.processId"=${frameInfo.processId} "frameInfo.frameId"=${frameInfo.frameId}`, { args });
 

--- a/src/common/ipc/ipc.ts
+++ b/src/common/ipc/ipc.ts
@@ -28,8 +28,9 @@ import { toJS } from "../utils/toJS";
 import logger from "../../main/logger";
 import { ClusterFrameInfo, clusterFrameMap } from "../cluster-frames";
 import type { Disposer } from "../utils";
+import type remote from "@electron/remote";
 
-const remote = ipcMain ? null : require("@electron/remote");
+const electronRemote = ipcMain ? null : require("@electron/remote");
 
 const subFramesChannel = "ipc:get-sub-frames";
 
@@ -48,9 +49,9 @@ function getSubFrames(): ClusterFrameInfo[] {
 }
 
 export function broadcastMessage(channel: string, ...args: any[]) {
-  const views = (webContents || remote?.webContents)?.getAllWebContents();
+  const views: undefined | ReturnType<typeof webContents.getAllWebContents> | ReturnType<typeof remote.webContents.getAllWebContents> = (webContents || electronRemote?.webContents)?.getAllWebContents();
 
-  if (!views) return;
+  if (!views || !Array.isArray(views) || views.length === 0) return;
   args = args.map(sanitizePayload);
 
   ipcRenderer?.send(channel, ...args);
@@ -63,15 +64,34 @@ export function broadcastMessage(channel: string, ...args: any[]) {
   subFramesP
     .then(subFrames => {
       for (const view of views) {
-        try {
-          logger.silly(`[IPC]: broadcasting "${channel}" to ${view.getType()}=${view.id}`, { args });
-          view.send(channel, ...args);
+        let viewType = "unknown";
 
-          for (const frameInfo of subFrames) {
-            view.sendToFrame([frameInfo.processId, frameInfo.frameId], channel, ...args);
-          }
+        // There will be a uncaught exception if the view is destroyed.
+        try {
+          viewType = view.getType();
+        } catch {
+          // We can ignore the view destroyed exception as viewType is only used for logging.
+        }
+
+        // Send message to views.
+        try {
+          logger.silly(`[IPC]: broadcasting "${channel}" to ${viewType}=${view.id}`, { args });
+          view.send(channel, ...args);
         } catch (error) {
-          logger.error("[IPC]: failed to send IPC message", { error: String(error) });
+          console.log(view);
+          logger.error(`[IPC]: failed to send IPC message "${channel}" to view "${viewType}=${view.id}"`, { error: String(error) });
+        }
+
+        // Send message to subFrames of views.
+
+        for (const frameInfo of subFrames) {
+          logger.silly(`[IPC]: broadcasting "${channel}" to subframe "frameInfo.processId"=${frameInfo.processId} "frameInfo.frameId"=${frameInfo.frameId}`, { args });
+
+          try {
+            view.sendToFrame([frameInfo.processId, frameInfo.frameId], channel, ...args);
+          } catch (error) {
+            logger.error(`[IPC]: failed to send IPC message "${channel}" to view "${viewType}=${view.id}"'s subframe "frameInfo.processId"=${frameInfo.processId} "frameInfo.frameId"=${frameInfo.frameId}`, { error: String(error) });
+          }
         }
       }
     });


### PR DESCRIPTION
- Make "broadcast" not stopping at an uncaught exception. Change/fix the `try...catch` block logic, make it continue to `view.sendToFrame` even if `view.send` throw, and continue if one of `view.sendToFrame` throws.
- Improve type of `views`.
- Better error message with `channel`, `view.type`, `view.id` and `subframe.id` for easier debugging.

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>