### PR TITLE
Fix not being able to clear set cluster icon

### DIFF
--- a/src/common/cluster-types.ts
+++ b/src/common/cluster-types.ts
@@ -90,7 +90,11 @@ export interface ClusterPreferences extends ClusterPrometheusPreferences {
   terminalCWD?: string;
   clusterName?: string;
   iconOrder?: number;
-  icon?: string;
+  /**
+   * The <img> src for the cluster. If set to `null` that means that it was
+   * cleared by preferences.
+   */
+  icon?: string | null;
   httpsProxy?: string;
   hiddenMetrics?: string[];
   nodeShellImage?: string;

--- a/src/main/cluster-manager.ts
+++ b/src/main/cluster-manager.ts
@@ -136,11 +136,16 @@ export class ClusterManager extends Singleton {
       entity.spec.metrics.prometheus = prometheus;
     }
 
-    // Only set the icon if the preference is set. If the preference is not set
-    // then let the source determine if a cluster has an icon.
     if (cluster.preferences.icon) {
       entity.spec.icon ??= {};
       entity.spec.icon.src = cluster.preferences.icon;
+    } else if (cluster.preferences.icon === null) {
+      /**
+       * NOTE: only clear the icon if set to `null` by ClusterIconSettings.
+       * We can then also clear that value too
+       */
+      entity.spec.icon = undefined;
+      cluster.preferences.icon = undefined;
     }
 
     catalogEntityRegistry.items.splice(index, 1, entity);
@@ -177,7 +182,8 @@ export class ClusterManager extends Singleton {
     }
   }
 
-  @action syncClustersFromCatalog(entities: KubernetesCluster[]) {
+  @action
+  protected syncClustersFromCatalog(entities: KubernetesCluster[]) {
     for (const entity of entities) {
       const cluster = this.store.getById(entity.metadata.uid);
 

--- a/src/renderer/components/cluster-settings/components/cluster-icon-settings.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-icon-settings.tsx
@@ -65,7 +65,11 @@ export class ClusterIconSetting extends React.Component<Props> {
   }
 
   clearIcon() {
-    this.props.cluster.preferences.icon = undefined;
+    /**
+     * NOTE: this needs to be `null` rather than `undefined` so that we can
+     * tell the difference between it not being there and being cleared.
+     */
+    this.props.cluster.preferences.icon = null;
   }
 
   @boundMethod


### PR DESCRIPTION
- Use `null` as a sentinal value distinct from `undefined` so that
  extensions can still set and clear icons themselves

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4540