### PR TITLE
Add more file system metrics to the pod and container graphs

### DIFF
--- a/src/common/k8s-api/endpoints/daemon-set.api.ts
+++ b/src/common/k8s-api/endpoints/daemon-set.api.ts
@@ -110,6 +110,8 @@ export function getMetricsForDaemonSets(daemonsets: DaemonSet[], namespace: stri
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/common/k8s-api/endpoints/deployment.api.ts
+++ b/src/common/k8s-api/endpoints/deployment.api.ts
@@ -83,6 +83,8 @@ export function getMetricsForDeployments(deployments: Deployment[], namespace: s
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/common/k8s-api/endpoints/job.api.ts
+++ b/src/common/k8s-api/endpoints/job.api.ts
@@ -133,6 +133,8 @@ export function getMetricsForJobs(jobs: Job[], namespace: string, selector = "")
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/common/k8s-api/endpoints/metrics.api.ts
+++ b/src/common/k8s-api/endpoints/metrics.api.ts
@@ -65,6 +65,8 @@ export interface IResourceMetrics<T extends IMetrics> {
   cpuUsage: T;
   memoryUsage: T;
   fsUsage: T;
+  fsWrites: T;
+  fsReads: T;
   networkReceive: T;
   networkTransmit: T;
 }

--- a/src/common/k8s-api/endpoints/namespaces.api.ts
+++ b/src/common/k8s-api/endpoints/namespaces.api.ts
@@ -63,6 +63,8 @@ export function getMetricsForNamespace(namespace: string, selector = ""): Promis
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/common/k8s-api/endpoints/pods.api.ts
+++ b/src/common/k8s-api/endpoints/pods.api.ts
@@ -46,6 +46,8 @@ export function getMetricsForPods(pods: Pod[], namespace: string, selector = "po
     memoryRequests: opts,
     memoryLimits: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {
@@ -57,7 +59,9 @@ export interface IPodMetrics<T = IMetrics> {
   [metric: string]: T;
   cpuUsage: T;
   memoryUsage: T;
-  fsUsage: T;
+  fsUsage: T,
+  fsWrites: T,
+  fsReads: T,
   networkReceive: T;
   networkTransmit: T;
   cpuRequests?: T;

--- a/src/common/k8s-api/endpoints/replica-set.api.ts
+++ b/src/common/k8s-api/endpoints/replica-set.api.ts
@@ -59,6 +59,8 @@ export function getMetricsForReplicaSets(replicasets: ReplicaSet[], namespace: s
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/common/k8s-api/endpoints/stateful-set.api.ts
+++ b/src/common/k8s-api/endpoints/stateful-set.api.ts
@@ -62,6 +62,8 @@ export function getMetricsForStatefulSets(statefulSets: StatefulSet[], namespace
     cpuUsage: opts,
     memoryUsage: opts,
     fsUsage: opts,
+    fsWrites: opts,
+    fsReads: opts,
     networkReceive: opts,
     networkTransmit: opts,
   }, {

--- a/src/main/prometheus/lens.ts
+++ b/src/main/prometheus/lens.ts
@@ -124,6 +124,10 @@ export class PrometheusLens extends PrometheusProvider {
             return `sum(kube_pod_container_resource_limits{pod=~"${opts.pods}",resource="memory",namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "fsUsage":
             return `sum(container_fs_usage_bytes{container!="POD",container!="",pod=~"${opts.pods}",namespace="${opts.namespace}"}) by (${opts.selector})`;
+          case "fsWrites":
+            return `sum(rate(container_fs_writes_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
+          case "fsReads":
+            return `sum(rate(container_fs_reads_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkReceive":
             return `sum(rate(container_network_receive_bytes_total{pod=~"${opts.pods}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkTransmit":

--- a/src/main/prometheus/operator.ts
+++ b/src/main/prometheus/operator.ts
@@ -109,6 +109,10 @@ export class PrometheusOperator extends PrometheusProvider {
             return `sum(kube_pod_container_resource_limits{pod=~"${opts.pods}", resource="memory", namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "fsUsage":
             return `sum(container_fs_usage_bytes{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}) by (${opts.selector})`;
+          case "fsWrites":
+            return `sum(rate(container_fs_writes_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
+          case "fsReads":
+            return `sum(rate(container_fs_reads_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkReceive":
             return `sum(rate(container_network_receive_bytes_total{pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkTransmit":

--- a/src/main/prometheus/stacklight.ts
+++ b/src/main/prometheus/stacklight.ts
@@ -124,6 +124,10 @@ export class PrometheusStacklight extends PrometheusProvider {
             return `sum(kube_pod_container_resource_limits{pod=~"${opts.pods}",resource="memory",namespace="${opts.namespace}"}) by (${opts.selector})`;
           case "fsUsage":
             return `sum(container_fs_usage_bytes{container!="POD",container!="",pod=~"${opts.pods}",namespace="${opts.namespace}"}) by (${opts.selector})`;
+          case "fsWrites":
+            return `sum(rate(container_fs_writes_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
+          case "fsReads":
+            return `sum(rate(container_fs_reads_bytes_total{container!="", pod=~"${opts.pods}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkReceive":
             return `sum(rate(container_network_receive_bytes_total{pod=~"${opts.pods}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (${opts.selector})`;
           case "networkTransmit":

--- a/src/renderer/components/+workloads-pods/container-charts.tsx
+++ b/src/renderer/components/+workloads-pods/container-charts.tsx
@@ -46,6 +46,8 @@ export const ContainerCharts = observer(() => {
     memoryRequests,
     memoryLimits,
     fsUsage,
+    fsWrites,
+    fsReads
   } = mapValues(metrics, metric => normalizeMetrics(metric).data.result[0].values);
 
   const datasets = [
@@ -105,6 +107,20 @@ export const ContainerCharts = observer(() => {
         tooltip: `Bytes consumed on this filesystem`,
         borderColor: "#ffc63d",
         data: fsUsage.map(([x, y]) => ({ x, y })),
+      },
+      {
+        id: "fsWrites",
+        label: `Writes`,
+        tooltip: `Bytes written on this filesystem`,
+        borderColor: "#ff963d",
+        data: fsWrites.map(([x, y]) => ({ x, y })),
+      },
+      {
+        id: "fsReads",
+        label: `Reads`,
+        tooltip: `Bytes read on this filesystem`,
+        borderColor: "#fff73d",
+        data: fsReads.map(([x, y]) => ({ x, y })),
       },
     ],
   ];

--- a/src/renderer/components/+workloads-pods/pod-charts.tsx
+++ b/src/renderer/components/+workloads-pods/pod-charts.tsx
@@ -51,6 +51,8 @@ export const PodCharts = observer(() => {
     cpuUsage,
     memoryUsage,
     fsUsage,
+    fsWrites,
+    fsReads,
     networkReceive,
     networkTransmit,
   } = mapValues(metrics, metric => normalizeMetrics(metric).data.result[0].values);
@@ -101,6 +103,20 @@ export const PodCharts = observer(() => {
         tooltip: `Bytes consumed on this filesystem`,
         borderColor: "#ffc63d",
         data: fsUsage.map(([x, y]) => ({ x, y })),
+      },
+      {
+        id: `${id}-fsWrites`,
+        label: `Writes`,
+        tooltip: `Bytes written on this filesystem`,
+        borderColor: "#ff963d",
+        data: fsWrites.map(([x, y]) => ({ x, y })),
+      },
+      {
+        id: `${id}-fsReads`,
+        label: `Reads`,
+        tooltip: `Bytes read on this filesystem`,
+        borderColor: "#fff73d",
+        data: fsReads.map(([x, y]) => ({ x, y })),
       },
     ],
   ];


### PR DESCRIPTION
What would you like to be added:
At the moment lens doesn't support `container_fs_usage_bytes ` metrics on a pod/container level as that's not supported in cAdvisor yet (gets [actively](https://github.com/google/cadvisor/pull/2936) worked [on](https://github.com/google/cadvisor/tree/containerd-cri)).

Other metrics we could add are `container_fs_writes_bytes_total` and `container_fs_reads_bytes_total`. Those are already supported and working in most systems.
Additionally it would also be neat to have the PVC I/O metrics directly in the graph, but that will need more visualization work.

Why is this needed:
While lens is no monitoring solution, people in operations could still benefit from the additional stats.

Would that be easy to support and something you want in here?

![image](https://user-images.githubusercontent.com/431376/136117555-bc1865ac-687b-4a70-99c7-19a190b7bce0.png)
