### PR TITLE
release v5.3.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.3.0-alpha.6",
+  "version": "5.3.0-alpha.7",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since v5.3.0-alpha.6

## 🚀 Features

* improved port-forward error reporting (#4155) @jim-docker

## 🐛 Bug Fixes

* Fix NamespaceSelectFilter (#4187) @Nokel81
* Only listen to CMD+f for <SearchInput> on macOS (#4175) @Nokel81
* ensure namespace placeholder reflects what will be saved to local storage (#4176) @jim-docker
* Revert "Upgrade to Electron@v13.6.0 (#4145)" (#4186) @panuhorsmalahti
* Fix: added missing "Upgrade" option in Helm Release menu (#4163) @ixrock
* Fix: helm chart icon has incorrect size when app's window too small (#4166) @ixrock
* Use filtered items in finding the default action catalog add button (#4170) @jweak
* Fix IPC race condition (#4169) @panuhorsmalahti
* Fix NamespaceSelectFilter all namespaces button (#3983) @Nokel81
* Increase maxBuffer size when getting helm release details (#4164) @Nokel81
* Fix cluster overview loading background (#4157) @aleksfront
* Disable sentry in cluster frame (#4161) @jakolehm
* Navigate cluster context menus via broadcastMessage (#4139) @aleksfront
* Stop using @electron/remote to obtain app.getPath() (#4078) @Nokel81

## 🧰 Maintenance

* Removing @testing-library/dom (#4190) @aleksfront
* Bump @typescript-eslint/parser from 4.29.1 to 4.33.0 (#4173) @dependabot
* Bump @types/react-router-dom from 5.3.1 to 5.3.2 (#4177) @dependabot
* Bump @testing-library/dom from 8.9.0 to 8.10.1 (#4178) @dependabot
* Clear up some NamespaceStore.toggleAll and NamespaceStore.hasAllContexts (#4167) @Nokel81
* Bump react-window from 1.8.5 to 1.8.6 (#4172) @dependabot
* Bump sass from 1.43.2 to 1.43.4 (#4165) @dependabot
* Bump mobx-react from 7.2.0 to 7.2.1 (#4162) @dependabot
* Bump @types/semver from 7.3.8 to 7.3.9 (#4156) @dependabot
* Update .yarnrc file (#4150) @Nokel81
* Bump @types/lodash from 4.14.155 to 4.14.176 (#4148) @dependabot
* Remove unused deps (#4146) @Nokel81
* Bump typedoc from 0.22.6 to 0.22.7 (#4149) @dependabot
