### PR TITLE
Export missing k8s api types for extensions

### DIFF
--- a/src/extensions/main-api/k8s-api.ts
+++ b/src/extensions/main-api/k8s-api.ts
@@ -43,3 +43,5 @@ export { CustomResourceDefinition, crdApi } from "../../common/k8s-api/endpoints
 export type { ILocalKubeApiConfig, IRemoteKubeApiConfig, IKubeApiCluster } from "../../common/k8s-api/kube-api";
 export type { IPodContainer, IPodContainerStatus } from "../../common/k8s-api/endpoints/pods.api";
 export type { ISecretRef } from "../../common/k8s-api/endpoints/secret.api";
+export type { KubeObjectMetadata, KubeStatusData } from "../../common/k8s-api/kube-object";
+export type { KubeObjectStoreLoadAllParams, KubeObjectStoreLoadingParams, KubeObjectStoreSubscribeParams } from "../../common/k8s-api/kube-object.store";

--- a/src/extensions/renderer-api/k8s-api.ts
+++ b/src/extensions/renderer-api/k8s-api.ts
@@ -46,6 +46,8 @@ export type { ILocalKubeApiConfig, IRemoteKubeApiConfig, IKubeApiCluster } from 
 export type { IPodContainer, IPodContainerStatus } from "../../common/k8s-api/endpoints";
 export type { ISecretRef } from "../../common/k8s-api/endpoints";
 export type { KubeObjectStatus } from "./kube-object-status";
+export type { KubeObjectMetadata, KubeStatusData } from "../../common/k8s-api/kube-object";
+export type { KubeObjectStoreLoadAllParams, KubeObjectStoreLoadingParams, KubeObjectStoreSubscribeParams } from "../../common/k8s-api/kube-object.store";
 
 // stores
 export type { EventStore } from "../../renderer/components/+events/event.store";


### PR DESCRIPTION
Imho these should have been exported from the start.