### PR TITLE
Fix: display of entity name while connecting

### DIFF
--- a/src/renderer/components/cluster-manager/cluster-view.tsx
+++ b/src/renderer/components/cluster-manager/cluster-view.tsx
@@ -89,10 +89,10 @@ export class ClusterView extends React.Component<Props> {
   }
 
   renderStatus(): React.ReactNode {
-    const { clusterId, cluster, isReady } = this;
+    const { cluster, isReady } = this;
 
     if (cluster && !isReady) {
-      return <ClusterStatus key={clusterId} clusterId={clusterId} className="box center"/>;
+      return <ClusterStatus cluster={cluster} className="box center"/>;
     }
 
     return null;


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This PR fixes the display of the connecting screen to display the entity name. It also passes the cluster instance down into the comment instead of getting it from the store as it seemed cleaner that way.