### PR TITLE
Fix cwd not being respected for local shells on windows

### DIFF
--- a/src/main/shell-session/local-shell-session.ts
+++ b/src/main/shell-session/local-shell-session.ts
@@ -50,7 +50,7 @@ export class LocalShellSession extends ShellSession {
 
     switch(path.basename(shell)) {
       case "powershell.exe":
-        return ["-NoExit", "-command", `& {Set-Location $Env:USERPROFILE; $Env:PATH="${helmpath};${kubectlPathDir};$Env:PATH"}`];
+        return ["-NoExit", "-command", `& {$Env:PATH="${helmpath};${kubectlPathDir};$Env:PATH"}`];
       case "bash":
         return ["--init-file", path.join(await this.kubectlBinDirP, ".bash_set_path")];
       case "fish":


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4319 

The issue was that we were overriding the CWD being passed in by the command.