### PR TITLE
Fix IPC race condition

### DIFF
--- a/src/common/ipc/ipc.ts
+++ b/src/common/ipc/ipc.ts
@@ -49,20 +49,20 @@ function getSubFrames(): ClusterFrameInfo[] {
 }
 
 export function broadcastMessage(channel: string, ...args: any[]) {
-  const views: undefined | ReturnType<typeof webContents.getAllWebContents> | ReturnType<typeof remote.webContents.getAllWebContents> = (webContents || electronRemote?.webContents)?.getAllWebContents();
-
-  if (!views || !Array.isArray(views) || views.length === 0) return;
-  args = args.map(sanitizePayload);
-
-  ipcRenderer?.send(channel, ...args);
-  ipcMain?.emit(channel, ...args);
-
   const subFramesP = ipcRenderer
     ? requestMain(subFramesChannel)
     : Promise.resolve(getSubFrames());
 
   subFramesP
     .then(subFrames => {
+      const views: undefined | ReturnType<typeof webContents.getAllWebContents> | ReturnType<typeof remote.webContents.getAllWebContents> = (webContents || electronRemote?.webContents)?.getAllWebContents();
+
+      if (!views || !Array.isArray(views) || views.length === 0) return;
+      args = args.map(sanitizePayload);
+
+      ipcRenderer?.send(channel, ...args);
+      ipcMain?.emit(channel, ...args);
+
       for (const view of views) {
         let viewType = "unknown";
 


### PR DESCRIPTION
* Fixes https://github.com/lensapp/lens/issues/4160
* The bug was caused by returning first the views, then the frames asychronously, during which time the splash window may have been already destroyed.
* The fix is to first return the frames, then the views and iterate them sychronously