### PR TITLE
release v5.3.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.3.0-alpha.0",
+  "version": "5.3.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.3.0-alpha.0

## 🚀 Features

* Add ability to configure lens release channel (#3971) @Nokel81
* Use cluster entity.status.phase when available (#4009) @chenhunghan
* Closing dock tabs with cmd+w on mac (#3849) @aleksfront
* Feature/port forward dashboard (#3922) @jim-docker
* Change onBeforeRun API  (#3981) @jweak

## 🐛 Bug Fixes

* Fix HelmChartDetails and HelmReleaseDetails Menu (#3986) @Nokel81
* Catch and display errors for release details (#3905) @Nokel81
* Use the served and storage version of a CRD instead of the first (#3999) @Nokel81
* Don't run store migrations on renderer (#3968) @Nokel81
* Catch metadata being undefined at KubeObject creation (#3960) @Nokel81
* Fix taints on nodes view (#3957) @Nokel81

## 🧰 Maintenance

* Bump @sentry/react from 6.8.0 to 6.13.3 (#4008) @dependabot
* Bump conf from 7.0.1 to 7.1.2 (#4005) @dependabot
* Fix make clean to actually remove *.tgz files (#3997) @Nokel81
* Bump ts-node from 10.1.0 to 10.2.1 (#3994) @dependabot
* Bump typescript from 4.3.2 to 4.4.3 (#3993) @dependabot
* Bump @types/proper-lockfile from 4.1.1 to 4.1.2 (#3991) @dependabot
* Bump tcp-port-used from 1.0.1 to 1.0.2 (#3992) @dependabot
* Remove directly depending on openid-client (#3935) @Nokel81
* Switch integration tests to get application menus by IDs (#3912) @Nokel81
* Bump @types/react-router-dom from 5.1.6 to 5.3.1 (#3976) @dependabot
* Bump typedoc from 0.21.0-beta.2 to 0.22.5 (#3977) @dependabot
* Bump @typescript-eslint/eslint-plugin from 4.29.0 to 4.33.0 (#3978) @dependabot
* Bump path-to-regexp from 6.1.0 to 6.2.0 (#3975) @dependabot
* Bump tempy from 0.5.0 to 1.0.1 (#3964) @dependabot
* Bump win-ca from 3.2.1 to 3.4.5 (#3963) @dependabot
* Bump sharp from 0.29.0 to 0.29.1 (#3962) @dependabot

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>