### PR TITLE
Use filtered items in finding the default action catalog add button

### DIFF
--- a/src/renderer/components/+catalog/catalog-add-button.tsx
+++ b/src/renderer/components/+catalog/catalog-add-button.tsx
@@ -73,8 +73,9 @@ export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
 
   @boundMethod
   onButtonClick() {
-    const defaultAction = this.menuItems.find(item => item.defaultAction)?.onClick;
-    const clickAction = defaultAction || (this.menuItems.length === 1 ? this.menuItems[0].onClick : null);
+    const filteredItems = this.props.category ? this.props.category.filteredItems(this.menuItems) : [];
+    const defaultAction = filteredItems.find(item => item.defaultAction)?.onClick;
+    const clickAction = defaultAction || (filteredItems.length === 1 ? filteredItems[0].onClick : null);
 
     clickAction?.();
   }


### PR DESCRIPTION
Signed-off-by: Juho Heikka <juho.heikka@gmail.com>

https://user-images.githubusercontent.com/774344/139266730-554ee277-763d-4c1d-b096-cba035dda94d.mov


Fixes the problem when the button wouldn't trigger the only shown item in the menu. 

Fixes: #4168