### PR TITLE
Update Node.getRoleLabels() to work with kube 1.16's defaults

### DIFF
--- a/src/common/k8s-api/__tests__/nodes.test.ts
+++ b/src/common/k8s-api/__tests__/nodes.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { Node } from "../endpoints";
+
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+describe("Nodes tests", () => {
+  describe("getRoleLabels()", () => {
+    it("should return empty string if labels is not present", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("");
+    });
+
+    it("should return empty string if labels is empty object", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {},
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("");
+    });
+
+    it("should return rest of keys with substring node-role.kubernetes.io/", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {
+            "node-role.kubernetes.io/foobar": "bat",
+            "hellonode-role.kubernetes.io/foobar1": "bat",
+          },
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("foobar, foobar1");
+    });
+
+    it("should return rest of keys with substring node-role.kubernetes.io/ after last /", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {
+            "node-role.kubernetes.io/foobar": "bat",
+            "hellonode-role.kubernetes.io//////foobar1": "bat",
+          },
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("foobar, foobar1");
+    });
+
+    it("should return value of label kubernetes.io/role if present", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {
+            "kubernetes.io/role": "master",
+          },
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("master");
+    });
+
+    it("should return value of label node.kubernetes.io/role if present", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {
+            "node.kubernetes.io/role": "master",
+          },
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("master");
+    });
+
+    it("all sources should be joined together", () => {
+      const node = new Node({
+        apiVersion: "foo",
+        kind: "Node",
+        metadata: {
+          name: "bar",
+          resourceVersion: "1",
+          uid: "bat",
+          labels: {
+            "aksjhdkjahsdnode-role.kubernetes.io/foobar": "bat",
+            "kubernetes.io/role": "master",
+            "node.kubernetes.io/role": "master-v2-max",
+          },
+        },
+      });
+
+      expect(node.getRoleLabels()).toBe("foobar, master, master-v2-max");
+    });
+  });
+});


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4767 