### PR TITLE
Fix accessible namespaces notification not navigating to correct settings

### DIFF
--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -38,6 +38,6 @@ fetchMock.enableMocks();
 // Mock __non_webpack_require__ for tests
 globalThis.__non_webpack_require__ = jest.fn();
 
-process.on("unhandledRejection", (err) => {
+process.on("unhandledRejection", (err: any) => {
   fail(err);
 });

--- a/src/renderer/components/cluster-manager/cluster-status.tsx
+++ b/src/renderer/components/cluster-manager/cluster-status.tsx
@@ -90,7 +90,7 @@ export class ClusterStatus extends React.Component<Props> {
       params: {
         entityId: this.props.clusterId,
       },
-      fragment: "Proxy",
+      fragment: "proxy",
     }));
   };
 

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -50,8 +50,13 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
   static defaultProps = defaultProps as object;
 
   async componentDidMount() {
+    const { hash } = window.location;
+
+    if (hash) {
+      document.querySelector(hash)?.scrollIntoView();
+    }
+
     window.addEventListener("keydown", this.onEscapeKey);
-    document.querySelector(window.location.hash)?.scrollIntoView();
   }
 
   componentWillUnmount() {

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -23,7 +23,7 @@ import "./setting-layout.scss";
 
 import React from "react";
 import { observer } from "mobx-react";
-import { boundMethod, cssNames, IClassName } from "../../utils";
+import { cssNames, IClassName } from "../../utils";
 import { navigation } from "../../navigation";
 import { Icon } from "../icon";
 
@@ -36,17 +36,10 @@ export interface SettingLayoutProps extends React.DOMAttributes<any> {
   back?: (evt: React.MouseEvent | KeyboardEvent) => void;
 }
 
-function scrollToAnchor() {
-  const { hash } = window.location;
-
-  if (hash) {
-    document.querySelector(`${hash}`).scrollIntoView();
-  }
-}
-
 const defaultProps: Partial<SettingLayoutProps> = {
   provideBackButtonNavigation: true,
   contentGaps: true,
+  back: () => navigation.goBack(),
 };
 
 /**
@@ -56,19 +49,9 @@ const defaultProps: Partial<SettingLayoutProps> = {
 export class SettingLayout extends React.Component<SettingLayoutProps> {
   static defaultProps = defaultProps as object;
 
-  @boundMethod
-  back(evt?: React.MouseEvent | KeyboardEvent) {
-    if (this.props.back) {
-      this.props.back(evt);
-    } else {
-      navigation.goBack();
-    }
-  }
-
   async componentDidMount() {
     window.addEventListener("keydown", this.onEscapeKey);
-
-    scrollToAnchor();
+    document.querySelector(window.location.hash)?.scrollIntoView();
   }
 
   componentWillUnmount() {
@@ -82,7 +65,7 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
 
     if (evt.code === "Escape") {
       evt.stopPropagation();
-      this.back(evt);
+      this.props.back(evt);
     }
   };
 
@@ -107,17 +90,18 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
             {children}
           </div>
           <div className="toolsRegion">
-            { this.props.provideBackButtonNavigation && (
-              <div className="fixedTools">
-                <div className="closeBtn" role="button" aria-label="Close" onClick={this.back}>
-                  <Icon material="close"/>
+            {
+              this.props.provideBackButtonNavigation && (
+                <div className="fixedTools">
+                  <div className="closeBtn" role="button" aria-label="Close" onClick={back}>
+                    <Icon material="close" />
+                  </div>
+                  <div className="esc" aria-hidden="true">
+                    ESC
+                  </div>
                 </div>
-
-                <div className="esc" aria-hidden="true">
-                  ESC
-                </div>
-              </div>
-            )}
+              )
+            }
           </div>
         </div>
       </div>

--- a/src/renderer/ipc/index.tsx
+++ b/src/renderer/ipc/index.tsx
@@ -77,16 +77,15 @@ function UpdateAvailableHandler(event: IpcRendererEvent, ...[backchannel, update
   );
 }
 
-const listNamespacesForbiddenHandlerDisplayedAt = new Map<string, number>();
+const notificationLastDisplayedAt = new Map<string, number>();
 const intervalBetweenNotifications = 1000 * 60; // 60s
 
 function ListNamespacesForbiddenHandler(event: IpcRendererEvent, ...[clusterId]: ListNamespaceForbiddenArgs): void {
-  const lastDisplayedAt = listNamespacesForbiddenHandlerDisplayedAt.get(clusterId);
-  const wasDisplayed = Boolean(lastDisplayedAt);
+  const lastDisplayedAt = notificationLastDisplayedAt.get(clusterId);
   const now = Date.now();
 
-  if (!wasDisplayed || (now - lastDisplayedAt) > intervalBetweenNotifications) {
-    listNamespacesForbiddenHandlerDisplayedAt.set(clusterId, now);
+  if (!notificationLastDisplayedAt.has(clusterId) || (now - lastDisplayedAt) > intervalBetweenNotifications) {
+    notificationLastDisplayedAt.set(clusterId, now);
   } else {
     // don't bother the user too often
     return;
@@ -94,21 +93,39 @@ function ListNamespacesForbiddenHandler(event: IpcRendererEvent, ...[clusterId]:
 
   const notificationId = `list-namespaces-forbidden:${clusterId}`;
 
+  if (notificationsStore.getById(notificationId)) {
+    // notification is still visible
+    return;
+  }
+
   Notifications.info(
     (
       <div className="flex column gaps">
         <b>Add Accessible Namespaces</b>
-        <p>Cluster <b>{ClusterStore.getInstance().getById(clusterId).name}</b> does not have permissions to list namespaces. Please add the namespaces you have access to.</p>
+        <p>
+          Cluster <b>{ClusterStore.getInstance().getById(clusterId).name}</b> does not have permissions to list namespaces.{" "}
+          Please add the namespaces you have access to.
+        </p>
         <div className="flex gaps row align-left box grow">
-          <Button active outlined label="Go to Accessible Namespaces Settings" onClick={() => {
-            navigate(entitySettingsURL({ params: { entityId: clusterId }, fragment: "accessible-namespaces" }));
-            notificationsStore.remove(notificationId);
-          }} />
+          <Button
+            active
+            outlined
+            label="Go to Accessible Namespaces Settings"
+            onClick={() => {
+              navigate(entitySettingsURL({ params: { entityId: clusterId }, fragment: "namespaces" }));
+              notificationsStore.remove(notificationId);
+            }}
+          />
         </div>
       </div>
     ),
     {
       id: notificationId,
+      /**
+       * Set the time when the notification is closed as well so that there is at
+       * least a minute between closing the notification as seeing it again
+       */
+      onClose: () => notificationLastDisplayedAt.set(clusterId, Date.now()),
     }
   );
 }


### PR DESCRIPTION
- Cleaned up the broadcasting of failure to that the debounding is only
  on renderer. This leads to faster initial notification.

- Improved logging to not log entire request.Response object

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4034 