### PR TITLE
Less noisy metrics-not-available error logging

### DIFF
--- a/src/main/routes/metrics-route.ts
+++ b/src/main/routes/metrics-route.ts
@@ -46,7 +46,7 @@ async function loadMetrics(promQueries: string[], cluster: Cluster, prometheusPa
           return await getMetrics(cluster, prometheusPath, { query, ...queryParams });
         } catch (error) {
           if (lastAttempt || (error?.statusCode >= 400 && error?.statusCode < 500)) {
-            logger.error("[Metrics]: metrics not available", error);
+            logger.error("[Metrics]: metrics not available", error?.response ? error.response?.body : error);
             throw new Error("Metrics not available");
           }
 


### PR DESCRIPTION
We really want to log only the response (if response is available).

Before:
```
<mile long error object>
```

After:
```
[0] error:   ┏ [Metrics]: metrics not available no endpoints available for service "prometheus-server" +5ms
[0] error:   ┗ [1] { kind: 'Status', apiVersion: 'v1', metadata: {}, status: 'Failure', reason: 'ServiceUnavailable', code: 503 }
```