### PR TITLE
Fix: do not pass blurOnEnter to html element

### DIFF
--- a/src/renderer/components/input/input.tsx
+++ b/src/renderer/components/input/input.tsx
@@ -353,6 +353,7 @@ export class Input extends React.Component<InputProps, State> {
       dirty: _dirty, // excluded from passing to input-element
       defaultValue,
       trim,
+      blurOnEnter,
       ...inputProps
     } = this.props;
     const { focused, dirty, valid, validating, errors } = this.state;


### PR DESCRIPTION
Fixing console.error

<img width="842" alt="blurOnEnter" src="https://user-images.githubusercontent.com/9607060/151337292-bb051f7f-b9a1-40cb-83ed-952891e3f715.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>