### PR TITLE
Check "user-supplied values only" by default when viewing a helm release

### DIFF
--- a/src/renderer/components/+apps-releases/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details.tsx
@@ -59,7 +59,7 @@ export class ReleaseDetails extends Component<Props> {
   @observable details: IReleaseDetails;
   @observable values = "";
   @observable valuesLoading = false;
-  @observable showOnlyUserSuppliedValues = false;
+  @observable showOnlyUserSuppliedValues = true;
   @observable saving = false;
   @observable releaseSecret: Secret;
 


### PR DESCRIPTION
This resolves #3937

Copying the "why" from there:

> When I go to look at a release I find myself checking the "user supplied values only" checkbox almost every time so for at least my use case it'd be preferred to load the smaller data set unless I have a reason to see the entire values file.
> 
> Additionally, charts that have large values files tend to fail to load with a blank error. For me that chart is kube-prometheus-stack but I'm guessing there's a better way to fix this.

Signed-off-by: Korvin Szanto <me@kor.vin>