### PR TITLE
Revert "Upgrade to Electron@v13.6.0 (#4145)"

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "13.6.0"
+target "13.5.1"
 runtime "electron"

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "css-loader": "^5.2.7",
     "deepdash": "^5.3.9",
     "dompurify": "^2.3.3",
-    "electron": "13.6.0",
+    "electron": "^13.5.1",
     "electron-builder": "^22.11.11",
     "electron-notarize": "^0.3.0",
     "esbuild": "^0.13.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,10 +5070,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@13.6.0:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.0.tgz#c61e516f7a087dec711c6fddd945a808cfa115d8"
-  integrity sha512-VDOUmRwa4eQ+5iXE+XHKXKX+2yk8Ey5uBe3nH9Hj6zNPUBY2S0EOClw7U90Ve2lLHXiQ6DnguNmDgOZKJLcHFQ==
+electron@^13.5.1:
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.1.tgz#76c02c39be228532f886a170b472cbd3d93f0d0f"
+  integrity sha512-ZyxhIhmdaeE3xiIGObf0zqEyCyuIDqZQBv9NKX8w5FNzGm87j4qR0H1+GQg6vz+cA1Nnv1x175Zvimzc0/UwEQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
This reverts commits 566d2a6797baa0528218c3b7e07671c487995793 and b4d5e74d16d503fc0cc4fead372dc8321bb4a719.

The new electron version [changed](https://github.com/electron/electron/commit/9a71ca545f4bccc081ac417a80d58bcab6786ee3) how certificate chain is validated and is causing a technical issue related to mac-ca/win-ca. Lets revert the update now, and update electron after a proper fix for the certificate issue.

Signed-off-by: Panu Horsmalahti <phorsmalahti@mirantis.com>