### PR TITLE
Fix quota entries layout in Add Resource Quota dialog

### DIFF
--- a/src/renderer/components/+config-resource-quotas/add-quota-dialog.scss
+++ b/src/renderer/components/+config-resource-quotas/add-quota-dialog.scss
@@ -9,19 +9,23 @@
   }
 
   .quota-entries {
-    margin: -$margin * 0.5;
+    display: flex;
+    gap: 8px;
+    margin-left: -1px;
+    flex-wrap: wrap;
 
     &:empty {
       display: none;
     }
 
     .quota {
-      --flex-gap: #{$padding};
       border: 1px solid var(--halfGray);
       border-radius: $radius;
-      margin: $margin * 0.5;
       padding: $padding * 0.5 $padding;
       transition: all 150ms ease;
+      display: flex;
+      align-items: center;
+      gap: 8px;
 
       &:hover {
         box-shadow: inset 0 0 0 1px var(--borderColor);


### PR DESCRIPTION
Before:
![broken quotas](https://user-images.githubusercontent.com/9607060/152136765-2c7cf456-3338-476e-8cc9-6bb321360bd5.png)

After:
![fixed quotas](https://user-images.githubusercontent.com/9607060/152136772-6e798e72-1e49-4ef6-9073-af85db6b9bc7.png)



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>