### PR TITLE
Don't emit build_id metadata on RPM builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,11 @@
         }
       ]
     },
+    "rpm": {
+      "fpm": [
+        "--rpm-rpmbuild-define=%define _build_id_links none"
+      ]
+    },
     "mac": {
       "hardenedRuntime": true,
       "gatekeeperAssess": false,


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4449 