### PR TITLE
Make editor editable when user-supplied values is selected

### DIFF
--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -165,7 +165,7 @@ export class ReleaseDetails extends Component<Props> {
             onChange={text => this.values = text}
             theme={ThemeStore.getInstance().activeTheme.monacoTheme}
             className={cssNames("MonacoEditor", {loading: valuesLoading})}
-            options={{readOnly: valuesLoading || this.showOnlyUserSuppliedValues, ...UserStore.getInstance().getEditorOptions()}}
+            options={{readOnly: valuesLoading, ...UserStore.getInstance().getEditorOptions()}}
           >
             {valuesLoading && <Spinner center />}
           </MonacoEditor>


### PR DESCRIPTION
Resolves #3775 

This PR changes the ace-editor to allow editing when `User-supplied values only` is checked.