### PR TITLE
Disable native window open

### DIFF
--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -74,7 +74,7 @@ export class WindowManager extends Singleton {
           nodeIntegrationInSubFrames: true,
           webviewTag: true,
           contextIsolation: false,
-          nativeWindowOpen: true,
+          nativeWindowOpen: false,
         },
       });
       this.windowState.manage(this.mainWindow);


### PR DESCRIPTION
Signed-off-by: Juho Heikka <juho.heikka@gmail.com>

Fixes a regression with Electron v14 update that broke Spaces extension `webview` `new-window` event handling 