### PR TITLE
Fix: increase catalog entity name col width

### DIFF
--- a/src/renderer/components/+catalog/catalog-tree.module.scss
+++ b/src/renderer/components/+catalog/catalog-tree.module.scss
@@ -22,6 +22,8 @@
 
 .content {
   min-height: 26px;
+  line-height: 1.3;
+  padding: 2px var(--padding) 2px 0;
 
   &:hover {
     background-color: var(--sidebarItemHoverBackground);
@@ -39,6 +41,8 @@
 
   .iconContainer {
     margin-left: 28px;
+    margin-top: 2px;
+    align-self: flex-start;
   }
 }
 

--- a/src/renderer/components/+catalog/catalog.module.scss
+++ b/src/renderer/components/+catalog/catalog.module.scss
@@ -20,6 +20,7 @@
   padding: 0 var(--padding);
   padding-bottom: 0;
   padding-right: 24px; // + reserved space for .pinIcon
+  flex-grow: 2.5!important;
 
   > span {
     overflow: hidden;

--- a/src/renderer/components/table/table-head.scss
+++ b/src/renderer/components/table/table-head.scss
@@ -4,7 +4,7 @@
  */
 
 .TableHead {
-  $border: 1px solid var(--layoutBackground);
+  $border: 1px solid var(--tableHeaderBorderColor);
 
   background-color: var(--tableHeaderBackground);
   border-bottom-width: var(--tableHeaderBorderWidth);


### PR DESCRIPTION
1. Increase catalog entity name column width to see more of it (temporary solution before we have table with adjustable columns).
2. Fixes catalog navigation paddings. Before:
![broken paddings](https://user-images.githubusercontent.com/9607060/151800549-c35c7035-16ae-465c-990d-66f77871a5e2.png)
3. Adjust table border.

![bigger name column](https://user-images.githubusercontent.com/9607060/151800427-71f62839-1d25-406d-b936-96f77c94836e.png)

Fixes https://github.com/lensapp/lenscloud-lens-extension/issues/1235