### PR TITLE
Remove iframe completely on disconnect

### DIFF
--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -113,13 +113,6 @@ export class App extends React.Component {
       window.location.reload();
     });
 
-    window.addEventListener("message", (ev: MessageEvent) => {
-      if (ev.data === "teardown") {
-        unmountComponentAtNode(rootElem);
-        window.location.href = "about:blank";
-      }
-    });
-
     window.onbeforeunload = () => {
       logger.info(`[APP]: Unload dashboard, clusterId=${App.clusterId}, frameId=${frameId}`);
 

--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -79,13 +79,7 @@ export async function autoCleanOnRemove(clusterId: ClusterId, iframe: HTMLIFrame
   logger.info(`[LENS-VIEW]: remove dashboard, clusterId=${clusterId}`);
   lensViews.delete(clusterId);
 
-  // Keep frame in DOM to avoid possible bugs when same cluster re-created after being removed.
-  // In that case for some reasons `webFrame.routingId` returns some previous frameId (usage in app.tsx)
-  // Issue: https://github.com/lensapp/lens/issues/811
-  iframe.style.display = "none";
-  iframe.dataset.meta = `${iframe.name} was removed at ${new Date().toLocaleString()}`;
-  iframe.removeAttribute("name");
-  iframe.contentWindow.postMessage("teardown", "*");
+  iframe.parentNode.removeChild(iframe);
 }
 
 export function refreshViews(visibleClusterId?: string) {


### PR DESCRIPTION
For some reason empty iframe that is left behind on disconnect causes nodejs event loop lockups in the next iframe (for the same cluster).