### PR TITLE
Allow to call KubeApi.delete without namespace parameter

### DIFF
--- a/src/common/k8s-api/__tests__/kube-api.test.ts
+++ b/src/common/k8s-api/__tests__/kube-api.test.ts
@@ -245,17 +245,40 @@ describe("KubeApi", () => {
       });
     });
 
-    it("sends correct request", async () => {
+    it("sends correct request with empty namespace", async () => {
       expect.hasAssertions();
       (fetch as any).mockResponse(async (request: Request) => {
-        console.log(request.url);
+        expect(request.method).toEqual("DELETE");
+        expect(request.url).toEqual("http://127.0.0.1:9999/api-kube/api/v1/pods/foo?propagationPolicy=Background");
+
+        return {};
+      });
+
+      await api.delete({ name: "foo", namespace: "" });
+    });
+
+    it("sends correct request without namespace", async () => {
+      expect.hasAssertions();
+      (fetch as any).mockResponse(async (request: Request) => {
         expect(request.method).toEqual("DELETE");
         expect(request.url).toEqual("http://127.0.0.1:9999/api-kube/api/v1/namespaces/default/pods/foo?propagationPolicy=Background");
 
         return {};
       });
 
-      await api.delete({ name: "foo", namespace: "default" });
+      await api.delete({ name: "foo" });
+    });
+
+    it("sends correct request with namespace", async () => {
+      expect.hasAssertions();
+      (fetch as any).mockResponse(async (request: Request) => {
+        expect(request.method).toEqual("DELETE");
+        expect(request.url).toEqual("http://127.0.0.1:9999/api-kube/api/v1/namespaces/kube-system/pods/foo?propagationPolicy=Background");
+
+        return {};
+      });
+
+      await api.delete({ name: "foo", namespace: "kube-system" });
     });
 
     it("allows to change propagationPolicy", async () => {

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -504,7 +504,7 @@ export class KubeApi<T extends KubeObject> {
     return parsed;
   }
 
-  async delete({ name = "", namespace = "default", propagationPolicy = "Background" }: { name: string, namespace: string, propagationPolicy?: PropagationPolicy }) {
+  async delete({ name = "", namespace = "default", propagationPolicy = "Background" }: { name: string, namespace?: string, propagationPolicy?: PropagationPolicy }) {
     await this.checkPreferredVersion();
     const apiUrl = this.getUrl({ namespace, name });
     const reqInit = {


### PR DESCRIPTION
Fixes regression from #4337.