### PR TITLE
Don't block other extensions from loading if one activation fails

### DIFF
--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -349,7 +349,6 @@ export class ExtensionLoader {
         extension.activated.catch((error) => {
           extension.activationError = error;
           logger.error(`${logModule}: activation extension error`, { ext: extension.installedExtension, error });
-          this.instances.delete(extension.extId);
         }),
       ),
     );

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -322,10 +322,8 @@ export class ExtensionLoader {
             this.instances.set(extId, instance);
 
             return {
-              extId,
               instance,
               installedExtension: extension,
-              isBundled: extension.isBundled,
               activated: instance.activate(),
             };
           } catch (err) {
@@ -358,7 +356,7 @@ export class ExtensionLoader {
       });
 
       return {
-        isBundled: extension.isBundled,
+        isBundled: extension.installedExtension.isBundled,
         loaded,
       };
     });

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -327,7 +327,6 @@ export class ExtensionLoader {
               installedExtension: extension,
               isBundled: extension.isBundled,
               activated: instance.activate(),
-              activationError: null,
             };
           } catch (err) {
             logger.error(`${logModule}: error loading extension`, { ext: extension, err });
@@ -347,7 +346,6 @@ export class ExtensionLoader {
       extensions.map(extension =>
         // If extension activation fails, log error
         extension.activated.catch((error) => {
-          extension.activationError = error;
           logger.error(`${logModule}: activation extension error`, { ext: extension.installedExtension, error });
         }),
       ),
@@ -355,7 +353,6 @@ export class ExtensionLoader {
 
     // Return ExtensionLoading[]
     return extensions
-      .filter(extension =>!extension.activationError)
       .map(extension => {
         const loaded = extension.instance.enable(register).catch((err) => {
           logger.error(`${logModule}: failed to enable`, { ext: extension, err });

--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -352,17 +352,16 @@ export class ExtensionLoader {
     );
 
     // Return ExtensionLoading[]
-    return extensions
-      .map(extension => {
-        const loaded = extension.instance.enable(register).catch((err) => {
-          logger.error(`${logModule}: failed to enable`, { ext: extension, err });
-        });
-
-        return {
-          isBundled: extension.isBundled,
-          loaded,
-        };
+    return extensions.map(extension => {
+      const loaded = extension.instance.enable(register).catch((err) => {
+        logger.error(`${logModule}: failed to enable`, { ext: extension, err });
       });
+
+      return {
+        isBundled: extension.isBundled,
+        loaded,
+      };
+    });
   }
 
   protected autoInitExtensions(register: (ext: LensExtension) => Promise<Disposer[]>) {

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -112,7 +112,6 @@ export class LensExtension {
     }
   }
 
-  @action
   async activate(): Promise<void> {
     return this.onActivate();
   }

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -113,8 +113,8 @@ export class LensExtension {
   }
 
   @action
-  activate() {
-    return Promise.resolve(this.onActivate());
+  async activate(): Promise<void> {
+    return this.onActivate();
   }
 
   protected onActivate(): Promise<void> | void {

--- a/src/extensions/lens-extension.ts
+++ b/src/extensions/lens-extension.ts
@@ -114,7 +114,7 @@ export class LensExtension {
 
   @action
   activate() {
-    return this.onActivate();
+    return Promise.resolve(this.onActivate());
   }
 
   protected onActivate(): Promise<void> | void {


### PR DESCRIPTION
* Fixes https://github.com/lensapp/lens/issues/4804
* Adjust error message to be correct (error was with loading, not activation)
* The issue was that Promise.all would throw if just one extension's `onActivate` method would throw.