### PR TITLE
Further tweaking to the release drafter description

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@ categories:
       - 'area/tests'
       - 'dependencies'
       - 'area/documentation'
-change-template: '* #$NUMBER @$AUTHOR'
+change-template: '$TITLE (**#$NUMBER**) @$AUTHOR  '
 template: |
   ## Changes since $PREVIOUS_TAG
 


### PR DESCRIPTION
This is an attempt to make the release drafter produce output easily copyable from the draft release description to the release PR description. It appears github expands #nnnn to include the PR title when found as markdown in a PR description but not in a Release description. It only adds the title when the line is a list item (i.e. starts with * or - or + so this PR removes the leading * and adds the title explicitly