### PR TITLE
Show all helm release statuses

### DIFF
--- a/src/main/helm/helm-release-manager.ts
+++ b/src/main/helm/helm-release-manager.ts
@@ -43,6 +43,7 @@ async function execHelm(args: string[], options?: BaseEncodingOptions & ExecFile
 export async function listReleases(pathToKubeconfig: string, namespace?: string): Promise<Record<string, any>[]> {
   const args = [
     "ls",
+    "--all",
     "--output", "json",
   ];
 


### PR DESCRIPTION
Fix #4586

Pass explicitly flag -a to helm
```
 -a, --all                  show all releases without any filter applied
```
