### PR TITLE
Fix crash in IngressDetails

### DIFF
--- a/src/common/k8s-api/endpoints/ingress.api.ts
+++ b/src/common/k8s-api/endpoints/ingress.api.ts
@@ -154,7 +154,7 @@ export class Ingress extends KubeObject {
     return routes;
   }
 
-  getServiceNamePort(): IExtensionsBackend | undefined {
+  getServiceNamePort(): IExtensionsBackend {
     const { spec: { backend, defaultBackend } = {}} = this;
 
     const serviceName = defaultBackend?.service?.name ?? backend?.serviceName;

--- a/src/common/k8s-api/endpoints/ingress.api.ts
+++ b/src/common/k8s-api/endpoints/ingress.api.ts
@@ -25,6 +25,7 @@ import { IMetrics, metricsApi } from "./metrics.api";
 import { KubeApi } from "../kube-api";
 import type { KubeJsonApiData } from "../kube-json-api";
 import { isClusterPageContext } from "../../utils/cluster-id-url-parsing";
+import type { RequireExactlyOne } from "type-fest";
 
 export class IngressApi extends KubeApi<Ingress> {
 }
@@ -58,7 +59,7 @@ export interface ILoadBalancerIngress {
 // extensions/v1beta1
 interface IExtensionsBackend {
   serviceName: string;
-  servicePort: number;
+  servicePort: number | string;
 }
 
 // networking.k8s.io/v1
@@ -102,13 +103,13 @@ export interface Ingress {
     // extensions/v1beta1
     backend?: IExtensionsBackend;
     // networking.k8s.io/v1
-    defaultBackend?: INetworkingBackend & {
+    defaultBackend?: RequireExactlyOne<INetworkingBackend & {
       resource: {
         apiGroup: string;
         kind: string;
         name: string;
       }
-    }
+    }>
   };
   status: {
     loadBalancer: {
@@ -153,10 +154,11 @@ export class Ingress extends KubeObject {
     return routes;
   }
 
-  getServiceNamePort() {
-    const { spec } = this;
-    const serviceName = spec?.defaultBackend?.service.name ?? spec?.backend?.serviceName;
-    const servicePort = spec?.defaultBackend?.service.port.number ?? spec?.defaultBackend?.service.port.name ?? spec?.backend?.servicePort;
+  getServiceNamePort(): IExtensionsBackend | undefined {
+    const { spec: { backend, defaultBackend } = {}} = this;
+
+    const serviceName = defaultBackend?.service?.name ?? backend?.serviceName;
+    const servicePort = defaultBackend?.service?.port.number ?? defaultBackend?.service?.port.name ?? backend?.servicePort;
 
     return {
       serviceName,

--- a/src/common/k8s-api/endpoints/ingress.api.ts
+++ b/src/common/k8s-api/endpoints/ingress.api.ts
@@ -102,7 +102,11 @@ export interface Ingress {
     }[];
     // extensions/v1beta1
     backend?: IExtensionsBackend;
-    // networking.k8s.io/v1
+    /**
+     * The default backend which is exactly on of:
+     * - service
+     * - resource
+     */
     defaultBackend?: RequireExactlyOne<INetworkingBackend & {
       resource: {
         apiGroup: string;


### PR DESCRIPTION
- Adds check in Ingress.getServiceNamePort() for a
  .spec.defaultBackend.resource instead of .spec.defaultBackend.service

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4265 