### PR TITLE
release v5.3.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha.0",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.2.5

## 🚀 Features

* Before hook for onRun of Catalog entities (#3911) @chenhunghan
* Check "user-supplied values only" by default when viewing a helm release (#3938) @KorvinSzanto
* Add terminal copy on select (#3904) @jweak 
* Make default catalog action to open entity (#3915) @Nokel81 
* Redirect from /catalog to last catalog page (#3807) @aleksfront 
* Expose forRemoteCluster in the extension API. (#3786) @panuhorsmalahti 
* Allow KubeApi connect directly to remote k8s (#3766) @jakolehm 
* Sidebar cluster avatar (#3765) @aleksfront 
* Fix development on M1 (Apple Silicon) (#3759) @jakolehm 
* Automatically check next pre-release channel (#3737) @jakolehm 
* Add catalogAddMenu filter to CatalogCategory (#3722) @panuhorsmalahti 
* Add CatalogCategory filter to the extension API (#3718) @panuhorsmalahti 
* Add ability to search and activate entities via the command dialog (#3692) @Nokel81 
* Support filtering catalog entities (#3647) @Nokel81 

## 🐛 Bug Fixes

* Fix prometheus operator support (#3653) @marcbachmann
* Use JSON patch for editing components (#3674) @Nokel81
* Don't override entity source on cluster icons (#3928) @Nokel81
* Specify tableId for DeploymentReplicaSets (#3950) @Nokel81
* Added tooltipOnParentHover to taint tooltip on nodes list page (#3939) @GabhenDM
* Make editor editable when user-supplied values is selected (#3776) @KorvinSzanto
* Add missing locale date in event view (#3931) @ArthurKnoep
* Update electron to 13.5.1 to enable X509_V_FLAG_TRUSTED_FIRST flag in BoringSSL (#3925) @chenhunghan 
* Electron 13.4.0 (#3820) @jakolehm 

## 🧰 Maintenance

* Bump @types/react-table from 7.7.0 to 7.7.6 (#3953) @dependabot
* Bump @types/jest from 26.0.22 to 26.0.24 (#3951) @dependabot
* Bump eslint from 7.7.0 to 7.32.0 (#3954) @dependabot
* Bump electron-updater from 4.5.2 to 4.6.0 (#3952) @dependabot
* Bump deepdash from 5.3.5 to 5.3.9 (#3947) @dependabot
* Bump @types/webpack from 4.41.30 to 4.41.31 (#3948) @dependabot
* Bump @types/webpack-env from 1.15.2 to 1.16.2 (#3949) @dependabot
* Bump esbuild-loader from 2.13.1 to 2.15.1 (#3936) @dependabot
* Bump @types/request-promise-native from 1.0.17 to 1.0.18 (#3933) @dependabot
* Bump css-loader from 5.2.6 to 5.2.7 (#3944) @dependabot
* Bump @types/html-webpack-plugin from 3.2.3 to 3.2.6 (#3934) @dependabot
* Bump url-parse from 1.5.1 to 1.5.3 (#3813) @dependabot
* Bump mini-css-extract-plugin from 1.6.0 to 1.6.2 (#3873) @dependabot
* Bump @types/webpack-dev-server from 3.11.1 to 3.11.6 (#3724) @dependabot
* Bump jsonpath from 1.0.2 to 1.1.1 (#3726) @dependabot
* Remove @materil-ui/core deprecation warning (#3784) @chenhunghan 
* Fix sass warnings (#3783) @chenhunghan 

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>