### PR TITLE
Fix immer/merge bug

### DIFF
--- a/src/renderer/utils/storageHelper.ts
+++ b/src/renderer/utils/storageHelper.ts
@@ -80,7 +80,7 @@ export class StorageHelper<T> {
     const notDefault = !this.isDefaultValue(data);
 
     if (notEmpty && notDefault) {
-      this.merge(data);
+      this.set(data);
     }
 
     this.initialized = true;
@@ -162,6 +162,8 @@ export class StorageHelper<T> {
       } else if (isPlainObject(value)) {
         Object.assign(draft, value);
       }
+
+      return draft;
     });
 
     this.set(nextValue);

--- a/src/renderer/utils/storageHelper.ts
+++ b/src/renderer/utils/storageHelper.ts
@@ -22,7 +22,7 @@
 // Helper for working with storages (e.g. window.localStorage, NodeJS/file-system, etc.)
 import { action, comparer, makeObservable, observable, toJS, when, } from "mobx";
 import produce, { Draft, isDraft } from "immer";
-import { isEqual } from "lodash";
+import { isEqual, isPlainObject } from "lodash";
 import logger from "../../main/logger";
 
 export interface StorageAdapter<T> {
@@ -159,7 +159,7 @@ export class StorageHelper<T> {
         if (newValue && !isDraft(newValue)) {
           Object.assign(draft, newValue);
         }
-      } else {
+      } else if (isPlainObject(value)) {
         Object.assign(draft, value);
       }
     });


### PR DESCRIPTION
This eliminates the error messages mentioned [here](https://github.com/lensapp/lens/pull/3882#issuecomment-946899952). 

But selected namespaces are always reset to just "default", and saved port-forwards are lost after disconnecting and then reconnecting the cluster.

It's a problem on loading the lens-local-storage files, because the contents are correct after disconnecting the cluster. Somewhere in the process of connecting the cluster the data is overwritten. This did work before PR #3882