### PR TITLE
Allow both catalog entity uid and entity object.

### DIFF
--- a/src/extensions/renderer-api/catalog.ts
+++ b/src/extensions/renderer-api/catalog.ts
@@ -21,6 +21,7 @@
 
 
 import type { CatalogCategory, CatalogEntity } from "../../common/catalog";
+import type { CatalogEntityUid } from "../../renderer/api/catalog-entity-registry";
 import { catalogEntityRegistry as registry } from "../../renderer/api/catalog-entity-registry";
 import type { CatalogEntityOnBeforeRun } from "../../renderer/api/catalog-entity-registry";
 import type { Disposer } from "../../common/utils";
@@ -52,12 +53,12 @@ export class CatalogEntityRegistry {
 
   /**
    * Add a onBeforeRun hook to a catalog entity. If `onBeforeRun` was previously added then it will not be added again
-   * @param catalogEntityUid The uid of the catalog entity
+   * @param entityOrId Catalog entity or the uid of the catalog entity
    * @param onBeforeRun The function that should return a boolean if the onRun of catalog entity should be triggered.
    * @returns A function to remove that hook
    */
-  addOnBeforeRun(entity: CatalogEntity, onBeforeRun: CatalogEntityOnBeforeRun): Disposer {
-    return registry.addOnBeforeRun(entity, onBeforeRun);
+  addOnBeforeRun(entityOrId: CatalogEntity | CatalogEntityUid, onBeforeRun: CatalogEntityOnBeforeRun): Disposer {
+    return registry.addOnBeforeRun(entityOrId, onBeforeRun);
   }
 }
 

--- a/src/renderer/api/catalog-entity-registry.ts
+++ b/src/renderer/api/catalog-entity-registry.ts
@@ -33,7 +33,7 @@ import { catalogEntityRunContext } from "./catalog-entity";
 export type EntityFilter = (entity: CatalogEntity) => any;
 export type CatalogEntityOnBeforeRun = (entity: CatalogEntity) => boolean | Promise<boolean>;
 
-type CatalogEntityUid = CatalogEntity["metadata"]["uid"];
+export type CatalogEntityUid = CatalogEntity["metadata"]["uid"];
 
 export class CatalogEntityRegistry {
   @observable protected activeEntityId: string | undefined = undefined;
@@ -180,7 +180,7 @@ export class CatalogEntityRegistry {
 
   /**
    * Add a onBeforeRun hook to a catalog entity. If `onBeforeRun` was previously added then it will not be added again
-   * @param catalogEntityUid The uid of the catalog entity
+   * @param entityOrId Catalog entity or the uid of the catalog entity
    * @param onBeforeRun The function that should return a boolean if the onRun of catalog entity should be triggered.
    * @returns A function to remove that hook
    */


### PR DESCRIPTION
Catalog entity on the renderer side does not necessary have `.getId()` (has been serialised to sent from main to renderer), we should allow add hooks using entity uid just as https://github.com/lensapp/lens/blob/master/src/renderer/api/catalog-entity-registry.ts#L206

- Update docs
- Add `CatalogEntityUid` to `Renderer.Catalog.catalogEntities.addOnBeforeRun`

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>