### PR TITLE
Fix dialog icons hover color

### DIFF
--- a/src/renderer/components/+catalog/catalog.module.scss
+++ b/src/renderer/components/+catalog/catalog.module.scss
@@ -43,6 +43,8 @@
   }
 
   .pinIcon {
+    --color-active: var(--textColorAccent);
+
     transition: none;
     opacity: 0;
     margin-left: var(--padding);

--- a/src/renderer/components/icon/icon.scss
+++ b/src/renderer/components/icon/icon.scss
@@ -111,7 +111,7 @@
   }
 
   &.active {
-    color: var(--textColorAccent);
+    color: var(--color-active);
     box-shadow: 0 0 0 2px var(--iconActiveBackground);
     background-color: var(--iconActiveBackground);
   }


### PR DESCRIPTION
Fixing regression from #4477 which caused dialog icons to be invisible on hover.


https://user-images.githubusercontent.com/9607060/152146827-249b0e58-ec6b-478f-8b02-079e93713634.mov



Fixes #4699 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>