### PR TITLE
Upgrade typedoc-plugin-markdown to fix verify-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "type-fest": "^1.0.2",
     "typed-emitter": "^1.3.1",
     "typedoc": "0.22.5",
-    "typedoc-plugin-markdown": "^3.9.0",
+    "typedoc-plugin-markdown": "^3.11.3",
     "typeface-roboto": "^1.1.13",
     "typescript": "^4.4.3",
     "typescript-plugin-css-modules": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13899,10 +13899,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-plugin-markdown@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.9.0.tgz#d9c0390b8ddeeda56fdbf01264521ef04b3c19c7"
-  integrity sha512-s445YeUe8bH7me15T+hsHZgNmAvvF7QIpX02vFgseLGtghAwmtdZYVOqPneWoKqRv/JNpPSuyZb3CeblML9jOg==
+typedoc-plugin-markdown@^3.11.3:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.3.tgz#be340b905903f1ce552fa2fa7d677db408ab1041"
+  integrity sha512-rWiHbEIe0oZetDIsBR24XJVxGOJ91kDcHoj2KhFKxCLoJGX659EKBQkHne9QJ4W2stGhu1fRgFyQaouSBnxukA==
   dependencies:
     handlebars "^4.7.7"
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes the very common failure of the verify-docs github action