### PR TITLE
Stop Sentry from capturing console.error and logger.error

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -25,7 +25,6 @@ import type Transport from "winston-transport";
 import { consoleFormat } from "winston-console-format";
 import { isDebugging, isTestEnv } from "./vars";
 import BrowserConsole from "winston-transport-browserconsole";
-import { SentryTransport } from "./logger-transports";
 import { getPath } from "./utils/getPath";
 
 const logLevel = process.env.LOG_LEVEL
@@ -36,9 +35,7 @@ const logLevel = process.env.LOG_LEVEL
       ? "error"
       : "info";
 
-const transports: Transport[] = [
-  new SentryTransport("error")
-];
+const transports: Transport[] = [];
 
 if (ipcMain) {
   transports.push(

--- a/src/common/sentry.ts
+++ b/src/common/sentry.ts
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { CaptureConsole, Dedupe, Offline } from "@sentry/integrations";
+import { Dedupe, Offline } from "@sentry/integrations";
 import * as Sentry from "@sentry/electron";
 import { sentryDsn, isProduction } from "./vars";
 import { UserStore } from "./user-store";
@@ -65,7 +65,6 @@ export function SentryInit() {
     },
     dsn: sentryDsn,
     integrations: [
-      new CaptureConsole({ levels: ["error"] }),
       new Dedupe(),
       new Offline(),
     ],


### PR DESCRIPTION
Only let it capture javascript exceptions. (less "spammy")

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>