### PR TITLE
Fix item menus for several pages

### DIFF
--- a/src/renderer/components/+user-management/+service-accounts/view.tsx
+++ b/src/renderer/components/+user-management/+service-accounts/view.tsx
@@ -58,9 +58,6 @@ export class ServiceAccounts extends React.Component<Props> {
             account.getNs(),
             account.getAge(),
           ]}
-          renderItemMenu={(item: ServiceAccount) => {
-            return <ServiceAccountMenu object={item}/>;
-          }}
           addRemoveButtons={{
             onAdd: () => CreateServiceAccountDialog.open(),
             addTooltip: "Create new Service Account",

--- a/src/renderer/components/+workloads-cronjobs/cronjobs.tsx
+++ b/src/renderer/components/+workloads-cronjobs/cronjobs.tsx
@@ -82,9 +82,6 @@ export class CronJobs extends React.Component<Props> {
           cronJob.getLastScheduleTime(),
           cronJob.getAge(),
         ]}
-        renderItemMenu={(item: CronJob) => {
-          return <CronJobMenu object={item}/>;
-        }}
       />
     );
   }

--- a/src/renderer/components/+workloads-deployments/deployments.tsx
+++ b/src/renderer/components/+workloads-deployments/deployments.tsx
@@ -91,7 +91,6 @@ export class Deployments extends React.Component<Props> {
           deployment.getAge(),
           this.renderConditions(deployment),
         ]}
-        renderItemMenu={item => <DeploymentMenu object={item} />}
       />
     );
   }

--- a/src/renderer/components/+workloads-replicasets/replicasets.tsx
+++ b/src/renderer/components/+workloads-replicasets/replicasets.tsx
@@ -70,9 +70,6 @@ export class ReplicaSets extends React.Component<Props> {
           replicaSet.getReady(),
           replicaSet.getAge(),
         ]}
-        renderItemMenu={(item: ReplicaSet) => {
-          return <ReplicaSetMenu object={item}/>;
-        }}
       />
     );
   }

--- a/src/renderer/components/+workloads-statefulsets/statefulsets.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulsets.tsx
@@ -72,7 +72,6 @@ export class StatefulSets extends React.Component<Props> {
           <KubeObjectStatusIcon key="icon" object={statefulSet}/>,
           statefulSet.getAge(),
         ]}
-        renderItemMenu={item => <StatefulSetMenu object={item} />}
       />
     );
   }


### PR DESCRIPTION
- ServiceAccounts
- CronJobs
- Deployments
- ReplicaSets
- StatefulSets

Signed-off-by: Sebastian Malton <sebastian@malton.name>

These lines were previously being overridden so they have been broken from months, it just wasn't exercised until #4752 was merged.