### PR TITLE
Fix disconnect on currently connecting cluster

### DIFF
--- a/src/common/cluster/cluster.ts
+++ b/src/common/cluster/cluster.ts
@@ -4,7 +4,7 @@
  */
 
 import { ipcMain } from "electron";
-import { action, comparer, computed, makeObservable, observable, reaction, when } from "mobx";
+import { action, comparer, computed, makeObservable, observable, reaction, runInAction, when } from "mobx";
 import { broadcastMessage } from "../ipc";
 import type { ContextHandler } from "../../main/context-handler/context-handler";
 import { HttpError, KubeConfig } from "@kubernetes/client-node";
@@ -287,7 +287,7 @@ export class Cluster implements ClusterModel, ClusterState {
    * @internal
    */
   protected bindEvents() {
-    logger.info(`[CLUSTER]: bind events`, this.getMeta());
+    logger.info(`[CLUSTER]: bind events`, this.getMeta(true));
     const refreshTimer = setInterval(() => !this.disconnected && this.refresh(), 30000); // every 30s
     const refreshMetadataTimer = setInterval(() => !this.disconnected && this.refreshMetadata(), 900000); // every 15 minutes
 
@@ -324,34 +324,38 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @action
   async activate(force = false) {
-    if (this.activated && !force) {
-      return this.pushState();
+    try {
+      logger.info(`[CLUSTER]: activating`, this.getMeta(true));
+
+      if (this.activated && !force) {
+        return this.pushState();
+      }
+
+      if (!this.eventsDisposer.length) {
+        this.bindEvents();
+      }
+
+      if (this.disconnected || !this.accessible) {
+        await this.reconnect();
+      }
+
+      this.broadcastConnectUpdate("Refreshing connection status ...");
+      await this.refreshConnectionStatus();
+
+      if (this.accessible) {
+        this.broadcastConnectUpdate("Refreshing cluster accessibility ...");
+        await this.refreshAccessibility();
+        // download kubectl in background, so it's not blocking dashboard
+        this.ensureKubectl()
+          .catch(error => logger.warn(`[CLUSTER]: failed to download kubectl for clusterId=${this.id}`, error));
+        this.broadcastConnectUpdate("Connected, waiting for view to load ...");
+      }
+
+      this.activated = true;
+      this.pushState();
+    } finally {
+      logger.info(`[CLUSTER]: activation finished`, this.getMeta());
     }
-
-    logger.info(`[CLUSTER]: activate`, this.getMeta());
-
-    if (!this.eventsDisposer.length) {
-      this.bindEvents();
-    }
-
-    if (this.disconnected || !this.accessible) {
-      await this.reconnect();
-    }
-
-    this.broadcastConnectUpdate("Refreshing connection status ...");
-    await this.refreshConnectionStatus();
-
-    if (this.accessible) {
-      this.broadcastConnectUpdate("Refreshing cluster accessibility ...");
-      await this.refreshAccessibility();
-      // download kubectl in background, so it's not blocking dashboard
-      this.ensureKubectl()
-        .catch(error => logger.warn(`[CLUSTER]: failed to download kubectl for clusterId=${this.id}`, error));
-      this.broadcastConnectUpdate("Connected, waiting for view to load ...");
-    }
-
-    this.activated = true;
-    this.pushState();
   }
 
   /**
@@ -368,19 +372,18 @@ export class Cluster implements ClusterModel, ClusterState {
   /**
    * @internal
    */
-  @action
   async reconnect() {
-    logger.info(`[CLUSTER]: reconnect`, this.getMeta());
+    runInAction(() => this.disconnected = false);
     this.contextHandler?.stopServer();
+    logger.info(`[CLUSTER]: starting proxy server`, this.getMeta(true));
     await this.contextHandler?.ensureServer();
-    this.disconnected = false;
   }
 
   /**
    * @internal
    */
   @action disconnect() {
-    logger.info(`[CLUSTER]: disconnecting`, { id: this.id });
+    logger.info(`[CLUSTER]: disconnecting`, this.getMeta(true));
     this.eventsDisposer();
     this.contextHandler?.stopServer();
     this.disconnected = true;
@@ -391,7 +394,7 @@ export class Cluster implements ClusterModel, ClusterState {
     this.allowedNamespaces = [];
     this.resourceAccessStatuses.clear();
     this.pushState();
-    logger.info(`[CLUSTER]: disconnected`, { id: this.id });
+    logger.info(`[CLUSTER]: disconnected`, this.getMeta(true));
   }
 
   /**
@@ -400,7 +403,7 @@ export class Cluster implements ClusterModel, ClusterState {
    */
   @action
   async refresh(opts: ClusterRefreshOptions = {}) {
-    logger.info(`[CLUSTER]: refresh`, this.getMeta());
+    logger.info(`[CLUSTER]: refresh`, this.getMeta(true));
     await this.refreshConnectionStatus();
 
     if (this.accessible) {
@@ -570,15 +573,23 @@ export class Cluster implements ClusterModel, ClusterState {
   }
 
   // get cluster system meta, e.g. use in "logger"
-  getMeta() {
-    return {
+  getMeta(basic = false) {
+    const meta = {
       id: this.id,
       name: this.contextName,
-      ready: this.ready,
-      online: this.online,
-      accessible: this.accessible,
-      disconnected: this.disconnected,
+      kubeconfigPath: this.kubeConfigPath,
     };
+
+    if (!basic) {
+      Object.assign(meta, {
+        ready: this.ready,
+        online: this.online,
+        accessible: this.accessible,
+        disconnected: this.disconnected,
+      });
+    }
+
+    return meta;
   }
 
   /**

--- a/src/renderer/components/cluster-manager/lens-views.ts
+++ b/src/renderer/components/cluster-manager/lens-views.ts
@@ -63,11 +63,7 @@ export class ClusterFrameHandler extends Singleton {
       () => !cluster.disconnected,
       () => {
         when(
-          () => {
-            const cluster = ClusterStore.getInstance().getById(clusterId);
-
-            return !cluster || (cluster.disconnected && this.views.get(clusterId)?.isLoaded);
-          },
+          () => !cluster || (cluster.disconnected && this.views.get(clusterId)?.isLoaded),
           () => {
             logger.info(`[LENS-VIEW]: remove dashboard, clusterId=${clusterId}`);
             this.views.delete(clusterId);


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This PR fixes the following bugs:

1. If you use the hotbar to disconnect from a cluster while it is connecting. It now correctly navigates you back to the catalog
2. If connecting is stuck and you navigate away and back to the same cluster, the cluster is now `forced` when activating