### PR TITLE
Fix captitalization in CrdResources component

### DIFF
--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -93,7 +93,7 @@ export class CrdResources extends React.Component<Props> {
         customizeHeader={({ searchProps, ...headerPlaceholders }) => ({
           searchProps: {
             ...searchProps,
-            placeholder: `Search ${crd.getNames().plural}...`,
+            placeholder: `${crd.getResourceKind()} search ...`,
           },
           ...headerPlaceholders
         })}

--- a/src/renderer/components/+custom-resources/crd-resources.tsx
+++ b/src/renderer/components/+custom-resources/crd-resources.tsx
@@ -89,11 +89,11 @@ export class CrdResources extends React.Component<Props> {
         searchFilters={[
           item => item.getSearchFields(),
         ]}
-        renderHeaderTitle={crd.getResourceTitle()}
+        renderHeaderTitle={crd.getResourceKind()}
         customizeHeader={({ searchProps, ...headerPlaceholders }) => ({
           searchProps: {
             ...searchProps,
-            placeholder: `Search ${crd.getResourceTitle()}...`,
+            placeholder: `Search ${crd.getNames().plural}...`,
           },
           ...headerPlaceholders
         })}


### PR DESCRIPTION
- Title should just be .spec.names.kind like the sidebar

- Searching should just be .spec.names.plural

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4081 