### PR TITLE
Fix <a href...> visibility

### DIFF
--- a/src/renderer/components/+add-cluster/add-cluster.scss
+++ b/src/renderer/components/+add-cluster/add-cluster.scss
@@ -50,4 +50,8 @@
     display: block;
     padding-top: 6px;
   }
+
+  a[href] {
+    color: var(--colorInfo);
+  }
 }

--- a/src/renderer/components/+add-cluster/add-cluster.tsx
+++ b/src/renderer/components/+add-cluster/add-cluster.tsx
@@ -119,8 +119,8 @@ export class AddCluster extends React.Component {
       <SettingLayout className="AddClusters">
         <h2>Add Clusters from Kubeconfig</h2>
         <p>
-          Clusters added here are <b>not</b> merged into the <code>~/.kube/config</code> file.
-          Read more about adding clusters <a href={`${docsUrl}/catalog/add-clusters/`} rel="noreferrer" target="_blank">here</a>.
+          Clusters added here are <b>not</b> merged into the <code>~/.kube/config</code> file.{" "}
+          <a href={`${docsUrl}/catalog/add-clusters/`} rel="noreferrer" target="_blank">Read more about adding clusters</a>.
         </p>
         <div className="flex column">
           <MonacoEditor

--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -19,8 +19,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-@import "tailwindcss/base";
-@import "tailwindcss/components";
 @import "tailwindcss/utilities";
 @import "~flex.box";
 @import "fonts";

--- a/src/renderer/components/error-boundary/error-boundary.scss
+++ b/src/renderer/components/error-boundary/error-boundary.scss
@@ -43,4 +43,8 @@
     background: $contentColor;
     color: $textColorSecondary;
   }
+
+  a {
+    color: var(--colorInfo);
+  }
 }


### PR DESCRIPTION
Tailwind base css rewrote our global styles from `app.scss` and removed `text-decoration: underline` for links making them invisible in some places. Current PR removes base css and improve style coloring in "Add Cluster" page and inside Error Boundary.
![add clusters from kubeconfig](https://user-images.githubusercontent.com/9607060/139626930-391f06da-8c71-41e4-b323-b4d9701cfede.png)
![extensions](https://user-images.githubusercontent.com/9607060/139626933-68b9a786-abe9-4207-a60f-3515a786d491.png)

Fixes #4159 
