### PR TITLE
Use propagationPolicy=Background by default for delete

### DIFF
--- a/src/common/k8s-api/__tests__/kube-api.test.ts
+++ b/src/common/k8s-api/__tests__/kube-api.test.ts
@@ -234,4 +234,40 @@ describe("KubeApi", () => {
       ], "json");
     });
   });
+
+  describe("delete", () => {
+    let api: TestKubeApi;
+
+    beforeEach(() => {
+      api = new TestKubeApi({
+        request,
+        objectConstructor: TestKubeObject,
+      });
+    });
+
+    it("sends correct request", async () => {
+      expect.hasAssertions();
+      (fetch as any).mockResponse(async (request: Request) => {
+        console.log(request.url);
+        expect(request.method).toEqual("DELETE");
+        expect(request.url).toEqual("http://127.0.0.1:9999/api-kube/api/v1/namespaces/default/pods/foo?propagationPolicy=Background");
+
+        return {};
+      });
+
+      await api.delete({ name: "foo", namespace: "default" });
+    });
+
+    it("allows to change propagationPolicy", async () => {
+      expect.hasAssertions();
+      (fetch as any).mockResponse(async (request: Request) => {
+        expect(request.method).toEqual("DELETE");
+        expect(request.url).toMatch("propagationPolicy=Orphan");
+
+        return {};
+      });
+
+      await api.delete({ name: "foo", namespace: "default", propagationPolicy: "Orphan" });
+    });
+  });
 });

--- a/src/common/k8s-api/endpoints/job.api.ts
+++ b/src/common/k8s-api/endpoints/job.api.ts
@@ -24,7 +24,6 @@ import { autoBind } from "../../utils";
 import { IAffinity, WorkloadKubeObject } from "../workload-kube-object";
 import { KubeApi } from "../kube-api";
 import { metricsApi } from "./metrics.api";
-import type { JsonApiParams } from "../json-api";
 import type { KubeJsonApiData } from "../kube-json-api";
 import type { IPodContainer, IPodMetrics } from "./pods.api";
 import { isClusterPageContext } from "../../utils/cluster-id-url-parsing";

--- a/src/common/k8s-api/endpoints/job.api.ts
+++ b/src/common/k8s-api/endpoints/job.api.ts
@@ -121,14 +121,6 @@ export class Job extends WorkloadKubeObject {
 
     return [...containers].map(container => container.image);
   }
-
-  delete() {
-    const params: JsonApiParams = {
-      query: { propagationPolicy: "Background" },
-    };
-
-    return super.delete(params);
-  }
 }
 
 export class JobApi extends KubeApi<Job> {

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -98,6 +98,8 @@ export interface ILocalKubeApiConfig {
   }
 }
 
+export type PropagationPolicy = undefined | "Orphan" | "Foreground" | "Background";
+
 /**
  * @deprecated
  */
@@ -502,11 +504,16 @@ export class KubeApi<T extends KubeObject> {
     return parsed;
   }
 
-  async delete({ name = "", namespace = "default" }) {
+  async delete({ name = "", namespace = "default", propagationPolicy = "Background" }: { name: string, namespace: string, propagationPolicy?: PropagationPolicy }) {
     await this.checkPreferredVersion();
     const apiUrl = this.getUrl({ namespace, name });
+    const reqInit = {
+      query: {
+        propagationPolicy,
+      },
+    };
 
-    return this.request.del(apiUrl);
+    return this.request.del(apiUrl, reqInit);
   }
 
   getWatchUrl(namespace = "", query: IKubeApiQueryParams = {}) {


### PR DESCRIPTION
- matches better kubectl functionality
- allows to override propagationPolicy for each delete request
- fixes removal of Job not triggering removal of related pods (regression from https://github.com/lensapp/lens/pull/4325)

