### PR TITLE
Fix bugs in ItemListLayouts/KubeObjectListLayouts

### DIFF
--- a/src/renderer/components/+apps-releases/release-details/release-details.injectable.ts
+++ b/src/renderer/components/+apps-releases/release-details/release-details.injectable.ts
@@ -10,7 +10,7 @@ import releaseInjectable from "./release.injectable";
 const releaseDetailsInjectable = getInjectable({
   instantiate: (di) =>
     asyncComputed(async () => {
-      const release = di.inject(releaseInjectable).value.get();
+      const release = di.inject(releaseInjectable).get();
 
       return await getRelease(release.name, release.namespace);
     }),

--- a/src/renderer/components/+apps-releases/release-details/release-details.tsx
+++ b/src/renderer/components/+apps-releases/release-details/release-details.tsx
@@ -7,7 +7,7 @@ import "./release-details.scss";
 
 import React, { Component } from "react";
 import groupBy from "lodash/groupBy";
-import { computed, makeObservable, observable } from "mobx";
+import { computed, IComputedValue, makeObservable, observable } from "mobx";
 import { Link } from "react-router-dom";
 import kebabCase from "lodash/kebabCase";
 import type { HelmRelease, IReleaseDetails, IReleaseUpdateDetails, IReleaseUpdatePayload } from "../../../../common/k8s-api/endpoints/helm-releases.api";
@@ -39,7 +39,7 @@ interface Props {
 }
 
 interface Dependencies {
-  release: IAsyncComputed<HelmRelease>
+  release: IComputedValue<HelmRelease>
   releaseDetails: IAsyncComputed<IReleaseDetails>
   releaseValues: IAsyncComputed<string>
   updateRelease: (name: string, namespace: string, payload: IReleaseUpdatePayload) => Promise<IReleaseUpdateDetails>
@@ -59,7 +59,7 @@ class NonInjectedReleaseDetails extends Component<Props & Dependencies> {
   }
 
   @computed get release() {
-    return this.props.release.value.get();
+    return this.props.release.get();
   }
 
   @computed get details() {

--- a/src/renderer/components/+apps-releases/release-details/release-values.injectable.ts
+++ b/src/renderer/components/+apps-releases/release-details/release-values.injectable.ts
@@ -13,6 +13,11 @@ const releaseValuesInjectable = getInjectable({
   instantiate: (di) =>
     asyncComputed(async () => {
       const release = di.inject(releaseInjectable).value.get();
+
+      if (!release) {
+        return "";
+      }
+
       const userSuppliedValuesAreShown = di.inject(userSuppliedValuesAreShownInjectable).value;
 
       try {

--- a/src/renderer/components/+apps-releases/release-details/release-values.injectable.ts
+++ b/src/renderer/components/+apps-releases/release-details/release-values.injectable.ts
@@ -12,8 +12,9 @@ import userSuppliedValuesAreShownInjectable from "./user-supplied-values-are-sho
 const releaseValuesInjectable = getInjectable({
   instantiate: (di) =>
     asyncComputed(async () => {
-      const release = di.inject(releaseInjectable).value.get();
+      const release = di.inject(releaseInjectable).get();
 
+      // TODO: Figure out way to get rid of defensive code
       if (!release) {
         return "";
       }

--- a/src/renderer/components/+apps-releases/release-details/release.injectable.ts
+++ b/src/renderer/components/+apps-releases/release-details/release.injectable.ts
@@ -6,14 +6,14 @@ import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { matches } from "lodash/fp";
 import releasesInjectable from "../releases.injectable";
 import releaseRouteParametersInjectable from "./release-route-parameters.injectable";
-import { asyncComputed } from "@ogre-tools/injectable-react";
+import { computed } from "mobx";
 
 const releaseInjectable = getInjectable({
   instantiate: (di) => {
     const releases = di.inject(releasesInjectable);
     const releaseRouteParameters = di.inject(releaseRouteParametersInjectable);
 
-    return asyncComputed(async () => {
+    return computed(() => {
       const { name, namespace } = releaseRouteParameters.get();
 
       if (!name || !namespace) {

--- a/src/renderer/components/+events/events.tsx
+++ b/src/renderer/components/+events/events.tsx
@@ -124,7 +124,7 @@ export class Events extends React.Component<Props> {
   };
 
   render() {
-    const { store, visibleItems } = this;
+    const { store } = this;
     const { compact, compactLimit, className, ...layoutProps } = this.props;
 
     const events = (
@@ -137,7 +137,7 @@ export class Events extends React.Component<Props> {
         renderHeaderTitle="Events"
         customizeHeader={this.customizeHeader}
         isSelectable={false}
-        items={visibleItems}
+        getItems={() => this.visibleItems}
         virtual={!compact}
         tableProps={{
           sortSyncWithUrl: false,

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -203,31 +203,43 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
   }
 
   renderTableHeader() {
-    const { customizeTableRowProps, renderTableHeader, isSelectable, isConfigurable, store } = this.props;
+    const { renderTableHeader } = this.props;
 
     if (!renderTableHeader) {
       return null;
     }
 
-    const enabledItems = this.props.getItems().filter(item => !customizeTableRowProps(item).disabled);
-
     return (
       <TableHead showTopLine nowrap>
-        {isSelectable && (
-          <TableCell
-            checkbox
-            isChecked={store.isSelectedAll(enabledItems)}
-            onClick={prevDefault(() => store.toggleSelectionAll(enabledItems))}
-          />
-        )}
-        {renderTableHeader.map((cellProps, index) => (
-          this.showColumn(cellProps) && (
-            <TableCell key={cellProps.id ?? index} {...cellProps} />
-          )
-        ))}
-        <TableCell className="menu">
-          {isConfigurable && this.renderColumnVisibilityMenu()}
-        </TableCell>
+        <Observer>
+          {() => {
+            const { store, isConfigurable, isSelectable, customizeTableRowProps } = this.props;
+            const enabledItems = this.props.getItems().filter(item => !customizeTableRowProps(item).disabled);
+
+            return (
+              <>
+                {isSelectable && (
+                  <TableCell
+                    checkbox
+                    isChecked={store.isSelectedAll(enabledItems)}
+                    onClick={prevDefault(() =>
+                      store.toggleSelectionAll(enabledItems),
+                    )}
+                  />
+                )}
+                {renderTableHeader.map(
+                  (cellProps, index) =>
+                    this.showColumn(cellProps) && (
+                      <TableCell key={cellProps.id ?? index} {...cellProps} />
+                    ),
+                )}
+                <TableCell className="menu">
+                  {isConfigurable && this.renderColumnVisibilityMenu()}
+                </TableCell>
+              </>
+            );
+          }}
+        </Observer>
       </TableHead>
     );
   }

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -7,7 +7,7 @@ import "./item-list-layout.scss";
 
 import React, { ReactNode } from "react";
 import { computed, makeObservable } from "mobx";
-import { observer } from "mobx-react";
+import { Observer, observer } from "mobx-react";
 import { ConfirmDialog, ConfirmDialogParams } from "../confirm-dialog";
 import { Table, TableCell, TableCellProps, TableHead, TableProps, TableRow, TableRowProps, TableSortCallbacks } from "../table";
 import { boundMethod, cssNames, IClassName, isReactNode, prevDefault, stopPropagation } from "../../utils";
@@ -70,58 +70,82 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
 
   @boundMethod
   getRow(uid: string) {
-    const {
-      isSelectable, renderTableHeader, renderTableContents, renderItemMenu,
-      store, hasDetailsView, onDetails,
-      copyClassNameFromHeadCells, customizeTableRowProps, detailsItem,
-    } = this.props;
-    const { isSelected } = store;
-    const item = this.props.getItems().find(item => item.getId() == uid);
-
-    if (!item) return null;
-    const itemId = item.getId();
-
     return (
-      <TableRow
-        key={itemId}
-        nowrap
-        searchItem={item}
-        sortItem={item}
-        selected={detailsItem && detailsItem.getId() === itemId}
-        onClick={hasDetailsView ? prevDefault(() => onDetails(item)) : undefined}
-        {...customizeTableRowProps(item)}
-      >
-        {isSelectable && (
-          <TableCell
-            checkbox
-            isChecked={isSelected(item)}
-            onClick={prevDefault(() => store.toggleSelection(item))}
-          />
-        )}
-        {
-          renderTableContents(item).map((content, index) => {
-            const cellProps: TableCellProps = isReactNode(content) ? { children: content } : content;
-            const headCell = renderTableHeader?.[index];
+      <div>
+        <Observer>
+          {() => {
+            const {
+              isSelectable,
+              renderTableHeader,
+              renderTableContents,
+              renderItemMenu,
+              store,
+              hasDetailsView,
+              onDetails,
+              copyClassNameFromHeadCells,
+              customizeTableRowProps,
+              detailsItem,
+            } = this.props;
+            const { isSelected } = store;
+            const item = this.props
+              .getItems()
+              .find((item) => item.getId() == uid);
 
-            if (copyClassNameFromHeadCells && headCell) {
-              cellProps.className = cssNames(cellProps.className, headCell.className);
-            }
+            if (!item) return null;
+            const itemId = item.getId();
 
-            if (!headCell || this.showColumn(headCell)) {
-              return <TableCell key={index} {...cellProps} />;
-            }
+            return (
+              <TableRow
+                key={itemId}
+                nowrap
+                searchItem={item}
+                sortItem={item}
+                selected={detailsItem && detailsItem.getId() === itemId}
+                onClick={
+                  hasDetailsView
+                    ? prevDefault(() => onDetails(item))
+                    : undefined
+                }
+                {...customizeTableRowProps(item)}
+              >
+                {isSelectable && (
+                  <TableCell
+                    checkbox
+                    isChecked={isSelected(item)}
+                    onClick={prevDefault(() => store.toggleSelection(item))}
+                  />
+                )}
+                {renderTableContents(item).map((content, index) => {
+                  const cellProps: TableCellProps = isReactNode(content)
+                    ? { children: content }
+                    : content;
+                  const headCell = renderTableHeader?.[index];
 
-            return null;
-          })
-        }
-        {renderItemMenu && (
-          <TableCell className="menu">
-            <div onClick={stopPropagation}>
-              {renderItemMenu(item, store)}
-            </div>
-          </TableCell>
-        )}
-      </TableRow>
+                  if (copyClassNameFromHeadCells && headCell) {
+                    cellProps.className = cssNames(
+                      cellProps.className,
+                      headCell.className,
+                    );
+                  }
+
+                  if (!headCell || this.showColumn(headCell)) {
+                    return <TableCell key={index} {...cellProps} />;
+                  }
+
+                  return null;
+                })}
+                {renderItemMenu && (
+                  <TableCell className="menu">
+                    <div onClick={stopPropagation}>
+                      {renderItemMenu(item, store)}
+                    </div>
+                  </TableCell>
+                )}
+              </TableRow>
+            );
+          }}
+        </Observer>
+      </div>
     );
   }
 

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -209,37 +209,35 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
       return null;
     }
 
+    const { store, isConfigurable, isSelectable, customizeTableRowProps } = this.props;
+
+    const enabledItems = this.props
+      .getItems()
+      .filter((item) => !customizeTableRowProps(item).disabled);
+
     return (
       <TableHead showTopLine nowrap>
-        <Observer>
-          {() => {
-            const { store, isConfigurable, isSelectable, customizeTableRowProps } = this.props;
-            const enabledItems = this.props.getItems().filter(item => !customizeTableRowProps(item).disabled);
+        {isSelectable && (
+          <Observer>
+            {() => (
+              <TableCell
+                checkbox
+                isChecked={store.isSelectedAll(enabledItems)}
+                onClick={prevDefault(() => store.toggleSelectionAll(enabledItems))}
+              />
+            )}
+          </Observer>
 
-            return (
-              <>
-                {isSelectable && (
-                  <TableCell
-                    checkbox
-                    isChecked={store.isSelectedAll(enabledItems)}
-                    onClick={prevDefault(() =>
-                      store.toggleSelectionAll(enabledItems),
-                    )}
-                  />
-                )}
-                {renderTableHeader.map(
-                  (cellProps, index) =>
-                    this.showColumn(cellProps) && (
-                      <TableCell key={cellProps.id ?? index} {...cellProps} />
-                    ),
-                )}
-                <TableCell className="menu">
-                  {isConfigurable && this.renderColumnVisibilityMenu()}
-                </TableCell>
-              </>
-            );
-          }}
-        </Observer>
+        )}
+        {renderTableHeader.map(
+          (cellProps, index) =>
+            this.showColumn(cellProps) && (
+              <TableCell key={cellProps.id ?? index} {...cellProps} />
+            ),
+        )}
+        <TableCell className="menu">
+          {isConfigurable && this.renderColumnVisibilityMenu()}
+        </TableCell>
       </TableHead>
     );
   }

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -71,7 +71,7 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
   @boundMethod
   getRow(uid: string) {
     return (
-      <div>
+      <div key={uid}>
         <Observer>
           {() => {
             const {
@@ -87,7 +87,6 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
 
             return (
               <TableRow
-                key={itemId}
                 nowrap
                 searchItem={item}
                 sortItem={item}

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -237,7 +237,6 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
       store, hasDetailsView, addRemoveButtons = {}, virtual, sortingCallbacks,
       detailsItem, className, tableProps = {}, tableId,
     } = this.props;
-    const { selectedItems } = store;
     const selectedItemId = detailsItem && detailsItem.getId();
     const classNames = cssNames(className, "box", "grow", ThemeStore.getInstance().activeTheme.type);
 
@@ -258,11 +257,18 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
           {this.renderTableHeader()}
           {this.renderItems()}
         </Table>
-        <AddRemoveButtons
-          onRemove={selectedItems.length ? this.removeItemsDialog : null}
-          removeTooltip={`Remove selected items (${selectedItems.length})`}
-          {...addRemoveButtons}
-        />
+
+        <Observer>
+          {() => (
+            <AddRemoveButtons
+              onRemove={
+                store.selectedItems.length ? this.removeItemsDialog : null
+              }
+              removeTooltip={`Remove selected items (${store.selectedItems.length})`}
+              {...addRemoveButtons}
+            />
+          )}
+        </Observer>
       </div>
     );
   }

--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -75,21 +75,12 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
         <Observer>
           {() => {
             const {
-              isSelectable,
-              renderTableHeader,
-              renderTableContents,
-              renderItemMenu,
-              store,
-              hasDetailsView,
-              onDetails,
-              copyClassNameFromHeadCells,
-              customizeTableRowProps,
-              detailsItem,
+              isSelectable, renderTableHeader, renderTableContents, renderItemMenu,
+              store, hasDetailsView, onDetails,
+              copyClassNameFromHeadCells, customizeTableRowProps, detailsItem,
             } = this.props;
             const { isSelected } = store;
-            const item = this.props
-              .getItems()
-              .find((item) => item.getId() == uid);
+            const item = this.props.getItems().find(item => item.getId() == uid);
 
             if (!item) return null;
             const itemId = item.getId();
@@ -101,11 +92,7 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
                 searchItem={item}
                 sortItem={item}
                 selected={detailsItem && detailsItem.getId() === itemId}
-                onClick={
-                  hasDetailsView
-                    ? prevDefault(() => onDetails(item))
-                    : undefined
-                }
+                onClick={hasDetailsView ? prevDefault(() => onDetails(item)) : undefined}
                 {...customizeTableRowProps(item)}
               >
                 {isSelectable && (
@@ -203,17 +190,13 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
   }
 
   renderTableHeader() {
-    const { renderTableHeader } = this.props;
+    const { customizeTableRowProps, renderTableHeader, isSelectable, isConfigurable, store } = this.props;
 
     if (!renderTableHeader) {
       return null;
     }
 
-    const { store, isConfigurable, isSelectable, customizeTableRowProps } = this.props;
-
-    const enabledItems = this.props
-      .getItems()
-      .filter((item) => !customizeTableRowProps(item).disabled);
+    const enabledItems = this.props.getItems().filter(item => !customizeTableRowProps(item).disabled);
 
     return (
       <TableHead showTopLine nowrap>
@@ -227,14 +210,12 @@ export class ItemListLayoutContent<I extends ItemObject> extends React.Component
               />
             )}
           </Observer>
-
         )}
-        {renderTableHeader.map(
-          (cellProps, index) =>
-            this.showColumn(cellProps) && (
-              <TableCell key={cellProps.id ?? index} {...cellProps} />
-            ),
-        )}
+        {renderTableHeader.map((cellProps, index) => (
+          this.showColumn(cellProps) && (
+            <TableCell key={cellProps.id ?? index} {...cellProps} />
+          )
+        ))}
         <TableCell className="menu">
           {isConfigurable && this.renderColumnVisibilityMenu()}
         </TableCell>

--- a/src/renderer/components/kube-detail-params/params.ts
+++ b/src/renderer/components/kube-detail-params/params.ts
@@ -46,7 +46,6 @@ export function hideDetails() {
 }
 
 export function getDetailsUrl(selfLink: string, resetSelected = false, mergeGlobals = true) {
-  console.debug("getDetailsUrl", { selfLink, resetSelected, mergeGlobals });
   const params = new URLSearchParams(mergeGlobals ? navigation.searchParams : "");
 
   params.set(kubeDetailsUrlParam.name, selfLink);


### PR DESCRIPTION
**Bugs:**

1. Scrolls to top when selecting a row - Closes #4793 
2. Scrolls to top when selecting all rows
3. Rendering of contents flicker
4. Getting release values sometimes throw
5. Render-storm in Events - Closes #4769 

**Other changes:**

1. Replace avoidable `asyncComputed` with normal `computed`
2. Remove noisy debugging from `getDetailsUrl`

**Still to be fixed:**

1. KubeObjectListLayout pages are re-rendered involuntarely losing scroll position
