### PR TITLE
Center text vertically in notifications

### DIFF
--- a/src/renderer/components/notifications/notifications.scss
+++ b/src/renderer/components/notifications/notifications.scss
@@ -50,6 +50,7 @@
       white-space: pre-line;
       padding-left: $padding;
       padding-right: $padding * 2;
+      align-self: center;
 
       a {
         color: inherit;
@@ -62,10 +63,6 @@
         color: $color-white;
         box-shadow: 0 0 20px var(--boxShadow);
       }
-    }
-
-    .close {
-      margin-top: -2px;
     }
   }
 }


### PR DESCRIPTION
old:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/774344/144059823-7f400ecb-68f7-4107-9f2a-ed3d7d72e367.png">

new:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/774344/144059434-935eef33-2e06-4f99-8ceb-95681c1ca264.png">


