### PR TITLE
fix inputs not blurring when pressing enter

### DIFF
--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -56,7 +56,6 @@ export class EditableList<T> extends React.Component<Props<T>> {
     if (val) {
       evt.preventDefault();
       this.props.add(val);
-      evt.stopPropagation();
     }
   }
 

--- a/src/renderer/components/editable-list/editable-list.tsx
+++ b/src/renderer/components/editable-list/editable-list.tsx
@@ -56,6 +56,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
     if (val) {
       evt.preventDefault();
       this.props.add(val);
+      evt.stopPropagation();
     }
   }
 
@@ -70,6 +71,7 @@ export class EditableList<T> extends React.Component<Props<T>> {
             onSubmit={this.onSubmit}
             validators={validators}
             placeholder={placeholder}
+            blurOnEnter={false}
             iconRight={({ isDirty }) => isDirty ? <Icon material="keyboard_return" size={16} /> : null}
           />
         </div>

--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -68,6 +68,7 @@ export type InputProps = Omit<InputElementProps, "onChange" | "onSubmit"> & {
   iconRight?: IconData;
   contentRight?: string | React.ReactNode; // Any component of string goes after iconRight
   validators?: InputValidator | InputValidator[];
+  blurOnEnter?: boolean;
   onChange?(value: string, evt: React.ChangeEvent<InputElement>): void;
   onSubmit?(value: string, evt: React.KeyboardEvent<InputElement>): void;
 };
@@ -86,6 +87,7 @@ const defaultProps: Partial<InputProps> = {
   maxRows: 10000,
   showValidationLine: true,
   validators: [],
+  blurOnEnter: true,
 };
 
 export class Input extends React.Component<InputProps, State> {
@@ -284,8 +286,10 @@ export class Input extends React.Component<InputProps, State> {
         this.setDirty();
       }
 
-      //pressing enter indicates that the edit is complete, we can unfocus now
-      this.blur();
+      if(this.props.blurOnEnter){
+        //pressing enter indicates that the edit is complete, we can unfocus now
+        this.blur();
+      }
     }
   }
 

--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -283,6 +283,9 @@ export class Input extends React.Component<InputProps, State> {
       } else {
         this.setDirty();
       }
+
+      //pressing enter indicates that the edit is complete, we can unfocus now
+      this.blur();
     }
   }
 

--- a/src/renderer/components/wizard/wizard.tsx
+++ b/src/renderer/components/wizard/wizard.tsx
@@ -26,6 +26,7 @@ import { Button } from "../button";
 import { Stepper } from "../stepper";
 import { SubTitle } from "../layout/sub-title";
 import { Spinner } from "../spinner";
+import { debounce } from "lodash";
 
 interface WizardCommonProps<D = any> {
   data?: Partial<D>;
@@ -195,14 +196,16 @@ export class WizardStep extends React.Component<WizardStepProps, WizardStepState
     }
   };
 
-  submit = () => {
+  //because submit MIGHT be called through pressing enter, it might be fired twice.
+  //we'll debounce it to ensure it isn't
+  submit = debounce(() => {
     if (!this.form.noValidate) {
       const valid = this.form.checkValidity();
 
       if (!valid) return;
     }
     this.next();
-  };
+  }, 100);
 
   renderLoading() {
     return (
@@ -210,6 +213,17 @@ export class WizardStep extends React.Component<WizardStepProps, WizardStepState
         <Spinner/>
       </div>
     );
+  }
+
+  //make sure we call submit if the "enter" keypress doesn't trigger the events
+  keyDown(evt: React.KeyboardEvent<HTMLElement>) {
+    if (evt.shiftKey || evt.metaKey || evt.altKey || evt.ctrlKey || evt.repeat) {
+      return;
+    }
+
+    if(evt.key === "Enter"){
+      this.submit();
+    }
   }
 
   render() {
@@ -232,6 +246,7 @@ export class WizardStep extends React.Component<WizardStepProps, WizardStepState
     return (
       <form className={className}
         onSubmit={prevDefault(this.submit)} noValidate={noValidate}
+        onKeyDown={(evt) => this.keyDown(evt)}
         ref={e => this.form = e}>
         {beforeContent}
         <div className={contentClass}>


### PR DESCRIPTION
Fixes #4669.

This fix/feature causes inputs to blur (causing the onChange event to be triggered) once the Enter key is pressed. As of now, the user has to manually click outside of the active input in order to save the value.