### PR TITLE
Remove type circularity in wizard.tsx

### DIFF
--- a/src/renderer/components/wizard/wizard.tsx
+++ b/src/renderer/components/wizard/wizard.tsx
@@ -61,7 +61,7 @@ export class Wizard extends React.Component<WizardProps, State> {
 
       return React.cloneElement(stepElem, {
         step: i + 1,
-        wizard: this,
+        wizard: this as Wizard,
         next: this.nextStep,
         prev: this.prevStep,
         first: this.firstStep,


### PR DESCRIPTION
This code has a type circularity that previously went undetected. Adding an `as Wizard` assertion here removes the circularity.

See https://github.com/microsoft/TypeScript/issues/46939 / https://github.com/microsoft/TypeScript/pull/46981 for more context