### PR TITLE
Allow port-forwards to be restarted with the same local port

### DIFF
--- a/src/renderer/port-forward/port-forward-dialog.tsx
+++ b/src/renderer/port-forward/port-forward-dialog.tsx
@@ -49,7 +49,6 @@ const dialogState = observable.object({
 
 @observer
 export class PortForwardDialog extends Component<Props> {
-  @observable ready = false;
   @observable currentPort = 0;
   @observable desiredPort = 0;
 
@@ -81,16 +80,13 @@ export class PortForwardDialog extends Component<Props> {
 
     this.currentPort = +portForward.forwardPort;
     this.desiredPort = this.currentPort;
-    this.ready = this.currentPort ? false : true;
   };
 
   onClose = () => {
-    this.ready = false;
   };
 
   changePort = (value: string) => {
     this.desiredPort = Number(value);
-    this.ready = Boolean(this.desiredPort == 0 || this.currentPort !== this.desiredPort);
   };
 
   startPortForward = async () => {
@@ -170,7 +166,7 @@ export class PortForwardDialog extends Component<Props> {
             contentClass="flex gaps column"
             next={this.startPortForward}
             nextLabel={this.currentPort === 0 ? "Start" : "Restart"}
-            disabledNext={!this.ready}
+            disabledNext={false}
           >
             {this.renderContents()}
           </WizardStep>

--- a/src/renderer/port-forward/port-forward-dialog.tsx
+++ b/src/renderer/port-forward/port-forward-dialog.tsx
@@ -166,7 +166,6 @@ export class PortForwardDialog extends Component<Props> {
             contentClass="flex gaps column"
             next={this.startPortForward}
             nextLabel={this.currentPort === 0 ? "Start" : "Restart"}
-            disabledNext={false}
           >
             {this.renderContents()}
           </WizardStep>


### PR DESCRIPTION
The current design restricts the user from restarting a port-forward with the same port. The restriction is not technically necessary, and in the event that the associated pod is terminated/restarted lifting this restriction makes it easy for the user to reconnect the port-forward. (the `kubectl port-forward` process does not stop when the associated pod is terminated).

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

addresses #2340 