### PR TITLE
Emit contextMenuOpen for WebLink CatalogEntity

### DIFF
--- a/src/common/catalog-entities/web-link.ts
+++ b/src/common/catalog-entities/web-link.ts
@@ -57,6 +57,10 @@ export class WebLink extends CatalogEntity<CatalogEntityMetadata, WebLinkStatus,
         }
       });
     }
+
+    catalogCategoryRegistry
+      .getCategoryForEntity<WebLinkCategory>(this)
+      ?.emit("contextMenuOpen", this, context);
   }
 }
 


### PR DESCRIPTION
This makes it possible for e.g. extension to add items to the Weblink CatalogEntity context menu. Currently this is possible for clusters but not weblinks.