### PR TITLE
Display loading spinner while switching between helm charts

### DIFF
--- a/src/renderer/components/+apps-helm-charts/helm-chart-details.tsx
+++ b/src/renderer/components/+apps-helm-charts/helm-chart-details.tsx
@@ -49,9 +49,9 @@ const LargeTooltip = withStyles({
 @observer
 export class HelmChartDetails extends Component<Props> {
   @observable chartVersions: HelmChart[];
-  @observable selectedChart: HelmChart;
-  @observable readme: string = null;
-  @observable error: string = null;
+  @observable selectedChart?: HelmChart;
+  @observable readme?: string;
+  @observable error?: string;
 
   private abortController?: AbortController;
 
@@ -68,6 +68,10 @@ export class HelmChartDetails extends Component<Props> {
     disposeOnUnmount(this, [
       reaction(() => this.props.chart, async ({ name, repo, version }) => {
         try {
+          this.selectedChart = undefined;
+          this.chartVersions = undefined;
+          this.readme = undefined;
+
           const { readme, versions } = await getChartDetails(repo, name, { version });
 
           this.readme = readme;


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Without this fix the previously selected helm chart will still be displayed while the new one is loading.