### PR TITLE
Remove unnecessary global watches in cluster view

### DIFF
--- a/src/renderer/components/+cluster/cluster-issues.tsx
+++ b/src/renderer/components/+cluster/cluster-issues.tsx
@@ -22,7 +22,7 @@
 import "./cluster-issues.scss";
 
 import React from "react";
-import { disposeOnUnmount, observer } from "mobx-react";
+import { observer } from "mobx-react";
 import { computed, makeObservable } from "mobx";
 import { Icon } from "../icon";
 import { SubHeader } from "../layout/sub-header";
@@ -34,7 +34,6 @@ import type { ItemObject } from "../../../common/item.store";
 import { Spinner } from "../spinner";
 import { ThemeStore } from "../../theme.store";
 import { kubeSelectedUrlParam, toggleDetails } from "../kube-detail-params";
-import { kubeWatchApi } from "../../../common/k8s-api/kube-watch-api";
 import { apiManager } from "../../../common/k8s-api/api-manager";
 
 interface Props {
@@ -66,10 +65,6 @@ export class ClusterIssues extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
     makeObservable(this);
-
-    disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([eventStore, nodesStore])
-    ]);
   }
 
   @computed get warnings() {

--- a/src/renderer/components/+cluster/cluster-overview.tsx
+++ b/src/renderer/components/+cluster/cluster-overview.tsx
@@ -36,6 +36,8 @@ import { ClusterPieCharts } from "./cluster-pie-charts";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { ClusterStore } from "../../../common/cluster-store";
+import { kubeWatchApi } from "../../../common/k8s-api/kube-watch-api";
+import { eventStore } from "../+events/event.store";
 
 @observer
 export class ClusterOverview extends React.Component {
@@ -53,6 +55,9 @@ export class ClusterOverview extends React.Component {
     this.metricPoller.start(true);
 
     disposeOnUnmount(this, [
+      kubeWatchApi.subscribeStores([podsStore, eventStore, nodesStore], {
+        preload: true,
+      }),
       reaction(
         () => clusterOverviewStore.metricNodeRole, // Toggle Master/Worker node switcher
         () => this.metricPoller.restart(true)
@@ -91,7 +96,7 @@ export class ClusterOverview extends React.Component {
   }
 
   render() {
-    const isLoaded = nodesStore.isLoaded && podsStore.isLoaded;
+    const isLoaded = nodesStore.isLoaded && eventStore.isLoaded;
     const isMetricHidden = getActiveClusterEntity()?.isMetricHidden(ClusterMetricsResourceType.Cluster);
 
     return (

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -42,9 +42,6 @@ import whatInput from "what-input";
 import { clusterSetFrameIdHandler } from "../../common/cluster-ipc";
 import { ClusterPageMenuRegistration, ClusterPageMenuRegistry } from "../../extensions/registries";
 import { StatefulSetScaleDialog } from "./+workloads-statefulsets/statefulset-scale-dialog";
-import { eventStore } from "./+events/event.store";
-import { nodesStore } from "./+nodes/nodes.store";
-import { podsStore } from "./+workloads-pods/pods.store";
 import { kubeWatchApi } from "../../common/k8s-api/kube-watch-api";
 import { ReplicaSetScaleDialog } from "./+workloads-replicasets/replicaset-scale-dialog";
 import { CommandContainer } from "./command-palette/command-container";
@@ -137,7 +134,7 @@ export class App extends React.Component {
 
   componentDidMount() {
     disposeOnUnmount(this, [
-      kubeWatchApi.subscribeStores([podsStore, nodesStore, eventStore, namespaceStore], {
+      kubeWatchApi.subscribeStores([namespaceStore], {
         preload: true,
       }),
 


### PR DESCRIPTION
These were originally implemented for notification badge (which Lens does not have anymore). Should improve UI performance on bigger clusters.