### PR TITLE
Make back/forward/refresh work the same as the arrow buttons in topbar

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -188,14 +188,14 @@ export function buildMenu(windowManager: WindowManager) {
         label: "Back",
         accelerator: "CmdOrCtrl+[",
         click() {
-          webContents.getFocusedWebContents()?.goBack();
+          webContents.getAllWebContents().filter(wc => wc.getType() === "window").forEach(wc => wc.goBack());
         }
       },
       {
         label: "Forward",
         accelerator: "CmdOrCtrl+]",
         click() {
-          webContents.getFocusedWebContents()?.goForward();
+          webContents.getAllWebContents().filter(wc => wc.getType() === "window").forEach(wc => wc.goForward());
         }
       },
       {

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -243,8 +243,10 @@ export class WindowManager extends Singleton {
     if (frameInfo) {
       this.sendToView({ channel: IpcRendererNavigationEvents.RELOAD_PAGE, frameInfo });
     } else {
-      webContents.getFocusedWebContents()?.reload();
-      webContents.getFocusedWebContents()?.clearHistory();
+      webContents.getAllWebContents().filter(wc => wc.getType() === "window").forEach(wc => {
+        wc.reload();
+        wc.clearHistory();
+      });
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/lensapp/lens/pull/3719, since `webContents.getFocusedWebContents()` is not a reliable way to check if Lens is focus on cluster view. This PR make the forward/back/reload in Menu work the same way as before even if there is other webviews present. (and more consistent as the forward/back buttons in Topbar.

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>