### PR TITLE
Display namespace for subject on ClusterRoleBinding details

### DIFF
--- a/src/renderer/components/+user-management/+cluster-role-bindings/details.tsx
+++ b/src/renderer/components/+user-management/+cluster-role-bindings/details.tsx
@@ -103,12 +103,13 @@ export class ClusterRoleBindingDetails extends React.Component<Props> {
           <Table selectable className="bindings box grow">
             <TableHead>
               <TableCell checkbox />
-              <TableCell className="binding">Name</TableCell>
               <TableCell className="type">Type</TableCell>
+              <TableCell className="binding">Name</TableCell>
+              <TableCell className="ns">Namespace</TableCell>
             </TableHead>
             {
               subjects.map((subject, i) => {
-                const { kind, name } = subject;
+                const { kind, name, namespace } = subject;
                 const isSelected = selectedSubjects.has(subject);
 
                 return (
@@ -118,8 +119,9 @@ export class ClusterRoleBindingDetails extends React.Component<Props> {
                     onClick={prevDefault(() => this.selectedSubjects.toggle(subject))}
                   >
                     <TableCell checkbox isChecked={isSelected} />
-                    <TableCell className="binding">{name}</TableCell>
                     <TableCell className="type">{kind}</TableCell>
+                    <TableCell className="binding">{name}</TableCell>
+                    <TableCell className="ns">{namespace || "-"}</TableCell>
                   </TableRow>
                 );
               })

--- a/src/renderer/components/+user-management/+role-bindings/details.tsx
+++ b/src/renderer/components/+user-management/+role-bindings/details.tsx
@@ -99,9 +99,9 @@ export class RoleBindingDetails extends React.Component<Props> {
           <Table selectable className="bindings box grow">
             <TableHead>
               <TableCell checkbox />
-              <TableCell className="binding">Name</TableCell>
               <TableCell className="type">Type</TableCell>
-              <TableCell className="type">Namespace</TableCell>
+              <TableCell className="binding">Name</TableCell>
+              <TableCell className="ns">Namespace</TableCell>
             </TableHead>
             {
               subjects.map((subject, i) => {
@@ -115,8 +115,8 @@ export class RoleBindingDetails extends React.Component<Props> {
                     onClick={prevDefault(() => this.selectedSubjects.toggle(subject))}
                   >
                     <TableCell checkbox isChecked={isSelected} />
-                    <TableCell className="binding">{name}</TableCell>
                     <TableCell className="type">{kind}</TableCell>
+                    <TableCell className="binding">{name}</TableCell>
                     <TableCell className="ns">{namespace || "-"}</TableCell>
                   </TableRow>
                 );


### PR DESCRIPTION
This PR displays missing `namespace` property for cluster role binding subject on details. This PR also changes the order of cells: `Type`, `Name` and `Namespace` for both `RoleBinding` and `ClusterRoleBinding`

![image](https://user-images.githubusercontent.com/455844/140069277-3187b2d8-c3a5-4150-b4e5-724c1002cce5.png) 
