### PR TITLE
Fix race condition with extension loading.

### DIFF
--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -325,6 +325,8 @@ export class ExtensionLoader {
               extension,
             );
 
+            this.instances.set(extId, instance);
+
             return {
               extId,
               instance,
@@ -352,8 +354,6 @@ export class ExtensionLoader {
       const loaded = extension.instance.enable(register).catch((err) => {
         logger.error(`${logModule}: failed to enable`, { ext: extension, err });
       });
-
-      this.instances.set(extension.extId, extension.instance);
 
       return {
         isBundled: extension.isBundled,


### PR DESCRIPTION
Regression from https://github.com/lensapp/lens/pull/4702.

If `loadExtensions` is called multiple times before an extension is activated, `this.instances.set(extId, instance);` was not called fast enough, which caused the extension to be activated multiple times.