### PR TITLE
Fix close button overflow in Preferences

### DIFF
--- a/src/renderer/components/layout/close-button.module.scss
+++ b/src/renderer/components/layout/close-button.module.scss
@@ -20,14 +20,33 @@
  */
 
 .closeButton {
-  @apply w-[35px] h-[35px] grid place-items-center cursor-pointer border-2 rounded-full border-solid border-textDimmed
-    hover:bg-[#72767d25] active:translate-y-px;
+  width: 35px;
+  height: 35px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  border: 2px solid var(--textColorDimmed);
+  border-radius: 50%;
+
+  &:hover {
+    background-color: #72767d25;
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
 }
 
 .icon {
-  @apply text-textAccent opacity-60;
+  color: var(--textColorAccent);
+  opacity: 0.6;
 }
 
 .esc {
-  @apply text-center mt-3 font-bold text-lg select-none text-textDimmed pointer-events-none;
+  text-align: center;
+  margin-top: var(--margin);
+  font-weight: bold;
+  user-select: none;
+  color: var(--textColorDimmed);
+  pointer-events: none;
 }

--- a/src/renderer/components/layout/close-button.module.scss
+++ b/src/renderer/components/layout/close-button.module.scss
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+.closeButton {
+  @apply w-[35px] h-[35px] grid place-items-center cursor-pointer border-2 rounded-full border-solid border-textDimmed
+    hover:bg-[#72767d25] active:translate-y-px;
+}
+
+.icon {
+  @apply text-textAccent opacity-60;
+}
+
+.esc {
+  @apply text-center mt-3 font-bold text-lg select-none text-textDimmed pointer-events-none;
+}

--- a/src/renderer/components/layout/close-button.tsx
+++ b/src/renderer/components/layout/close-button.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2021 OpenLens Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import styles from "./close-button.module.scss";
+
+import React, { HTMLAttributes } from "react";
+import { Icon } from "../icon";
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+}
+
+export function CloseButton(props: Props) {
+  return (
+    <div {...props}>
+      <div className={styles.closeButton} role="button" aria-label="Close">
+        <Icon material="close" className={styles.icon}/>
+      </div>
+      <div className={styles.esc} aria-hidden="true">
+        ESC
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/layout/setting-layout.scss
+++ b/src/renderer/components/layout/setting-layout.scss
@@ -138,41 +138,7 @@
     }
 
     > .toolsRegion {
-      .fixedTools {
-        position: fixed;
-        top: 60px;
-
-        .closeBtn {
-          width: 35px;
-          height: 35px;
-          display: grid;
-          place-items: center;
-          border: 2px solid var(--textColorDimmed);
-          border-radius: 50%;
-          cursor: pointer;
-
-          &:hover {
-            background-color: #72767d4d;
-          }
-
-          &:active {
-            transform: translateY(1px);
-          }
-
-          .Icon {
-            color: var(--textColorTertiary);
-          }
-        }
-
-        .esc {
-          text-align: center;
-          margin-top: 4px;
-          font-weight: 600;
-          font-size: 14px;
-          color: var(--textColorDimmed);
-          pointer-events: none;
-        }
-      }
+      width: 45px;
     }
   }
 

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -104,11 +104,19 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
           <div className="toolsRegion">
             {
               this.props.provideBackButtonNavigation && (
-                <div className="fixedTools">
-                  <div className="closeBtn" role="button" aria-label="Close" onClick={back}>
-                    <Icon material="close" />
+                <div className="fixed top-[60px]">
+                  <div
+                    className="w-[35px] h-[35px] grid place-items-center pointer border-2 rounded-full border-solid border-textDimmed hover:bg-[#72767d25] active:translate-y-px"
+                    role="button"
+                    aria-label="Close"
+                    onClick={back}
+                  >
+                    <Icon material="close" className="text-textAccent opacity-60" />
                   </div>
-                  <div className="esc" aria-hidden="true">
+                  <div
+                    className="text-center mt-3 font-bold text-lg select-none text-textDimmed pointer-events-none"
+                    aria-hidden="true"
+                  >
                     ESC
                   </div>
                 </div>

--- a/src/renderer/components/layout/setting-layout.tsx
+++ b/src/renderer/components/layout/setting-layout.tsx
@@ -25,8 +25,8 @@ import React from "react";
 import { observer } from "mobx-react";
 import { cssNames, IClassName } from "../../utils";
 import { navigation } from "../../navigation";
-import { Icon } from "../icon";
 import { catalogURL } from "../../../common/routes";
+import { CloseButton } from "./close-button";
 
 export interface SettingLayoutProps extends React.DOMAttributes<any> {
   className?: IClassName;
@@ -105,20 +105,7 @@ export class SettingLayout extends React.Component<SettingLayoutProps> {
             {
               this.props.provideBackButtonNavigation && (
                 <div className="fixed top-[60px]">
-                  <div
-                    className="w-[35px] h-[35px] grid place-items-center pointer border-2 rounded-full border-solid border-textDimmed hover:bg-[#72767d25] active:translate-y-px"
-                    role="button"
-                    aria-label="Close"
-                    onClick={back}
-                  >
-                    <Icon material="close" className="text-textAccent opacity-60" />
-                  </div>
-                  <div
-                    className="text-center mt-3 font-bold text-lg select-none text-textDimmed pointer-events-none"
-                    aria-hidden="true"
-                  >
-                    ESC
-                  </div>
+                  <CloseButton onClick={back}/>
                 </div>
               )
             }

--- a/src/renderer/components/select/select.scss
+++ b/src/renderer/components/select/select.scss
@@ -228,10 +228,15 @@ html {
       }
 
       .Select {
+        &__value-container {
+          margin-top: 2px;
+          margin-bottom: 2px;
+        }
+
         &__control {
           box-shadow: 0 0 0 1px var(--inputControlBorder);
           background: var(--inputControlBackground);
-          border-radius: 5px;
+          border-radius: var(--border-radius);
         }
 
         &__single-value {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,7 +26,14 @@ module.exports = {
     fontFamily: {
       sans: ["Roboto", "Helvetica", "Arial", "sans-serif"],
     },
-    extend: {},
+    extend: {
+      colors: {
+        textAccent: "var(--textColorAccent)",
+        textPrimary: "var(--textColorPrimary)",
+        textTertiary: "var(--textColorTertiary)",
+        textDimmed: "var(--textColorDimmed)",
+      },
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
In small window size, close button might disappear moving behind the viewport. Current PR:
- fixes close button position so it's always visible
- adjusting `Select` dropdowns to look similar along with other inputs

Before:

![hiding close button](https://user-images.githubusercontent.com/9607060/147465257-1526ad26-ce3a-41fd-a9eb-1402646a8545.png)
![different inputs](https://user-images.githubusercontent.com/9607060/147465263-fb5db10e-9959-4627-978f-89e36a5251e4.png)

After:
![visible close button](https://user-images.githubusercontent.com/9607060/147465271-ed90a5f2-8e59-426a-a1a9-e8e8dfdf15e4.gif)
![similar inputs](https://user-images.githubusercontent.com/9607060/147465303-2c09e11c-a2db-4221-a082-7ad0508b500a.png)

Fixes https://github.com/lensapp/lenscloud-lens-extension/issues/986
