### PR TITLE
Clear up some NamespaceStore.toggleAll and NamespaceStore.hasAllContexts

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -121,10 +121,7 @@ export class NamespaceSelectFilter extends React.Component<SelectProps> {
         namespaceStore.toggleSingle(namespace);
       }
     } else {
-      /**
-       * WARNING: only ever call this method with `false` as an argument
-       */
-      namespaceStore.toggleAll(false);
+      namespaceStore.selectAll();
     }
   };
 

--- a/src/renderer/components/+namespaces/namespace.store.ts
+++ b/src/renderer/components/+namespaces/namespace.store.ts
@@ -148,8 +148,11 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
       .every(namespace => this.selectedNamespaces.includes(namespace));
   }
 
+  /**
+   * Is `true` if all available namespaces are selected, otherwise `false`
+   */
   @computed get hasAllContexts(): boolean {
-    return this.selectedNamespaces.length === this.allowedNamespaces.length;
+    return this.contextNamespaces.length === this.allowedNamespaces.length;
   }
 
   @action
@@ -167,17 +170,21 @@ export class NamespaceStore extends KubeObjectStore<Namespace> {
     this.selectNamespaces(namespace);
   }
 
-  @action
-  toggleAll(showAll?: boolean) {
-    if (typeof showAll === "boolean") {
-      if (showAll) {
-        this.selectNamespaces(this.allowedNamespaces);
-      } else {
-        this.selectNamespaces([]); // empty context considered as "All namespaces"
-      }
-    } else {
-      this.toggleAll(!this.hasAllContexts);
-    }
+  /**
+   * Selects all available namespaces.
+   *
+   * Note: If new namespaces appear in the future those will be selected too
+   */
+  selectAll() {
+    this.selectNamespaces([]);
+  }
+
+  /**
+   * @deprecated Use `NamespaceStore.selectAll` instead
+   */
+  toggleAll(selectAll?: boolean) {
+    void selectAll;
+    this.selectAll();
   }
 
   @action


### PR DESCRIPTION
- Deprecate toggleAll in favour of selectAll because the other was
  dangerous, mostly broken, and didn't toggle

- Fix hasAllContexts to be true in the [] case

Signed-off-by: Sebastian Malton <sebastian@malton.name>