### PR TITLE
Ignore .prettierrc from VCS so that it can be used locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ types/extension-renderer-api.d.ts
 extensions/*/dist
 docs/extensions/api
 site/
+.prettierrc


### PR DESCRIPTION
Adding `.prettierrc` to `.gitignore` just so developers who wants to use it, can do with local configuration. 

ESLint remains master for code style, but prettier does so much more. If developer chooses to use prettier locally, she should always make sure that it doesn't affect existing code style where not needed and it doesn't conflict with ESLint. 