### PR TITLE
Fix light theme pin icon visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,7 +382,6 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.2",
     "webpack-node-externals": "^1.7.2",
-    "what-input": "^5.2.10",
     "xterm": "^4.14.1",
     "xterm-addon-fit": "^0.5.0"
   }

--- a/src/renderer/cluster-frame.tsx
+++ b/src/renderer/cluster-frame.tsx
@@ -38,7 +38,6 @@ import { ClusterPageRegistry, getExtensionPageUrl } from "../extensions/registri
 import { ExtensionLoader } from "../extensions/extension-loader";
 import { appEventBus } from "../common/event-bus";
 import { requestMain } from "../common/ipc";
-import whatInput from "what-input";
 import { clusterSetFrameIdHandler } from "../common/cluster-ipc";
 import { ClusterPageMenuRegistration, ClusterPageMenuRegistry } from "../extensions/registries";
 import { StatefulSetScaleDialog } from "./components/+workloads-statefulsets/statefulset-scale-dialog";
@@ -121,8 +120,6 @@ export class ClusterFrame extends React.Component {
 
       unmountComponentAtNode(rootElem);
     };
-
-    whatInput.ask(); // Start to monitor user input device
 
     const clusterContext = new FrameContext(cluster);
 

--- a/src/renderer/components/icon/icon.scss
+++ b/src/renderer/components/icon/icon.scss
@@ -127,7 +127,7 @@
   }
 
   &.active {
-    color: var(--color-active);
+    color: var(--textColorAccent);
     box-shadow: 0 0 0 2px var(--iconActiveBackground);
     background-color: var(--iconActiveBackground);
   }
@@ -137,16 +137,8 @@
     transition: 250ms color, 250ms opacity, 150ms background-color, 150ms box-shadow;
     border-radius: var(--border-radius);
 
-    &.focusable:focus:not(:hover) {
+    &.focusable:focus-visible {
       box-shadow: 0 0 0 2px var(--focus-color);
-
-      [data-whatintent='mouse'] & {
-        box-shadow: none;
-
-        &.active {
-          box-shadow: 0 0 0 2px var(--iconActiveBackground);
-        }
-      }
     }
 
     &:hover {

--- a/src/renderer/components/layout/sidebar-cluster.module.css
+++ b/src/renderer/components/layout/sidebar-cluster.module.css
@@ -32,7 +32,6 @@
   &:focus-visible {
     .dropdown {
       box-shadow: 0 0 0 2px var(--focus-color);
-      color: white;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14349,11 +14349,6 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-what-input@^5.2.10:
-  version "5.2.10"
-  resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.10.tgz#f79f5b65cf95d75e55e6d580bb0a6b98174cad4e"
-  integrity sha512-7AQoIMGq7uU8esmKniOtZG3A+pzlwgeyFpkS3f/yzRbxknSL68tvn5gjE6bZ4OMFxCPjpaBd2udUTqlZ0HwrXQ==
-
 whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"


### PR DESCRIPTION
* Fixing icons focus and hover state
* Remove `what-input` dependency and replace is with `:focus-visible` pseudo-class.

https://user-images.githubusercontent.com/9607060/144250519-167c65a3-28b7-4af7-bce1-340d59a9687b.mov


