### PR TITLE
Adapt to recent simplifications in injectable

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
     "@hapi/call": "^8.0.1",
     "@hapi/subtext": "^7.0.3",
     "@kubernetes/client-node": "^0.16.1",
-    "@ogre-tools/injectable": "1.5.0",
-    "@ogre-tools/injectable-react": "1.5.2",
+    "@ogre-tools/injectable": "2.0.0",
+    "@ogre-tools/injectable-react": "2.0.0",
     "@sentry/electron": "^2.5.4",
     "@sentry/integrations": "^6.15.0",
     "abort-controller": "^3.0.0",
@@ -265,7 +265,7 @@
     "ws": "^7.5.5"
   },
   "devDependencies": {
-    "@async-fn/jest": "^1.5.0",
+    "@async-fn/jest": "1.5.3",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/src/extensions/extension-loader/extension-loader.injectable.ts
+++ b/src/extensions/extension-loader/extension-loader.injectable.ts
@@ -18,14 +18,13 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
+import { getInjectable } from "@ogre-tools/injectable";
 import { lifecycleEnum } from "@ogre-tools/injectable";
 import { ExtensionLoader } from "./extension-loader";
 
-const extensionLoaderInjectable: Injectable<ExtensionLoader> = {
-  getDependencies: () => ({}),
+const extensionLoaderInjectable = getInjectable({
   instantiate: () => new ExtensionLoader(),
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default extensionLoaderInjectable;

--- a/src/extensions/extensions.injectable.ts
+++ b/src/extensions/extensions.injectable.ts
@@ -18,24 +18,18 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { Injectable, lifecycleEnum } from "@ogre-tools/injectable";
-import { computed, IComputedValue } from "mobx";
-import type { LensExtension } from "./lens-extension";
-import type { ExtensionLoader } from "./extension-loader";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { computed } from "mobx";
 import extensionLoaderInjectable from "./extension-loader/extension-loader.injectable";
 
-const extensionsInjectable: Injectable<
-  IComputedValue<LensExtension[]>,
-  { extensionLoader: ExtensionLoader }
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
+const extensionsInjectable = getInjectable({
+  instantiate: (di) => {
+    const extensionLoader = di.inject(extensionLoaderInjectable);
+
+    return computed(() => extensionLoader.enabledExtensionInstances);
+  },
 
   lifecycle: lifecycleEnum.singleton,
-
-  instantiate: ({ extensionLoader }) =>
-    computed(() => extensionLoader.enabledExtensionInstances),
-};
+});
 
 export default extensionsInjectable;

--- a/src/extensions/main-extensions.injectable.ts
+++ b/src/extensions/main-extensions.injectable.ts
@@ -18,18 +18,16 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { getInjectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import { unpackExtension } from "./unpack-extension";
-import extensionLoaderInjectable from "../../../../../extensions/extension-loader/extension-loader.injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import type { IComputedValue } from "mobx";
+import extensionsInjectable from "./extensions.injectable";
+import type { LensMainExtension } from "./lens-main-extension";
 
-const unpackExtensionInjectable = getInjectable({
-  instantiate: (di) =>
-    unpackExtension({
-      extensionLoader: di.inject(extensionLoaderInjectable),
-    }),
-
+const mainExtensionsInjectable = getInjectable({
   lifecycle: lifecycleEnum.singleton,
+
+  instantiate: (di) =>
+    di.inject(extensionsInjectable) as IComputedValue<LensMainExtension[]>,
 });
 
-export default unpackExtensionInjectable;
+export default mainExtensionsInjectable;

--- a/src/main/menu/electron-menu-items.injectable.ts
+++ b/src/main/menu/electron-menu-items.injectable.ts
@@ -18,24 +18,20 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { Injectable, lifecycleEnum } from "@ogre-tools/injectable";
-import { computed, IComputedValue } from "mobx";
-import type { LensMainExtension } from "../../extensions/lens-main-extension";
-import extensionsInjectable from "../../extensions/extensions.injectable";
-import type { MenuRegistration } from "./menu-registration";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { computed } from "mobx";
+import mainExtensionsInjectable from "../../extensions/main-extensions.injectable";
 
-const electronMenuItemsInjectable: Injectable<
-  IComputedValue<MenuRegistration[]>,
-  { extensions: IComputedValue<LensMainExtension[]> }
-> = {
+const electronMenuItemsInjectable = getInjectable({
   lifecycle: lifecycleEnum.singleton,
 
-  getDependencies: di => ({
-    extensions: di.inject(extensionsInjectable),
-  }),
+  instantiate: (di) => {
+    const extensions = di.inject(mainExtensionsInjectable);
 
-  instantiate: ({ extensions }) =>
-    computed(() => extensions.get().flatMap(extension => extension.appMenus)),
-};
+    return computed(() =>
+      extensions.get().flatMap((extension) => extension.appMenus),
+    );
+  },
+});
 
 export default electronMenuItemsInjectable;

--- a/src/main/menu/electron-menu-items.test.ts
+++ b/src/main/menu/electron-menu-items.test.ts
@@ -24,8 +24,8 @@ import electronMenuItemsInjectable from "./electron-menu-items.injectable";
 import type { IComputedValue } from "mobx";
 import { computed, ObservableMap, runInAction } from "mobx";
 import type { MenuRegistration } from "./menu-registration";
-import extensionsInjectable from "../../extensions/extensions.injectable";
 import { getDiForUnitTesting } from "../getDiForUnitTesting";
+import mainExtensionsInjectable from "../../extensions/main-extensions.injectable";
 
 describe("electron-menu-items", () => {
   let di: ConfigurableDependencyInjectionContainer;
@@ -38,8 +38,8 @@ describe("electron-menu-items", () => {
     extensionsStub = new ObservableMap();
 
     di.override(
-      extensionsInjectable,
-      computed(() => [...extensionsStub.values()]),
+      mainExtensionsInjectable,
+      () => computed(() => [...extensionsStub.values()]),
     );
 
     electronMenuItems = di.inject(electronMenuItemsInjectable);

--- a/src/main/protocol-handler/lens-protocol-router-main/lens-protocol-router-main.injectable.ts
+++ b/src/main/protocol-handler/lens-protocol-router-main/lens-protocol-router-main.injectable.ts
@@ -18,23 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import extensionLoaderInjectable from "../../../extensions/extension-loader/extension-loader.injectable";
-import type { Dependencies } from "./lens-protocol-router-main";
 import { LensProtocolRouterMain } from "./lens-protocol-router-main";
 
-const lensProtocolRouterMainInjectable: Injectable<
-  LensProtocolRouterMain,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
-
-  instantiate: dependencies => new LensProtocolRouterMain(dependencies),
+const lensProtocolRouterMainInjectable = getInjectable({
+  instantiate: (di) =>
+    new LensProtocolRouterMain({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+    }),
 
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default lensProtocolRouterMainInjectable;

--- a/src/main/protocol-handler/lens-protocol-router-main/lens-protocol-router-main.ts
+++ b/src/main/protocol-handler/lens-protocol-router-main/lens-protocol-router-main.ts
@@ -51,7 +51,7 @@ function checkHost<Query>(url: URLParse<Query>): boolean {
   }
 }
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader
 }
 

--- a/src/renderer/components/+extensions/attempt-install-by-info/attempt-install-by-info.injectable.ts
+++ b/src/renderer/components/+extensions/attempt-install-by-info/attempt-install-by-info.injectable.ts
@@ -18,20 +18,19 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import { attemptInstallByInfo, ExtensionInfo } from "./attempt-install-by-info";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { attemptInstallByInfo } from "./attempt-install-by-info";
 import attemptInstallInjectable from "../attempt-install/attempt-install.injectable";
 import getBaseRegistryUrlInjectable from "../get-base-registry-url/get-base-registry-url.injectable";
 
-const attemptInstallByInfoInjectable: Injectable<(extensionInfo: ExtensionInfo) => Promise<void>, {}> = {
-  getDependencies: di => ({
-    attemptInstall: di.inject(attemptInstallInjectable),
-    getBaseRegistryUrl: di.inject(getBaseRegistryUrlInjectable),
-  }),
+const attemptInstallByInfoInjectable = getInjectable({
+  instantiate: (di) =>
+    attemptInstallByInfo({
+      attemptInstall: di.inject(attemptInstallInjectable),
+      getBaseRegistryUrl: di.inject(getBaseRegistryUrlInjectable),
+    }),
 
-  instantiate: attemptInstallByInfo,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default attemptInstallByInfoInjectable;

--- a/src/renderer/components/+extensions/attempt-install-by-info/attempt-install-by-info.tsx
+++ b/src/renderer/components/+extensions/attempt-install-by-info/attempt-install-by-info.tsx
@@ -35,7 +35,7 @@ export interface ExtensionInfo {
   requireConfirmation?: boolean;
 }
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstall: (request: InstallRequest, d: ExtendableDisposer) => Promise<void>;
   getBaseRegistryUrl: () => Promise<string>;
 }

--- a/src/renderer/components/+extensions/attempt-install/attempt-install.injectable.ts
+++ b/src/renderer/components/+extensions/attempt-install/attempt-install.injectable.ts
@@ -18,29 +18,21 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-
-import type { ExtendableDisposer } from "../../../../common/utils";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";
 import uninstallExtensionInjectable from "../uninstall-extension/uninstall-extension.injectable";
-import type { Dependencies } from "./attempt-install";
 import { attemptInstall } from "./attempt-install";
-import type { InstallRequest } from "./install-request";
 import unpackExtensionInjectable from "./unpack-extension/unpack-extension.injectable";
 
-const attemptInstallInjectable: Injectable<
-  (request: InstallRequest, d?: ExtendableDisposer) => Promise<void>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-    uninstallExtension: di.inject(uninstallExtensionInjectable),
-    unpackExtension: di.inject(unpackExtensionInjectable),
-  }),
+const attemptInstallInjectable = getInjectable({
+  instantiate: (di) =>
+    attemptInstall({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+      uninstallExtension: di.inject(uninstallExtensionInjectable),
+      unpackExtension: di.inject(unpackExtensionInjectable),
+    }),
 
-  instantiate: attemptInstall,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default attemptInstallInjectable;

--- a/src/renderer/components/+extensions/attempt-install/attempt-install.tsx
+++ b/src/renderer/components/+extensions/attempt-install/attempt-install.tsx
@@ -41,7 +41,7 @@ import {
 import { getExtensionDestFolder } from "./get-extension-dest-folder/get-extension-dest-folder";
 import type { InstallRequest } from "./install-request";
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader;
   uninstallExtension: (id: LensExtensionId) => Promise<boolean>;
   unpackExtension: (

--- a/src/renderer/components/+extensions/attempt-install/unpack-extension/unpack-extension.tsx
+++ b/src/renderer/components/+extensions/attempt-install/unpack-extension/unpack-extension.tsx
@@ -32,7 +32,7 @@ import fse from "fs-extra";
 import { when } from "mobx";
 import React from "react";
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader
 }
 

--- a/src/renderer/components/+extensions/attempt-installs/attempt-installs.injectable.ts
+++ b/src/renderer/components/+extensions/attempt-installs/attempt-installs.injectable.ts
@@ -18,21 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import { attemptInstalls, Dependencies } from "./attempt-installs";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { attemptInstalls } from "./attempt-installs";
 import attemptInstallInjectable from "../attempt-install/attempt-install.injectable";
 
-const attemptInstallsInjectable: Injectable<
-  (filePaths: string[]) => Promise<void>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    attemptInstall: di.inject(attemptInstallInjectable),
-  }),
+const attemptInstallsInjectable = getInjectable({
+  instantiate: (di) =>
+    attemptInstalls({
+      attemptInstall: di.inject(attemptInstallInjectable),
+    }),
 
-  instantiate: attemptInstalls,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default attemptInstallsInjectable;

--- a/src/renderer/components/+extensions/attempt-installs/attempt-installs.ts
+++ b/src/renderer/components/+extensions/attempt-installs/attempt-installs.ts
@@ -22,7 +22,7 @@ import { readFileNotify } from "../read-file-notify/read-file-notify";
 import path from "path";
 import type { InstallRequest } from "../attempt-install/install-request";
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstall: (request: InstallRequest) => Promise<void>;
 }
 

--- a/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.injectable.ts
+++ b/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.injectable.ts
@@ -18,25 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import {
-  confirmUninstallExtension,
-  Dependencies,
-} from "./confirm-uninstall-extension";
-import type { InstalledExtension } from "../../../../extensions/extension-discovery";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { confirmUninstallExtension } from "./confirm-uninstall-extension";
 import uninstallExtensionInjectable from "../uninstall-extension/uninstall-extension.injectable";
 
-const confirmUninstallExtensionInjectable: Injectable<
-  (extension: InstalledExtension) => Promise<void>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    uninstallExtension: di.inject(uninstallExtensionInjectable),
-  }),
+const confirmUninstallExtensionInjectable = getInjectable({
+  instantiate: (di) =>
+    confirmUninstallExtension({
+      uninstallExtension: di.inject(uninstallExtensionInjectable),
+    }),
 
-  instantiate: confirmUninstallExtension,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default confirmUninstallExtensionInjectable;

--- a/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.tsx
+++ b/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.tsx
@@ -24,7 +24,7 @@ import type { LensExtensionId } from "../../../../extensions/lens-extension";
 import { extensionDisplayName } from "../../../../extensions/lens-extension";
 import { ConfirmDialog } from "../../confirm-dialog";
 
-export interface Dependencies {
+interface Dependencies {
   uninstallExtension: (id: LensExtensionId) => Promise<boolean>;
 }
 

--- a/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.tsx
+++ b/src/renderer/components/+extensions/confirm-uninstall-extension/confirm-uninstall-extension.tsx
@@ -25,7 +25,7 @@ import { extensionDisplayName } from "../../../../extensions/lens-extension";
 import { ConfirmDialog } from "../../confirm-dialog";
 
 export interface Dependencies {
-  uninstallExtension: (id: LensExtensionId) => Promise<void>;
+  uninstallExtension: (id: LensExtensionId) => Promise<boolean>;
 }
 
 export const confirmUninstallExtension =

--- a/src/renderer/components/+extensions/disable-extension/disable-extension.injectable.ts
+++ b/src/renderer/components/+extensions/disable-extension/disable-extension.injectable.ts
@@ -18,23 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";
-import type { LensExtensionId } from "../../../../extensions/lens-extension";
-import { Dependencies, disableExtension } from "./disable-extension";
+import { disableExtension } from "./disable-extension";
 
-const disableExtensionInjectable: Injectable<
-  (id: LensExtensionId) => void,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
-
-  instantiate: disableExtension,
+const disableExtensionInjectable = getInjectable({
+  instantiate: (di) =>
+    disableExtension({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+    }),
 
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default disableExtensionInjectable;

--- a/src/renderer/components/+extensions/disable-extension/disable-extension.ts
+++ b/src/renderer/components/+extensions/disable-extension/disable-extension.ts
@@ -21,7 +21,7 @@
 import type { LensExtensionId } from "../../../../extensions/lens-extension";
 import type { ExtensionLoader } from "../../../../extensions/extension-loader";
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader;
 }
 

--- a/src/renderer/components/+extensions/enable-extension/enable-extension.injectable.ts
+++ b/src/renderer/components/+extensions/enable-extension/enable-extension.injectable.ts
@@ -18,23 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";
-import type { LensExtensionId } from "../../../../extensions/lens-extension";
-import { Dependencies, enableExtension } from "./enable-extension";
+import { enableExtension } from "./enable-extension";
 
-const enableExtensionInjectable: Injectable<
-  (id: LensExtensionId) => void,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
-
-  instantiate: enableExtension,
+const enableExtensionInjectable = getInjectable({
+  instantiate: (di) =>
+    enableExtension({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+    }),
 
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default enableExtensionInjectable;

--- a/src/renderer/components/+extensions/enable-extension/enable-extension.ts
+++ b/src/renderer/components/+extensions/enable-extension/enable-extension.ts
@@ -21,7 +21,7 @@
 import type { LensExtensionId } from "../../../../extensions/lens-extension";
 import type { ExtensionLoader } from "../../../../extensions/extension-loader";
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader;
 }
 

--- a/src/renderer/components/+extensions/get-base-registry-url/get-base-registry-url.injectable.ts
+++ b/src/renderer/components/+extensions/get-base-registry-url/get-base-registry-url.injectable.ts
@@ -19,18 +19,20 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Injectable, lifecycleEnum } from "@ogre-tools/injectable";
+import {
+  getInjectable,
+  lifecycleEnum,
+} from "@ogre-tools/injectable";
 import { UserStore } from "../../../../common/user-store";
-import { Dependencies, getBaseRegistryUrl } from "./get-base-registry-url";
+import { getBaseRegistryUrl } from "./get-base-registry-url";
 
-const getBaseRegistryUrlInjectable: Injectable<() => Promise<string>, Dependencies> = {
-  getDependencies: () => ({
+const getBaseRegistryUrlInjectable = getInjectable({
+  instantiate: () => getBaseRegistryUrl({
     // TODO: use injection
     getRegistryUrlPreference: () => UserStore.getInstance().extensionRegistryUrl,
   }),
-
-  instantiate: getBaseRegistryUrl,
+  
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default getBaseRegistryUrlInjectable;

--- a/src/renderer/components/+extensions/get-base-registry-url/get-base-registry-url.tsx
+++ b/src/renderer/components/+extensions/get-base-registry-url/get-base-registry-url.tsx
@@ -24,7 +24,7 @@ import { defaultExtensionRegistryUrl, ExtensionRegistry, ExtensionRegistryLocati
 import { promiseExecFile } from "../../../utils";
 import { Notifications } from "../../notifications";
 
-export interface Dependencies {
+interface Dependencies {
   getRegistryUrlPreference: () => ExtensionRegistry,
 }
 

--- a/src/renderer/components/+extensions/install-from-input/install-from-input.injectable.ts
+++ b/src/renderer/components/+extensions/install-from-input/install-from-input.injectable.ts
@@ -18,25 +18,19 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import attemptInstallInjectable from "../attempt-install/attempt-install.injectable";
-import type { Dependencies } from "./install-from-input";
 import { installFromInput } from "./install-from-input";
-import attemptInstallByInfoInjectable
-  from "../attempt-install-by-info/attempt-install-by-info.injectable";
+import attemptInstallByInfoInjectable from "../attempt-install-by-info/attempt-install-by-info.injectable";
 
-const installFromInputInjectable: Injectable<
-  (input: string) => Promise<void>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    attemptInstall: di.inject(attemptInstallInjectable),
-    attemptInstallByInfo: di.inject(attemptInstallByInfoInjectable),
-  }),
+const installFromInputInjectable = getInjectable({
+  instantiate: (di) =>
+    installFromInput({
+      attemptInstall: di.inject(attemptInstallInjectable),
+      attemptInstallByInfo: di.inject(attemptInstallByInfoInjectable),
+    }),
 
-  instantiate: installFromInput,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default installFromInputInjectable;

--- a/src/renderer/components/+extensions/install-from-input/install-from-input.tsx
+++ b/src/renderer/components/+extensions/install-from-input/install-from-input.tsx
@@ -30,7 +30,7 @@ import { readFileNotify } from "../read-file-notify/read-file-notify";
 import type { InstallRequest } from "../attempt-install/install-request";
 import type { ExtensionInfo } from "../attempt-install-by-info/attempt-install-by-info";
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstall: (request: InstallRequest, disposer?: ExtendableDisposer) => Promise<void>,
   attemptInstallByInfo: (extensionInfo: ExtensionInfo) => Promise<void>
 }

--- a/src/renderer/components/+extensions/install-from-select-file-dialog/install-from-select-file-dialog.injectable.ts
+++ b/src/renderer/components/+extensions/install-from-select-file-dialog/install-from-select-file-dialog.injectable.ts
@@ -18,18 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import { Dependencies, installFromSelectFileDialog } from "./install-from-select-file-dialog";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { installFromSelectFileDialog } from "./install-from-select-file-dialog";
 import attemptInstallsInjectable from "../attempt-installs/attempt-installs.injectable";
 
-const installFromSelectFileDialogInjectable: Injectable<() => Promise<void>, Dependencies> = {
-  getDependencies: di => ({
-    attemptInstalls: di.inject(attemptInstallsInjectable),
-  }),
-  
-  instantiate: installFromSelectFileDialog,
+const installFromSelectFileDialogInjectable = getInjectable({
+  instantiate: (di) =>
+    installFromSelectFileDialog({
+      attemptInstalls: di.inject(attemptInstallsInjectable),
+    }),
+
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default installFromSelectFileDialogInjectable;

--- a/src/renderer/components/+extensions/install-from-select-file-dialog/install-from-select-file-dialog.ts
+++ b/src/renderer/components/+extensions/install-from-select-file-dialog/install-from-select-file-dialog.ts
@@ -22,7 +22,7 @@ import { dialog } from "../../../remote-helpers";
 import { AppPaths } from "../../../../common/app-paths";
 import { supportedExtensionFormats } from "../supported-extension-formats";
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstalls: (filePaths: string[]) => Promise<void>
 }
 

--- a/src/renderer/components/+extensions/install-on-drop/install-on-drop.injectable.ts
+++ b/src/renderer/components/+extensions/install-on-drop/install-on-drop.injectable.ts
@@ -18,21 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import { Dependencies, installOnDrop } from "./install-on-drop";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { installOnDrop } from "./install-on-drop";
 import attemptInstallsInjectable from "../attempt-installs/attempt-installs.injectable";
 
-const installOnDropInjectable: Injectable<
-  (files: File[]) => Promise<void>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    attemptInstalls: di.inject(attemptInstallsInjectable),
-  }),
+const installOnDropInjectable = getInjectable({
+  instantiate: (di) =>
+    installOnDrop({
+      attemptInstalls: di.inject(attemptInstallsInjectable),
+    }),
 
-  instantiate: installOnDrop,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default installOnDropInjectable;

--- a/src/renderer/components/+extensions/install-on-drop/install-on-drop.tsx
+++ b/src/renderer/components/+extensions/install-on-drop/install-on-drop.tsx
@@ -20,7 +20,7 @@
  */
 import logger from "../../../../main/logger";
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstalls: (filePaths: string[]) => Promise<void>;
 }
 

--- a/src/renderer/components/+extensions/uninstall-extension/uninstall-extension.injectable.ts
+++ b/src/renderer/components/+extensions/uninstall-extension/uninstall-extension.injectable.ts
@@ -18,23 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import type { LensExtensionId } from "../../../../extensions/lens-extension";
-import extensionLoaderInjectable
-  from "../../../../extensions/extension-loader/extension-loader.injectable";
-import { Dependencies, uninstallExtension } from "./uninstall-extension";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";
+import { uninstallExtension } from "./uninstall-extension";
 
-const uninstallExtensionInjectable: Injectable<
-  (extensionId: LensExtensionId) => Promise<boolean>,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
+const uninstallExtensionInjectable = getInjectable({
+  instantiate: (di) =>
+    uninstallExtension({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+    }),
 
-  instantiate: uninstallExtension,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default uninstallExtensionInjectable;

--- a/src/renderer/components/+extensions/uninstall-extension/uninstall-extension.tsx
+++ b/src/renderer/components/+extensions/uninstall-extension/uninstall-extension.tsx
@@ -28,7 +28,7 @@ import React from "react";
 import { when } from "mobx";
 import { getMessageFromError } from "../get-message-from-error/get-message-from-error";
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader
 }
 

--- a/src/renderer/components/+extensions/user-extensions/user-extensions.injectable.ts
+++ b/src/renderer/components/+extensions/user-extensions/user-extensions.injectable.ts
@@ -18,24 +18,18 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { Injectable, lifecycleEnum } from "@ogre-tools/injectable";
-import { computed, IComputedValue } from "mobx";
-import type { InstalledExtension } from "../../../../extensions/extension-discovery";
-import type { ExtensionLoader } from "../../../../extensions/extension-loader";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { computed } from "mobx";
 import extensionLoaderInjectable from "../../../../extensions/extension-loader/extension-loader.injectable";
 
-const userExtensionsInjectable: Injectable<
-  IComputedValue<InstalledExtension[]>,
-  { extensionLoader: ExtensionLoader }
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
-
+const userExtensionsInjectable = getInjectable({
   lifecycle: lifecycleEnum.singleton,
 
-  instantiate: ({ extensionLoader }) =>
-    computed(() => [...extensionLoader.userExtensions.values()]),
-};
+  instantiate: (di) => {
+    const extensionLoader = di.inject(extensionLoaderInjectable);
+
+    return computed(() => [...extensionLoader.userExtensions.values()]);
+  },
+});
 
 export default userExtensionsInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/api-manager.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/api-manager.injectable.ts
@@ -18,15 +18,12 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { ApiManager } from "../../../../common/k8s-api/api-manager";
 import { apiManager } from "../../../../common/k8s-api/api-manager";
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 
-const apiManagerInjectable: Injectable<ApiManager> = {
-  getDependencies: () => ({}),
+const apiManagerInjectable = getInjectable({
   instantiate: () => apiManager,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default apiManagerInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/cluster-name.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/cluster-name.injectable.ts
@@ -19,23 +19,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import type { Cluster } from "../../../../main/cluster";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import clusterInjectable from "./cluster.injectable";
 
-interface Dependencies {
-  cluster: Cluster;
-}
+const clusterNameInjectable = getInjectable({
+  instantiate: (di) => {
+    const cluster = di.inject(clusterInjectable);
 
-const clusterNameInjectable: Injectable<string | undefined, Dependencies> = {
-  getDependencies: di => ({
-    cluster: di.inject(clusterInjectable),
-  }),
-
-  instantiate: ({ cluster }) => cluster?.name,
+    return cluster?.name;
+  },
 
   lifecycle: lifecycleEnum.transient,
-};
+});
 
 export default clusterNameInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/cluster.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/cluster.injectable.ts
@@ -20,14 +20,11 @@
  */
 import { getActiveClusterEntity } from "../../../api/catalog-entity-registry";
 
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
-import type { Cluster } from "../../../../main/cluster";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 
-const clusterInjectable: Injectable<Cluster | null> = {
-  getDependencies: () => ({}),
+const clusterInjectable = getInjectable({
   instantiate: () => getActiveClusterEntity(),
   lifecycle: lifecycleEnum.transient,
-};
+});
 
 export default clusterInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/edit-resource-tab.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/edit-resource-tab.injectable.ts
@@ -19,13 +19,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import { editResourceTab } from "../../dock/edit-resource.store";
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 
-const editResourceTabInjectable: Injectable<typeof editResourceTab> = {
-  getDependencies: () => ({}),
+const editResourceTabInjectable = getInjectable({
   instantiate: () => editResourceTab,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default editResourceTabInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/hide-details.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/hide-details.injectable.ts
@@ -19,13 +19,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import { hideDetails } from "../../kube-detail-params";
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 
-export const hideDetailsInjectable: Injectable<typeof hideDetails> = {
-  getDependencies: () => ({}),
+export const hideDetailsInjectable = getInjectable({
   instantiate: () => hideDetails,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default hideDetailsInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/get-kube-object-menu-items.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/get-kube-object-menu-items.ts
@@ -21,23 +21,18 @@
 import type { KubeObjectMenuRegistry } from "../../../../../extensions/registries";
 import type { KubeObject } from "../../../../../common/k8s-api/kube-object";
 
-export interface Dependencies {
+export const getKubeObjectMenuItems = ({
+  kubeObjectMenuRegistry,
+  kubeObject,
+}: {
   kubeObjectMenuRegistry: KubeObjectMenuRegistry;
-}
-
-export interface InstantiationParameter {
   kubeObject: KubeObject;
-}
-
-export const getKubeObjectMenuItems = (
-  { kubeObjectMenuRegistry }: Dependencies,
-  { kubeObject }: InstantiationParameter,
-) => {
+}) => {
   if (!kubeObject) {
     return [];
   }
 
   return kubeObjectMenuRegistry
     .getItemsForKind(kubeObject.kind, kubeObject.apiVersion)
-    .map(item => item.components.MenuItem);
+    .map((item) => item.components.MenuItem);
 };

--- a/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/kube-object-menu-items.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/kube-object-menu-items.injectable.ts
@@ -18,27 +18,20 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { Injectable, lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import kubeObjectMenuRegistryInjectable from "./kube-object-menu-registry.injectable";
 
-import {
-  InstantiationParameter,
-  Dependencies,
-  getKubeObjectMenuItems,
-} from "./get-kube-object-menu-items";
+import { getKubeObjectMenuItems } from "./get-kube-object-menu-items";
+import type { KubeObject } from "../../../../../common/k8s-api/kube-object";
 
-const kubeObjectMenuItemsInjectable: Injectable<
-  ReturnType<typeof getKubeObjectMenuItems>,
-  Dependencies,
-  InstantiationParameter
-> = {
-  getDependencies: di => ({
-    kubeObjectMenuRegistry: di.inject(kubeObjectMenuRegistryInjectable),
-  }),
-
-  instantiate: getKubeObjectMenuItems,
+const kubeObjectMenuItemsInjectable = getInjectable({
+  instantiate: (di, { kubeObject }: { kubeObject: KubeObject }) =>
+    getKubeObjectMenuItems({
+      kubeObjectMenuRegistry: di.inject(kubeObjectMenuRegistryInjectable),
+      kubeObject,
+    }),
 
   lifecycle: lifecycleEnum.transient,
-};
+});
 
 export default kubeObjectMenuItemsInjectable;

--- a/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/kube-object-menu-registry.injectable.ts
+++ b/src/renderer/components/kube-object-menu/dependencies/kube-object-menu-items/kube-object-menu-registry.injectable.ts
@@ -19,13 +19,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import { KubeObjectMenuRegistry } from "../../../../../extensions/registries";
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 
-const kubeObjectMenuRegistryInjectable: Injectable<KubeObjectMenuRegistry> = {
-  getDependencies: () => ({}),
+const kubeObjectMenuRegistryInjectable = getInjectable({
   instantiate: () => KubeObjectMenuRegistry.getInstance(),
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default kubeObjectMenuRegistryInjectable;

--- a/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -55,18 +55,18 @@ describe("kube-object-menu", () => {
 
     render = renderFor(di);
 
-    di.override(clusterInjectable, {
+    di.override(clusterInjectable, () => ({
       name: "Some name",
-    } as Cluster);
+    }) as Cluster);
 
-    di.override(apiManagerInjectable, {
+    di.override(apiManagerInjectable, () => ({
       // eslint-disable-next-line unused-imports/no-unused-vars-ts
       getStore: api => undefined,
-    } as ApiManager);
+    }) as ApiManager);
 
-    di.override(hideDetailsInjectable, () => {});
+    di.override(hideDetailsInjectable, () => () => {});
 
-    di.override(editResourceTabInjectable, () => ({
+    di.override(editResourceTabInjectable, () => () => ({
       id: "irrelevant",
       kind: TabKind.TERMINAL,
       pinned: false,
@@ -93,7 +93,7 @@ describe("kube-object-menu", () => {
   });
 
   it("given no cluster, does not crash", () => {
-    di.override(clusterInjectable, null);
+    di.override(clusterInjectable, () => null);
 
     expect(() => {
       render(<KubeObjectMenu object={null} toolbar={true} />);
@@ -110,7 +110,7 @@ describe("kube-object-menu", () => {
 
   describe("given kube object", () => {
     let baseElement: Element;
-    let removeActionMock: AsyncFnMock<Function>;
+    let removeActionMock: AsyncFnMock<() => void>;
 
     beforeEach(async () => {
       const objectStub = KubeObject.create({

--- a/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.injectable.ts
+++ b/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.injectable.ts
@@ -18,24 +18,18 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import attemptInstallByInfoInjectable from "../../components/+extensions/attempt-install-by-info/attempt-install-by-info.injectable";
-import {
-  bindProtocolAddRouteHandlers,
-  Dependencies,
-} from "./bind-protocol-add-route-handlers";
-import lensProtocolRouterRendererInjectable
-  from "../lens-protocol-router-renderer/lens-protocol-router-renderer.injectable";
+import { bindProtocolAddRouteHandlers } from "./bind-protocol-add-route-handlers";
+import lensProtocolRouterRendererInjectable from "../lens-protocol-router-renderer/lens-protocol-router-renderer.injectable";
 
-const bindProtocolAddRouteHandlersInjectable: Injectable<() => void, Dependencies> = {
-  getDependencies: di => ({
+const bindProtocolAddRouteHandlersInjectable = getInjectable({
+  instantiate: di=> bindProtocolAddRouteHandlers({
     attemptInstallByInfo: di.inject(attemptInstallByInfoInjectable),
     lensProtocolRouterRenderer: di.inject(lensProtocolRouterRendererInjectable),
   }),
 
-  instantiate: bindProtocolAddRouteHandlers,
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default bindProtocolAddRouteHandlersInjectable;

--- a/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.injectable.ts
+++ b/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.injectable.ts
@@ -24,10 +24,13 @@ import { bindProtocolAddRouteHandlers } from "./bind-protocol-add-route-handlers
 import lensProtocolRouterRendererInjectable from "../lens-protocol-router-renderer/lens-protocol-router-renderer.injectable";
 
 const bindProtocolAddRouteHandlersInjectable = getInjectable({
-  instantiate: di=> bindProtocolAddRouteHandlers({
-    attemptInstallByInfo: di.inject(attemptInstallByInfoInjectable),
-    lensProtocolRouterRenderer: di.inject(lensProtocolRouterRendererInjectable),
-  }),
+  instantiate: (di) =>
+    bindProtocolAddRouteHandlers({
+      attemptInstallByInfo: di.inject(attemptInstallByInfoInjectable),
+      lensProtocolRouterRenderer: di.inject(
+        lensProtocolRouterRendererInjectable,
+      ),
+    }),
 
   lifecycle: lifecycleEnum.singleton,
 });

--- a/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
+++ b/src/renderer/protocol-handler/bind-protocol-add-route-handlers/bind-protocol-add-route-handlers.tsx
@@ -33,7 +33,7 @@ import { Notifications } from "../../components/notifications";
 import * as routes from "../../../common/routes";
 import type { ExtensionInfo } from "../../components/+extensions/attempt-install-by-info/attempt-install-by-info";
 
-export interface Dependencies {
+interface Dependencies {
   attemptInstallByInfo: (extensionInfo: ExtensionInfo) => Promise<void>;
   lensProtocolRouterRenderer: LensProtocolRouterRenderer;
 }

--- a/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.injectable.ts
+++ b/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.injectable.ts
@@ -18,23 +18,17 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import type { Injectable } from "@ogre-tools/injectable";
-import { lifecycleEnum } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import extensionLoaderInjectable from "../../../extensions/extension-loader/extension-loader.injectable";
-import type { Dependencies } from "./lens-protocol-router-renderer";
 import { LensProtocolRouterRenderer } from "./lens-protocol-router-renderer";
 
-const lensProtocolRouterRendererInjectable: Injectable<
-  LensProtocolRouterRenderer,
-  Dependencies
-> = {
-  getDependencies: di => ({
-    extensionLoader: di.inject(extensionLoaderInjectable),
-  }),
-
-  instantiate: dependencies => new LensProtocolRouterRenderer(dependencies),
+const lensProtocolRouterRendererInjectable = getInjectable({
+  instantiate: (di) =>
+    new LensProtocolRouterRenderer({
+      extensionLoader: di.inject(extensionLoaderInjectable),
+    }),
 
   lifecycle: lifecycleEnum.singleton,
-};
+});
 
 export default lensProtocolRouterRendererInjectable;

--- a/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.tsx
+++ b/src/renderer/protocol-handler/lens-protocol-router-renderer/lens-protocol-router-renderer.tsx
@@ -47,7 +47,7 @@ function verifyIpcArgs(args: unknown[]): args is [string, RouteAttempt] {
   }
 }
 
-export interface Dependencies {
+interface Dependencies {
   extensionLoader: ExtensionLoader
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.1.1.tgz#9274ec7460652f9c632c59addf24efb1684ef876"
   integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
 
-"@async-fn/jest@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@async-fn/jest/-/jest-1.5.0.tgz#dda820de3e48eca6d5b17b00a01bdb060dfcc233"
-  integrity sha512-IeuTZj1TdoBS64fpNfHG9efw6dW3UQuIXfEv0qhxyNro3368kKz9E/eO46zvPmQBxbBCox3RCbKexAJH1WAY+Q==
+"@async-fn/jest@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@async-fn/jest/-/jest-1.5.3.tgz#42be6c0e8ba5ccd737e006ca600e7e319fe2a591"
+  integrity sha512-iQ9gAPZFW5U6TNcFS99ffwYYsB9LNecTnvG73BaDc/zAD0qOWctY1imEACC1pLymmm/xaf/OUq9I9QenfkatTA==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -972,28 +972,28 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@ogre-tools/fp@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@ogre-tools/fp/-/fp-1.4.0.tgz#94c50378c5bc51ea1571f775e4428256f22c61b5"
-  integrity sha512-Eh/pK67CoYU/tJPWHeuNFEp+YdE8RPAAxZlSDAoXUDAd8sta3e+1vG7OEJlkYIJW4L8sCGKLWZu2DZ8uI6URhA==
+"@ogre-tools/fp@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ogre-tools/fp/-/fp-2.0.0.tgz#751b280959e7b7132e85ae031a96ea59c951178f"
+  integrity sha512-L3UWyIHuA1z746jSsHV4iwy5Yc/qz8g/0YktiMgYjU6aU5jFtX0vaVVS7MRJWMnOAFg5JcJyg3KqgyYXSe5GKA==
   dependencies:
     lodash "^4.17.21"
 
-"@ogre-tools/injectable-react@1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@ogre-tools/injectable-react/-/injectable-react-1.5.2.tgz#7df925ca5abda86210f527333774ddbf027f0693"
-  integrity sha512-n26NyGLYjwyIbfwsLj1tg0uNPK6SI/H0vGisMNpNfrcdci2QiLQBSKemnLMMRn7LF/+JhA/NQClTetiMkcSCuw==
+"@ogre-tools/injectable-react@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ogre-tools/injectable-react/-/injectable-react-2.0.0.tgz#4a0990426dba0485d6c71e9693ba8882aa42a5d0"
+  integrity sha512-yhYi7jhhi2CitO07xVPHOWBCOESmTgmGcSILWoY6IPjoKdzl88PqMkTem8kO+k6YO3sTQQexEQcCi9NEmR9hOg==
   dependencies:
-    "@ogre-tools/fp" "^1.4.0"
-    "@ogre-tools/injectable" "^1.5.0"
+    "@ogre-tools/fp" "^2.0.0"
+    "@ogre-tools/injectable" "^2.0.0"
     lodash "^4.17.21"
 
-"@ogre-tools/injectable@1.5.0", "@ogre-tools/injectable@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@ogre-tools/injectable/-/injectable-1.5.0.tgz#edf911f360e73bb5f10ac669f147108d1465fc45"
-  integrity sha512-k0Wgc8QqB+p/gHcWPVWJV8N8xX5cMpagEjZ1C5bPVeRyB+73od/yHgb1HOgL2pPzlE6qOtTdkiUrWuTAoqnqUw==
+"@ogre-tools/injectable@2.0.0", "@ogre-tools/injectable@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ogre-tools/injectable/-/injectable-2.0.0.tgz#16e6255062443ae8aca9a2d149c5b591533b63a8"
+  integrity sha512-9R8J9vJp/obaKKTGSDiJ+PTodJtZ2JCUdzGexL2lQK4s/xvVTjpBhCgQZVCG87uA/6d0oB6rxov/Dkv001rwCw==
   dependencies:
-    "@ogre-tools/fp" "^1.4.0"
+    "@ogre-tools/fp" "^2.0.0"
     lodash "^4.17.21"
 
 "@panva/asn1.js@^1.0.0":


### PR DESCRIPTION
# Simplifications:

1. Type parameters are inferred instead of explicit by using `getInjectable`.
2. Boilerplate function `getDependencies` is removed. There is only `instantiate`.
3. `instantiate` can be async.
4. `Dependencies` -type does not need to be exported.