### PR TITLE
Allow users of KubeObjectListLayout to override all props of ItemListLayout

### DIFF
--- a/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
@@ -104,7 +104,6 @@ class NonInjectedKubeObjectListLayout<K extends KubeObject> extends React.Compon
 
     return (
       <ItemListLayout
-        {...layoutProps}
         className={cssNames("KubeObjectListLayout", className)}
         store={store}
         items={items}
@@ -133,6 +132,7 @@ class NonInjectedKubeObjectListLayout<K extends KubeObject> extends React.Compon
           ...[customizeHeader].flat(),
         ]}
         renderItemMenu={item => <KubeObjectMenu object={item} />}
+        {...layoutProps}
       />
     );
   }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4748 