### PR TITLE
Use cluster entity.status.phase when available

### DIFF
--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -160,6 +160,10 @@ export class ClusterManager extends Singleton {
           return "connecting";
         }
 
+        if (entity?.status?.phase) {
+          return entity.status.phase;
+        }
+
         return "disconnected";
       })();
 


### PR DESCRIPTION
This is needed for space extension to set dev cluster phase: "provisioning" | "stopped" | "aviable" etc.

Signed-off-by: Hung-Han (Henry) Chen <chenhungh@gmail.com>