### PR TITLE
Fixing setting page bottom margin

### DIFF
--- a/src/renderer/components/layout/setting-layout.scss
+++ b/src/renderer/components/layout/setting-layout.scss
@@ -136,13 +136,9 @@
       width: 100%;
       max-width: 740px;
       min-width: 460px;
-      padding: 60px 40px 80px;
-
-      > section {
-        &:last-of-type {
-          margin-bottom: 80px;
-        }
-      }
+      padding: 60px 40px 0;
+      height: max-content;
+      margin-bottom: 60px;
     }
 
     > .toolsRegion {


### PR DESCRIPTION
Adding extra bottom margin to Settings content area for better viewing/scrolling page experience.

Before:

https://user-images.githubusercontent.com/9607060/141983196-d8ff8fec-86de-43dd-9880-7f1bca8a11ee.mov

After:


https://user-images.githubusercontent.com/9607060/141983229-fb7b5ed6-4363-479a-acea-735efec89210.mov


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>