### PR TITLE
Allow kube-state-metrics to watch ingresses in networking.k8s.io apiGroup

### DIFF
--- a/extensions/metrics-cluster-feature/resources/12-kube-state-metrics-clusterrole.yml
+++ b/extensions/metrics-cluster-feature/resources/12-kube-state-metrics-clusterrole.yml
@@ -32,6 +32,13 @@ rules:
     - list
     - watch
   - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
+    verbs:
+    - list
+    - watch
+  - apiGroups:
     - apps
     resources:
     - statefulsets

--- a/src/common/system-ca.ts
+++ b/src/common/system-ca.ts
@@ -66,7 +66,7 @@ export function getWinRootCA(): Promise<string[]> {
       },
       onend: () => {
         resolve(CAs.filter(isCertActive));
-      }
+      },
     });
   });
 }
@@ -98,7 +98,7 @@ export async function injectSystemCAs() {
       console.warn(`[MAC-CA]: Error injecting root CAs from MacOSX. ${error?.message}`);
     }
   }
-  
+
   if (isWindows) {
     try {
       const winRootCAs = await getWinRootCA();


### PR DESCRIPTION
If kubernetes api does not serve `extensions` api group,  kube-state-metrics is not able to list/watch ingress resources. This PR will add rule to list and watch `ingress` resources on `networking.k8s.io` apiGroup to `lens-kube-state-metrics` cluster role.
