### PR TITLE
Ensure Drawer copyTitle() copies everything after the first ':'

### DIFF
--- a/src/renderer/components/drawer/drawer.tsx
+++ b/src/renderer/components/drawer/drawer.tsx
@@ -147,9 +147,9 @@ export class Drawer extends React.Component<DrawerProps> {
   };
 
   copyTitle = (title: string) => {
-    const k8sObjName = title.split(":")[1] || title; // copy whole if no :
+    const itemName = title.split(":").splice(1).join(":") || title; // copy whole if no :
 
-    clipboard.writeText(k8sObjName.trim());
+    clipboard.writeText(itemName.trim());
     this.setState({ isCopied: true });
     setTimeout(() => {
       this.setState({ isCopied: false });


### PR DESCRIPTION
For a port-forward details page title something like `Port Forward: http://localhost:65269` was cutoff to `http` because copyTitle() was returning the string only from the first `:` up to the second `:`