### PR TITLE
Use forked node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "moment-timezone": "^0.5.33",
     "monaco-editor": "^0.29.1",
     "monaco-editor-webpack-plugin": "^5.0.0",
-    "node-fetch": "^2.6.6",
+    "node-fetch": "lensapp/node-fetch#2.x",
     "node-pty": "^0.10.1",
     "npm": "^6.14.15",
     "p-limit": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9763,7 +9763,7 @@ node-fetch@2.6.1:
 
 node-fetch@lensapp/node-fetch#2.x:
   version "2.6.6"
-  resolved "https://codeload.github.com/lensapp/node-fetch/tar.gz/2eab2ed3e66aa66cae941319687ab0c69cd42c85"
+  resolved "https://codeload.github.com/lensapp/node-fetch/tar.gz/c869d40ba7dd3bce392c34e36118c225b6ada8fb"
   dependencies:
     whatwg-url "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9761,10 +9761,9 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.6.6:
+node-fetch@lensapp/node-fetch#2.x:
   version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  resolved "https://codeload.github.com/lensapp/node-fetch/tar.gz/2eab2ed3e66aa66cae941319687ab0c69cd42c85"
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Includes fix from https://github.com/node-fetch/node-fetch/pull/1172 . We can move back to upstream once the backport has been merged & released.

Fixes #4295