### PR TITLE
Restrict title name to be only string

### DIFF
--- a/src/renderer/components/+catalog/custom-category-columns.ts
+++ b/src/renderer/components/+catalog/custom-category-columns.ts
@@ -12,7 +12,7 @@ import type { TableCellProps } from "../table";
  */
 export interface TitleCellProps {
   className?: string;
-  title: React.ReactNode;
+  title: string;
 }
 
 export interface CategoryColumnRegistration {


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Given what we have learned from the `StatusBar` registry, I don't think this should be `React.ReactNode` anymore, instead I think we should only support `string` for the time being.