### PR TITLE
don't allow delete of the active cluster before setting to new active cluster

### DIFF
--- a/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
+++ b/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
@@ -123,7 +123,15 @@ export class DeleteClusterDialog extends React.Component {
   }
 
   @computed get disableDelete() {
-    return this.showContextSwitch && (this.newCurrentContext === "");
+    const { cluster, config } = dialogState;
+    const noContextsAvailable = config.contexts.filter(context => context.name !== cluster.contextName).length == 0;
+    const newContextNotSelected = this.newCurrentContext === "";
+
+    if (noContextsAvailable) {
+      return false;
+    }
+
+    return this.showContextSwitch && newContextNotSelected;
   }
 
   isCurrentContext() {
@@ -172,7 +180,7 @@ export class DeleteClusterDialog extends React.Component {
       </div>
     );
   }
-  
+
   getWarningMessage() {
     const { cluster, config } = dialogState;
     const contexts = config.contexts.filter(context => context.name !== cluster.contextName);

--- a/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
+++ b/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
@@ -161,16 +161,16 @@ export class DeleteClusterDialog extends React.Component {
     if (cluster.isInLocalKubeconfig()) {
       return (
         <div>
-          Delete the <b>{cluster.getMeta().name}</b> context from Lens's internal kubeconfig?
+          Delete the <b>{cluster.getMeta().name}</b> context from Lens&apos;s internal kubeconfig?
         </div>
-      )
+      );
     }
 
     return (
       <div>
         Delete the <b>{cluster.getMeta().name}</b> context from <b>{cluster.kubeConfigPath}</b>?
       </div>
-    )
+    );
   }
   
   getWarningMessage() {


### PR DESCRIPTION
- "Delete Context" button is disabled if the "select current-context" checkbox is checked and no context has been selected from the dropdown.
- The "select current-context" checkbox cannot be unchecked if the cluster to delete is the active cluster
- The file path of a Lens private config kept in Lens's app data is not shown in the delete dialog message

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>