### PR TITLE
Redirect from /catalog to last catalog page

### DIFF
--- a/src/common/routes/catalog.ts
+++ b/src/common/routes/catalog.ts
@@ -31,3 +31,5 @@ export const catalogRoute: RouteProps = {
 };
 
 export const catalogURL = buildURL<CatalogViewRouteParam>(catalogRoute.path);
+
+export const browseCatalogTab = "browse";

--- a/src/common/routes/catalog.ts
+++ b/src/common/routes/catalog.ts
@@ -31,7 +31,14 @@ export const catalogRoute: RouteProps = {
 };
 
 export const getPreviousTabUrl = (path: string) => {
-  return `${catalogURL()}/${path || browseCatalogTab}`;
+  const [group, kind] = path.split("/");
+
+  return catalogURL({
+    params: {
+      group: group || browseCatalogTab,
+      kind
+    }
+  });
 };
 
 export const catalogURL = buildURL<CatalogViewRouteParam>(catalogRoute.path);

--- a/src/common/routes/catalog.ts
+++ b/src/common/routes/catalog.ts
@@ -30,6 +30,10 @@ export const catalogRoute: RouteProps = {
   path: "/catalog/:group?/:kind?"
 };
 
+export const getPreviousTabUrl = (path: string) => {
+  return `${catalogURL()}/${path || browseCatalogTab}`;
+};
+
 export const catalogURL = buildURL<CatalogViewRouteParam>(catalogRoute.path);
 
 export const browseCatalogTab = "browse";

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -44,7 +44,8 @@ import { CatalogMenu } from "./catalog-menu";
 import { HotbarIcon } from "../hotbar/hotbar-icon";
 import { RenderDelay } from "../render-delay/render-delay";
 
