### PR TITLE
Add option for providing request options to watch requests

### DIFF
--- a/src/common/k8s-api/json-api.ts
+++ b/src/common/k8s-api/json-api.ts
@@ -75,7 +75,7 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
   public onData = new EventEmitter<[D, Response]>();
   public onError = new EventEmitter<[JsonApiErrorParsed, Response]>();
   
-  private getRequestOptions?: () => Promise<RequestInit>;
+  private getRequestOptions?: JsonApiConfig["getRequestOptions"];
 
   get<T = D>(path: string, params?: P, reqInit: RequestInit = {}) {
     return this.request<T>(path, params, { ...reqInit, method: "get" });

--- a/src/common/k8s-api/json-api.ts
+++ b/src/common/k8s-api/json-api.ts
@@ -69,13 +69,13 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
     this.config = Object.assign({}, JsonApi.configDefault, config);
     this.reqInit = merge({}, JsonApi.reqInitDefault, reqInit);
     this.parseResponse = this.parseResponse.bind(this);
-    this.getRequestOptions = config.getRequestOptions;
+    this.getRequestOptions = config.getRequestOptions ?? (() => Promise.resolve({}));
   }
 
   public onData = new EventEmitter<[D, Response]>();
   public onError = new EventEmitter<[JsonApiErrorParsed, Response]>();
   
-  private getRequestOptions?: JsonApiConfig["getRequestOptions"];
+  private getRequestOptions: JsonApiConfig["getRequestOptions"];
 
   get<T = D>(path: string, params?: P, reqInit: RequestInit = {}) {
     return this.request<T>(path, params, { ...reqInit, method: "get" });
@@ -86,7 +86,7 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
     const reqInit: RequestInit = merge(
       {},
       this.reqInit,
-      this.getRequestOptions ? (await this.getRequestOptions()) : {},
+      await this.getRequestOptions(),
       init
     );
     const { query } = params || {} as P;
@@ -125,7 +125,7 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
     const reqInit: RequestInit = merge(
       {},
       this.reqInit,
-      this.getRequestOptions ? (await this.getRequestOptions()) : {},
+      await this.getRequestOptions(),
       init
     );
     const { data, query } = params || {} as P;

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -137,7 +137,7 @@ export function forRemoteCluster<T extends KubeObject>(config: IRemoteKubeApiCon
   const reqInit: RequestInit = {};
   const token = config.user.token;
 
-  if (!isFunction(token)) {
+  if (token && !isFunction(token)) {
     reqInit.headers = {
       "Authorization": `Bearer ${token}`
     };

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -22,7 +22,7 @@
 // Base class for building all kubernetes apis
 
 import merge from "lodash/merge";
-import isFunction from "lodash/isfunction";
+import { isFunction } from "lodash";
 import { stringify } from "querystring";
 import { apiKubePrefix, isDevelopment } from "../../common/vars";
 import logger from "../../main/logger";

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -133,8 +133,6 @@ export function forCluster<T extends KubeObject>(cluster: ILocalKubeApiConfig, k
   });
 }
 
-// const getToken = (token: string | (() => Promise<string>)) => isFunction(token) ? token() : token;
-
 export function forRemoteCluster<T extends KubeObject>(config: IRemoteKubeApiConfig, kubeClass: KubeObjectConstructor<T>): KubeApi<T> {
   const reqInit: RequestInit = {};
   const token = config.user.token;

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -507,7 +507,7 @@ export class KubeApi<T extends KubeObject> {
     });
 
     const watchUrl = this.getWatchUrl(namespace);
-    const responsePromise = this.request.getResponse(watchUrl, null,{ signal, timeout: 600_000 });
+    const responsePromise = this.request.getResponse(watchUrl, null, { signal, timeout: 600_000 });
 
     logger.info(`[KUBE-API] watch (${watchId}) ${retry === true ? "retried" : "started"} ${watchUrl}`);
 

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -135,13 +135,6 @@ export function forCluster<T extends KubeObject>(cluster: ILocalKubeApiConfig, k
 
 export function forRemoteCluster<T extends KubeObject>(config: IRemoteKubeApiConfig, kubeClass: KubeObjectConstructor<T>): KubeApi<T> {
   const reqInit: RequestInit = {};
-  const token = config.user.token;
-
-  if (token && !isFunction(token)) {
-    reqInit.headers = {
-      "Authorization": `Bearer ${token}`
-    };
-  }
 
   const agentOptions: AgentOptions = {};
 
@@ -165,14 +158,15 @@ export function forRemoteCluster<T extends KubeObject>(config: IRemoteKubeApiCon
     reqInit.agent = new Agent(agentOptions);
   }
 
+  const token = config.user.token;
   const request = new KubeJsonApi({
     serverAddress: config.cluster.server,
     apiBase: "",
     debug: isDevelopment,
-    ...(isFunction(token) ? {
+    ...(token ? {
       getRequestOptions: async () => ({
         headers: {
-          "Authorization": `Bearer ${await token()}`
+          "Authorization": `Bearer ${isFunction(token) ? await token() : token}`
         }
       })
     } : {})


### PR DESCRIPTION
This is needed if e.g. token for the request would expire in a subsequent watch retry. This option can be used to provide a new token.