### PR TITLE
Fix: remove catalog first column padding

### DIFF
--- a/src/renderer/components/+catalog/catalog.module.scss
+++ b/src/renderer/components/+catalog/catalog.module.scss
@@ -4,11 +4,6 @@
  */
 
 .Catalog {
-  :global(.TableHead) .entityName {
-    /* offset for icon to align texts in the column */
-    padding-left: calc(21px + var(--padding) * 2.5);
-  }
-
   :global(.TableRow):hover .pinIcon {
     opacity: 1;
   }


### PR DESCRIPTION
Left padding on `.entityName` column shifted all other table head columns.

Before:
<img width="659" alt="shifted columns" src="https://user-images.githubusercontent.com/9607060/151330181-d8a5bf83-f2bf-4485-a712-166972b09f93.png">

After:
<img width="659" alt="fixed columns" src="https://user-images.githubusercontent.com/9607060/151330192-fd4ba955-5a21-4c70-b924-c23e5a2da5ff.png">


It's okay to have `Name` column above avatars.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>