### PR TITLE
Fix race condition in refreshViews

### DIFF
--- a/src/main/catalog/catalog-entity-registry.ts
+++ b/src/main/catalog/catalog-entity-registry.ts
@@ -20,7 +20,7 @@
  */
 
 import { action, computed, IComputedValue, IObservableArray, makeObservable, observable } from "mobx";
-import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity, CatalogEntityKindData } from "../../common/catalog";
+import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity, CatalogEntityConstructor, CatalogEntityKindData } from "../../common/catalog";
 import { iter } from "../../common/utils";
 
 export class CatalogEntityRegistry {
@@ -59,7 +59,7 @@ export class CatalogEntityRegistry {
     return this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind) as T[];
   }
 
-  getItemsByEntityClass<T extends CatalogEntity>({ apiVersion, kind }: CatalogEntityKindData): T[] {
+  getItemsByEntityClass<T extends CatalogEntity>({ apiVersion, kind }: CatalogEntityKindData & CatalogEntityConstructor<T>): T[] {
     return this.getItemsForApiKind(apiVersion, kind);
   }
 }

--- a/src/main/initializers/ipc.ts
+++ b/src/main/initializers/ipc.ts
@@ -20,13 +20,12 @@
  */
 
 import { BrowserWindow, dialog, IpcMainInvokeEvent } from "electron";
-import { KubernetesCluster } from "../../common/catalog-entities";
 import { clusterFrameMap } from "../../common/cluster-frames";
 import { clusterActivateHandler, clusterSetFrameIdHandler, clusterVisibilityHandler, clusterRefreshHandler, clusterDisconnectHandler, clusterKubectlApplyAllHandler, clusterKubectlDeleteAllHandler, clusterDeleteHandler, clusterSetDeletingHandler, clusterClearDeletingHandler } from "../../common/cluster-ipc";
 import type { ClusterId } from "../../common/cluster-types";
 import { ClusterStore } from "../../common/cluster-store";
 import { appEventBus } from "../../common/event-bus";
-import { dialogShowOpenDialogHandler, ipcMainHandle } from "../../common/ipc";
+import { dialogShowOpenDialogHandler, ipcMainHandle, ipcMainOn } from "../../common/ipc";
 import { catalogEntityRegistry } from "../catalog";
 import { pushCatalogToRenderer } from "../catalog-pusher";
 import { ClusterManager } from "../cluster-manager";
@@ -54,16 +53,8 @@ export function initIpcMainHandlers() {
     }
   });
 
-  ipcMainHandle(clusterVisibilityHandler, (event: IpcMainInvokeEvent, clusterId: ClusterId, visible: boolean) => {
-    const entity = catalogEntityRegistry.getById(clusterId);
-
-    for (const kubeEntity of catalogEntityRegistry.getItemsByEntityClass(KubernetesCluster)) {
-      kubeEntity.status.active = false;
-    }
-
-    if (entity) {
-      entity.status.active = visible;
-    }
+  ipcMainOn(clusterVisibilityHandler, (event, clusterId?: ClusterId) => {
+    ClusterManager.getInstance().visibleCluster = clusterId;
   });
 
   ipcMainHandle(clusterRefreshHandler, (event, clusterId: ClusterId) => {

--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -89,7 +89,7 @@ export class ClusterFrameHandler extends Singleton {
         this.views.delete(clusterId);
 
         iframe.parentNode.removeChild(iframe);
-      }
+      },
     );
   }
 
@@ -124,7 +124,7 @@ export class ClusterFrameHandler extends Singleton {
           logger.info(`[LENS-VIEW]: cluster id=${clusterId} should now be visible`);
           lensView.frame.style.display = "flex";
           ipcRenderer.send(clusterVisibilityHandler, clusterId);
-        }
+        },
       );
     }
   };

--- a/src/renderer/lens-app.tsx
+++ b/src/renderer/lens-app.tsx
@@ -38,6 +38,7 @@ import { IpcRendererNavigationEvents } from "./navigation/events";
 import { catalogEntityRegistry } from "./api/catalog-entity-registry";
 import logger from "../common/logger";
 import { unmountComponentAtNode } from "react-dom";
+import { ClusterFrameHandler } from "./components/cluster-manager/lens-views";
 
 injectSystemCAs();
 
@@ -59,6 +60,12 @@ export class LensApp extends React.Component {
 
       unmountComponentAtNode(rootElem);
     };
+  }
+
+  constructor(props: {}) {
+    super(props);
+
+    ClusterFrameHandler.createInstance();
   }
 
   componentDidMount() {


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

I believe that this is a fix for the lens views not showing up some of the time. I noticed that if `refreshViews` was called before the cluster is ready and available then none of the views would be shown.