### PR TITLE
fix: use non-deprecated delete flag with node drain

### DIFF
--- a/extensions/node-menu/src/node-menu.tsx
+++ b/extensions/node-menu/src/node-menu.tsx
@@ -77,7 +77,7 @@ export function NodeMenu(props: NodeMenuProps) {
   };
 
   const drain = () => {
-    const command = `${kubectlPath} drain ${nodeName} --delete-local-data --ignore-daemonsets --force`;
+    const command = `${kubectlPath} drain ${nodeName} --delete-emptydir-data --ignore-daemonsets --force`;
 
     ConfirmDialog.open({
       ok: () => sendToTerminal(command),


### PR DESCRIPTION
# Problem

`kubectl drain` calls a deprecated flag, `--delete-local-data`, per https://github.com/kubernetes/kubernetes/pull/95076.

# Solution

Use the designated replacement.

# Result

No warning errors about the `--delete-local-data` flag deprecation on node drain.