### PR TITLE
Fix material icons flash on app load

### DIFF
--- a/src/renderer/components/fonts.scss
+++ b/src/renderer/components/fonts.scss
@@ -28,6 +28,7 @@
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
+  font-display: block;
   src: url("../fonts/MaterialIcons-Regular.ttf") format("truetype");
 }
 


### PR DESCRIPTION
Using `font-display: block` css rule to hide all icons before material icon font gets loaded.

https://user-images.githubusercontent.com/9607060/142387454-2f22de7c-2631-42f1-a16a-8ae62fb66dee.mov

Fixes #3850 


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>