### PR TITLE
Remove cors headers from LensProxy

### DIFF
--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -200,10 +200,6 @@ export class LensProxy extends Singleton {
       const proxyTarget = await this.getProxyTarget(req, cluster.contextHandler);
 
       if (proxyTarget) {
-        // allow to fetch apis in "clusterId.localhost:port" from "localhost:port"
-        // this should be safe because we have already validated cluster uuid
-        res.setHeader("Access-Control-Allow-Origin", "*");
-
         return this.proxy.web(req, res, proxyTarget);
       }
     }


### PR DESCRIPTION
Those are not needed anymore because we are using node-fetch internally.