### PR TITLE
log kubectl port-forward stderr output as debug

### DIFF
--- a/src/main/routes/port-forward-route.ts
+++ b/src/main/routes/port-forward-route.ts
@@ -95,7 +95,7 @@ class PortForward {
     });
 
     this.process.stderr.on("data", (data) => {
-      logger.warn(`[PORT-FORWARD-ROUTE]: kubectl port-forward process stderr: ${data}`);
+      logger.debug(`[PORT-FORWARD-ROUTE]: kubectl port-forward process stderr: ${data}`);
     });
 
     const internalPort = await getPortFrom(this.process.stdout, {


### PR DESCRIPTION
kubectl seems to use stderr for more than just error output; switching to debug to avoid spamming the logs