### PR TITLE
Specify GiB for lens prometheus metrics instead of GB

### DIFF
--- a/extensions/metrics-cluster-feature/src/metrics-settings.tsx
+++ b/extensions/metrics-cluster-feature/src/metrics-settings.tsx
@@ -61,14 +61,14 @@ export class MetricsSettings extends React.Component<Props> {
     persistence: {
       enabled: false,
       storageClass: null,
-      size: "20G",
+      size: "20GiB",
     },
     nodeExporter: {
       enabled: false,
     },
     retention: {
       time: "2d",
-      size: "5GB",
+      size: "5GiB",
     },
     kubeStateMetrics: {
       enabled: false,


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #3587