### PR TITLE
Fix catalog button border-radius when modal is shown

### DIFF
--- a/src/renderer/components/+catalog/catalog-add-button.scss
+++ b/src/renderer/components/+catalog/catalog-add-button.scss
@@ -26,6 +26,7 @@
 
   .MuiFab-primary {
     background-color: var(--blue);
+    border-radius: 50%;
 
     &:hover {
       background-color: #317bb3;


### PR DESCRIPTION
Before: 
<img width="870" alt="image" src="https://user-images.githubusercontent.com/774344/140035884-963173cd-6dd1-4f0e-abfc-aa9f47d35e56.png">



After:
<img width="881" alt="image" src="https://user-images.githubusercontent.com/774344/140033832-a43e721a-fd59-4294-95b3-2d680702d9f3.png">
