### PR TITLE
Fix cluster overview loading background

### DIFF
--- a/src/renderer/components/+cluster/cluster-pie-charts.tsx
+++ b/src/renderer/components/+cluster/cluster-pie-charts.tsx
@@ -229,7 +229,7 @@ export const ClusterPieCharts = observer(() => {
 
     if (!metricsLoaded) {
       return (
-        <div className="flex justify-center align-center box grow empty">
+        <div className={cssNames(styles.empty, "flex justify-center align-center box grow")}>
           <Spinner/>
         </div>
       );


### PR DESCRIPTION
A fix for #4104 

Cluster overview pie charts was missing background in loading state.

Before:

![missing spinner background](https://user-images.githubusercontent.com/9607060/139200765-cdf119ad-a83a-4a89-adef-850ffc6ea492.png)


After:

![loading with bg](https://user-images.githubusercontent.com/9607060/139200794-a3673817-7929-44d1-a68c-b1932f3c116a.gif)

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>