### PR TITLE
Export KubeStatus to extensions api

### DIFF
--- a/src/extensions/main-api/k8s-api.ts
+++ b/src/extensions/main-api/k8s-api.ts
@@ -23,7 +23,7 @@ export { isAllowedResource } from "../../common/utils/allowed-resource";
 export { ResourceStack } from "../../common/k8s/resource-stack";
 export { apiManager } from "../../common/k8s-api/api-manager";
 export { KubeApi, forCluster, forRemoteCluster } from "../../common/k8s-api/kube-api";
-export { KubeObject } from "../../common/k8s-api/kube-object";
+export { KubeObject, KubeStatus } from "../../common/k8s-api/kube-object";
 export { KubeObjectStore } from "../../common/k8s-api/kube-object.store";
 export { Pod, podsApi, PodsApi } from "../../common/k8s-api/endpoints/pods.api";
 export { Node, nodesApi, NodesApi } from "../../common/k8s-api/endpoints/nodes.api";

--- a/src/extensions/renderer-api/k8s-api.ts
+++ b/src/extensions/renderer-api/k8s-api.ts
@@ -24,7 +24,7 @@ export { ResourceStack } from "../../common/k8s/resource-stack";
 export { apiManager } from "../../common/k8s-api/api-manager";
 export { KubeObjectStore } from "../../common/k8s-api/kube-object.store";
 export { KubeApi, forCluster, forRemoteCluster } from "../../common/k8s-api/kube-api";
-export { KubeObject } from "../../common/k8s-api/kube-object";
+export { KubeObject, KubeStatus } from "../../common/k8s-api/kube-object";
 export { Pod, podsApi, PodsApi } from "../../common/k8s-api/endpoints";
 export { Node, nodesApi, NodesApi } from "../../common/k8s-api/endpoints";
 export { Deployment, deploymentApi, DeploymentApi } from "../../common/k8s-api/endpoints";


### PR DESCRIPTION
This can be used to differentiate kube-api watch callback errors in an extension.