### PR TITLE
Fix Cluster.refresh sometimes taking upwards of 20s

### DIFF
--- a/src/common/cluster/authorization-review.injectable.ts
+++ b/src/common/cluster/authorization-review.injectable.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { AuthorizationV1Api, KubeConfig, V1ResourceAttributes } from "@kubernetes/client-node";
+import logger from "../logger";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+
+export type CanI = (resourceAttributes: V1ResourceAttributes) => Promise<boolean>;
+
+/**
+ * @param proxyConfig This config's `currentContext` field must be set, and will be used as the target cluster
+   */
+export function authorizationReview(proxyConfig: KubeConfig): CanI {
+  const api = proxyConfig.makeApiClient(AuthorizationV1Api);
+
+  /**
+   * Requests the permissions for actions on the kube cluster
+   * @param resourceAttributes The descriptor of the action that is desired to be known if it is allowed
+   * @returns `true` if the actions described are allowed
+   */
+  return async (resourceAttributes: V1ResourceAttributes): Promise<boolean> => {
+    try {
+      const { body } = await api.createSelfSubjectAccessReview({
+        apiVersion: "authorization.k8s.io/v1",
+        kind: "SelfSubjectAccessReview",
+        spec: { resourceAttributes },
+      });
+
+      return body.status?.allowed ?? false;
+    } catch (error) {
+      logger.error(`[AUTHORIZATION-REVIEW]: failed to create access review: ${error}`, { resourceAttributes });
+
+      return false;
+    }
+  };
+}
+
+const authorizationReviewInjectable = getInjectable({
+  instantiate: () => authorizationReview,
+  lifecycle: lifecycleEnum.singleton,
+});
+
+export default authorizationReviewInjectable;

--- a/src/common/cluster/list-namespaces.injectable.ts
+++ b/src/common/cluster/list-namespaces.injectable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { CoreV1Api, KubeConfig } from "@kubernetes/client-node";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
+
+export type ListNamespaces = () => Promise<string[]>;
+
+export function listNamespaces(config: KubeConfig): ListNamespaces {
+  const coreApi = config.makeApiClient(CoreV1Api);
+
+  return async () => {
+    const { body: { items }} = await coreApi.listNamespace();
+
+    return items.map(ns => ns.metadata.name);
+  };
+}
+
+const listNamespacesInjectable = getInjectable({
+  instantiate: () => listNamespaces,
+  lifecycle: lifecycleEnum.singleton,
+});
+
+export default listNamespacesInjectable;

--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -39,6 +39,8 @@ import { Kubectl } from "../kubectl/kubectl";
 import { getDiForUnitTesting } from "../getDiForUnitTesting";
 import type { ClusterModel } from "../../common/cluster-types";
 import { createClusterInjectionToken } from "../../common/cluster/create-cluster-injection-token";
+import authorizationReviewInjectable from "../../common/cluster/authorization-review.injectable";
+import listNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
 
 console = new Console(process.stdout, process.stderr); // fix mockFS
 
@@ -76,6 +78,9 @@ describe("create clusters", () => {
     });
 
     await di.runSetups();
+
+    di.override(authorizationReviewInjectable, () => () => () => Promise.resolve(true));
+    di.override(listNamespacesInjectable, () => () => () => Promise.resolve([ "default" ]));
 
     createCluster = di.inject(createClusterInjectionToken);
 
@@ -117,7 +122,6 @@ describe("create clusters", () => {
     } as any;
 
     jest.spyOn(cluster, "reconnect");
-    jest.spyOn(cluster, "canI");
     jest.spyOn(cluster, "refreshConnectionStatus");
 
     await cluster.activate();

--- a/src/main/create-cluster/create-cluster.injectable.ts
+++ b/src/main/create-cluster/create-cluster.injectable.ts
@@ -3,24 +3,27 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import type { ClusterModel } from "../../common/cluster-types";
-import { Cluster } from "../../common/cluster/cluster";
+import { Cluster, ClusterDependencies } from "../../common/cluster/cluster";
 import directoryForKubeConfigsInjectable from "../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import createKubeconfigManagerInjectable from "../kubeconfig-manager/create-kubeconfig-manager.injectable";
 import createKubectlInjectable from "../kubectl/create-kubectl.injectable";
 import createContextHandlerInjectable from "../context-handler/create-context-handler.injectable";
 import { createClusterInjectionToken } from "../../common/cluster/create-cluster-injection-token";
+import authorizationReviewInjectable from "../../common/cluster/authorization-review.injectable";
+import listNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
 
 const createClusterInjectable = getInjectable({
   instantiate: (di) => {
-    const dependencies = {
+    const dependencies: ClusterDependencies = {
       directoryForKubeConfigs: di.inject(directoryForKubeConfigsInjectable),
       createKubeconfigManager: di.inject(createKubeconfigManagerInjectable),
       createKubectl: di.inject(createKubectlInjectable),
       createContextHandler: di.inject(createContextHandlerInjectable),
+      createAuthorizationReview: di.inject(authorizationReviewInjectable),
+      createListNamespaces: di.inject(listNamespacesInjectable),
     };
 
-    return (model: ClusterModel) => new Cluster(dependencies, model);
+    return (model) => new Cluster(dependencies, model);
   },
 
   injectionToken: createClusterInjectionToken,

--- a/src/renderer/create-cluster/create-cluster.injectable.ts
+++ b/src/renderer/create-cluster/create-cluster.injectable.ts
@@ -3,21 +3,22 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
-import type { ClusterModel } from "../../common/cluster-types";
-import { Cluster } from "../../common/cluster/cluster";
+import { Cluster, ClusterDependencies } from "../../common/cluster/cluster";
 import directoryForKubeConfigsInjectable from "../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import { createClusterInjectionToken } from "../../common/cluster/create-cluster-injection-token";
 
 const createClusterInjectable = getInjectable({
   instantiate: (di) => {
-    const dependencies = {
+    const dependencies: ClusterDependencies = {
       directoryForKubeConfigs: di.inject(directoryForKubeConfigsInjectable),
       createKubeconfigManager: () => { throw new Error("Tried to access back-end feature in front-end."); },
       createKubectl: () => { throw new Error("Tried to access back-end feature in front-end.");},
       createContextHandler: () => { throw new Error("Tried to access back-end feature in front-end."); },
+      createAuthorizationReview: () => { throw new Error("Tried to access back-end feature in front-end."); },
+      createListNamespaces: () => { throw new Error("Tried to access back-end feature in front-end."); },
     };
 
-    return (model: ClusterModel) => new Cluster(dependencies, model);
+    return (model) => new Cluster(dependencies, model);
   },
 
   injectionToken: createClusterInjectionToken,


### PR DESCRIPTION
- Only read and parse the proxy config once

- Reuse the AuthorizationV1Api instance for the entire refresh instead
  of recreating it between 32 and 302 times, this should allow for
  reusing sockets

Signed-off-by: Sebastian Malton <sebastian@malton.name>