### PR TITLE
replacing the deprecated substr() with slice()

### DIFF
--- a/src/common/k8s-api/endpoints/crd.api.ts
+++ b/src/common/k8s-api/endpoints/crd.api.ts
@@ -140,7 +140,7 @@ export class CustomResourceDefinition extends KubeObject {
   getResourceTitle() {
     const name = this.getPluralName();
 
-    return name[0].toUpperCase() + name.substr(1);
+    return name[0].toUpperCase() + name.slice(1);
   }
 
   getGroup() {

--- a/src/common/utils/getRandId.ts
+++ b/src/common/utils/getRandId.ts
@@ -22,7 +22,7 @@
 // Create random system name
 
 export function getRandId({ prefix = "", suffix = "", sep = "_" } = {}) {
-  const randId = () => Math.random().toString(16).substr(2);
+  const randId = () => Math.random().toString(16).slice(2);
 
   return [prefix, randId(), suffix].filter(s => s).join(sep);
 }


### PR DESCRIPTION
Fixes #4683 

**Description of changes:**
- using slice() instead of substr()