-export const previousActiveTab = createAppStorage("catalog-previous-active-tab", "");
+export const browseCatalogPage = "browse";
+export const previousActiveTab = createAppStorage("catalog-previous-active-tab", browseCatalogPage);
 
 enum sortBy {
   name = "name",
@@ -75,7 +76,7 @@ export class Catalog extends React.Component<Props> {
       return `${group}/${kind}`;
     }
 
-    return "";
+    return browseCatalogPage;
   }
 
   async componentDidMount() {
@@ -89,7 +90,7 @@ export class Catalog extends React.Component<Props> {
         previousActiveTab.set(this.routeActiveTab);
 
         try {
-          await when(() => (routeTab === "" || !!catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab)), { timeout: 5_000 }); // we need to wait because extensions might take a while to load
+          await when(() => (routeTab === browseCatalogPage || !!catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab)), { timeout: 5_000 }); // we need to wait because extensions might take a while to load
           const item = catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab);
 
           runInAction(() => {
@@ -153,7 +154,7 @@ export class Catalog extends React.Component<Props> {
     if (activeCategory) {
       navigate(catalogURL({ params: {group: activeCategory.spec.group, kind: activeCategory.spec.names.kind }}));
     } else {
-      navigate(catalogURL());
+      navigate(`${catalogURL()}/browse`);
     }
   };
 

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -39,13 +39,12 @@ import { MainLayout } from "../layout/main-layout";
 import { createAppStorage, cssNames } from "../../utils";
 import { makeCss } from "../../../common/utils/makeCss";
 import { CatalogEntityDetails } from "./catalog-entity-details";
-import { catalogURL, CatalogViewRouteParam } from "../../../common/routes";
+import { browseCatalogTab, catalogURL, CatalogViewRouteParam } from "../../../common/routes";
 import { CatalogMenu } from "./catalog-menu";
 import { HotbarIcon } from "../hotbar/hotbar-icon";
 import { RenderDelay } from "../render-delay/render-delay";
 
-export const browseCatalogPage = "browse";
-export const previousActiveTab = createAppStorage("catalog-previous-active-tab", browseCatalogPage);
+export const previousActiveTab = createAppStorage("catalog-previous-active-tab", browseCatalogTab);
 
 enum sortBy {
   name = "name",
@@ -76,7 +75,7 @@ export class Catalog extends React.Component<Props> {
       return `${group}/${kind}`;
     }
 
-    return browseCatalogPage;
+    return browseCatalogTab;
   }
 
   async componentDidMount() {
@@ -90,7 +89,7 @@ export class Catalog extends React.Component<Props> {
         previousActiveTab.set(this.routeActiveTab);
 
         try {
-          await when(() => (routeTab === browseCatalogPage || !!catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab)), { timeout: 5_000 }); // we need to wait because extensions might take a while to load
+          await when(() => (routeTab === browseCatalogTab || !!catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab)), { timeout: 5_000 }); // we need to wait because extensions might take a while to load
           const item = catalogCategoryRegistry.filteredItems.find(i => i.getId() === routeTab);
 
           runInAction(() => {
@@ -154,7 +153,7 @@ export class Catalog extends React.Component<Props> {
     if (activeCategory) {
       navigate(catalogURL({ params: {group: activeCategory.spec.group, kind: activeCategory.spec.names.kind }}));
     } else {
-      navigate(`${catalogURL()}/browse`);
+      navigate(catalogURL({ params: { group: browseCatalogTab }}));
     }
   };
 

--- a/src/renderer/components/cluster-manager/cluster-manager.tsx
+++ b/src/renderer/components/cluster-manager/cluster-manager.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { BottomBar } from "./bottom-bar";
-import { Catalog } from "../+catalog";
+import { browseCatalogPage, Catalog, previousActiveTab } from "../+catalog";
 import { Preferences } from "../+preferences";
 import { AddCluster } from "../+add-cluster";
 import { ClusterView } from "./cluster-view";
@@ -40,6 +40,7 @@ import { reaction } from "mobx";
 import { navigation } from "../../navigation";
 import { setEntityOnRouteMatch } from "../../../main/catalog-sources/helpers/general-active-sync";
 import { TopBar } from "../layout/topbar";
+import { catalogURL } from "../../../common/routes";
 
 @observer
 export class ClusterManager extends React.Component {
@@ -56,6 +57,7 @@ export class ClusterManager extends React.Component {
         <main>
           <div id="lens-views"/>
           <Switch>
+            <Redirect exact from={catalogURL()} to={`${catalogURL()}/${previousActiveTab.get() || browseCatalogPage}`}/>
             <Route component={Welcome} {...routes.welcomeRoute} />
             <Route component={Catalog} {...routes.catalogRoute} />
             <Route component={Preferences} {...routes.preferencesRoute} />

--- a/src/renderer/components/cluster-manager/cluster-manager.tsx
+++ b/src/renderer/components/cluster-manager/cluster-manager.tsx
@@ -40,7 +40,7 @@ import { reaction } from "mobx";
 import { navigation } from "../../navigation";
 import { setEntityOnRouteMatch } from "../../../main/catalog-sources/helpers/general-active-sync";
 import { TopBar } from "../layout/topbar";
-import { browseCatalogTab, catalogURL } from "../../../common/routes";
+import { catalogURL, getPreviousTabUrl } from "../../../common/routes";
 
 @observer
 export class ClusterManager extends React.Component {
@@ -57,7 +57,7 @@ export class ClusterManager extends React.Component {
         <main>
           <div id="lens-views"/>
           <Switch>
-            <Redirect exact from={catalogURL()} to={`${catalogURL()}/${previousActiveTab.get() || browseCatalogTab}`}/>
+            <Redirect exact from={catalogURL()} to={getPreviousTabUrl(previousActiveTab.get())}/>
             <Route component={Welcome} {...routes.welcomeRoute} />
             <Route component={Catalog} {...routes.catalogRoute} />
             <Route component={Preferences} {...routes.preferencesRoute} />

--- a/src/renderer/components/cluster-manager/cluster-manager.tsx
+++ b/src/renderer/components/cluster-manager/cluster-manager.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { BottomBar } from "./bottom-bar";
-import { browseCatalogPage, Catalog, previousActiveTab } from "../+catalog";
+import { Catalog, previousActiveTab } from "../+catalog";
 import { Preferences } from "../+preferences";
 import { AddCluster } from "../+add-cluster";
 import { ClusterView } from "./cluster-view";
@@ -40,7 +40,7 @@ import { reaction } from "mobx";
 import { navigation } from "../../navigation";
 import { setEntityOnRouteMatch } from "../../../main/catalog-sources/helpers/general-active-sync";
 import { TopBar } from "../layout/topbar";
-import { catalogURL } from "../../../common/routes";
+import { browseCatalogTab, catalogURL } from "../../../common/routes";
 
 @observer
 export class ClusterManager extends React.Component {
@@ -57,7 +57,7 @@ export class ClusterManager extends React.Component {
         <main>
           <div id="lens-views"/>
           <Switch>
-            <Redirect exact from={catalogURL()} to={`${catalogURL()}/${previousActiveTab.get() || browseCatalogPage}`}/>
+            <Redirect exact from={catalogURL()} to={`${catalogURL()}/${previousActiveTab.get() || browseCatalogTab}`}/>
             <Route component={Welcome} {...routes.welcomeRoute} />
             <Route component={Catalog} {...routes.catalogRoute} />
             <Route component={Preferences} {...routes.preferencesRoute} />

--- a/src/renderer/components/cluster-manager/cluster-view.tsx
+++ b/src/renderer/components/cluster-manager/cluster-view.tsx
@@ -33,7 +33,6 @@ import { clusterActivateHandler } from "../../../common/cluster-ipc";
 import { catalogEntityRegistry } from "../../api/catalog-entity-registry";
 import { navigate } from "../../navigation";
 import { catalogURL, ClusterViewRouteParams } from "../../../common/routes";
-import { previousActiveTab } from "../+catalog";
 
 interface Props extends RouteComponentProps<ClusterViewRouteParams> {
 }
@@ -85,7 +84,7 @@ export class ClusterView extends React.Component<Props> {
         const disconnected = values[1];
 
         if (hasLoadedView(this.clusterId) && disconnected) {
-          navigate(`${catalogURL()}/${previousActiveTab.get()}`); // redirect to catalog when active cluster get disconnected/not available
+          navigate(catalogURL()); // redirect to catalog when active cluster get disconnected/not available
         }
       }),
     ]);

--- a/src/renderer/components/layout/topbar.tsx
+++ b/src/renderer/components/layout/topbar.tsx
@@ -30,7 +30,6 @@ import { ipcRendererOn } from "../../../common/ipc";
 import { watchHistoryState } from "../../remote-helpers/history-updater";
 import { isActiveRoute, navigate } from "../../navigation";
 import { catalogRoute, catalogURL } from "../../../common/routes";
-import { previousActiveTab } from "../+catalog";
 
 interface Props extends React.HTMLAttributes<any> {
 }
@@ -72,7 +71,7 @@ export const TopBar = observer(({ children, ...rest }: Props) => {
   };
 
   const goHome = () => {
-    navigate(`${catalogURL()}/${previousActiveTab.get()}`);
+    navigate(catalogURL());
   };
 
   const goBack = () => {


### PR DESCRIPTION
Setting redirect from `/catalog` url to `/catalog` + last page from storage (or `browse`).


https://user-images.githubusercontent.com/9607060/133383419-73a7f472-781e-4f2a-8840-68dd63817031.mov



Fixes #3642

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>