### PR TITLE
Show splash window until bundled extensions have been loaded

### DIFF
--- a/src/common/ipc/extension-loader.ipc.ts
+++ b/src/common/ipc/extension-loader.ipc.ts
@@ -18,13 +18,4 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
-export const dialogShowOpenDialogHandler = "dialog:show-open-dialog";
-
-export * from "./ipc";
-export * from "./invalid-kubeconfig";
-export * from "./update-available.ipc";
-export * from "./cluster.ipc";
-export * from "./type-enforced-ipc";
-export * from "./hotbar";
-export * from "./extension-loader.ipc";
+export const BundledExtensionsLoaded = "extension-loader:bundled-extensions-loaded";

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -255,7 +255,8 @@ export class ExtensionLoader {
 
   loadOnClusterManagerRenderer() {
     logger.debug(`${logModule}: load on main renderer (cluster manager)`);
-    const bundledLoaded = this.autoInitExtensions(async (extension: LensRendererExtension) => {
+
+    return this.autoInitExtensions(async (extension: LensRendererExtension) => {
       const removeItems = [
         registries.GlobalPageRegistry.getInstance().add(extension.globalPages, extension),
         registries.AppPreferenceRegistry.getInstance().add(extension.appPreferences),
@@ -278,8 +279,6 @@ export class ExtensionLoader {
 
       return removeItems;
     });
-
-    return bundledLoaded;
   }
 
   loadOnClusterRenderer() {

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -24,7 +24,7 @@ import { makeObservable, observable } from "mobx";
 import { app, BrowserWindow, dialog, ipcMain, shell, webContents } from "electron";
 import windowStateKeeper from "electron-window-state";
 import { appEventBus } from "../common/event-bus";
-import { ipcMainOn } from "../common/ipc";
+import { BundledExtensionsLoaded, ipcMainOn } from "../common/ipc";
 import { delay, iter, Singleton } from "../common/utils";
 import { ClusterFrameInfo, clusterFrameMap } from "../common/cluster-frames";
 import { IpcRendererNavigationEvents } from "../renderer/navigation/events";
@@ -181,7 +181,7 @@ export class WindowManager extends Singleton {
 
     if (!this.mainWindow) {
       viewHasLoaded = new Promise<void>(resolve => {
-        ipcMain.once(IpcRendererNavigationEvents.LOADED, () => resolve());
+        ipcMain.once(BundledExtensionsLoaded, () => resolve());
       });
       await this.initMainWindow(showSplash);
     }

--- a/src/renderer/root-frame.tsx
+++ b/src/renderer/root-frame.tsx
@@ -56,7 +56,10 @@ export class RootFrame extends React.Component {
     catalogEntityRegistry.init();
 
     try {
-      await extensionLoader.loadOnClusterManagerRenderer();
+      const loadingExtensions = extensionLoader.loadOnClusterManagerRenderer();
+      const loadingBundledExtensions = loadingExtensions.filter(e => e.isBundled).map(e => e.loaded);
+
+      await Promise.all(loadingBundledExtensions);
     } finally {
       ipcRenderer.send(BundledExtensionsLoaded);
     }

--- a/src/renderer/root-frame.tsx
+++ b/src/renderer/root-frame.tsx
@@ -29,7 +29,7 @@ import { ErrorBoundary } from "./components/error-boundary";
 import { Notifications } from "./components/notifications";
 import { ConfirmDialog } from "./components/confirm-dialog";
 import type { ExtensionLoader } from "../extensions/extension-loader";
-import { broadcastMessage } from "../common/ipc";
+import { broadcastMessage, BundledExtensionsLoaded } from "../common/ipc";
 import { CommandContainer } from "./components/command-palette/command-container";
 import { registerIpcListeners } from "./ipc";
 import { ipcRenderer } from "electron";
@@ -54,8 +54,14 @@ export class RootFrame extends React.Component {
     lensProtocolRouterRendererInjectable: LensProtocolRouterRenderer,
   ) {
     catalogEntityRegistry.init();
-    extensionLoader.loadOnClusterManagerRenderer();
+
+    try {
+      await extensionLoader.loadOnClusterManagerRenderer();
+    } finally {
+      ipcRenderer.send(BundledExtensionsLoaded);
+    }
     lensProtocolRouterRendererInjectable.init();
+
     bindProtocolAddRouteHandlers();
 
     window.addEventListener("offline", () => broadcastMessage("network:offline"));


### PR DESCRIPTION
Change app start up so that startup waits until the bundled extensions have been loaded and enabled before splash window is hidden and main window is shown.

This is because some of the extensions want to render UI elements and they should be ready when the main screen is shown. Less flicker and better UX.

Signed-off-by: Juho Heikka <juho.heikka@gmail.com>