### PR TITLE
Fix: helm chart icon has incorrect size when app's window too small

### DIFF
--- a/src/renderer/components/+apps-helm-charts/helm-charts.scss
+++ b/src/renderer/components/+apps-helm-charts/helm-charts.scss
@@ -37,12 +37,14 @@
     }
 
     &.icon {
-      display: flex;
-      flex-grow: 0.3;
+      $iconSize: $unit * 3.5;
+
       padding: 0;
+      display: flex;
+      flex-grow: 0;
+      flex-basis: $iconSize;
 
       figure {
-        $iconSize: $unit * 3.5;
         width: $iconSize;
         height: $iconSize;
         border-radius: 50%;


### PR DESCRIPTION
**Before:**
<img width="766" alt="Screenshot 2021-10-28 at 14 55 27" src="https://user-images.githubusercontent.com/6377066/139252719-32ec1b04-719a-4986-a0fd-356efa77da09.png">

**After:**
<img width="621" alt="Screenshot 2021-10-28 at 15 03 04" src="https://user-images.githubusercontent.com/6377066/139252727-6afda79e-f789-464f-a22e-bb04b467103d.png">
