### PR TITLE
Remove @materil-ui/core deprecation warning

### DIFF
--- a/src/renderer/mui-base-theme.tsx
+++ b/src/renderer/mui-base-theme.tsx
@@ -20,9 +20,9 @@
  */
 
 import React from "react";
-import { createMuiTheme, ThemeProvider } from "@material-ui/core";
+import { createTheme, ThemeProvider } from "@material-ui/core";
 
-const defaultTheme = createMuiTheme({
+const defaultTheme = createTheme({
   props: {
     MuiIconButton: {
       color: "inherit",


### PR DESCRIPTION
createMuiTheme (deprecated) > createTheme

Removed this.
<img width="481" alt="Screenshot 2021-09-13 at 09 36 17" src="https://user-images.githubusercontent.com/1474479/133035531-cc76154b-3c22-4559-9733-73f4df1dab2a.png">

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>