### PR TITLE
Fix drawer icons unexpected outline

### DIFF
--- a/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-entity-drawer-menu.tsx
@@ -87,6 +87,7 @@ export class CatalogEntityDrawerMenu<T extends CatalogEntity> extends React.Comp
       items.push(
         <MenuItem key={menuItem.title} onClick={() => this.onMenuItemClick(menuItem)}>
           <Icon
+            interactive
             tooltip={menuItem.title}
             {...{ [key]: menuItem.icon }}
           />
@@ -98,8 +99,8 @@ export class CatalogEntityDrawerMenu<T extends CatalogEntity> extends React.Comp
       <HotbarToggleMenuItem
         key="hotbar-toggle"
         entity={entity}
-        addContent={<Icon material="push_pin" small tooltip="Add to Hotbar"/>}
-        removeContent={<Icon svg="push_off" small tooltip="Remove from Hotbar"/>}
+        addContent={<Icon material="push_pin" interactive small tooltip="Add to Hotbar"/>}
+        removeContent={<Icon svg="push_off" interactive small tooltip="Remove from Hotbar"/>}
       />,
     );
 

--- a/src/renderer/components/menu/menu-actions.scss
+++ b/src/renderer/components/menu/menu-actions.scss
@@ -21,7 +21,7 @@
 
 .MenuActions {
   &.toolbar {
-    --flex-gap: #{$padding * 0.5};
+    --flex-gap: var(--padding);
 
     position: static;
     padding: 0;
@@ -31,8 +31,8 @@
     margin-right: var(--flex-gap) !important;
 
     .Icon {
-      color: var(--textColorAccent);
-      padding-right: 0;
+      width: 21px;
+      height: 21px;
     }
 
     .title, .arrow {
@@ -42,6 +42,10 @@
     > .MenuItem {
       background: none !important;
       padding: 0;
+      margin-bottom: 0;
+      border: none;
+      width: 21px;
+      height: 21px;
 
       > .SubMenu {
         $offset: $margin;


### PR DESCRIPTION
Fixing drawer toolbar icons by removing outline, fixing sizing and hover effect.
![catalog drawer](https://user-images.githubusercontent.com/9607060/142155598-4b2e46c5-4119-4571-b704-c6bfd5037420.gif)
![deployments drawer](https://user-images.githubusercontent.com/9607060/142155612-d3317ac5-e338-4000-b884-39d67a82228d.gif)

Fixes #4360 

