### PR TITLE
Fix the back/forward button on topbar

### DIFF
--- a/src/renderer/components/layout/__tests__/topbar.test.tsx
+++ b/src/renderer/components/layout/__tests__/topbar.test.tsx
@@ -50,11 +50,12 @@ const goForward = jest.fn();
 jest.mock("@electron/remote", () => {
   return {
     webContents: {
-      getFocusedWebContents: () => {
-        return {
+      getAllWebContents: () => {
+        return [{
+          getType: () => "window",
           goBack,
           goForward
-        };
+        }];
       }
     }
   };

--- a/src/renderer/components/layout/topbar.tsx
+++ b/src/renderer/components/layout/topbar.tsx
@@ -69,11 +69,11 @@ export const TopBar = observer(({ children, ...rest }: Props) => {
   };
 
   const goBack = () => {
-    webContents.getFocusedWebContents()?.goBack();
+    webContents.getAllWebContents().find((webContent) => webContent.getType() === "window")?.goBack();
   };
 
   const goForward = () => {
-    webContents.getFocusedWebContents()?.goForward();
+    webContents.getAllWebContents().find((webContent) => webContent.getType() === "window")?.goForward();
   };
 
   useEffect(() => {

--- a/src/renderer/remote-helpers/history-updater.ts
+++ b/src/renderer/remote-helpers/history-updater.ts
@@ -26,7 +26,25 @@ import { navigation } from "../navigation";
 
 export function watchHistoryState() {
   return reaction(() => navigation.location, () => {
-    broadcastMessage("history:can-go-back", webContents.getFocusedWebContents()?.canGoBack());
-    broadcastMessage("history:can-go-forward", webContents.getFocusedWebContents()?.canGoForward());
+    const getAllWebContents = webContents.getAllWebContents();
+
+    const canGoBack = getAllWebContents.some((webContent) => {
+      if (webContent.getType() === "window") {
+        return webContent.canGoBack();
+      }
+
+      return false;
+    });
+
+    const canGoForward = getAllWebContents.some((webContent) => {
+      if (webContent.getType() === "window") {
+        return webContent.canGoForward();
+      }
+
+      return false;
+    });
+
+    broadcastMessage("history:can-go-back", canGoBack);
+    broadcastMessage("history:can-go-forward", canGoForward);
   });
 }


### PR DESCRIPTION
There can be other `webContents` which is `focus`, for example, the `<webview />` injected by space extension, `webContents.getFocusedWebContents()` is not a reliable way to check if Lens is focus on cluster view.

This PR use `webContents.getAllWebContents()` and check/use only type of `webcontent === 'window'` for `back/forward` button.

Please test with space extension enabled.

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>