### PR TITLE
Cleanup HelmRepoManager and <HelmCharts>

### DIFF
--- a/integration/__tests__/app-preferences.tests.ts
+++ b/integration/__tests__/app-preferences.tests.ts
@@ -60,9 +60,7 @@ describe("preferences page tests", () => {
   // Skipping, but will turn it on again in the follow up PR
   it.skip("ensures helm repos", async () => {
     await window.click("[data-testid=kubernetes-tab]");
-    await window.waitForSelector("[data-testid=repository-name]", {
-      timeout: 140_000,
-    });
+    await window.waitForSelector("[data-testid=repository-name]");
     await window.click("#HelmRepoSelect");
     await window.waitForSelector("div.Select__option");
   }, 10*60*1000);

--- a/src/main/helm/helm-release-manager.ts
+++ b/src/main/helm/helm-release-manager.ts
@@ -104,10 +104,8 @@ export async function upgradeRelease(name: string, chart: string, values: any, n
   ];
 
   try {
-    const output = await execHelm(args);
-
     return {
-      log: output,
+      log: await execHelm(args),
       release: getRelease(name, namespace, kubeconfigPath, kubectlPath),
     };
   } finally {

--- a/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
+++ b/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
@@ -61,11 +61,11 @@ export class AddHelmRepoDialog extends React.Component<Props> {
   @observable showOptions = false;
 
   @action
-  close = () => {
-    AddHelmRepoDialog.close();
-    this.helmRepo = getEmptyRepo();
-    this.showOptions = false;
-  };
+    close = () => {
+      AddHelmRepoDialog.close();
+      this.helmRepo = getEmptyRepo();
+      this.showOptions = false;
+    };
 
   setFilepath(type: FileType, value: string) {
     this.helmRepo[type] = value;
@@ -95,7 +95,7 @@ export class AddHelmRepoDialog extends React.Component<Props> {
   async addCustomRepo() {
     try {
       await HelmRepoManager.getInstance().addRepo(this.helmRepo);
-      Notifications.ok(<>Helm repository <b>{this.helmRepo.name}</b> has added</>);
+      Notifications.ok(<>Helm repository <b>{this.helmRepo.name}</b> has been added</>);
       this.props.onAddRepo();
       this.close();
     } catch (err) {

--- a/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
+++ b/src/renderer/components/+preferences/add-helm-repo-dialog.tsx
@@ -7,7 +7,7 @@ import "./add-helm-repo-dialog.scss";
 
 import React from "react";
 import type { FileFilter } from "electron";
-import { observable, makeObservable } from "mobx";
+import { observable, makeObservable, action } from "mobx";
 import { observer } from "mobx-react";
 import { Dialog, DialogProps } from "../dialog";
 import { Wizard, WizardStep } from "../wizard";
@@ -35,10 +35,12 @@ const dialogState = observable.object({
   isOpen: false,
 });
 
+function getEmptyRepo(): HelmRepo {
+  return { name: "", url: "", username: "", password: "", insecureSkipTlsVerify: false, caFile: "", keyFile: "", certFile: "" };
+}
+
 @observer
 export class AddHelmRepoDialog extends React.Component<Props> {
-  private emptyRepo = { name: "", url: "", username: "", password: "", insecureSkipTlsVerify: false, caFile:"", keyFile: "", certFile: "" };
-
   private static keyExtensions = ["key", "keystore", "jks", "p12", "pfx", "pem"];
   private static certExtensions = ["crt", "cer", "ca-bundle", "p7b", "p7c", "p7s", "p12", "pfx", "pem"];
 
@@ -55,12 +57,13 @@ export class AddHelmRepoDialog extends React.Component<Props> {
     dialogState.isOpen = false;
   }
 
-  @observable helmRepo : HelmRepo = this.emptyRepo;
+  @observable helmRepo = getEmptyRepo();
   @observable showOptions = false;
 
+  @action
   close = () => {
     AddHelmRepoDialog.close();
-    this.helmRepo = this.emptyRepo;
+    this.helmRepo = getEmptyRepo();
     this.showOptions = false;
   };
 
@@ -91,7 +94,7 @@ export class AddHelmRepoDialog extends React.Component<Props> {
 
   async addCustomRepo() {
     try {
-      await HelmRepoManager.addCustomRepo(this.helmRepo);
+      await HelmRepoManager.getInstance().addRepo(this.helmRepo);
       Notifications.ok(<>Helm repository <b>{this.helmRepo.name}</b> has added</>);
       this.props.onAddRepo();
       this.close();
@@ -127,9 +130,9 @@ export class AddHelmRepoDialog extends React.Component<Props> {
           value={this.helmRepo.insecureSkipTlsVerify}
           onChange={v => this.helmRepo.insecureSkipTlsVerify = v}
         />
-        {this.renderFileInput(`Key file`, FileType.KeyFile, AddHelmRepoDialog.keyExtensions)}
-        {this.renderFileInput(`Ca file`, FileType.CaFile, AddHelmRepoDialog.certExtensions)}
-        {this.renderFileInput(`Certificate file`, FileType.CertFile, AddHelmRepoDialog.certExtensions)}
+        {this.renderFileInput("Key file", FileType.KeyFile, AddHelmRepoDialog.keyExtensions)}
+        {this.renderFileInput("Ca file", FileType.CaFile, AddHelmRepoDialog.certExtensions)}
+        {this.renderFileInput("Certificate file", FileType.CertFile, AddHelmRepoDialog.certExtensions)}
         <SubTitle title="Chart Repository Credentials" />
         <Input
           placeholder="Username"


### PR DESCRIPTION
- Makes integration tests less flaky

- Seperates the two loading states so that the UI updates faster

Follow up to #4514 