### PR TITLE
Make ws:// authentication more timing safe

### DIFF
--- a/src/main/proxy-functions/shell-api-request.ts
+++ b/src/main/proxy-functions/shell-api-request.ts
@@ -65,7 +65,7 @@ export class ShellRequestAuthenticator extends Singleton {
     const authToken = clusterTokens.get(tabId);
     const buf = Uint8Array.from(Buffer.from(token, "base64"));
 
-    if (authToken instanceof Uint8Array && crypto.timingSafeEqual(authToken, buf)) {
+    if (authToken instanceof Uint8Array && authToken.length === buf.length && crypto.timingSafeEqual(authToken, buf)) {
       // remove the token because it is a single use token
       clusterTokens.delete(tabId);
 

--- a/src/main/proxy-functions/shell-api-request.ts
+++ b/src/main/proxy-functions/shell-api-request.ts
@@ -63,15 +63,7 @@ export class ShellRequestAuthenticator extends Singleton {
     }
 
     const authToken = clusterTokens.get(tabId);
-    const buf = Uint8Array.from(token.split(",").map(ar => {
-      const res = +ar;
-
-      if (isNaN(res)) {
-        throw new TypeError("Token must be a CSV list of digits");
-      }
-
-      return res;
-    }));
+    const buf = Uint8Array.from(Buffer.from(token, "base64"));
 
     if (authToken instanceof Uint8Array && crypto.timingSafeEqual(authToken, buf)) {
       // remove the token because it is a single use token

--- a/src/renderer/api/terminal-api.ts
+++ b/src/renderer/api/terminal-api.ts
@@ -89,7 +89,7 @@ export class TerminalApi extends WebSocketApi {
       pathname: "/api",
       query: {
         ...this.query,
-        shellToken: authTokenArray.toString(),
+        shellToken: Buffer.from(authTokenArray).toString("base64"),
       },
       slashes: true,
     });

--- a/src/renderer/api/terminal-api.ts
+++ b/src/renderer/api/terminal-api.ts
@@ -75,7 +75,12 @@ export class TerminalApi extends WebSocketApi {
   async connect() {
     this.emitStatus("Connecting ...");
 
-    const shellToken = await ipcRenderer.invoke("cluster:shell-api", getHostedClusterId(), this.query.id);
+    const authTokenArray = await ipcRenderer.invoke("cluster:shell-api", getHostedClusterId(), this.query.id);
+
+    if (!(authTokenArray instanceof Uint8Array)) {
+      throw new TypeError("ShellApi token is not a Uint8Array");
+    }
+
     const { hostname, protocol, port } = location;
     const socketUrl = url.format({
       protocol: protocol.includes("https") ? "wss" : "ws",
@@ -84,7 +89,7 @@ export class TerminalApi extends WebSocketApi {
       pathname: "/api",
       query: {
         ...this.query,
-        shellToken,
+        shellToken: authTokenArray.toString(),
       },
       slashes: true,
     });


### PR DESCRIPTION
- Switch to crypto.timingSafeEqual() and Uint8Array (because of the
  crypto function)

Signed-off-by: Sebastian Malton <sebastian@malton.name>

follow up to #4285 

I think this is timing safe, but I don't know if the `throw new TypeError(...)`'s are.