### PR TITLE
Fix ERR_UNSAFE_PORT from LensProxy

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,7 +28,7 @@ import * as LensExtensionsCommonApi from "../extensions/common-api";
 import * as LensExtensionsMainApi from "../extensions/main-api";
 import { app, autoUpdater, dialog, powerMonitor } from "electron";
 import { appName, isIntegrationTesting, isMac, isWindows, productName } from "../common/vars";
-import { LensProxy } from "./lens-proxy";
+import { LensProxy, UnsafePortError } from "./lens-proxy";
 import { WindowManager } from "./window-manager";
 import { ClusterManager } from "./cluster-manager";
 import { shellSync } from "./shell-sync";
@@ -184,13 +184,39 @@ app.on("ready", async () => {
 
   initializers.initClusterMetadataDetectors();
 
-  try {
-    logger.info("🔌 Starting LensProxy");
-    await lensProxy.listen();
-  } catch (error) {
-    dialog.showErrorBox("Lens Error", `Could not start proxy: ${error?.message || "unknown error"}`);
+  logger.info("🔌 Starting LensProxy");
 
-    return app.exit();
+  for (let attempt = 0;; attempt += 1) {
+    try {
+      await lensProxy.listen();
+      break;
+    } catch (error) {
+      if (error instanceof UnsafePortError) {
+        lensProxy.close();
+
+        if (attempt < 16) {
+          continue;
+        }
+
+        const result = await dialog.showMessageBox({
+          title: "Lens Error",
+          message: "Tried to start several times but only got ports that chromium considers unsafe. Would you like to continue trying?",
+          buttons: ["No", "Yes"],
+          cancelId: 0,
+          defaultId: 1,
+          type: "error",
+        });
+
+        if (result.response === 1) {
+          attempt = 0;
+          continue;
+        }
+      }
+
+      dialog.showErrorBox("Lens Error", `Could not start proxy: ${error?.message || "unknown error"}`);
+
+      return app.exit();
+    }
   }
 
   // test proxy connection

--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -50,6 +50,26 @@ export function isLongRunningRequest(reqUrl: string) {
   return getBoolean(url.searchParams, watchParam) || getBoolean(url.searchParams, followParam);
 }
 
+/**
+ * This is the list of ports that chrome considers unsafe to allow HTTP
+ * conntections to. Because they are the standard ports for processes that are
+ * too forgiving in the connection types they accept.
+ *
+ * If we get one of these ports, the easiest thing to do is to just try again.
+ *
+ * Source: https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/net/base/port_util.cc
+ */
+const disallowedPorts = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79,
+  87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137,
+  139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532,
+  540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723,
+  2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6697,
+  10080,
+]);
+
+export class UnsafePortError {}
+
 export class LensProxy extends Singleton {
   protected origin: string;
   protected proxyServer: http.Server;
@@ -105,6 +125,12 @@ export class LensProxy extends Singleton {
 
           const { address, port } = this.proxyServer.address() as net.AddressInfo;
 
+          if (disallowedPorts.has(port)) {
+            logger.warn(`[LENS-PROXY]: Proxy server has with port known to be considered unsafe to connect to by chrome, restarting...`);
+
+            return reject(new UnsafePortError());
+          }
+
           logger.info(`[LENS-PROXY]: Proxy server has started at ${address}:${port}`);
 
           this.proxyServer.on("error", (error) => {
@@ -123,7 +149,7 @@ export class LensProxy extends Singleton {
   }
 
   close() {
-    logger.info("Closing proxy server");
+    logger.info("[LENS-PROXY]: Closing server");
     this.proxyServer.close();
     this.closed = true;
   }


### PR DESCRIPTION
- Use the current list of ports from chromium as it is much easier to
  just reject using one of those instead of trying to handle the
  ERR_UNSAFE_PORT laod error from a BrowserWindow.on("did-fail-load")

Signed-off-by: Sebastian Malton <sebastian@malton.name>