### PR TITLE
Convert CloseButton styles out from css modules

### DIFF
--- a/src/renderer/components/layout/close-button.scss
+++ b/src/renderer/components/layout/close-button.scss
@@ -20,25 +20,27 @@
  */
 
 .SettingsCloseButton {
-  width: 35px;
-  height: 35px;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  border: 2px solid var(--textColorDimmed);
-  border-radius: 50%;
+  .closeIcon {
+    width: 35px;
+    height: 35px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    border: 2px solid var(--textColorDimmed);
+    border-radius: 50%;
 
-  &:hover {
-    background-color: #72767d25;
-  }
+    &:hover {
+      background-color: #72767d25;
+    }
 
-  &:active {
-    transform: translateY(1px);
-  }
+    &:active {
+      transform: translateY(1px);
+    }
 
-  .Icon {
-    color: var(--textColorAccent);
-    opacity: 0.6;
+    .Icon {
+      color: var(--textColorAccent);
+      opacity: 0.6;
+    }
   }
 
   .escLabel {

--- a/src/renderer/components/layout/close-button.scss
+++ b/src/renderer/components/layout/close-button.scss
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-.closeButton {
+.SettingsCloseButton {
   width: 35px;
   height: 35px;
   display: grid;
@@ -35,18 +35,18 @@
   &:active {
     transform: translateY(1px);
   }
-}
 
-.icon {
-  color: var(--textColorAccent);
-  opacity: 0.6;
-}
+  .Icon {
+    color: var(--textColorAccent);
+    opacity: 0.6;
+  }
 
-.esc {
-  text-align: center;
-  margin-top: var(--margin);
-  font-weight: bold;
-  user-select: none;
-  color: var(--textColorDimmed);
-  pointer-events: none;
+  .escLabel {
+    text-align: center;
+    margin-top: var(--margin);
+    font-weight: bold;
+    user-select: none;
+    color: var(--textColorDimmed);
+    pointer-events: none;
+  }
 }

--- a/src/renderer/components/layout/close-button.tsx
+++ b/src/renderer/components/layout/close-button.tsx
@@ -29,8 +29,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 export function CloseButton(props: Props) {
   return (
-    <div {...props}>
-      <div className="SettingsCloseButton" role="button" aria-label="Close">
+    <div className="SettingsCloseButton" {...props}>
+      <div className="closeIcon" role="button" aria-label="Close">
         <Icon material="close" />
       </div>
       <div className="escLabel" aria-hidden="true">

--- a/src/renderer/components/layout/close-button.tsx
+++ b/src/renderer/components/layout/close-button.tsx
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import styles from "./close-button.module.scss";
+import "./close-button.scss";
 
 import React, { HTMLAttributes } from "react";
 import { Icon } from "../icon";
@@ -30,10 +30,10 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 export function CloseButton(props: Props) {
   return (
     <div {...props}>
-      <div className={styles.closeButton} role="button" aria-label="Close">
-        <Icon material="close" className={styles.icon}/>
+      <div className="SettingsCloseButton" role="button" aria-label="Close">
+        <Icon material="close" />
       </div>
-      <div className={styles.esc} aria-hidden="true">
+      <div className="escLabel" aria-hidden="true">
         ESC
       </div>
     </div>


### PR DESCRIPTION
Extensions webpack config doesn't allow to export components using scss modules for styling.

This PR converts styles to "regular" scss instead of scss modules as a workaround. 

<img width="1044" alt="esc button" src="https://user-images.githubusercontent.com/9607060/150196452-8e175644-b7b3-47c5-8d6f-04e0d1bd2da1.png">


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>