### PR TITLE
Fix cluster icon click in sidebar redirecting to wrong route

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -193,7 +193,7 @@ export class Sidebar extends React.Component<Props> {
           source={metadata.source}
           src={spec.icon?.src}
           className="mr-5"
-          onClick={() => navigate(routes.clusterURL())}
+          onClick={() => navigate("/")}
         />
         <div className={styles.clusterName}>
           {metadata.name}


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4033