### PR TITLE
Release/v5.2.6 beta.0

### DIFF
--- a/.azure-pipelines-k8s-matrix.yml
+++ b/.azure-pipelines-k8s-matrix.yml
@@ -15,7 +15,7 @@ trigger: none
 jobs:
   - job: Linux
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     strategy:
       matrix:
         kube_1.16:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,6 +41,9 @@ jobs:
       - bash: |
           set -e
           git clone "https://${GH_TOKEN}@github.com/lensapp/lens-ide.git" .lens-ide-overlay
+          cd .lens-ide-overlay
+          git checkout -b v5.2 0d3d9140a0f151c3ca6d7651c092f8ba44091794
+          cd ..
           rm -rf .lens-ide-overlay/.git
           cp -r .lens-ide-overlay/* ./
           jq -s '.[0] * .[1]' package.json package.ide.json > package.custom.json && mv package.custom.json package.json
@@ -87,6 +90,9 @@ jobs:
       - bash: |
           set -e
           git clone "https://${GH_TOKEN}@github.com/lensapp/lens-ide.git" .lens-ide-overlay
+          cd .lens-ide-overlay
+          git checkout -b v5.2 0d3d9140a0f151c3ca6d7651c092f8ba44091794
+          cd ..
           rm -rf .lens-ide-overlay/.git
           cp -r .lens-ide-overlay/* ./
           jq -s '.[0] * .[1]' package.json package.ide.json > package.custom.json && mv package.custom.json package.json
@@ -135,6 +141,9 @@ jobs:
       - bash: |
           set -e
           git clone "https://${GH_TOKEN}@github.com/lensapp/lens-ide.git" .lens-ide-overlay
+          cd .lens-ide-overlay
+          git checkout -b v5.2 0d3d9140a0f151c3ca6d7651c092f8ba44091794
+          cd ..
           rm -rf .lens-ide-overlay/.git
           cp -r .lens-ide-overlay/* ./
           jq -s '.[0] * .[1]' package.json package.ide.json > package.custom.json && mv package.custom.json package.json

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     strategy:
       matrix:
         node_14.x:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "12.2.1"
+target "13.4.0"
 runtime "electron"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.2.5",
+  "version": "5.2.6-beta.0",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "css-loader": "^5.2.6",
     "deepdash": "^5.3.5",
     "dompurify": "^2.3.1",
-    "electron": "^12.2.1",
+    "electron": "^13.4.0",
     "electron-builder": "^22.10.5",
     "electron-notarize": "^0.3.0",
     "esbuild": "^0.12.24",

--- a/src/main/context-handler.ts
+++ b/src/main/context-handler.ts
@@ -114,7 +114,7 @@ export class ContextHandler {
     await this.ensureServer();
     const path = this.clusterUrl.path !== "/" ? this.clusterUrl.path : "";
 
-    return `http://127.0.0.1:${this.kubeAuthProxy.port}${path}`;
+    return `http://127.0.0.1:${this.kubeAuthProxy.port}${this.kubeAuthProxy.apiPrefix}${path}`;
   }
 
   async getApiTarget(isLongRunningRequest = false): Promise<httpProxy.ServerOptions> {

--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -200,10 +200,6 @@ export class LensProxy extends Singleton {
       const proxyTarget = await this.getProxyTarget(req, cluster.contextHandler);
 
       if (proxyTarget) {
-        // allow to fetch apis in "clusterId.localhost:port" from "localhost:port"
-        // this should be safe because we have already validated cluster uuid
-        res.setHeader("Access-Control-Allow-Origin", "*");
-
         return this.proxy.web(req, res, proxyTarget);
       }
     }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -109,10 +109,6 @@ export class WindowManager extends Singleton {
           app.dock?.hide(); // hide icon in dock (mac-os)
         })
         .webContents
-        .on("new-window", (event, url) => {
-          event.preventDefault();
-          shell.openExternal(url);
-        })
         .on("dom-ready", () => {
           appEventBus.emit({ name: "app", action: "dom-ready" });
         })
@@ -150,6 +146,10 @@ export class WindowManager extends Singleton {
 
           // Always disable Node.js integration for all webviews
           webPreferences.nodeIntegration = false;
+        }).setWindowOpenHandler((details) => {
+          shell.openExternal(details.url);
+
+          return { action: "deny" };
         });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,10 +5269,10 @@ electron@*:
     "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
-electron@^12.2.1:
-  version "12.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.2.1.tgz#ef138fde11efd01743934c3e0df717cc53ee362b"
-  integrity sha512-Gp+rO81qoaRDP7PTVtBOvnSgDgGlwUuAEWXxi621uOJMIlYFas9ChXe8pjdL0R0vyUpiHVzp6Vrjx41VZqEpsw==
+electron@^13.4.0:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.4.0.tgz#f9f9e518d8c6bf23bfa8b69580447eea3ca0f880"
+  integrity sha512-KJGWS2qa0xZXIMPMDUNkRVO8/JxRd4+M0ejYYOzu2LIQ5ijecPzNuNR9nvDkml9XyyRBzu975FkhJcwD17ietQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
This PR also contains a commit to get the appropriate version of lens-ide for the 5.2 branch, which is not part of the changelog

## Changes since v5.2.5

## 🚀 Features

- Use random api prefix on kubectl-proxy (#4137) @jakolehm
## 🐛 Bug Fixes

- Remove cors headers from LensProxy (#4126) @jakolehm
- Electron 13.4.0 (#3820) @jakolehm
