### PR TITLE
Removing JS adding #terminal-init so that unit tests don't have global state

### DIFF
--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -91,6 +91,15 @@ html, body {
   overflow: hidden;
 }
 
+#terminal-init {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 0;
+  visibility: hidden;
+  overflow: hidden;
+}
+
 #app {
   height: 100%;
   min-height: 100%;

--- a/src/renderer/components/dock/terminal.ts
+++ b/src/renderer/components/dock/terminal.ts
@@ -34,17 +34,9 @@ import { clipboard } from "electron";
 import logger from "../../../common/logger";
 
 export class Terminal {
-  public static readonly spawningPool = (() => {
-    // terminal element must be in DOM before attaching via xterm.open(elem)
-    // https://xtermjs.org/docs/api/terminal/classes/terminal/#open
-    const pool = document.createElement("div");
-
-    pool.className = "terminal-init";
-    pool.style.cssText = "position: absolute; top: 0; left: 0; height: 0; visibility: hidden; overflow: hidden";
-    document.body.appendChild(pool);
-
-    return pool;
-  })();
+  public static get spawningPool() {
+    return document.getElementById("terminal-init");
+  }
 
   static async preloadFonts() {
     const fontPath = require("../fonts/roboto-mono-nerd.ttf").default; // eslint-disable-line @typescript-eslint/no-var-requires

--- a/src/renderer/template.html
+++ b/src/renderer/template.html
@@ -6,6 +6,7 @@
 <body>
 
 <div id="app"></div>
+<div id="terminal-init"></div>
 
 </body>
 </html>


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>