### PR TITLE
Correctly handle promises and rejections around cluster connection

### DIFF
--- a/src/main/__test__/kubeconfig-manager.test.ts
+++ b/src/main/__test__/kubeconfig-manager.test.ts
@@ -142,9 +142,9 @@ describe("kubeconfig manager tests", () => {
     const configPath = await kubeConfManager.getPath();
 
     expect(await fse.pathExists(configPath)).toBe(true);
-    await kubeConfManager.unlink();
+    await kubeConfManager.clear();
     expect(await fse.pathExists(configPath)).toBe(false);
-    await kubeConfManager.unlink(); // doesn't throw
+    await kubeConfManager.clear(); // doesn't throw
     expect(async () => {
       await kubeConfManager.getPath();
     }).rejects.toThrow("already unlinked");


### PR DESCRIPTION
- Remove duplicate log in LensProxy

- Cleanup constructor of KubeAuthProxy

Signed-off-by: Sebastian Malton <sebastian@malton.name>

---

I noticed this while trying to figure out why https://github.com/lensapp/lens/issues/3272 might be happening. I don't think this is a fix but I think it should be done anyway.