### PR TITLE
Use PATCH verb to scale deployments and statefulsets

### DIFF
--- a/src/common/k8s-api/__tests__/deployment.api.test.ts
+++ b/src/common/k8s-api/__tests__/deployment.api.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { Deployment, DeploymentApi } from "../endpoints/deployment.api";
+import type { KubeJsonApi } from "../kube-json-api";
+
+class DeploymentApiTest extends DeploymentApi {
+  public setRequest(request: any) {
+    this.request = request;
+  }
+}
+
+describe("DeploymentApi", () => {
+  describe("scale", () => {
+    const requestMock = {
+      patch: () => ({}),
+    } as unknown as KubeJsonApi;
+
+    const sub = new DeploymentApiTest({ objectConstructor: Deployment });
+
+    sub.setRequest(requestMock);
+
+    it("requests Kubernetes API with PATCH verb and correct amount of replicas", () => {
+      const patchSpy = jest.spyOn(requestMock, "patch");
+
+      sub.scale({ namespace: "default", name: "deployment-1"}, 5);
+
+      expect(patchSpy).toHaveBeenCalledWith("/apis/apps/v1/namespaces/default/deployments/deployment-1/scale", {
+        data: {
+          spec: {
+            replicas: 5
+          }
+        }
+      },
+      {
+        headers: {
+          "content-type": "application/merge-patch+json"
+        }
+      });
+    });
+  });
+});

--- a/src/common/k8s-api/__tests__/stateful-set.api.test.ts
+++ b/src/common/k8s-api/__tests__/stateful-set.api.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { StatefulSet, StatefulSetApi } from "../endpoints/stateful-set.api";
+import type { KubeJsonApi } from "../kube-json-api";
+
+class StatefulSetApiTest extends StatefulSetApi {
+  public setRequest(request: any) {
+    this.request = request;
+  }
+}
+
+describe("StatefulSetApi", () => {
+  describe("scale", () => {
+    const requestMock = {
+      patch: () => ({}),
+    } as unknown as KubeJsonApi;
+
+    const sub = new StatefulSetApiTest({ objectConstructor: StatefulSet });
+
+    sub.setRequest(requestMock);
+
+    it("requests Kubernetes API with PATCH verb and correct amount of replicas", () => {
+      const patchSpy = jest.spyOn(requestMock, "patch");
+
+      sub.scale({ namespace: "default", name: "statefulset-1"}, 5);
+
+      expect(patchSpy).toHaveBeenCalledWith("/apis/apps/v1/namespaces/default/statefulsets/statefulset-1/scale", {
+        data: {
+          spec: {
+            replicas: 5
+          }
+        }
+      },
+      {
+        headers: {
+          "content-type": "application/merge-patch+json"
+        }
+      });
+    });
+  });
+});

--- a/src/common/k8s-api/endpoints/deployment.api.ts
+++ b/src/common/k8s-api/endpoints/deployment.api.ts
@@ -41,12 +41,16 @@ export class DeploymentApi extends KubeApi<Deployment> {
   }
 
   scale(params: { namespace: string; name: string }, replicas: number) {
-    return this.request.put(this.getScaleApiUrl(params), {
+    return this.request.patch(this.getScaleApiUrl(params), {
       data: {
-        metadata: params,
         spec: {
           replicas
         }
+      }
+    },
+    {
+      headers: {
+        "content-type": "application/merge-patch+json"
       }
     });
   }

--- a/src/common/k8s-api/endpoints/stateful-set.api.ts
+++ b/src/common/k8s-api/endpoints/stateful-set.api.ts
@@ -39,12 +39,16 @@ export class StatefulSetApi extends KubeApi<StatefulSet> {
   }
 
   scale(params: { namespace: string; name: string }, replicas: number) {
-    return this.request.put(this.getScaleApiUrl(params), {
+    return this.request.patch(this.getScaleApiUrl(params), {
       data: {
-        metadata: params,
         spec: {
           replicas
         }
+      }
+    },
+    {
+      headers: {
+        "content-type": "application/merge-patch+json"
       }
     });
   }


### PR DESCRIPTION
This PR aligns scaling deployments and statefulsets with kubectl, so people can use the same rbac rules for users to allow scaling.

Fixes #3721 