### PR TITLE
Support extending KubernetesCluster in extensions

### DIFF
--- a/docs/extensions/guides/README.md
+++ b/docs/extensions/guides/README.md
@@ -20,6 +20,7 @@ Each guide or code sample includes the following:
 | [Main process extension](main-extension.md) | Main.LensExtension |
 | [Renderer process extension](renderer-extension.md) | Renderer.LensExtension |
 | [Resource stack (cluster feature)](resource-stack.md) | |
+| [Extending KubernetesCluster)](extending-kubernetes-cluster.md) | |
 | [Stores](stores.md) | |
 | [Components](components.md) | |
 | [KubeObjectListLayout](kube-object-list-layout.md) | |

--- a/docs/extensions/guides/extending-kubernetes-cluster.md
+++ b/docs/extensions/guides/extending-kubernetes-cluster.md
@@ -1,0 +1,69 @@
+# Extending KubernetesCluster
+
+Extension can specify it's own subclass of Common.Catalog.KubernetesCluster. Extension can also specify a new Category for it in the Catalog.
+
+## Extending Common.Catalog.KubernetesCluster
+
+``` typescript
+import { Common } from "@k8slens/extensions";
+
+// The kind must be different from KubernetesCluster's kind
+export const kind = "ManagedDevCluster";
+
+export class ManagedDevCluster extends Common.Catalog.KubernetesCluster {
+  public static readonly kind = kind;
+
+  public readonly kind = kind;
+}
+```
+
+## Extending Common.Catalog.CatalogCategory
+
+These custom Catalog entities can be added a new Category in the Catalog.
+
+``` typescript
+import { Common } from "@k8slens/extensions";
+import { kind, ManagedDevCluster } from "../entities/ManagedDevCluster";
+
+class ManagedDevClusterCategory extends Common.Catalog.CatalogCategory {
+  public readonly apiVersion = "catalog.k8slens.dev/v1alpha1";
+  public readonly kind = "CatalogCategory";
+  public metadata = {
+    name: "Managed Dev Clusters",
+    icon: ""
+  };
+  public spec: Common.Catalog.CatalogCategorySpec = {
+    group: "entity.k8slens.dev",
+    versions: [
+      {
+        name: "v1alpha1",
+        entityClass: ManagedDevCluster as any,
+      },
+    ],
+    names: {
+      kind
+    },
+  };
+}
+
+export { ManagedDevClusterCategory };
+export type { ManagedDevClusterCategory as ManagedDevClusterCategoryType };
+```
+
+The category needs to be registered in the `onActivate()` method both in main and renderer
+
+``` typescript
+// in main's on onActivate
+Main.Catalog.catalogCategories.add(new ManagedDevClusterCategory());
+```
+
+``` typescript
+// in renderer's on onActivate
+Renderer.Catalog.catalogCategories.add(new ManagedDevClusterCategory());
+```
+
+You can then add the entities to the Catalog as a new source:
+
+``` typescript
+this.addCatalogSource("managedDevClusters", this.managedDevClusters);
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Renderer Extension: extensions/guides/renderer-extension.md
     - Catalog: extensions/guides/catalog.md
     - Resource Stack: extensions/guides/resource-stack.md
+    - Extending KubernetesCluster: extensions/guides/extending-kubernetes-cluster.md
     - Stores: extensions/guides/stores.md
     - Working with MobX: extensions/guides/working-with-mobx.md
     - Protocol Handlers: extensions/guides/protocol-handlers.md

--- a/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/src/common/catalog-entities/kubernetes-cluster.ts
@@ -59,7 +59,7 @@ export interface KubernetesClusterStatus extends CatalogEntityStatus {
 }
 
 export class KubernetesCluster extends CatalogEntity<KubernetesClusterMetadata, KubernetesClusterStatus, KubernetesClusterSpec> {
-  public static readonly apiVersion = "entity.k8slens.dev/v1alpha1";
+  public static readonly apiVersion: string = "entity.k8slens.dev/v1alpha1";
   public static readonly kind: string = "KubernetesCluster";
 
   public readonly apiVersion = KubernetesCluster.apiVersion;

--- a/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/src/common/catalog-entities/kubernetes-cluster.ts
@@ -60,7 +60,7 @@ export interface KubernetesClusterStatus extends CatalogEntityStatus {
 
 export class KubernetesCluster extends CatalogEntity<KubernetesClusterMetadata, KubernetesClusterStatus, KubernetesClusterSpec> {
   public static readonly apiVersion = "entity.k8slens.dev/v1alpha1";
-  public static readonly kind = "KubernetesCluster";
+  public static readonly kind: string = "KubernetesCluster";
 
   public readonly apiVersion = KubernetesCluster.apiVersion;
   public readonly kind = KubernetesCluster.kind;

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -270,7 +270,7 @@ export class ExtensionLoader {
     });
   };
 
-  loadOnClusterRenderer(getCluster: () => KubernetesCluster) {
+  loadOnClusterRenderer = (getCluster: () => KubernetesCluster) => {
     logger.debug(`${logModule}: load on cluster renderer (dashboard)`);
 
     this.autoInitExtensions(async (extension: LensRendererExtension) => {
@@ -298,7 +298,7 @@ export class ExtensionLoader {
 
       return removeItems;
     });
-  }
+  };
 
   protected async loadExtensions(installedExtensions: Map<string, InstalledExtension>, register: (ext: LensExtension) => Promise<Disposer[]>) {
     // Steps of the function:
@@ -364,13 +364,13 @@ export class ExtensionLoader {
     });
   }
 
-  protected autoInitExtensions = (register: (ext: LensExtension) => Promise<Disposer[]>) => {
+  protected autoInitExtensions(register: (ext: LensExtension) => Promise<Disposer[]>) {
     // Setup reaction to load extensions on JSON changes
     reaction(() => this.toJSON(), installedExtensions => this.loadExtensions(installedExtensions, register));
 
     // Load initial extensions
     return this.loadExtensions(this.toJSON(), register);
-  };
+  }
 
   protected requireExtension(extension: InstalledExtension): LensExtensionConstructor | null {
     const entryPointName = ipcRenderer ? "renderer" : "main";

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -270,11 +270,12 @@ export class ExtensionLoader {
     });
   };
 
-  loadOnClusterRenderer = (entity: KubernetesCluster) => {
+  loadOnClusterRenderer(getCluster: () => KubernetesCluster) {
     logger.debug(`${logModule}: load on cluster renderer (dashboard)`);
 
     this.autoInitExtensions(async (extension: LensRendererExtension) => {
-      if ((await extension.isEnabledForCluster(entity)) === false) {
+      // getCluster must be a callback, as the entity might be available only after an extension has been loaded
+      if ((await extension.isEnabledForCluster(getCluster())) === false) {
         return [];
       }
 

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -364,7 +364,7 @@ export class ExtensionLoader {
     });
   }
 
-  protected autoInitExtensions(register: (ext: LensExtension) => Promise<Disposer[]>) {
+  protected autoInitExtensions = (register: (ext: LensExtension) => Promise<Disposer[]>) => {
     // Setup reaction to load extensions on JSON changes
     reaction(() => this.toJSON(), installedExtensions => this.loadExtensions(installedExtensions, register));
 

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -298,7 +298,7 @@ export class ExtensionLoader {
 
       return removeItems;
     });
-  };
+  }
 
   protected autoInitExtensions(register: (ext: LensExtension) => Promise<Disposer[]>) {
     const loadingExtensions: ExtensionLoading[] = [];

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -331,7 +331,7 @@ export class ExtensionLoader {
               extId,
               instance,
               isBundled: extension.isBundled,
-              activated: instance.activate()
+              activated: instance.activate(),
             };
           } catch (err) {
             logger.error(`${logModule}: activation extension error`, { ext: extension, err });
@@ -370,7 +370,7 @@ export class ExtensionLoader {
 
     // Load initial extensions
     return this.loadExtensions(this.toJSON(), register);
-  }
+  };
 
   protected requireExtension(extension: InstalledExtension): LensExtensionConstructor | null {
     const entryPointName = ipcRenderer ? "renderer" : "main";

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -309,7 +309,6 @@ export class ExtensionLoader {
 
     const extensions = [...installedExtensions.entries()]
       .map(([extId, extension]) => {
-        // for (const [extId, extension] of installedExtensions) {
         const alreadyInit = this.instances.has(extId) || this.nonInstancesByName.has(extension.manifest.name);
 
         if (extension.isCompatible && extension.isEnabled && !alreadyInit) {

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -86,7 +86,6 @@ export class LensExtension {
     }
 
     try {
-      await this.onActivate();
       this._isEnabled = true;
 
       this[Disposers].push(...await register(this));
@@ -111,6 +110,11 @@ export class LensExtension {
     } catch (error) {
       logger.error(`[EXTENSION]: disabling ${this.name}@${this.version} threw an error: ${error}`);
     }
+  }
+
+  @action
+  activate() {
+    return this.onActivate();
   }
 
   protected onActivate(): Promise<void> | void {

--- a/src/main/catalog/catalog-entity-registry.ts
+++ b/src/main/catalog/catalog-entity-registry.ts
@@ -43,12 +43,8 @@ export class CatalogEntityRegistry {
     return this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind) as T[];
   }
 
-  getItemsOfType<T extends CatalogEntity>(Constructor: CatalogEntityConstructor<T>): T[] {
-    return this.items.filter((item) => item instanceof Constructor) as T[];
-  }
-
   getItemsByEntityClass<T extends CatalogEntity>(constructor: CatalogEntityConstructor<T>): T[] {
-    return this.getItemsOfType(constructor);
+    return this.items.filter((item) => item instanceof constructor) as T[];
   }
 }
 

--- a/src/main/catalog/catalog-entity-registry.ts
+++ b/src/main/catalog/catalog-entity-registry.ts
@@ -4,7 +4,7 @@
  */
 
 import { action, computed, IComputedValue, IObservableArray, makeObservable, observable } from "mobx";
-import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity, CatalogEntityConstructor, CatalogEntityKindData } from "../../common/catalog";
+import { CatalogCategoryRegistry, catalogCategoryRegistry, CatalogEntity, CatalogEntityConstructor } from "../../common/catalog";
 import { iter } from "../../common/utils";
 
 export class CatalogEntityRegistry {
@@ -43,8 +43,12 @@ export class CatalogEntityRegistry {
     return this.items.filter((item) => item.apiVersion === apiVersion && item.kind === kind) as T[];
   }
 
-  getItemsByEntityClass<T extends CatalogEntity>({ apiVersion, kind }: CatalogEntityKindData & CatalogEntityConstructor<T>): T[] {
-    return this.getItemsForApiKind(apiVersion, kind);
+  getItemsOfType<T extends CatalogEntity>(Constructor: CatalogEntityConstructor<T>): T[] {
+    return this.items.filter((item) => item instanceof Constructor) as T[];
+  }
+
+  getItemsByEntityClass<T extends CatalogEntity>(constructor: CatalogEntityConstructor<T>): T[] {
+    return this.getItemsOfType(constructor);
   }
 }
 

--- a/src/renderer/api/catalog-entity-registry.ts
+++ b/src/renderer/api/catalog-entity-registry.ts
@@ -47,8 +47,23 @@ export class CatalogEntityRegistry {
     makeObservable(this);
   }
 
-  get activeEntity(): CatalogEntity | null {
+  protected getActiveEntityById() {
     return this._entities.get(this.activeEntityId) || null;
+  }
+
+  get activeEntity(): CatalogEntity | null {
+    const entity = this.getActiveEntityById();
+
+    // If the entity was not found but there are rawEntities to be processed,
+    // try to process them and return the entity.
+    // This might happen if an extension registered a new Catalog category.
+    if (this.activeEntityId && !entity && this.rawEntities.length > 0) {
+      this.processRawEntities();
+
+      return this.getActiveEntityById();
+    }
+
+    return entity;
   }
 
   set activeEntity(raw: CatalogEntity | string | null) {

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
@@ -13,11 +13,9 @@ import clusterFrameContextInjectable from "../../../cluster-frame-context/cluste
 
 const initClusterFrameInjectable = getInjectable({
   instantiate: (di) => {
-    const extensionLoader = di.inject(extensionLoaderInjectable);
-
     return initClusterFrame({
       hostedCluster: di.inject(hostedClusterInjectable),
-      loadExtensions: extensionLoader.loadOnClusterRenderer.bind(extensionLoader),
+      loadExtensions: di.inject(extensionLoaderInjectable).loadOnClusterRenderer,
       catalogEntityRegistry: di.inject(catalogEntityRegistryInjectable),
       frameRoutingId: di.inject(frameRoutingIdInjectable),
       emitEvent: di.inject(appEventBusInjectable).emit,

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
@@ -12,8 +12,8 @@ import appEventBusInjectable from "../../../../common/app-event-bus/app-event-bu
 import clusterFrameContextInjectable from "../../../cluster-frame-context/cluster-frame-context.injectable";
 
 const initClusterFrameInjectable = getInjectable({
-  instantiate: (di) => {
-    return initClusterFrame({
+  instantiate: (di) =>
+    initClusterFrame({
       hostedCluster: di.inject(hostedClusterInjectable),
       loadExtensions: di.inject(extensionLoaderInjectable).loadOnClusterRenderer,
       catalogEntityRegistry: di.inject(catalogEntityRegistryInjectable),
@@ -21,8 +21,7 @@ const initClusterFrameInjectable = getInjectable({
       emitEvent: di.inject(appEventBusInjectable).emit,
 
       clusterFrameContext: di.inject(clusterFrameContextInjectable),
-    });
-  },
+    }),
 
   lifecycle: lifecycleEnum.singleton,
 });

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
@@ -12,16 +12,19 @@ import appEventBusInjectable from "../../../../common/app-event-bus/app-event-bu
 import clusterFrameContextInjectable from "../../../cluster-frame-context/cluster-frame-context.injectable";
 
 const initClusterFrameInjectable = getInjectable({
-  instantiate: (di) =>
-    initClusterFrame({
+  instantiate: (di) => {
+    const extensionLoader = di.inject(extensionLoaderInjectable);
+
+    return initClusterFrame({
       hostedCluster: di.inject(hostedClusterInjectable),
-      loadExtensions: di.inject(extensionLoaderInjectable).loadOnClusterRenderer,
+      loadExtensions: extensionLoader.loadOnClusterRenderer.bind(extensionLoader),
       catalogEntityRegistry: di.inject(catalogEntityRegistryInjectable),
       frameRoutingId: di.inject(frameRoutingIdInjectable),
       emitEvent: di.inject(appEventBusInjectable).emit,
 
       clusterFrameContext: di.inject(clusterFrameContextInjectable),
-    }),
+    });
+  },
 
   lifecycle: lifecycleEnum.singleton,
 });

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -47,9 +47,9 @@ export const initClusterFrame =
 
       catalogEntityRegistry.activeEntity = hostedCluster.id;
 
-      // Only load the extensions once the catalog has been populated
+      // Only load the extensions once the catalog has been populated.
+      // Note that the Catalog might still have unprocessed entities until the extensions are fully loaded.
       when(
-        // watch for .items, as .activeEntity might be populated only after extensions are loaded (if using custom Catalog Category)
         () => catalogEntityRegistry.items.length > 0,
         () =>
           loadExtensions(() => catalogEntityRegistry.activeEntity as KubernetesCluster),

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -19,7 +19,7 @@ import { KubeObjectStore } from "../../../../common/k8s-api/kube-object.store";
 
 interface Dependencies {
   hostedCluster: Cluster;
-  loadExtensions: (entity: CatalogEntity) => void;
+  loadExtensions: (getCluster: () => CatalogEntity) => void;
   catalogEntityRegistry: CatalogEntityRegistry;
   frameRoutingId: number;
   emitEvent: (event: AppEvent) => void;
@@ -52,7 +52,7 @@ export const initClusterFrame =
         // watch for .items, as .activeEntity might be populated only after extensions are loaded (if using custom Catalog Category)
         () => catalogEntityRegistry.items.length > 0,
         () =>
-          loadExtensions(catalogEntityRegistry.activeEntity as KubernetesCluster),
+          loadExtensions(() => catalogEntityRegistry.activeEntity as KubernetesCluster),
         {
           timeout: 15_000,
           onError: (error) => {

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -49,7 +49,8 @@ export const initClusterFrame =
 
       // Only load the extensions once the catalog has been populated
       when(
-        () => Boolean(catalogEntityRegistry.activeEntity),
+        // watch for .items, as .activeEntity might be populated only after extensions are loaded (if using custom Catalog Category)
+        () => catalogEntityRegistry.items.length > 0,
         () =>
           loadExtensions(catalogEntityRegistry.activeEntity as KubernetesCluster),
         {

--- a/src/renderer/frames/root-frame/init-root-frame/init-root-frame.ts
+++ b/src/renderer/frames/root-frame/init-root-frame/init-root-frame.ts
@@ -11,15 +11,15 @@ import type { ExtensionLoading } from "../../../../extensions/extension-loader";
 import type { CatalogEntityRegistry } from "../../../api/catalog-entity-registry";
 
 interface Dependencies {
-  loadExtensions: () => ExtensionLoading[]
+  loadExtensions: () => Promise<ExtensionLoading[]>;
 
   // TODO: Move usages of third party library behind abstraction
-  ipcRenderer: { send: (name: string) => void }
+  ipcRenderer: { send: (name: string) => void };
 
   // TODO: Remove dependencies being here only for correct timing of initialization
   bindProtocolAddRouteHandlers: () => void;
   lensProtocolRouterRenderer: { init: () => void };
-  catalogEntityRegistry: CatalogEntityRegistry
+  catalogEntityRegistry: CatalogEntityRegistry;
 }
 
 const logPrefix = "[ROOT-FRAME]:";
@@ -40,7 +40,7 @@ export const initRootFrame =
       // maximum time to let bundled extensions finish loading
         const timeout = delay(10000);
 
-        const loadingExtensions = loadExtensions();
+        const loadingExtensions = await loadExtensions();
 
         const loadingBundledExtensions = loadingExtensions
           .filter((e) => e.isBundled)


### PR DESCRIPTION
This PR allows extension to specify a new KubernetesCluster by extending it.

Example use in extension:
```ts
const kind = "ManagedDevCluster";

export class ManagedDevCluster extends Common.Catalog.KubernetesCluster {
  public static readonly kind = kind;

  public readonly kind = kind;
}
```

This is required for an extension to add a new category to the catalog for specific type of cluster.

Three issues are fixed:
* the`kind` of `KubernetesCluster` is typed `string` so that the child class can change it
* `getItemsByEntityClass` is changed to use `instanceof` instead of `apiVersion`/`kind`. This way the child class (e.g. `ManagedDevCluster`)  will be true for `instanceof KubernetesCluster`, and Lens has hardcoded using `KubernetesCluster` in a few places.
* A `when` is changed to use  `catalogEntityRegistry.items` to check for "catalog has been populated". `.activeEntity` doesn't work, since that depends on extension being loaded (which will add the custom category to the catalog)
* Refactor `autoInitExtensions` to be async and return the array properly