### PR TITLE
Fix missing query parameter

### DIFF
--- a/src/common/k8s-api/kube-object.store.ts
+++ b/src/common/k8s-api/kube-object.store.ts
@@ -159,7 +159,7 @@ export abstract class KubeObjectStore<T extends KubeObject> extends ItemStore<T>
         this.loadedNamespaces = namespaces;
 
         return Promise // load resources per namespace
-          .all(namespaces.map(namespace => api.list({ namespace, reqInit })))
+          .all(namespaces.map(namespace => api.list({ namespace, reqInit }, this.query)))
           .then(items => items.flat().filter(Boolean));
       }
     }


### PR DESCRIPTION
Noticed while doing performance tests. Causes to fetch events without limits if not fetching all namespaces.