### PR TITLE
Remove ClusterStore.removedClusters and correctly delete lens storage file

### DIFF
--- a/src/common/cluster-store.ts
+++ b/src/common/cluster-store.ts
@@ -40,7 +40,6 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
   private static StateChannel = "cluster:state";
 
   clusters = observable.map<ClusterId, Cluster>();
-  removedClusters = observable.map<ClusterId, Cluster>();
 
   protected disposer = disposer();
 
@@ -144,7 +143,6 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
   protected fromStore({ clusters = [] }: ClusterStoreModel = {}) {
     const currentClusters = new Map(this.clusters);
     const newClusters = new Map<ClusterId, Cluster>();
-    const removedClusters = new Map<ClusterId, Cluster>();
 
     // update new clusters
     for (const clusterModel of clusters) {
@@ -162,15 +160,7 @@ export class ClusterStore extends BaseStore<ClusterStoreModel> {
       }
     }
 
-    // update removed clusters
-    currentClusters.forEach(cluster => {
-      if (!newClusters.has(cluster.id)) {
-        removedClusters.set(cluster.id, cluster);
-      }
-    });
-
     this.clusters.replace(newClusters);
-    this.removedClusters.replace(removedClusters);
   }
 
   toJSON(): ClusterStoreModel {

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -21,7 +21,7 @@
 
 import "../common/cluster-ipc";
 import type http from "http";
-import { action, autorun, makeObservable, observable, observe, reaction, toJS } from "mobx";
+import { action, makeObservable, observable, observe, reaction, toJS } from "mobx";
 import { Cluster } from "./cluster";
 import logger from "./logger";
 import { apiKubePrefix } from "../common/vars";
@@ -69,21 +69,6 @@ export class ClusterManager extends Singleton {
       if (change.type === "add") {
         this.updateEntityStatus(catalogEntityRegistry.getById(change.newValue));
       }
-    });
-
-    // auto-stop removed clusters
-    autorun(() => {
-      const removedClusters = Array.from(this.store.removedClusters.values());
-
-      if (removedClusters.length > 0) {
-        const meta = removedClusters.map(cluster => cluster.getMeta());
-
-        logger.info(`${logPrefix} removing clusters`, meta);
-        removedClusters.forEach(cluster => cluster.disconnect());
-        this.store.removedClusters.clear();
-      }
-    }, {
-      delay: 250
     });
 
     ipcMainOn("network:offline", this.onNetworkOffline);

--- a/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
+++ b/src/renderer/components/delete-cluster-dialog/delete-cluster-dialog.tsx
@@ -116,6 +116,7 @@ export class DeleteClusterDialog extends React.Component {
       await requestMain(clusterDeleteHandler, cluster.id);
     } catch(error) {
       Notifications.error(`Cannot remove cluster, failed to process config file. ${error}`);
+    } finally {
       await requestMain(clusterClearDeletingHandler, cluster.id);
     }
 

--- a/src/renderer/utils/createStorage.ts
+++ b/src/renderer/utils/createStorage.ts
@@ -25,7 +25,6 @@ import path from "path";
 import { comparer, observable, reaction, toJS, when } from "mobx";
 import fse from "fs-extra";
 import { StorageHelper } from "./storageHelper";
-import { ClusterStore } from "../../common/cluster-store";
 import logger from "../../main/logger";
 import { getHostedClusterId, getPath } from "../../common/utils";
 import { isTestEnv } from "../../common/vars";
@@ -75,11 +74,6 @@ export function createAppStorage<T>(key: string, defaultValue: T, clusterId?: st
       equals: comparer.structural, // save only when something really changed
     });
 
-    // remove json-file when cluster deleted
-    if (clusterId !== undefined) {
-      when(() => ClusterStore.getInstance(false)?.removedClusters.has(clusterId)).then(removeFile);
-    }
-
     async function saveFile(state: Record<string, any> = {}) {
       logger.info(`${logPrefix} saving ${filePath}`);
 
@@ -91,11 +85,6 @@ export function createAppStorage<T>(key: string, defaultValue: T, clusterId?: st
           json: state, jsonFilePath: filePath
         });
       }
-    }
-
-    function removeFile() {
-      logger.debug(`${logPrefix} removing ${filePath}`);
-      fse.unlink(filePath).catch(Function);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

We never add clusters to `removedClusters` so the files were never being removed. This PR now correctly deletes the cluster from `ClusterStore` on deleting the context and removes the file under `lens-local-storage` on delete as well, which was attempted to do in the `createStorage` function but won't ever actually be triggered.