### PR TITLE
Remove unnecesarry TerminalApi.destroy and TerminalApi.reconnect overloads

### DIFF
--- a/src/renderer/api/terminal-api.ts
+++ b/src/renderer/api/terminal-api.ts
@@ -144,18 +144,6 @@ export class TerminalApi extends WebSocketApi<TerminalEvents> {
     this.socket.binaryType = "arraybuffer";
   }
 
-  destroy() {
-    if (!this.socket) return;
-    const controlCode = String.fromCharCode(4); // ctrl+d
-
-    this.sendMessage({ type: TerminalChannels.STDIN, data: controlCode });
-    setTimeout(() => super.destroy(), 2000);
-  }
-
-  reconnect() {
-    super.reconnect();
-  }
-
   sendMessage(message: TerminalMessage) {
     return this.send(serialize(message));
   }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>