### PR TITLE
Fix PodDetailsList being empty over 100 pods

### DIFF
--- a/src/renderer/components/+workloads-pods/pod-details-list.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-list.tsx
@@ -146,6 +146,8 @@ export class PodDetailsList extends React.Component<Props> {
       return null;
     }
 
+    const virtual = pods.length > 20;
+
     return (
       <div className="PodDetailsList flex column">
         <DrawerTitle title="Pods" />
@@ -154,8 +156,9 @@ export class PodDetailsList extends React.Component<Props> {
           items={pods}
           selectable
           scrollable={false}
-          virtual
-          virtualHeight={600}
+          virtual={virtual}
+          // 660 is the exact hight required for 20 items with the default paddings
+          virtualHeight={660}
           sortable={{
             [sortBy.name]: pod => pod.getName(),
             [sortBy.namespace]: pod => pod.getNs(),
@@ -165,6 +168,7 @@ export class PodDetailsList extends React.Component<Props> {
           sortByDefault={{ sortBy: sortBy.cpu, orderBy: "desc" }}
           sortSyncWithUrl={false}
           getTableRow={this.getTableRow}
+          renderRow={!virtual && (pod => this.getTableRow(pod.getId()))}
           className="box grow"
         >
           <TableHead>

--- a/src/renderer/components/virtual-list/virtual-list.tsx
+++ b/src/renderer/components/virtual-list/virtual-list.tsx
@@ -44,6 +44,12 @@ interface Props<T extends ItemObject = any> {
   getRow?: (uid: string | number) => React.ReactElement<any>;
   onScroll?: (props: ListOnScrollProps) => void;
   outerRef?: React.Ref<any>
+
+  /**
+   * If specified then AutoSizer will not be used and instead a fixed height
+   * virtual list will be rendered
+   */
+  fixedHeight?: number;
 }
 
 interface State {
@@ -98,34 +104,45 @@ export class VirtualList extends Component<Props, State> {
     this.listRef.current?.scrollToItem(index, align);
   };
 
-  render() {
-    const { width, className, items, getRow, onScroll, outerRef } = this.props;
+  renderVSL(height: number | undefined) {
+    const { width, items, getRow, onScroll, outerRef } = this.props;
     const { overscanCount } = this.state;
-    const rowData: RowData = {
-      items,
-      getRow
-    };
+
+    return (
+      <VariableSizeList
+        className="list"
+        width={width}
+        height={height}
+        itemSize={this.getItemSize}
+        itemCount={items.length}
+        itemData={{
+          items,
+          getRow
+        }}
+        overscanCount={overscanCount}
+        ref={this.listRef}
+        outerRef={outerRef}
+        onScroll={onScroll}
+      >
+        {Row}
+      </VariableSizeList>
+    );
+  }
+
+  render() {
+    const { className, fixedHeight } = this.props;
 
     return (
       <div className={cssNames("VirtualList", className)}>
-        <AutoSizer disableWidth>
-          {({ height }) => (
-            <VariableSizeList
-              className="list"
-              width={width}
-              height={height}
-              itemSize={this.getItemSize}
-              itemCount={items.length}
-              itemData={rowData}
-              overscanCount={overscanCount}
-              ref={this.listRef}
-              outerRef={outerRef}
-              onScroll={onScroll}
-            >
-              {Row}
-            </VariableSizeList>
-          )}
-        </AutoSizer>
+        {
+          typeof fixedHeight === "number"
+            ? this.renderVSL(fixedHeight)
+            : (
+              <AutoSizer disableWidth>
+                {({ height }) => this.renderVSL(height)}
+              </AutoSizer>
+            )
+        }
       </div>
     );
   }

--- a/src/renderer/components/virtual-list/virtual-list.tsx
+++ b/src/renderer/components/virtual-list/virtual-list.tsx
@@ -104,7 +104,7 @@ export class VirtualList extends Component<Props, State> {
     this.listRef.current?.scrollToItem(index, align);
   };
 
-  renderVSL(height: number | undefined) {
+  renderList(height: number | undefined) {
     const { width, items, getRow, onScroll, outerRef } = this.props;
     const { overscanCount } = this.state;
 
@@ -136,10 +136,10 @@ export class VirtualList extends Component<Props, State> {
       <div className={cssNames("VirtualList", className)}>
         {
           typeof fixedHeight === "number"
-            ? this.renderVSL(fixedHeight)
+            ? this.renderList(fixedHeight)
             : (
               <AutoSizer disableWidth>
-                {({ height }) => this.renderVSL(height)}
+                {({ height }) => this.renderList(height)}
               </AutoSizer>
             )
         }


### PR DESCRIPTION
- Add fixedHeight prop to VirtualList which bypasses AutoSizer behaviour
  when used as a child to "overflow: scroll" DOM nodes

- Minor cleanup on Table

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4067 