### PR TITLE
Added Status to the Port Forwarding list items

### DIFF
--- a/src/renderer/components/+network-port-forwards/port-forwards.scss
+++ b/src/renderer/components/+network-port-forwards/port-forwards.scss
@@ -24,5 +24,10 @@
     &.warning {
       @include table-cell-warning;
     }
+
+    &.status {
+      @include port-forward-status-colors;
+      flex: 0.6;
+    }
   }
 }

--- a/src/renderer/components/+network-port-forwards/port-forwards.tsx
+++ b/src/renderer/components/+network-port-forwards/port-forwards.tsx
@@ -33,6 +33,7 @@ enum columnId {
   kind = "kind",
   port = "port",
   forwardPort = "forwardPort",
+  status = "status",
 }
 
 @observer
@@ -68,6 +69,7 @@ export class PortForwards extends React.Component {
             [columnId.kind]: item => item.getKind(),
             [columnId.port]: item => item.getPort(),
             [columnId.forwardPort]: item => item.getForwardPort(),
+            [columnId.status]: item => item.getStatus(),
           }}
           searchFilters={[
             item => item.getSearchFields(),
@@ -79,6 +81,7 @@ export class PortForwards extends React.Component {
             { title: "Kind", className: "kind", sortBy: columnId.kind, id: columnId.kind },
             { title: "Pod Port", className: "port", sortBy: columnId.port, id: columnId.port },
             { title: "Local Port", className: "forwardPort", sortBy: columnId.forwardPort, id: columnId.forwardPort },
+            { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
           ]}
           renderTableContents={item => [
             item.getName(),
@@ -86,6 +89,7 @@ export class PortForwards extends React.Component {
             item.getKind(),
             item.getPort(),
             item.getForwardPort(),
+            { title: item.getStatus(), className: item.getStatus().toLowerCase() },
           ]}
           renderItemMenu={pf => (
             <PortForwardMenu

--- a/src/renderer/components/+network/network-mixins.scss
+++ b/src/renderer/components/+network/network-mixins.scss
@@ -31,3 +31,15 @@ $service-status-color-list: (
     }
   }
 }
+
+$port-forward-status-color-list: (
+  active: $colorOk,
+);
+
+@mixin port-forward-status-colors {
+  @each $status, $color in $port-forward-status-color-list {
+    &.#{$status} {
+      color: $color;
+    }
+  }
+}

--- a/src/renderer/port-forward/port-forward-item.ts
+++ b/src/renderer/port-forward/port-forward-item.ts
@@ -78,6 +78,10 @@ export class PortForwardItem implements ItemObject {
   getForwardPort() {
     return this.forwardPort;
   }
+
+  getStatus() {
+    return "Active"; // to-do allow port-forward-items to be stopped (without removing them)
+  }
   
   getSearchFields() {
     return [


### PR DESCRIPTION
![Screen Shot 2021-10-18 at 11 18 29 AM](https://user-images.githubusercontent.com/40840436/137760984-8e40244d-bf14-4ea5-9df1-e374d24e00e1.png)

fixes #4062

Currently the only status is "Active" since port-forwards are removed if they are stopped.  When the ability to disable port-forwards without removing them is implemented this will be adapted.

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>