### PR TITLE
Fix kube-api watch leak on window unload

### DIFF
--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -29,7 +29,7 @@ import * as ReactRouterDom from "react-router-dom";
 import * as LensExtensionsCommonApi from "../extensions/common-api";
 import * as LensExtensionsRendererApi from "../extensions/renderer-api";
 import { monaco } from "react-monaco-editor";
-import { render, unmountComponentAtNode } from "react-dom";
+import { render } from "react-dom";
 import { delay } from "../common/utils";
 import { isMac, isDevelopment } from "../common/vars";
 import { ClusterStore } from "../common/cluster-store";
@@ -66,7 +66,7 @@ async function attachChromeDebugger() {
 }
 
 type AppComponent = React.ComponentType & {
-  init?(): Promise<void>;
+  init?(rootElem: HTMLElement): Promise<void>;
 };
 
 export async function bootstrap(App: AppComponent) {
@@ -125,16 +125,8 @@ export async function bootstrap(App: AppComponent) {
 
   // init app's dependencies if any
   if (App.init) {
-    await App.init();
+    await App.init(rootElem);
   }
-  window.addEventListener("message", (ev: MessageEvent) => {
-    if (ev.data === "teardown") {
-      UserStore.getInstance(false)?.unregisterIpcListener();
-      ClusterStore.getInstance(false)?.unregisterIpcListener();
-      unmountComponentAtNode(rootElem);
-      window.location.href = "about:blank";
-    }
-  });
   render(<>
     {isMac && <div id="draggable-top" />}
     {DefaultProps(App)}

--- a/src/renderer/lens-app.tsx
+++ b/src/renderer/lens-app.tsx
@@ -37,10 +37,12 @@ import { ipcRenderer } from "electron";
 import { IpcRendererNavigationEvents } from "./navigation/events";
 import { catalogEntityRegistry } from "./api/catalog-entity-registry";
 import { registerKeyboardShortcuts } from "./keyboard-shortcuts";
+import logger from "../common/logger";
+import { unmountComponentAtNode } from "react-dom";
 
 @observer
 export class LensApp extends React.Component {
-  static async init() {
+  static async init(rootElem: HTMLElement) {
     catalogEntityRegistry.init();
     ExtensionLoader.getInstance().loadOnClusterManagerRenderer();
     LensProtocolRouterRenderer.createInstance().init();
@@ -51,6 +53,12 @@ export class LensApp extends React.Component {
 
     registerKeyboardShortcuts();
     registerIpcListeners();
+
+    window.onbeforeunload = () => {
+      logger.info("[App]: Unload app");
+
+      unmountComponentAtNode(rootElem);
+    };
   }
 
   componentDidMount() {


### PR DESCRIPTION
`node-fetch` connection is not always automatically cleaned when window reloads. This PR aims to fix that by unmounting app when window unloads.