### PR TITLE
Reduce JSON-API logging

### DIFF
--- a/src/common/k8s-api/json-api.ts
+++ b/src/common/k8s-api/json-api.ts
@@ -201,7 +201,7 @@ export class JsonApi<D = JsonApiData, P extends JsonApiParams = JsonApiParams> {
   protected writeLog(log: JsonApiLog) {
     const { method, reqUrl, ...params } = log;
 
-    logger.info(`[JSON-API] request ${method} ${reqUrl}`, params);
+    logger.debug(`[JSON-API] request ${method} ${reqUrl}`, params);
   }
 }
 


### PR DESCRIPTION
* JSON-API logging can reveal secrets and is often not necessary (and it can be very verbose). This PR changes the logging level to debug.