### PR TITLE
Expose Electron powerMonitor API to extensions

### DIFF
--- a/src/extensions/main-api/index.ts
+++ b/src/extensions/main-api/index.ts
@@ -6,6 +6,7 @@
 import * as Catalog from "./catalog";
 import * as Navigation from "./navigation";
 import * as K8sApi from "./k8s-api";
+import * as Power from "./power";
 import { IpcMain as Ipc } from "../ipc/ipc-main";
 import { LensMainExtension as LensExtension } from "../lens-main-extension";
 
@@ -15,4 +16,5 @@ export {
   K8sApi,
   Ipc,
   LensExtension,
+  Power,
 };

--- a/src/extensions/main-api/power.ts
+++ b/src/extensions/main-api/power.ts
@@ -4,7 +4,7 @@
  */
 import { powerMonitor } from "electron";
 import type { Disposer } from "../../common/utils/disposer";
-type PowerEventListener = () => void;
+export type PowerEventListener = () => void;
 
 export const onSuspend = (listener: PowerEventListener): Disposer => {
   powerMonitor.on("suspend", listener);

--- a/src/extensions/main-api/power.ts
+++ b/src/extensions/main-api/power.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+export { powerMonitor } from "electron";
+

--- a/src/extensions/main-api/power.ts
+++ b/src/extensions/main-api/power.ts
@@ -4,8 +4,17 @@
  */
 import { powerMonitor } from "electron";
 import type { Disposer } from "../../common/utils/disposer";
+
+/**
+ * Event listener for system power events
+ */
 export type PowerEventListener = () => void;
 
+/**
+ * Adds event listener to system suspend events
+ * @param listener function which will be called on system suspend
+ * @returns function to remove event listener
+ */
 export const onSuspend = (listener: PowerEventListener): Disposer => {
   powerMonitor.on("suspend", listener);
 
@@ -14,6 +23,11 @@ export const onSuspend = (listener: PowerEventListener): Disposer => {
   };
 };
 
+/**
+ * Adds event listener to system resume event
+ * @param listener function which will be called on system resume
+ * @returns function to remove event listener
+ */
 export const onResume = (listener: PowerEventListener): Disposer => {
   powerMonitor.on("resume", listener);
 
@@ -22,6 +36,12 @@ export const onResume = (listener: PowerEventListener): Disposer => {
   };
 };
 
+/**
+ * Adds event listener to the event which is emitted when
+ * the system is about to reboot or shut down
+ * @param listener function which will be called on system shutdown
+ * @returns function to remove event listener
+ */
 export const onShutdown = (listener: PowerEventListener): Disposer => {
   powerMonitor.on("shutdown", listener);
 

--- a/src/extensions/main-api/power.ts
+++ b/src/extensions/main-api/power.ts
@@ -2,5 +2,30 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-export { powerMonitor } from "electron";
+import { powerMonitor } from "electron";
+import type { Disposer } from "../../common/utils/disposer";
+type PowerEventListener = () => void;
 
+export const onSuspend = (listener: PowerEventListener): Disposer => {
+  powerMonitor.on("suspend", listener);
+
+  return () => {
+    powerMonitor.off("suspend", listener);
+  };
+};
+
+export const onResume = (listener: PowerEventListener): Disposer => {
+  powerMonitor.on("resume", listener);
+
+  return () => {
+    powerMonitor.off("resume", listener);
+  };
+};
+
+export const onShutdown = (listener: PowerEventListener): Disposer => {
+  powerMonitor.on("shutdown", listener);
+
+  return () => {
+    powerMonitor.off("shutdown", listener);
+  };
+};


### PR DESCRIPTION
Signed-off-by: Juho Heikka <juho.heikka@gmail.com>

Electron API lets extension to react on `suspend` and `resume` events.