### PR TITLE
Added tooltipOnParentHover to taint tooltip on nodes list page

### DIFF
--- a/src/renderer/components/+nodes/nodes.tsx
+++ b/src/renderer/components/+nodes/nodes.tsx
@@ -236,7 +236,7 @@ export class Nodes extends React.Component<Props> {
               this.renderDiskUsage(node),
               <>
                 <span id={tooltipId}>{node.getTaints().length}</span>
-                <Tooltip targetId={tooltipId} style={{ whiteSpace: "pre-line" }}>
+                <Tooltip targetId={tooltipId} tooltipOnParentHover={true} style={{ whiteSpace: "pre-line" }}>
                   {node.getTaints().map(({ key, effect }) => `${key}: ${effect}`).join("\n")}
                 </Tooltip>
               </>,


### PR DESCRIPTION
Added tooltipOnParentHover to true on Taint Tooltip on node. Tooltip now appears when hovering over table cell, not only upon hovering on the number.

Closes #2988

Happy Hacktoberfest! 👻 