### PR TITLE
Fix concurrent loadItems in CatalogEntityStore

### DIFF
--- a/src/common/item.store.ts
+++ b/src/common/item.store.ts
@@ -97,12 +97,22 @@ export abstract class ItemStore<Item extends ItemObject> {
   }
 
   protected async loadItems(...args: any[]): Promise<any>;
+  /**
+   * Load items to this.items
+   * @param request Function to return the items to be loaded.
+   * @param sortItems If true, items will be sorted.
+   * @param concurrency If true, concurrent loadItems() calls will all be executed. If false, only the first.
+   * @returns
+   */
   @action
-  protected async loadItems(request: () => Promise<Item[] | any>, sortItems = true) {
+  protected async loadItems(request: () => Promise<Item[] | any>, sortItems = true, concurrency = false) {
     if (this.isLoading) {
       await when(() => !this.isLoading);
 
-      return;
+      // If concurrency for loading is disabled, return instead of loading
+      if (!concurrency) {
+        return;
+      }
     }
     this.isLoading = true;
 

--- a/src/renderer/api/catalog-entity-registry.ts
+++ b/src/renderer/api/catalog-entity-registry.ts
@@ -171,7 +171,7 @@ export class CatalogEntityRegistry {
    * @param fn The function that should return a truthy value if that entity should be sent currently "active"
    * @returns A function to remove that filter
    */
-  addCatalogFilter(fn: EntityFilter): Disposer {
+  @action addCatalogFilter(fn: EntityFilter): Disposer {
     this.filters.add(fn);
 
     return once(() => void this.filters.delete(fn));
@@ -182,9 +182,7 @@ export class CatalogEntityRegistry {
    * @param onBeforeRun The function that should return a boolean if the onRun of catalog entity should be triggered.
    * @returns A function to remove that hook
    */
-  addOnBeforeRun(onBeforeRun: CatalogEntityOnBeforeRun): Disposer {
-    logger.debug(`[CATALOG-ENTITY-REGISTRY]: adding onBeforeRun hook`);
-
+  @action addOnBeforeRun(onBeforeRun: CatalogEntityOnBeforeRun): Disposer {
     this.onBeforeRunHooks.add(onBeforeRun);
 
     return once(() => void this.onBeforeRunHooks.delete(onBeforeRun));

--- a/src/renderer/components/+catalog/catalog-entity.store.tsx
+++ b/src/renderer/components/+catalog/catalog-entity.store.tsx
@@ -68,19 +68,4 @@ export class CatalogEntityStore extends ItemStore<CatalogEntityItem<CatalogEntit
     // concurrency is true to fix bug if catalog filter is removed and added at the same time
     return this.loadItems(() => this.entities, undefined, true);
   }
-
-  /**
-   * Override ItemStore::loadItems, the only difference is that
-   * if isLoading is true, we await for it to be false and then continue
-   * loading.
-   * This avoids a bug where if there were two or more concurrent loadItems() calls,
-   * only the first one would complete.
-   */
-  protected loadItems(
-    request: (() => Promise<CatalogEntityItem<CatalogEntity>[] | any>) | (() => CatalogEntityItem<CatalogEntity>[] | any),
-    sortItems = true,
-    concurrency = false,
-  ) {
-    return super.loadItems(request, sortItems, concurrency);
-  }
 }


### PR DESCRIPTION
If `CatalogEntityStore.loadItems()` were called concurrently two or more times, the `return` inside `if (this.isLoading) {` of `ItemStore.loadItems()` would ignore the second call, which causes a bug where e.g. old filter would remain applied in the Catalog.

I decided not to modify `ItemStore` to avoid making changes to the loading behavior of that class, and instead overriding the method in `CatalogEntityStore`.

The PR also adds missing `@action` to `addCatalogFilter` and `addOnBeforeRun`.