### PR TITLE
Fix all-or-nothing when initially loading extensions

### DIFF
--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -20,7 +20,7 @@
  */
 
 import { watch } from "chokidar";
-import { ipcRenderer } from "electron";
+import { dialog, ipcRenderer } from "electron";
 import { EventEmitter } from "events";
 import fse from "fs-extra";
 import { observable, reaction, when, makeObservable } from "mobx";
@@ -393,7 +393,14 @@ export class ExtensionDiscovery extends Singleton {
 
     for (const extension of userExtensions) {
       if ((await fse.pathExists(extension.manifestPath)) === false) {
-        await this.installPackage(extension.absolutePath);
+        try {
+          await this.installPackage(extension.absolutePath);
+        } catch (error) {
+          const message = error.message || error?.toString() || "unknown error";
+          const { name, version } = extension.manifest;
+
+          dialog.showErrorBox("Lens Extension Install Failure", `Failed to install user extension ${name}@${version}: ${message}`);
+        }
       }
     }
 

--- a/src/extensions/extension-discovery.ts
+++ b/src/extensions/extension-discovery.ts
@@ -20,7 +20,7 @@
  */
 
 import { watch } from "chokidar";
-import { dialog, ipcRenderer } from "electron";
+import { ipcRenderer } from "electron";
 import { EventEmitter } from "events";
 import fse from "fs-extra";
 import { observable, reaction, when, makeObservable } from "mobx";
@@ -396,10 +396,10 @@ export class ExtensionDiscovery extends Singleton {
         try {
           await this.installPackage(extension.absolutePath);
         } catch (error) {
-          const message = error.message || error?.toString() || "unknown error";
+          const message = error.message || error || "unknown error";
           const { name, version } = extension.manifest;
 
-          dialog.showErrorBox("Lens Extension Install Failure", `Failed to install user extension ${name}@${version}: ${message}`);
+          logger.error(`${logModule}: failed to install user extension ${name}@${version}`, message);
         }
       }
     }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/3482

This isn't the best of fixes, but I think it is the simplest in terms of scope. It is very hard to follow exactly what is being done when extensions are included from all of the various sources but I think simplifying the design is for future work.