### PR TITLE
Navigate cluster context menus via broadcastMessage

### DIFF
--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -57,8 +57,8 @@ export class Sidebar extends React.Component<Props> {
   static displayName = "Sidebar";
   @observable private contextMenu: CatalogEntityContextMenuContext = {
     menuItems: [],
-    navigate: (url: string, inMainFrame = true) => {
-      if (inMainFrame) {
+    navigate: (url: string, forceMainFrame = true) => {
+      if (forceMainFrame) {
         broadcastMessage(IpcRendererNavigationEvents.NAVIGATE_IN_APP, url);
       } else {
         navigate(url);

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -45,6 +45,8 @@ import { HotbarIcon } from "../hotbar/hotbar-icon";
 import { makeObservable, observable } from "mobx";
 import type { CatalogEntityContextMenuContext } from "../../../common/catalog";
 import { HotbarStore } from "../../../common/hotbar-store";
+import { broadcastMessage } from "../../../common/ipc";
+import { IpcRendererNavigationEvents } from "../../navigation/events";
 
 interface Props {
   className?: string;
@@ -55,7 +57,7 @@ export class Sidebar extends React.Component<Props> {
   static displayName = "Sidebar";
   @observable private contextMenu: CatalogEntityContextMenuContext = {
     menuItems: [],
-    navigate,
+    navigate: (url: string) => broadcastMessage(IpcRendererNavigationEvents.NAVIGATE_IN_APP, url),
   };
 
   constructor(props: Props) {

--- a/src/renderer/components/layout/sidebar.tsx
+++ b/src/renderer/components/layout/sidebar.tsx
@@ -57,7 +57,13 @@ export class Sidebar extends React.Component<Props> {
   static displayName = "Sidebar";
   @observable private contextMenu: CatalogEntityContextMenuContext = {
     menuItems: [],
-    navigate: (url: string) => broadcastMessage(IpcRendererNavigationEvents.NAVIGATE_IN_APP, url),
+    navigate: (url: string, inMainFrame = true) => {
+      if (inMainFrame) {
+        broadcastMessage(IpcRendererNavigationEvents.NAVIGATE_IN_APP, url);
+      } else {
+        navigate(url);
+      }
+    }
   };
 
   constructor(props: Props) {


### PR DESCRIPTION
Part 1 of 2 PRs in order to fix #4088 

Extension should navigate to `Settings` no matter where this action triggered - in hotbar menu or from in-cluster view.

Should be merged along with https://github.com/lensapp/lenscloud-lens-extension/pull/812

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>