### PR TITLE
Fix auto-update channel checking and pinning

### DIFF
--- a/src/common/user-store/preferences-helpers.ts
+++ b/src/common/user-store/preferences-helpers.ts
@@ -23,9 +23,10 @@ import moment from "moment-timezone";
 import path from "path";
 import os from "os";
 import { ThemeStore } from "../../renderer/theme.store";
-import { ObservableToggleSet } from "../utils";
+import { getAppVersion, ObservableToggleSet } from "../utils";
 import type {monaco} from "react-monaco-editor";
 import merge from "lodash/merge";
+import { SemVer } from "semver";
 
 export interface KubeconfigSyncEntry extends KubeconfigSyncValue {
   filePath: string;
@@ -260,9 +261,8 @@ const editorConfiguration: PreferenceDescription<EditorConfiguration, EditorConf
   },
 };
 
-const defaultUpdateChannel = "latest";
 const updateChannels = new Map([
-  [defaultUpdateChannel, {
+  ["latest", {
     label: "Stable"
   }],
   ["beta", {
@@ -272,6 +272,7 @@ const updateChannels = new Map([
     label: "Alpha"
   }],
 ]);
+const defaultUpdateChannel = new SemVer(getAppVersion()).prerelease[0].toString();
 
 const updateChannel: PreferenceDescription<string> = {
   fromStore(val) {
@@ -318,6 +319,5 @@ export const DESCRIPTORS = {
 };
 
 export const CONSTANTS = {
-  defaultUpdateChannel,
   updateChannels,
 };

--- a/src/common/user-store/preferences-helpers.ts
+++ b/src/common/user-store/preferences-helpers.ts
@@ -272,7 +272,7 @@ const updateChannels = new Map([
     label: "Alpha"
   }],
 ]);
-const defaultUpdateChannel = new SemVer(getAppVersion()).prerelease[0].toString();
+const defaultUpdateChannel = new SemVer(getAppVersion()).prerelease[0]?.toString() || "latest";
 
 const updateChannel: PreferenceDescription<string> = {
   fromStore(val) {

--- a/src/common/user-store/user-store.ts
+++ b/src/common/user-store/user-store.ts
@@ -20,7 +20,7 @@
  */
 
 import { app, ipcMain } from "electron";
-import semver from "semver";
+import semver, { SemVer } from "semver";
 import { action, computed, observable, reaction, makeObservable } from "mobx";
 import { BaseStore } from "../base-store";
 import migrations from "../../migrations/user-store";
@@ -30,7 +30,7 @@ import { appEventBus } from "../event-bus";
 import path from "path";
 import { fileNameMigration } from "../../migrations/user-store";
 import { ObservableToggleSet, toJS } from "../../renderer/utils";
-import { DESCRIPTORS, KubeconfigSyncValue, UserPreferencesModel, EditorConfiguration, CONSTANTS } from "./preferences-helpers";
+import { DESCRIPTORS, KubeconfigSyncValue, UserPreferencesModel, EditorConfiguration } from "./preferences-helpers";
 import logger from "../../main/logger";
 import type { monaco } from "react-monaco-editor";
 import { getPath } from "../utils/getPath";
@@ -107,9 +107,7 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
     return this.shell || process.env.SHELL || process.env.PTYSHELL;
   }
 
-  @computed get isAllowedToDowngrade(): boolean {
-    return this.updateChannel !== CONSTANTS.defaultUpdateChannel;
-  }
+  readonly isAllowedToDowngrade = new SemVer(getAppVersion()).prerelease[0] !== "latest";
 
   startMainReactions() {
     // track telemetry availability

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -29,7 +29,6 @@ import { ipcMain } from "electron";
 import { nextUpdateChannel } from "./utils/update-channel";
 import { UserStore } from "../common/user-store";
 
-const updateChannel = autoUpdater.channel;
 let installVersion: null | string = null;
 
 export function isAutoUpdateEnabled() {
@@ -59,13 +58,13 @@ export const startUpdateChecking = once(function (interval = 1000 * 60 * 60 * 24
     return;
   }
 
-  const us = UserStore.getInstance();
+  const userStore = UserStore.getInstance();
 
   autoUpdater.logger = logger;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
-  autoUpdater.channel = us.updateChannel;
-  autoUpdater.allowDowngrade = us.isAllowedToDowngrade;
+  autoUpdater.channel = userStore.updateChannel;
+  autoUpdater.allowDowngrade = userStore.isAllowedToDowngrade;
 
   autoUpdater
     .on("update-available", (info: UpdateInfo) => {
@@ -109,7 +108,7 @@ export const startUpdateChecking = once(function (interval = 1000 * 60 * 60 * 24
       }
     })
     .on("update-not-available", () => {
-      const nextChannel = nextUpdateChannel(updateChannel, autoUpdater.channel);
+      const nextChannel = nextUpdateChannel(userStore.updateChannel, autoUpdater.channel);
 
       logger.info(`${AutoUpdateLogPrefix}: update not available from ${autoUpdater.channel}, will check ${nextChannel} channel next`);
 

--- a/src/main/utils/__test__/update-channel.test.ts
+++ b/src/main/utils/__test__/update-channel.test.ts
@@ -33,17 +33,17 @@ describe("nextUpdateChannel", () => {
     expect(nextUpdateChannel("latest", "alpha")).toEqual("beta");
   });
 
-  it("returns rc if current channel is beta", () => {
-    expect(nextUpdateChannel("alpha", "beta")).toEqual("rc");
-    expect(nextUpdateChannel("beta", "beta")).toEqual("rc");
-    expect(nextUpdateChannel("rc", "beta")).toEqual("rc");
-    expect(nextUpdateChannel("latest", "beta")).toEqual("rc");
+  it("returns latest if current channel is beta", () => {
+    expect(nextUpdateChannel("alpha", "beta")).toEqual("latest");
+    expect(nextUpdateChannel("beta", "beta")).toEqual("latest");
+    expect(nextUpdateChannel("rc", "beta")).toEqual("latest");
+    expect(nextUpdateChannel("latest", "beta")).toEqual("latest");
   });
 
-  it("returns latest if current channel is rc", () => {
-    expect(nextUpdateChannel("alpha", "rc")).toEqual("latest");
-    expect(nextUpdateChannel("beta", "rc")).toEqual("latest");
-    expect(nextUpdateChannel("rc", "rc")).toEqual("latest");
+  it("returns default if current channel is unknown", () => {
+    expect(nextUpdateChannel("alpha", "rc")).toEqual("alpha");
+    expect(nextUpdateChannel("beta", "rc")).toEqual("beta");
+    expect(nextUpdateChannel("rc", "rc")).toEqual("rc");
     expect(nextUpdateChannel("latest", "rc")).toEqual("latest");
   });
 });

--- a/src/main/utils/update-channel.ts
+++ b/src/main/utils/update-channel.ts
@@ -19,14 +19,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * Compute the next update channel from the current updating channel
+ * @param defaultChannel The default (initial) channel to check
+ * @param channel The current channel that did not have a new version associated with it
+ * @returns The channel name of the next release version
+ */
 export function nextUpdateChannel(defaultChannel: string, channel: string): string {
-  if (channel === "alpha") {
-    return "beta";
-  } else if (channel === "beta") {
-    return "rc";
-  } else if (channel === "rc") {
-    return "latest";
-  } else {
-    return defaultChannel;
+  switch (channel) {
+    case "alpha":
+      return "beta";
+    case "beta":
+      return "latest"; // there is no RC currently
+    default:
+      return defaultChannel;
   }
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes error from auto-update `nextUpdateChannel` and from the auto-updater not using the current channel by default.