### PR TITLE
ensure namespace placeholder reflects what will be saved to local storage

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -36,10 +36,10 @@ import { isMac } from "../../../common/vars";
 const Placeholder = observer((props: PlaceholderProps<any, boolean>) => {
   const getPlaceholder = (): React.ReactNode => {
     const namespaces = namespaceStore.contextNamespaces;
+    const length = namespaceStore.selectedNamespaces.length ? namespaces.length : 0;
 
-    switch (namespaces.length) {
+    switch (length) {
       case 0:
-      case namespaceStore.allowedNamespaces.length:
         return <>All namespaces</>;
       case 1:
         return <>Namespace: {namespaces[0]}</>;

--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -36,9 +36,8 @@ import { isMac } from "../../../common/vars";
 const Placeholder = observer((props: PlaceholderProps<any, boolean>) => {
   const getPlaceholder = (): React.ReactNode => {
     const namespaces = namespaceStore.contextNamespaces;
-    const length = namespaceStore.selectedNamespaces.length ? namespaces.length : 0;
 
-    switch (length) {
+    switch (namespaceStore.selectedNamespaces.length) {
       case 0:
         return <>All namespaces</>;
       case 1:

--- a/src/renderer/components/+namespaces/namespace-select-filter.tsx
+++ b/src/renderer/components/+namespaces/namespace-select-filter.tsx
@@ -37,14 +37,15 @@ const Placeholder = observer((props: PlaceholderProps<any, boolean>) => {
   const getPlaceholder = (): React.ReactNode => {
     const namespaces = namespaceStore.contextNamespaces;
 
-    switch (namespaceStore.selectedNamespaces.length) {
-      case 0:
-        return <>All namespaces</>;
-      case 1:
-        return <>Namespace: {namespaces[0]}</>;
-      default:
-        return <>Namespaces: {namespaces.join(", ")}</>;
+    if (!namespaceStore.selectedNamespaces.length || !namespaces.length) {
+      return <>All namespaces</>;
     }
+
+    if (namespaces.length === 1) {
+      return <>Namespace: {namespaces[0]}</>;
+    }
+
+    return <>Namespaces: {namespaces.join(", ")}</>;
   };
 
   return (
@@ -100,9 +101,9 @@ export class NamespaceSelectFilter extends React.Component<SelectProps> {
 
       return (
         <div className="flex gaps align-center">
-          <Icon small material="layers"/>
+          <Icon small material="layers" />
           <span>{namespace}</span>
-          {isSelected && <Icon small material="check" className="box right"/>}
+          {isSelected && <Icon small material="check" className="box right" />}
         </div>
       );
     }


### PR DESCRIPTION
If all of the namespaces have been manually selected by the user then those
namespaces are explicitly saved to the namespace store (not `[]`, representing
all namespaces). Thus, in this case, the placeholder in the selector should show this list,
not "All namespaces".

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

fixes #4171