### PR TITLE
Fixing unexpected avatar width shrink

### DIFF
--- a/src/renderer/components/avatar/avatar.module.css
+++ b/src/renderer/components/avatar/avatar.module.css
@@ -29,6 +29,7 @@
   align-items: center;
   justify-content: center;
   user-select: none;
+  flex-shrink: 0;
 
   img {
     width: 100%;


### PR DESCRIPTION
Before:

<img width="714" alt="shrinked avatar" src="https://user-images.githubusercontent.com/9607060/144415859-6d7158ed-349a-400b-9f50-8ce7240b4c40.png">

After:
<img width="825" alt="fixed avatar" src="https://user-images.githubusercontent.com/9607060/144415872-5207c33f-2010-4cf6-8930-7b7cdb420eaa.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>