### PR TITLE
Fix: added missing "Upgrade" option in Helm Release menu

### DIFF
--- a/src/renderer/components/+apps-releases/release-menu.tsx
+++ b/src/renderer/components/+apps-releases/release-menu.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import type { HelmRelease } from "../../../common/k8s-api/endpoints/helm-releases.api";
-import { boundMethod, cssNames } from "../../utils";
+import { cssNames } from "../../utils";
 import { releaseStore } from "./release.store";
 import { MenuActions, MenuActionsProps } from "../menu/menu-actions";
 import { MenuItem } from "../menu";
@@ -35,23 +35,20 @@ interface Props extends MenuActionsProps {
 }
 
 export class HelmReleaseMenu extends React.Component<Props> {
-  @boundMethod
-  remove() {
+  remove = () => {
     return releaseStore.remove(this.props.release);
-  }
+  };
 
-  @boundMethod
-  upgrade() {
+  upgrade = () => {
     const { release, hideDetails } = this.props;
 
     createUpgradeChartTab(release);
     hideDetails?.();
-  }
+  };
 
-  @boundMethod
-  rollback() {
+  rollback = () => {
     ReleaseRollbackDialog.open(this.props.release);
-  }
+  };
 
   renderContent() {
     const { release, toolbar } = this.props;
@@ -67,6 +64,10 @@ export class HelmReleaseMenu extends React.Component<Props> {
             <span className="title">Rollback</span>
           </MenuItem>
         )}
+        <MenuItem onClick={this.upgrade}>
+          <Icon material="refresh" interactive={toolbar} tooltip="Upgrade"/>
+          <span className="title">Upgrade</span>
+        </MenuItem>
       </>
     );
   }


### PR DESCRIPTION
<img width="615" alt="Screenshot 2021-10-28 at 14 41 48" src="https://user-images.githubusercontent.com/6377066/139249717-fae05444-1e9e-4359-b558-e51769a8399d.png">

Currently button `Upgrade` anyway available in the details view which is not convenient way to reach that action.

<img width="911" alt="Screenshot 2021-10-28 at 14 31 06" src="https://user-images.githubusercontent.com/6377066/139249913-8d6c77b5-0e60-431f-8b9a-8dff4e2ce59a.png">
