### PR TITLE
Release/v5.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "readable-stream": "^3.6.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
+    "rfc6902": "^4.0.2",
     "semver": "^7.3.2",
     "serializr": "^2.0.5",
     "shell-env": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.2.6-beta.1",
+  "version": "5.2.6",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/src/common/k8s-api/endpoints/resource-applier.api.ts
+++ b/src/common/k8s-api/endpoints/resource-applier.api.ts
@@ -22,19 +22,27 @@
 import jsYaml from "js-yaml";
 import type { KubeJsonApiData } from "../kube-json-api";
 import { apiBase } from "../index";
+import type { Patch } from "rfc6902";
 
-export const resourceApplierApi = {
-  annotations: [
-    "kubectl.kubernetes.io/last-applied-configuration"
-  ],
+export const annotations = [
+  "kubectl.kubernetes.io/last-applied-configuration"
+];
 
-  async update(resource: object | string): Promise<KubeJsonApiData | null> {
-    if (typeof resource === "string") {
-      resource = jsYaml.safeLoad(resource);
-    }
-
-    const [data = null] = await apiBase.post<KubeJsonApiData[]>("/stack", { data: resource });
-
-    return data;
+export async function update(resource: object | string): Promise<KubeJsonApiData> {
+  if (typeof resource === "string") {
+    resource = jsYaml.safeLoad(resource);
   }
-};
+
+  return apiBase.post<KubeJsonApiData>("/stack", { data: resource });
+}
+
+export async function patch(name: string, kind: string, ns: string, patch: Patch): Promise<KubeJsonApiData> {
+  return apiBase.patch<KubeJsonApiData>("/stack", {
+    data: {
+      name,
+      kind,
+      ns,
+      patch,
+    },
+  });
+}

--- a/src/common/k8s-api/json-api.ts
+++ b/src/common/k8s-api/json-api.ts
@@ -27,8 +27,7 @@ import { stringify } from "querystring";
 import { EventEmitter } from "../../common/event-emitter";
 import logger from "../../common/logger";
 
-export interface JsonApiData {
-}
+export interface JsonApiData {}
 
 export interface JsonApiError {
   code?: number;

--- a/src/main/resource-applier.ts
+++ b/src/main/resource-applier.ts
@@ -22,55 +22,96 @@
 import type { Cluster } from "./cluster";
 import type { KubernetesObject } from "@kubernetes/client-node";
 import { exec } from "child_process";
-import fs from "fs";
+import fs from "fs-extra";
 import * as yaml from "js-yaml";
 import path from "path";
 import * as tempy from "tempy";
 import logger from "./logger";
 import { appEventBus } from "../common/event-bus";
 import { cloneJsonObject } from "../common/utils";
+import type { Patch } from "rfc6902";
+import { promiseExecFile } from "./promise-exec";
 
 export class ResourceApplier {
-  constructor(protected cluster: Cluster) {
+  constructor(protected cluster: Cluster) {}
+
+  /**
+   * Patch a kube resource's manifest, throwing any error that occurs.
+   * @param name The name of the kube resource
+   * @param kind The kind of the kube resource
+   * @param patch The list of JSON operations
+   * @param ns The optional namespace of the kube resource
+   */
+  async patch(name: string, kind: string, patch: Patch, ns?: string): Promise<string> {
+    appEventBus.emit({ name: "resource", action: "patch" });
+
+    const kubectl = await this.cluster.ensureKubectl();
+    const kubectlPath = await kubectl.getPath();
+    const proxyKubeconfigPath = await this.cluster.getProxyKubeconfigPath();
+    const args = [
+      "--kubeconfig", proxyKubeconfigPath,
+      "patch",
+      kind,
+      name,
+    ];
+
+    if (ns) {
+      args.push("--namespace", ns);
+    }
+
+    args.push(
+      "--type", "json",
+      "--patch", JSON.stringify(patch),
+      "-o", "json"
+    );
+
+    try {
+      const { stdout } = await promiseExecFile(kubectlPath, args);
+
+      return stdout;
+    } catch (error) {
+      throw error.stderr ?? error;
+    }
   }
 
   async apply(resource: KubernetesObject | any): Promise<string> {
     resource = this.sanitizeObject(resource);
     appEventBus.emit({ name: "resource", action: "apply" });
 
-    return await this.kubectlApply(yaml.safeDump(resource));
+    return this.kubectlApply(yaml.safeDump(resource));
   }
 
   protected async kubectlApply(content: string): Promise<string> {
     const kubectl = await this.cluster.ensureKubectl();
     const kubectlPath = await kubectl.getPath();
     const proxyKubeconfigPath = await this.cluster.getProxyKubeconfigPath();
+    const fileName = tempy.file({ name: "resource.yaml" });
+    const args = [
+      "apply",
+      "--kubeconfig", proxyKubeconfigPath,
+      "-o", "json",
+      "-f", fileName,
+    ];
 
-    return new Promise<string>((resolve, reject) => {
-      const fileName = tempy.file({ name: "resource.yaml" });
+    logger.debug(`shooting manifests with ${kubectlPath}`, { args });
 
-      fs.writeFileSync(fileName, content);
-      const cmd = `"${kubectlPath}" apply --kubeconfig "${proxyKubeconfigPath}" -o json -f "${fileName}"`;
+    const execEnv = { ...process.env };
+    const httpsProxy = this.cluster.preferences?.httpsProxy;
 
-      logger.debug(`shooting manifests with: ${cmd}`);
-      const execEnv: NodeJS.ProcessEnv = Object.assign({}, process.env);
-      const httpsProxy = this.cluster.preferences?.httpsProxy;
+    if (httpsProxy) {
+      execEnv.HTTPS_PROXY = httpsProxy;
+    }
 
-      if (httpsProxy) {
-        execEnv["HTTPS_PROXY"] = httpsProxy;
-      }
-      exec(cmd, { env: execEnv },
-        (error, stdout, stderr) => {
-          if (stderr != "") {
-            fs.unlinkSync(fileName);
-            reject(stderr);
+    try {
+      await fs.writeFile(fileName, content);
+      const { stdout } = await promiseExecFile(kubectlPath, args);
 
-            return;
-          }
-          fs.unlinkSync(fileName);
-          resolve(JSON.parse(stdout));
-        });
-    });
+      return stdout;
+    } catch (error) {
+      throw error?.stderr ?? error;
+    } finally {
+      await fs.unlink(fileName);
+    }
   }
 
   public async kubectlApplyAll(resources: string[], extraArgs = ["-o", "json"]): Promise<string> {

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -198,5 +198,6 @@ export class Router {
 
     // Resource Applier API
     this.router.add({ method: "post", path: `${apiPrefix}/stack` }, ResourceApplierApiRoute.applyResource);
+    this.router.add({ method: "patch", path: `${apiPrefix}/stack` }, ResourceApplierApiRoute.patchResource);
   }
 }

--- a/src/main/routes/resource-applier-route.ts
+++ b/src/main/routes/resource-applier-route.ts
@@ -30,7 +30,19 @@ export class ResourceApplierApiRoute {
     try {
       const resource = await new ResourceApplier(cluster).apply(payload);
 
-      respondJson(response, [resource], 200);
+      respondJson(response, resource, 200);
+    } catch (error) {
+      respondText(response, error, 422);
+    }
+  }
+
+  static async patchResource(request: LensApiRequest) {
+    const { response, cluster, payload } = request;
+
+    try {
+      const resource = await new ResourceApplier(cluster).patch(payload.name, payload.kind, payload.patch, payload.ns);
+
+      respondJson(response, resource, 200);
     } catch (error) {
       respondText(response, error, 422);
     }

--- a/src/main/utils/http-responses.ts
+++ b/src/main/utils/http-responses.ts
@@ -21,14 +21,37 @@
 
 import type http from "http";
 
-export function respondJson(res: http.ServerResponse, content: any, status = 200) {
-  respond(res, JSON.stringify(content), "application/json", status);
+/**
+ * Respond to a HTTP request with a body of JSON data
+ * @param res The HTTP response to write data to
+ * @param content The data or its JSON stringified version of it
+ * @param status [200] The status code to respond with
+ */
+export function respondJson(res: http.ServerResponse, content: Object | string, status = 200) {
+  const normalizedContent = typeof content === "object" 
+    ? JSON.stringify(content) 
+    : content;
+
+  respond(res, normalizedContent, "application/json", status);
 }
 
+/**
+ * Respond to a HTTP request with a body of plain text data
+ * @param res The HTTP response to write data to
+ * @param content The string data to respond with
+ * @param status [200] The status code to respond with
+ */
 export function respondText(res: http.ServerResponse, content: string, status = 200) {
   respond(res, content, "text/plain", status);
 }
 
+/**
+ * Respond to a HTTP request with a body of plain text data
+ * @param res The HTTP response to write data to
+ * @param content The string data to respond with
+ * @param contentType The HTTP Content-Type header value
+ * @param status [200] The status code to respond with
+ */
 export function respond(res: http.ServerResponse, content: string, contentType: string, status = 200) {
   res.setHeader("Content-Type", contentType);
   res.statusCode = status;

--- a/src/renderer/components/+config-autoscalers/hpa-details.tsx
+++ b/src/renderer/components/+config-autoscalers/hpa-details.tsx
@@ -33,6 +33,7 @@ import { Table, TableCell, TableHead, TableRow } from "../table";
 import { apiManager } from "../../../common/k8s-api/api-manager";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { getDetailsUrl } from "../kube-detail-params";
+import logger from "../../../common/logger";
 
 export interface HpaDetailsProps extends KubeObjectDetailsProps<HorizontalPodAutoscaler> {
 }
@@ -80,17 +81,13 @@ export class HpaDetails extends React.Component<HpaDetailsProps> {
           <TableCell className="metrics">Current / Target</TableCell>
         </TableHead>
         {
-          hpa.getMetrics().map((metric, index) => {
-            const name = renderName(metric);
-            const values = hpa.getMetricValues(metric);
-
-            return (
+          hpa.getMetrics()
+            .map((metric, index) => (
               <TableRow key={index}>
-                <TableCell className="name">{name}</TableCell>
-                <TableCell className="metrics">{values}</TableCell>
+                <TableCell className="name">{renderName(metric)}</TableCell>
+                <TableCell className="metrics">{hpa.getMetricValues(metric)}</TableCell>
               </TableRow>
-            );
-          })
+            ))
         }
       </Table>
     );
@@ -99,7 +96,16 @@ export class HpaDetails extends React.Component<HpaDetailsProps> {
   render() {
     const { object: hpa } = this.props;
 
-    if (!hpa) return null;
+    if (!hpa) {
+      return null;
+    }
+
+    if (!(hpa instanceof HorizontalPodAutoscaler)) {
+      logger.error("[HpaDetails]: passed object that is not an instanceof HorizontalPodAutoscaler", hpa);
+
+      return null;
+    }
+
     const { scaleTargetRef } = hpa.spec;
 
     return (

--- a/src/renderer/components/+config-limit-ranges/limit-range-details.tsx
+++ b/src/renderer/components/+config-limit-ranges/limit-range-details.tsx
@@ -28,6 +28,7 @@ import { LimitPart, LimitRange, LimitRangeItem, Resource } from "../../../common
 import { KubeObjectMeta } from "../kube-object-meta";
 import { DrawerItem } from "../drawer/drawer-item";
 import { Badge } from "../badge";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<LimitRange> {
 }
@@ -57,15 +58,13 @@ function renderResourceLimits(limit: LimitRangeItem, resource: Resource) {
 
 function renderLimitDetails(limits: LimitRangeItem[], resources: Resource[]) {
 
-  return resources.map(resource =>
+  return resources.map(resource => (
     <DrawerItem key={resource} name={resource}>
       {
-        limits.map(limit =>
-          renderResourceLimits(limit, resource)
-        )
+        limits.map(limit => renderResourceLimits(limit, resource))
       }
     </DrawerItem>
-  );
+  ));
 }
 
 @observer
@@ -73,7 +72,16 @@ export class LimitRangeDetails extends React.Component<Props> {
   render() {
     const { object: limitRange } = this.props;
 
-    if (!limitRange) return null;
+    if (!limitRange) {
+      return null;
+    }
+
+    if (!(limitRange instanceof LimitRange)) {
+      logger.error("[LimitRangeDetails]: passed object that is not an instanceof LimitRange", limitRange);
+
+      return null;
+    }
+
     const containerLimits = limitRange.getContainerLimits();
     const podLimits = limitRange.getPodLimits();
     const pvcLimits = limitRange.getPVCLimits();

--- a/src/renderer/components/+config-maps/config-map-details.tsx
+++ b/src/renderer/components/+config-maps/config-map-details.tsx
@@ -72,6 +72,8 @@ export class ConfigMapDetails extends React.Component<Props> {
           <>ConfigMap <b>{configMap.getName()}</b> successfully updated.</>
         </p>
       );
+    } catch (error) {
+      Notifications.error(`Failed to save config map: ${error}`);
     } finally {
       this.isSaving = false;
     }

--- a/src/renderer/components/+config-maps/config-map-details.tsx
+++ b/src/renderer/components/+config-maps/config-map-details.tsx
@@ -30,8 +30,9 @@ import { Input } from "../input";
 import { Button } from "../button";
 import { configMapsStore } from "./config-maps.store";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { ConfigMap } from "../../../common/k8s-api/endpoints";
+import { ConfigMap } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<ConfigMap> {
 }
@@ -82,7 +83,16 @@ export class ConfigMapDetails extends React.Component<Props> {
   render() {
     const { object: configMap } = this.props;
 
-    if (!configMap) return null;
+    if (!configMap) {
+      return null;
+    }
+
+    if (!(configMap instanceof ConfigMap)) {
+      logger.error("[ConfigMapDetails]: passed object that is not an instanceof ConfigMap", configMap);
+
+      return null;
+    }
+
     const data = Array.from(this.data.entries());
 
     return (
@@ -93,22 +103,20 @@ export class ConfigMapDetails extends React.Component<Props> {
             <>
               <DrawerTitle title="Data"/>
               {
-                data.map(([name, value]) => {
-                  return (
-                    <div key={name} className="data">
-                      <div className="name">{name}</div>
-                      <div className="flex gaps align-flex-start">
-                        <Input
-                          multiLine
-                          theme="round-black"
-                          className="box grow"
-                          value={value}
-                          onChange={v => this.data.set(name, v)}
-                        />
-                      </div>
+                data.map(([name, value]) => (
+                  <div key={name} className="data">
+                    <div className="name">{name}</div>
+                    <div className="flex gaps align-flex-start">
+                      <Input
+                        multiLine
+                        theme="round-black"
+                        className="box grow"
+                        value={value}
+                        onChange={v => this.data.set(name, v)}
+                      />
                     </div>
-                  );
-                })
+                  </div>
+                ))
               }
               <Button
                 primary

--- a/src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx
+++ b/src/renderer/components/+config-pod-disruption-budgets/pod-disruption-budgets-details.tsx
@@ -26,8 +26,9 @@ import { observer } from "mobx-react";
 import { DrawerItem } from "../drawer";
 import { Badge } from "../badge";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { PodDisruptionBudget } from "../../../common/k8s-api/endpoints";
+import { PodDisruptionBudget } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<PodDisruptionBudget> {
 }
@@ -38,7 +39,16 @@ export class PodDisruptionBudgetDetails extends React.Component<Props> {
   render() {
     const { object: pdb } = this.props;
 
-    if (!pdb) return null;
+    if (!pdb) {
+      return null;
+    }
+
+    if (!(pdb instanceof PodDisruptionBudget)) {
+      logger.error("[PodDisruptionBudgetDetails]: passed object that is not an instanceof PodDisruptionBudget", pdb);
+
+      return null;
+    }
+
     const selectors = pdb.getSelectors();
 
     return (

--- a/src/renderer/components/+config-resource-quotas/resource-quota-details.tsx
+++ b/src/renderer/components/+config-resource-quotas/resource-quota-details.tsx
@@ -26,10 +26,11 @@ import { observer } from "mobx-react";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { cpuUnitsToNumber, cssNames, unitsToBytes, metricUnitsToNumber } from "../../utils";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { ResourceQuota } from "../../../common/k8s-api/endpoints/resource-quota.api";
+import { ResourceQuota } from "../../../common/k8s-api/endpoints/resource-quota.api";
 import { LineProgress } from "../line-progress";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<ResourceQuota> {
 }
@@ -77,7 +78,15 @@ export class ResourceQuotaDetails extends React.Component<Props> {
   render() {
     const { object: quota } = this.props;
 
-    if (!quota) return null;
+    if (!quota) {
+      return null;
+    }
+
+    if (!(quota instanceof ResourceQuota)) {
+      logger.error("[ResourceQuotaDetails]: passed object that is not an instanceof ResourceQuota", quota);
+
+      return null;
+    }
 
     return (
       <div className="ResourceQuotaDetails">

--- a/src/renderer/components/+config-secrets/secret-details.tsx
+++ b/src/renderer/components/+config-secrets/secret-details.tsx
@@ -33,8 +33,9 @@ import { base64 } from "../../utils";
 import { Icon } from "../icon";
 import { secretsStore } from "./secrets.store";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { Secret } from "../../../common/k8s-api/endpoints";
+import { Secret } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Secret> {
 }
@@ -84,7 +85,15 @@ export class SecretDetails extends React.Component<Props> {
   render() {
     const { object: secret } = this.props;
 
-    if (!secret) return null;
+    if (!secret) {
+      return null;
+    }
+
+    if (!(secret instanceof Secret)) {
+      logger.error("[SecretDetails]: passed object that is not an instanceof Secret", secret);
+
+      return null;
+    }
 
     return (
       <div className="SecretDetails">

--- a/src/renderer/components/+custom-resources/crd-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-details.tsx
@@ -24,7 +24,7 @@ import "./crd-details.scss";
 import React from "react";
 import { Link } from "react-router-dom";
 import { observer } from "mobx-react";
-import type { CustomResourceDefinition } from "../../../common/k8s-api/endpoints/crd.api";
+import { CustomResourceDefinition } from "../../../common/k8s-api/endpoints/crd.api";
 import { cssNames } from "../../utils";
 import { ThemeStore } from "../../theme.store";
 import { Badge } from "../badge";
@@ -35,6 +35,7 @@ import { Input } from "../input";
 import { KubeObjectMeta } from "../kube-object-meta";
 import MonacoEditor from "react-monaco-editor";
 import { UserStore } from "../../../common/user-store";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<CustomResourceDefinition> {
 }
@@ -44,7 +45,16 @@ export class CRDDetails extends React.Component<Props> {
   render() {
     const { object: crd } = this.props;
 
-    if (!crd) return null;
+    if (!crd) {
+      return null;
+    }
+
+    if (!(crd instanceof CustomResourceDefinition)) {
+      logger.error("[CRDDetails]: passed object that is not an instanceof CustomResourceDefinition", crd);
+
+      return null;
+    }
+
     const { plural, singular, kind, listKind } = crd.getNames();
     const printerColumns = crd.getPrinterColumns();
     const validation = crd.getValidation();

--- a/src/renderer/components/+custom-resources/crd-resource-details.tsx
+++ b/src/renderer/components/+custom-resources/crd-resource-details.tsx
@@ -30,9 +30,10 @@ import { DrawerItem } from "../drawer";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { Input } from "../input";
-import type { AdditionalPrinterColumnsV1, CustomResourceDefinition } from "../../../common/k8s-api/endpoints/crd.api";
+import { AdditionalPrinterColumnsV1, CustomResourceDefinition } from "../../../common/k8s-api/endpoints/crd.api";
 import { parseJsonPath } from "../../utils/jsonPath";
-import type { KubeObject, KubeObjectMetadata, KubeObjectStatus } from "../../../common/k8s-api/kube-object";
+import { KubeObject, KubeObjectMetadata, KubeObjectStatus } from "../../../common/k8s-api/kube-object";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<KubeObject> {
   crd: CustomResourceDefinition;
@@ -98,6 +99,18 @@ export class CrdResourceDetails extends React.Component<Props> {
     const { props: { object, crd } } = this;
 
     if (!object || !crd) {
+      return null;
+    }
+
+    if (!(object instanceof KubeObject)) {
+      logger.error("[CrdResourceDetails]: passed object that is not an instanceof KubeObject", object);
+
+      return null;
+    }
+
+    if (!(crd instanceof CustomResourceDefinition)) {
+      logger.error("[CrdResourceDetails]: passed crd that is not an instanceof CustomResourceDefinition", crd);
+
       return null;
     }
 

--- a/src/renderer/components/+events/event-details.tsx
+++ b/src/renderer/components/+events/event-details.tsx
@@ -27,12 +27,13 @@ import { DrawerItem, DrawerTitle } from "../drawer";
 import { Link } from "react-router-dom";
 import { observer } from "mobx-react";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { KubeEvent } from "../../../common/k8s-api/endpoints/events.api";
+import { KubeEvent } from "../../../common/k8s-api/endpoints/events.api";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 import { LocaleDate } from "../locale-date";
 import { getDetailsUrl } from "../kube-detail-params";
 import { apiManager } from "../../../common/k8s-api/api-manager";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<KubeEvent> {
 }
@@ -42,7 +43,16 @@ export class EventDetails extends React.Component<Props> {
   render() {
     const { object: event } = this.props;
 
-    if (!event) return null;
+    if (!event) {
+      return null;
+    }
+
+    if (!(event instanceof KubeEvent)) {
+      logger.error("[EventDetails]: passed object that is not an instanceof KubeEvent", event);
+
+      return null;
+    }
+
     const { message, reason, count, type, involvedObject } = event;
     const { kind, name, namespace, fieldPath } = involvedObject;
 

--- a/src/renderer/components/+events/kube-event-details.tsx
+++ b/src/renderer/components/+events/kube-event-details.tsx
@@ -23,10 +23,11 @@ import "./kube-event-details.scss";
 
 import React from "react";
 import { observer } from "mobx-react";
-import type { KubeObject } from "../../../common/k8s-api/kube-object";
+import { KubeObject } from "../../../common/k8s-api/kube-object";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { cssNames } from "../../utils";
 import { eventStore } from "./event.store";
+import logger from "../../../common/logger";
 
 export interface KubeEventDetailsProps {
   object: KubeObject;
@@ -40,6 +41,17 @@ export class KubeEventDetails extends React.Component<KubeEventDetailsProps> {
 
   render() {
     const { object } = this.props;
+
+    if (!object) {
+      return null;
+    }
+
+    if (!(object instanceof KubeObject)) {
+      logger.error("[KubeEventDetails]: passed object that is not an instanceof KubeObject", object);
+
+      return null;
+    }
+
     const events = eventStore.getEventsByObject(object);
 
     if (!events.length) {

--- a/src/renderer/components/+namespaces/namespace-details.tsx
+++ b/src/renderer/components/+namespaces/namespace-details.tsx
@@ -38,6 +38,7 @@ import { PodCharts, podMetricTabs } from "../+workloads-pods/pod-charts";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { getDetailsUrl } from "../kube-detail-params";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Namespace> {
 }
@@ -81,7 +82,16 @@ export class NamespaceDetails extends React.Component<Props> {
   render() {
     const { object: namespace } = this.props;
 
-    if (!namespace) return null;
+    if (!namespace) {
+      return null;
+    }
+
+    if (!(namespace instanceof Namespace)) {
+      logger.error("[NamespaceDetails]: passed object that is not an instanceof Namespace", namespace);
+
+      return null;
+    }
+
     const status = namespace.getStatus();
     const isMetricHidden = getActiveClusterEntity()?.isMetricHidden(ClusterMetricsResourceType.Namespace);
 

--- a/src/renderer/components/+network-endpoints/endpoint-details.tsx
+++ b/src/renderer/components/+network-endpoints/endpoint-details.tsx
@@ -25,9 +25,10 @@ import React from "react";
 import { observer } from "mobx-react";
 import { DrawerTitle } from "../drawer";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { Endpoint } from "../../../common/k8s-api/endpoints";
+import { Endpoint } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { EndpointSubsetList } from "./endpoint-subset-list";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Endpoint> {
 }
@@ -37,7 +38,15 @@ export class EndpointDetails extends React.Component<Props> {
   render() {
     const { object: endpoint } = this.props;
 
-    if (!endpoint) return null;
+    if (!endpoint) {
+      return null;
+    }
+
+    if (!(endpoint instanceof Endpoint)) {
+      logger.error("[EndpointDetails]: passed object that is not an instanceof Endpoint", endpoint);
+
+      return null;
+    }
 
     return (
       <div className="EndpointDetails">

--- a/src/renderer/components/+network-ingresses/ingress-details.tsx
+++ b/src/renderer/components/+network-ingresses/ingress-details.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { makeObservable, observable, reaction } from "mobx";
 import { DrawerItem, DrawerTitle } from "../drawer";
-import type { ILoadBalancerIngress, Ingress } from "../../../common/k8s-api/endpoints";
+import { ILoadBalancerIngress, Ingress } from "../../../common/k8s-api/endpoints";
 import { Table, TableCell, TableHead, TableRow } from "../table";
 import { ResourceMetrics } from "../resource-metrics";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
@@ -35,6 +35,7 @@ import { getBackendServiceNamePort, getMetricsForIngress, IIngressMetrics } from
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Ingress> {
 }
@@ -129,6 +130,12 @@ export class IngressDetails extends React.Component<Props> {
     const { object: ingress } = this.props;
 
     if (!ingress) {
+      return null;
+    }
+
+    if (!(ingress instanceof Ingress)) {
+      logger.error("[IngressDetails]: passed object that is not an instanceof Ingress", ingress);
+
       return null;
     }
 

--- a/src/renderer/components/+network-policies/network-policy-details.tsx
+++ b/src/renderer/components/+network-policies/network-policy-details.tsx
@@ -24,12 +24,13 @@ import "./network-policy-details.scss";
 import get from "lodash/get";
 import React, { Fragment } from "react";
 import { DrawerItem, DrawerTitle } from "../drawer";
-import type { IPolicyEgress, IPolicyIngress, IPolicyIpBlock, IPolicySelector, NetworkPolicy } from "../../../common/k8s-api/endpoints/network-policy.api";
+import { IPolicyEgress, IPolicyIngress, IPolicyIpBlock, IPolicySelector, NetworkPolicy } from "../../../common/k8s-api/endpoints/network-policy.api";
 import { Badge } from "../badge";
 import { SubTitle } from "../layout/sub-title";
 import { observer } from "mobx-react";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<NetworkPolicy> {
 }
@@ -117,6 +118,13 @@ export class NetworkPolicyDetails extends React.Component<Props> {
     if (!policy) {
       return null;
     }
+
+    if (!(policy instanceof NetworkPolicy)) {
+      logger.error("[NetworkPolicyDetails]: passed object that is not an instanceof NetworkPolicy", policy);
+
+      return null;
+    }
+
     const { ingress, egress } = policy.spec;
     const selector = policy.getMatchLabels();
 

--- a/src/renderer/components/+network-services/service-details.tsx
+++ b/src/renderer/components/+network-services/service-details.tsx
@@ -26,12 +26,13 @@ import { disposeOnUnmount, observer } from "mobx-react";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { Service } from "../../../common/k8s-api/endpoints";
+import { Service } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { ServicePortComponent } from "./service-port-component";
 import { endpointStore } from "../+network-endpoints/endpoints.store";
 import { ServiceDetailsEndpoint } from "./service-details-endpoint";
 import { kubeWatchApi } from "../../../common/k8s-api/kube-watch-api";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Service> {
 }
@@ -52,7 +53,16 @@ export class ServiceDetails extends React.Component<Props> {
   render() {
     const { object: service } = this.props;
 
-    if (!service) return null;
+    if (!service) {
+      return null;
+    }
+
+    if (!(service instanceof Service)) {
+      logger.error("[ServiceDetails]: passed object that is not an instanceof Service", service);
+
+      return null;
+    }
+
     const { spec } = service;
     const endpoint = endpointStore.getByName(service.getName(), service.getNs());
 

--- a/src/renderer/components/+nodes/node-details.tsx
+++ b/src/renderer/components/+nodes/node-details.tsx
@@ -40,6 +40,7 @@ import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { NodeDetailsResources } from "./node-details-resources";
 import { DrawerTitle } from "../drawer/drawer-title";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Node> {
 }
@@ -72,7 +73,16 @@ export class NodeDetails extends React.Component<Props> {
   render() {
     const { object: node } = this.props;
 
-    if (!node) return null;
+    if (!node) {
+      return null;
+    }
+
+    if (!(node instanceof Node)) {
+      logger.error("[NodeDetails]: passed object that is not an instanceof Node", node);
+
+      return null;
+    }
+
     const { status } = node;
     const { nodeInfo, addresses } = status;
     const conditions = node.getActiveConditions();

--- a/src/renderer/components/+storage-classes/storage-class-details.tsx
+++ b/src/renderer/components/+storage-classes/storage-class-details.tsx
@@ -27,11 +27,12 @@ import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
 import { observer } from "mobx-react";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
-import type { StorageClass } from "../../../common/k8s-api/endpoints";
+import { StorageClass } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { storageClassStore } from "./storage-class.store";
 import { VolumeDetailsList } from "../+storage-volumes/volume-details-list";
 import { volumesStore } from "../+storage-volumes/volumes.store";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<StorageClass> {
 }
@@ -44,9 +45,18 @@ export class StorageClassDetails extends React.Component<Props> {
 
   render() {
     const { object: storageClass } = this.props;
-    const persistentVolumes = storageClassStore.getPersistentVolumes(storageClass);
 
-    if (!storageClass) return null;
+    if (!storageClass) {
+      return null;
+    }
+
+    if (!(storageClass instanceof StorageClass)) {
+      logger.error("[StorageClassDetails]: passed object that is not an instanceof StorageClass", storageClass);
+
+      return null;
+    }
+
+    const persistentVolumes = storageClassStore.getPersistentVolumes(storageClass);
     const { provisioner, parameters, mountOptions } = storageClass;
 
     return (

--- a/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
+++ b/src/renderer/components/+storage-volume-claims/volume-claim-details.tsx
@@ -37,6 +37,7 @@ import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { getDetailsUrl } from "../kube-detail-params";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<PersistentVolumeClaim> {
 }
@@ -68,6 +69,13 @@ export class PersistentVolumeClaimDetails extends React.Component<Props> {
     if (!volumeClaim) {
       return null;
     }
+
+    if (!(volumeClaim instanceof PersistentVolumeClaim)) {
+      logger.error("[PersistentVolumeClaimDetails]: passed object that is not an instanceof PersistentVolumeClaim", volumeClaim);
+
+      return null;
+    }
+
     const { storageClassName, accessModes } = volumeClaim.spec;
     const { metrics } = this;
     const pods = volumeClaim.getPods(podsStore.items);

--- a/src/renderer/components/+storage-volumes/volume-details.tsx
+++ b/src/renderer/components/+storage-volumes/volume-details.tsx
@@ -31,6 +31,7 @@ import { PersistentVolume, pvcApi } from "../../../common/k8s-api/endpoints";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
 import { KubeObjectMeta } from "../kube-object-meta";
 import { getDetailsUrl } from "../kube-detail-params";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<PersistentVolume> {
 }
@@ -43,6 +44,13 @@ export class PersistentVolumeDetails extends React.Component<Props> {
     if (!volume) {
       return null;
     }
+
+    if (!(volume instanceof PersistentVolume)) {
+      logger.error("[PersistentVolumeDetails]: passed object that is not an instanceof PersistentVolume", volume);
+
+      return null;
+    }
+
     const { accessModes, capacity, persistentVolumeReclaimPolicy, storageClassName, claimRef, flexVolume, mountOptions, nfs } = volume.spec;
 
     return (

--- a/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjob-details.tsx
@@ -31,8 +31,9 @@ import { Link } from "react-router-dom";
 import { cronJobStore } from "./cronjob.store";
 import type { KubeObjectDetailsProps } from "../kube-object-details";
 import { getDetailsUrl } from "../kube-detail-params";
-import type { CronJob, Job } from "../../../common/k8s-api/endpoints";
+import { CronJob, Job } from "../../../common/k8s-api/endpoints";
 import { KubeObjectMeta } from "../kube-object-meta";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<CronJob> {
 }
@@ -46,18 +47,27 @@ export class CronJobDetails extends React.Component<Props> {
   render() {
     const { object: cronJob } = this.props;
 
-    if (!cronJob) return null;
+    if (!cronJob) {
+      return null;
+    }
+
+    if (!(cronJob instanceof CronJob)) {
+      logger.error("[CronJobDetails]: passed object that is not an instanceof CronJob", cronJob);
+
+      return null;
+    }
+
     const childJobs = jobStore.getJobsByOwner(cronJob);
 
     return (
       <div className="CronJobDetails">
         <KubeObjectMeta object={cronJob}/>
         <DrawerItem name="Schedule">
-          {cronJob.isNeverRun() ? (
-            <>
-              never ({cronJob.getSchedule()})
-            </>
-          ) : cronJob.getSchedule()}
+          {
+            cronJob.isNeverRun()
+              ? `never (${cronJob.getSchedule()})`
+              : cronJob.getSchedule()
+          }
         </DrawerItem>
         <DrawerItem name="Active">
           {cronJobStore.getActiveJobsNum(cronJob)}

--- a/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-details.tsx
@@ -40,6 +40,7 @@ import { KubeObjectMeta } from "../kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<DaemonSet> {
 }
@@ -72,7 +73,16 @@ export class DaemonSetDetails extends React.Component<Props> {
   render() {
     const { object: daemonSet } = this.props;
 
-    if (!daemonSet) return null;
+    if (!daemonSet) {
+      return null;
+    }
+
+    if (!(daemonSet instanceof DaemonSet)) {
+      logger.error("[DaemonSetDetails]: passed object that is not an instanceof DaemonSet", daemonSet);
+
+      return null;
+    }
+
     const { spec } = daemonSet;
     const selectors = daemonSet.getSelectors();
     const images = daemonSet.getImages();

--- a/src/renderer/components/+workloads-deployments/deployment-details.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-details.tsx
@@ -42,6 +42,7 @@ import { DeploymentReplicaSets } from "./deployment-replicasets";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Deployment> {
 }
@@ -75,7 +76,16 @@ export class DeploymentDetails extends React.Component<Props> {
   render() {
     const { object: deployment } = this.props;
 
-    if (!deployment) return null;
+    if (!deployment) {
+      return null;
+    }
+
+    if (!(deployment instanceof Deployment)) {
+      logger.error("[DeploymentDetails]: passed object that is not an instanceof Deployment", deployment);
+
+      return null;
+    }
+
     const { status, spec } = deployment;
     const nodeSelector = deployment.getNodeSelectors();
     const selectors = deployment.getSelectors();

--- a/src/renderer/components/+workloads-deployments/deployment-scale-dialog.test.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-scale-dialog.test.tsx
@@ -112,6 +112,7 @@ const dummyDeployment: Deployment = {
   toPlainObject: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  patch: jest.fn(),
 };
 
 describe("<DeploymentScaleDialog />", () => {

--- a/src/renderer/components/+workloads-jobs/job-details.tsx
+++ b/src/renderer/components/+workloads-jobs/job-details.tsx
@@ -44,6 +44,7 @@ import { ResourceMetrics } from "../resource-metrics";
 import { boundMethod } from "autobind-decorator";
 import { getDetailsUrl } from "../kube-detail-params";
 import { apiManager } from "../../../common/k8s-api/api-manager";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Job> {
 }
@@ -71,7 +72,16 @@ export class JobDetails extends React.Component<Props> {
   render() {
     const { object: job } = this.props;
 
-    if (!job) return null;
+    if (!job) {
+      return null;
+    }
+
+    if (!(job instanceof Job)) {
+      logger.error("[JobDetails]: passed object that is not an instanceof Job", job);
+
+      return null;
+    }
+
     const selectors = job.getSelectors();
     const nodeSelector = job.getNodeSelectors();
     const images = job.getImages();

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -43,6 +43,7 @@ import { KubeObjectMeta } from "../kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { getDetailsUrl } from "../kube-detail-params";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<Pod> {
 }
@@ -77,7 +78,16 @@ export class PodDetails extends React.Component<Props> {
   render() {
     const { object: pod } = this.props;
 
-    if (!pod) return null;
+    if (!pod) {
+      return null;
+    }
+
+    if (!(pod instanceof Pod)) {
+      logger.error("[PodDetails]: passed object that is not an instanceof Pod", pod);
+
+      return null;
+    }
+
     const { status, spec } = pod;
     const { conditions, podIP } = status;
     const podIPs = pod.getIPs();

--- a/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-details.tsx
@@ -39,6 +39,7 @@ import { KubeObjectMeta } from "../kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<ReplicaSet> {
 }
@@ -71,7 +72,16 @@ export class ReplicaSetDetails extends React.Component<Props> {
   render() {
     const { object: replicaSet } = this.props;
 
-    if (!replicaSet) return null;
+    if (!replicaSet) {
+      return null;
+    }
+
+    if (!(replicaSet instanceof ReplicaSet)) {
+      logger.error("[ReplicaSetDetails]: passed object that is not an instanceof ReplicaSet", replicaSet);
+
+      return null;
+    }
+
     const { metrics } = this;
     const { status } = replicaSet;
     const { availableReplicas, replicas } = status;

--- a/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.test.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicaset-scale-dialog.test.tsx
@@ -107,6 +107,7 @@ const dummyReplicaSet: ReplicaSet = {
   toPlainObject: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  patch: jest.fn(),
 };
 
 describe("<ReplicaSetScaleDialog />", () => {

--- a/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-details.tsx
@@ -40,6 +40,7 @@ import { KubeObjectMeta } from "../kube-object-meta";
 import { getActiveClusterEntity } from "../../api/catalog-entity-registry";
 import { ClusterMetricsResourceType } from "../../../common/cluster-types";
 import { boundMethod } from "../../utils";
+import logger from "../../../common/logger";
 
 interface Props extends KubeObjectDetailsProps<StatefulSet> {
 }
@@ -72,7 +73,16 @@ export class StatefulSetDetails extends React.Component<Props> {
   render() {
     const { object: statefulSet } = this.props;
 
-    if (!statefulSet) return null;
+    if (!statefulSet) {
+      return null;
+    }
+
+    if (!(statefulSet instanceof StatefulSet)) {
+      logger.error("[StatefulSetDetails]: passed object that is not an instanceof StatefulSet", statefulSet);
+
+      return null;
+    }
+
     const images = statefulSet.getImages();
     const selectors = statefulSet.getSelectors();
     const nodeSelector = statefulSet.getNodeSelectors();

--- a/src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.test.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-scale-dialog.test.tsx
@@ -117,6 +117,7 @@ const dummyStatefulSet: StatefulSet = {
   toPlainObject: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  patch: jest.fn(),
 };
 
 describe("<StatefulSetScaleDialog />", () => {

--- a/src/renderer/components/dock/__test__/log-tab.store.test.ts
+++ b/src/renderer/components/dock/__test__/log-tab.store.test.ts
@@ -25,9 +25,11 @@ import { Pod } from "../../../../common/k8s-api/endpoints";
 import { ThemeStore } from "../../../theme.store";
 import { dockStore } from "../dock.store";
 import { logTabStore } from "../log-tab.store";
-import { TerminalStore } from "../terminal.store";
 import { deploymentPod1, deploymentPod2, deploymentPod3, dockerPod } from "./pod.mock";
 import fse from "fs-extra";
+import { mockWindow } from "../../../../../__mocks__/windowMock";
+
+mockWindow();
 
 jest.mock("react-monaco-editor", () => null);
 
@@ -45,7 +47,6 @@ describe("log tab store", () => {
   beforeEach(() => {
     UserStore.createInstance();
     ThemeStore.createInstance();
-    TerminalStore.createInstance();
   });
 
   afterEach(() => {
@@ -53,7 +54,6 @@ describe("log tab store", () => {
     dockStore.reset();
     UserStore.resetInstance();
     ThemeStore.resetInstance();
-    TerminalStore.resetInstance();
     fse.remove("tmp");
   });
 
@@ -135,11 +135,11 @@ describe("log tab store", () => {
   });
 
   // FIXME: this is failed when it's not .only == depends on something above
-  it.only("closes tab if no pods left in store", () => {
+  it.only("closes tab if no pods left in store", async () => {
     const selectedPod = new Pod(deploymentPod1);
     const selectedContainer = selectedPod.getInitContainers()[0];
 
-    logTabStore.createPodTab({
+    const id = logTabStore.createPodTab({
       selectedPod,
       selectedContainer
     });
@@ -147,6 +147,7 @@ describe("log tab store", () => {
     podsStore.items.clear();
 
     expect(logTabStore.getData(dockStore.selectedTabId)).toBeUndefined();
-    expect(dockStore.getTabById(dockStore.selectedTabId)).toBeUndefined();
+    expect(logTabStore.getData(id)).toBeUndefined();
+    expect(dockStore.getTabById(id)).toBeUndefined();
   });
 });

--- a/src/renderer/components/dock/dock.store.ts
+++ b/src/renderer/components/dock/dock.store.ts
@@ -160,7 +160,7 @@ export class DockStore implements DockStorageState {
     window.addEventListener("resize", throttle(this.adjustHeight, 250));
     // create monaco models
     this.whenReady.then(() => {this.tabs.forEach(tab => {
-      if (this.usesMonacoEditor(tab)) {     
+      if (this.usesMonacoEditor(tab)) {
         monacoModelsManager.addModel(tab.id);
       }
     });});
@@ -274,7 +274,7 @@ export class DockStore implements DockStorageState {
       title
     };
 
-    // add monaco model 
+    // add monaco model
     if (this.usesMonacoEditor(tab)) {
       monacoModelsManager.addModel(id);
     }
@@ -287,14 +287,14 @@ export class DockStore implements DockStorageState {
   }
 
   @action
-  async closeTab(tabId: TabId) {
+  closeTab(tabId: TabId) {
     const tab = this.getTabById(tabId);
 
     if (!tab || tab.pinned) {
       return;
     }
 
-    // remove monaco model 
+    // remove monaco model
     if (this.usesMonacoEditor(tab)) {
       monacoModelsManager.removeModel(tabId);
     }
@@ -305,12 +305,6 @@ export class DockStore implements DockStorageState {
       if (this.tabs.length) {
         const newTab = this.tabs.slice(-1)[0]; // last
 
-        if (newTab?.kind === TabKind.TERMINAL) {
-          // close the dock when selected sibling inactive terminal tab
-          const { TerminalStore } = await import("./terminal.store");
-
-          if (!TerminalStore.getInstance(false)?.isConnected(newTab.id)) this.close();
-        }
         this.selectTab(newTab.id);
       } else {
         this.selectedTabId = null;

--- a/src/renderer/components/dock/edit-resource.store.ts
+++ b/src/renderer/components/dock/edit-resource.store.ts
@@ -31,6 +31,7 @@ import {monacoModelsManager} from "./monaco-model-manager";
 export interface EditingResource {
   resource: string; // resource path, e.g. /api/v1/namespaces/default
   draft?: string; // edited draft in yaml
+  firstDraft?: string;
 }
 
 export class EditResourceStore extends DockTabStore<EditingResource> {
@@ -104,6 +105,10 @@ export class EditResourceStore extends DockTabStore<EditingResource> {
     }) || [];
 
     return dockStore.getTabById(tabId);
+  }
+
+  clearInitialDraft(tabId: TabId): void {
+    delete this.getData(tabId)?.firstDraft;
   }
 
   reset() {

--- a/src/renderer/components/dock/editor-panel.tsx
+++ b/src/renderer/components/dock/editor-panel.tsx
@@ -91,10 +91,7 @@ export class EditorPanel extends React.Component<Props> {
 
   onChange = (value: string) => {
     this.validate(value);
-
-    if (this.props.onChange) {
-      this.props.onChange(value, this.yamlError);
-    }
+    this.props.onChange?.(value, this.yamlError);
   };
 
   render() {

--- a/src/renderer/components/dock/log-tab.store.ts
+++ b/src/renderer/components/dock/log-tab.store.ts
@@ -25,6 +25,7 @@ import { podsStore } from "../+workloads-pods/pods.store";
 
 import { IPodContainer, Pod } from "../../../common/k8s-api/endpoints";
 import type { WorkloadKubeObject } from "../../../common/k8s-api/workload-kube-object";
+import logger from "../../../common/logger";
 import { DockTabStore } from "./dock-tab.store";
 import { dockStore, DockTabCreateSpecific, TabKind } from "./dock.store";
 
@@ -51,17 +52,15 @@ export class LogTabStore extends DockTabStore<LogTabData> {
       storageKey: "pod_logs"
     });
 
-    reaction(() => podsStore.items.length, () => {
-      this.updateTabsData();
-    });
+    reaction(() => podsStore.items.length, () => this.updateTabsData());
   }
 
-  createPodTab({ selectedPod, selectedContainer }: PodLogsTabData): void {
+  createPodTab({ selectedPod, selectedContainer }: PodLogsTabData): string {
     const podOwner = selectedPod.getOwnerRefs()[0];
     const pods = podsStore.getPodsByOwnerId(podOwner?.uid);
     const title = `Pod ${selectedPod.getName()}`;
 
-    this.createLogsTab(title, {
+    return this.createLogsTab(title, {
       pods: pods.length ? pods : [selectedPod],
       selectedPod,
       selectedContainer
@@ -95,9 +94,9 @@ export class LogTabStore extends DockTabStore<LogTabData> {
       ...tabParams,
       kind: TabKind.POD_LOGS,
     }, false);
-  }
+  } 
 
-  private createLogsTab(title: string, data: LogTabData) {
+  private createLogsTab(title: string, data: LogTabData): string {
     const id = uniqueId("log-tab-");
 
     this.createDockTab({ id, title });
@@ -106,38 +105,45 @@ export class LogTabStore extends DockTabStore<LogTabData> {
       showTimestamps: false,
       previous: false
     });
+
+    return id;
   }
 
-  private async updateTabsData() {
-    const promises: Promise<void>[] = [];
-
+  private updateTabsData() {
     for (const [tabId, tabData] of this.data) {
-      const pod = new Pod(tabData.selectedPod);
-      const pods = podsStore.getPodsByOwnerId(pod.getOwnerRefs()[0]?.uid);
-      const isSelectedPodInList = pods.find(item => item.getId() == pod.getId());
-      const selectedPod = isSelectedPodInList ? pod : pods[0];
-      const selectedContainer = isSelectedPodInList ? tabData.selectedContainer : pod.getAllContainers()[0];
+      try {
+        if (!tabData.selectedPod) {
+          tabData.selectedPod = tabData.pods[0];
+        }
 
-      if (pods.length) {
-        this.setData(tabId, {
-          ...tabData,
-          selectedPod,
-          selectedContainer,
-          pods
-        });
-
-        this.renameTab(tabId);
-      } else {
-        promises.push(this.closeTab(tabId));
+        const pod = new Pod(tabData.selectedPod);
+        const pods = podsStore.getPodsByOwnerId(pod.getOwnerRefs()[0]?.uid);
+        const isSelectedPodInList = pods.find(item => item.getId() == pod.getId());
+        const selectedPod = isSelectedPodInList ? pod : pods[0];
+        const selectedContainer = isSelectedPodInList ? tabData.selectedContainer : pod.getAllContainers()[0];
+  
+        if (pods.length > 0) {
+          this.setData(tabId, {
+            ...tabData,
+            selectedPod,
+            selectedContainer,
+            pods
+          });
+  
+          this.renameTab(tabId);
+        } else {
+          this.closeTab(tabId);
+        }
+      } catch (error) {
+        logger.error(`[LOG-TAB-STORE]: failed to set data for tabId=${tabId} deleting`, error,);
+        this.data.delete(tabId);
       }
     }
-
-    await Promise.all(promises);
   }
 
-  private async closeTab(tabId: string) {
+  private closeTab(tabId: string) {
     this.clearData(tabId);
-    await dockStore.closeTab(tabId);
+    dockStore.closeTab(tabId);
   }
 }
 

--- a/src/renderer/components/kube-object-menu/kube-object-menu.tsx
+++ b/src/renderer/components/kube-object-menu/kube-object-menu.tsx
@@ -44,15 +44,11 @@ export class KubeObjectMenu<T extends KubeObject> extends React.Component<KubeOb
   }
 
   get isEditable() {
-    const { editable } = this.props;
-
-    return editable !== undefined ? editable : !!(this.store && this.store.update);
+    return this.props.editable ?? Boolean(this.store?.patch);
   }
 
   get isRemovable() {
-    const { removable } = this.props;
-
-    return removable !== undefined ? removable : !!(this.store && this.store.remove);
+    return this.props.removable ?? Boolean(this.store?.remove);
   }
 
   @boundMethod

--- a/src/renderer/components/kube-object-meta/kube-object-meta.tsx
+++ b/src/renderer/components/kube-object-meta/kube-object-meta.tsx
@@ -20,13 +20,14 @@
  */
 
 import React from "react";
-import type { KubeMetaField, KubeObject } from "../../../common/k8s-api/kube-object";
+import { KubeMetaField, KubeObject } from "../../../common/k8s-api/kube-object";
 import { DrawerItem, DrawerItemLabels } from "../drawer";
 import { apiManager } from "../../../common/k8s-api/api-manager";
 import { Link } from "react-router-dom";
 import { KubeObjectStatusIcon } from "../kube-object-status-icon";
 import { LocaleDate } from "../locale-date";
 import { getDetailsUrl } from "../kube-detail-params";
+import logger from "../../../common/logger";
 
 export interface KubeObjectMetaProps {
   object: KubeObject;
@@ -46,6 +47,17 @@ export class KubeObjectMeta extends React.Component<KubeObjectMetaProps> {
 
   render() {
     const { object } = this.props;
+
+    if (!object) {
+      return null;
+    }
+
+    if (!(object instanceof KubeObject)) {
+      logger.error("[KubeObjectMeta]: passed object that is not an instanceof KubeObject", object);
+
+      return null;
+    }
+
     const {
       getNs, getLabels, getResourceVersion, selfLink, getAnnotations,
       getFinalizers, getId, getAge, getName, metadata: { creationTimestamp },

--- a/src/renderer/utils/createStorage.ts
+++ b/src/renderer/utils/createStorage.ts
@@ -28,6 +28,7 @@ import { StorageHelper } from "./storageHelper";
 import { ClusterStore } from "../../common/cluster-store";
 import logger from "../../main/logger";
 import { getHostedClusterId, getPath } from "../../common/utils";
+import { isTestEnv } from "../../common/vars";
 
 const storage = observable({
   initialized: false,
@@ -62,7 +63,9 @@ export function createAppStorage<T>(key: string, defaultValue: T, clusterId?: st
       .then(data => storage.data = data)
       .catch(() => null) // ignore empty / non-existing / invalid json files
       .finally(() => {
-        logger.info(`${logPrefix} loading finished for ${filePath}`);
+        if (!isTestEnv) {
+          logger.info(`${logPrefix} loading finished for ${filePath}`);
+        }
         storage.loaded = true;
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12446,6 +12446,11 @@ rfc4648@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.3.0.tgz#2a69c76f05bc0e388feab933672de9b492af95f1"
   integrity sha512-x36K12jOflpm1V8QjPq3I+pt7Z1xzeZIjiC8J2Oxd7bE1efTrOG241DTYVJByP/SxR9jl1t7iZqYxDX864jgBQ==
 
+rfc6902@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rfc6902/-/rfc6902-4.0.2.tgz#ce99d3562b9e3287d403462e6bcc81eead8fcea0"
+  integrity sha512-MJOC4iDSv3Qn5/QvhPbrNoRongti6moXSShcRmtbNqOk0WPxlviEdMV4bb9PaULhSxLUXzWd4AjAMKQ3j3y54w==
+
 rimraf@2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"


### PR DESCRIPTION
## Changes since v5.2.5

## 🚀 Features

- Use random api prefix on kubectl-proxy (#4137) @jakolehm

## 🐛 Bug Fixes

- Check object instanceof on all detail panels (#4054) @Nokel81
- Use the served and storage version of a CRD instead of the first (#3999) @Nokel81
- Catch metadata being undefined at KubeObject creation (#3960) @Nokel81 
- Use JSON patch for editing components (#3674) @Nokel81 
- Disable sentry in cluster frame (#4161) @jakolehm
- Remove iframe completely on disconnect (#4116) @jakolehm
- Remove unnecessary global watches in cluster view (#4073) @jakolehm
- Fix kube-api watch leak on window unload (#3858) @jakolehm
- Remove cors headers from LensProxy (#4126) @jakolehm
