### PR TITLE
Use Ubuntu 18.04 for builds

### DIFF
--- a/.azure-pipelines-k8s-matrix.yml
+++ b/.azure-pipelines-k8s-matrix.yml
@@ -15,7 +15,7 @@ trigger: none
 jobs:
   - job: Linux
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-18.04
     strategy:
       matrix:
         kube_1.16:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-18.04
     strategy:
       matrix:
         node_14.x:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-18.04, macos-11, windows-2019]
         node-version: [14.x]
     steps:
       - name: Checkout Release from lens


### PR DESCRIPTION
#3025 changed deprecated 16.04 to 20.04. But actually we should build on as old ubuntu as possible (for compatibility reasons).