### PR TITLE
Fix: keep ItemListLayout scrollable with custom catalog category views

### DIFF
--- a/src/renderer/components/+catalog/catalog.module.scss
+++ b/src/renderer/components/+catalog/catalog.module.scss
@@ -12,6 +12,8 @@
   :global(.TableRow):hover .pinIcon {
     opacity: 1;
   }
+
+  flex-grow: 1;
 }
 
 .entityName {
@@ -127,4 +129,11 @@
 
 .catalogAvatar {
   font-size: 1.2ch;
+}
+
+.views {
+  padding: calc(var(--padding) * 2);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }

--- a/src/renderer/components/+catalog/catalog.tsx
+++ b/src/renderer/components/+catalog/catalog.tsx
@@ -282,7 +282,7 @@ class NonInjectedCatalog extends React.Component<Props & Dependencies> {
 
     return (
       <MainLayout sidebar={this.renderNavigation()}>
-        <div className="p-6 h-full">
+        <div className={styles.views}>
           {this.renderViews()}
         </div>
         {

--- a/src/renderer/components/layout/main-layout.module.scss
+++ b/src/renderer/components/layout/main-layout.module.scss
@@ -25,6 +25,7 @@
 .contents {
   grid-area: contents;
   overflow: auto;
+  height: calc(100vh - var(--bottom-bar-height) - var(--main-layout-header));
 }
 
 .footer {


### PR DESCRIPTION
When custom category views added using #4733 whole content view started to be scrollable (which is bad). Current PR fixes styles allowing list area to shrink until some minimal height while keeping it scrollable.

The problem:
![unnecessary content scroll](https://user-images.githubusercontent.com/9607060/150793003-566f03ac-d594-43c2-b1d6-14a0b9629656.png)


The fix:


https://user-images.githubusercontent.com/9607060/150793422-db124c33-4de5-4b1c-aeeb-2d742b8f0f1e.mov


Fixes #4735 

**Note** It's better to set `max-height` property on any of custom views if they should have fixed height. Otherwise, they will have flex height adapting viewport one.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>