### PR TITLE
Catalog Browse page Add Button with menu

### DIFF
--- a/src/renderer/components/+catalog/catalog-add-button.tsx
+++ b/src/renderer/components/+catalog/catalog-add-button.tsx
@@ -35,12 +35,12 @@ export type CatalogAddButtonProps = {
   category: CatalogCategory
 };
 
-type categoryId = string;
+type CategoryId = string;
 
 @observer
 export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
   @observable protected isOpen = false;
-  @observable menuItems = new Map<categoryId, CatalogEntityAddMenu[]>();
+  @observable menuItems = new Map<CategoryId, CatalogEntityAddMenu[]>();
 
   constructor(props: CatalogAddButtonProps) {
     super(props);
@@ -61,6 +61,7 @@ export class CatalogAddButton extends React.Component<CatalogAddButtonProps> {
     return catalogCategoryRegistry.filteredItems;
   }
 
+  @action
   updateMenuItems() {
     this.menuItems.clear();
 


### PR DESCRIPTION
Adding big blue button to the `/browse` catalog page. It will collect menu items from all categories. Option 1 from https://github.com/lensapp/lenscloud-lens-extension/issues/832

https://user-images.githubusercontent.com/9607060/139847468-425b9134-6832-42aa-8d50-650630b98b88.mov



