### PR TITLE
Consolidate way of passing items to ItemListLayout

### DIFF
--- a/src/renderer/components/+helm-charts/helm-charts.tsx
+++ b/src/renderer/components/+helm-charts/helm-charts.tsx
@@ -73,6 +73,7 @@ export class HelmCharts extends Component<Props> {
           tableId="helm_charts"
           className="HelmCharts"
           store={helmChartStore}
+          getItems={() => helmChartStore.items}
           isSelectable={false}
           sortingCallbacks={{
             [columnId.name]: chart => chart.getName(),

--- a/src/renderer/components/+helm-releases/releases.tsx
+++ b/src/renderer/components/+helm-releases/releases.tsx
@@ -147,6 +147,7 @@ class NonInjectedHelmReleases extends Component<Dependencies & Props> {
       <>
         <ItemListLayout
           store={legacyReleaseStore}
+          getItems={() => legacyReleaseStore.items}
           preloadStores={false}
           isConfigurable
           tableId="helm_releases"

--- a/src/renderer/components/+network-port-forwards/port-forwards.tsx
+++ b/src/renderer/components/+network-port-forwards/port-forwards.tsx
@@ -86,7 +86,9 @@ class NonInjectedPortForwards extends React.Component<Props & Dependencies> {
         <ItemListLayout
           isConfigurable
           tableId="port_forwards"
-          className="PortForwards" store={this.props.portForwardStore}
+          className="PortForwards"
+          store={this.props.portForwardStore}
+          getItems={() => this.props.portForwardStore.items}
           sortingCallbacks={{
             [columnId.name]: item => item.getName(),
             [columnId.namespace]: item => item.getNs(),

--- a/src/renderer/components/item-object-list/list-layout.tsx
+++ b/src/renderer/components/item-object-list/list-layout.tsx
@@ -41,8 +41,7 @@ export type HeaderCustomizer = (placeholders: HeaderPlaceholders) => HeaderPlace
 export interface ItemListLayoutProps<I extends ItemObject> {
   tableId?: string;
   className: IClassName;
-  items?: I[];
-  getItems?: () => I[];
+  getItems: () => I[];
   store: ItemStore<I>;
   dependentStores?: ItemStore<ItemObject>[];
   preloadStores?: boolean;
@@ -213,7 +212,7 @@ class NonInjectedItemListLayout<I extends ItemObject> extends React.Component<It
       }
     }
 
-    const items = this.props.getItems?.() ?? this.props.items ?? this.props.store.items;
+    const items = this.props.getItems();
 
     return applyFilters(filterItems.concat(this.props.filterItems), items);
   }

--- a/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
+++ b/src/renderer/components/kube-object-list-layout/kube-object-list-layout.tsx
@@ -21,11 +21,14 @@ import { TooltipPosition } from "../tooltip";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import type { ClusterFrameContext } from "../../cluster-frame-context/cluster-frame-context";
 import clusterFrameContextInjectable from "../../cluster-frame-context/cluster-frame-context.injectable";
-import kubeWatchApiInjectable
-  from "../../kube-watch-api/kube-watch-api.injectable";
+import kubeWatchApiInjectable from "../../kube-watch-api/kube-watch-api.injectable";
 import type { KubeWatchSubscribeStoreOptions } from "../../kube-watch-api/kube-watch-api";
 
-export interface KubeObjectListLayoutProps<K extends KubeObject> extends ItemListLayoutProps<K> {
+type ItemListLayoutPropsWithoutGetItems<K extends KubeObject> = Omit<ItemListLayoutProps<K>, "getItems">;
+
+export interface KubeObjectListLayoutProps<K extends KubeObject> extends ItemListLayoutPropsWithoutGetItems<K> {
+  items?: K[];
+  getItems?: () => K[];
   store: KubeObjectStore<K>;
   dependentStores?: KubeObjectStore<KubeObject>[];
   subscribeStores?: boolean;


### PR DESCRIPTION
Consolidate way of passing items to ItemListLayout to prevent accidental de-referencing of MobX observables

Signed-off-by: Janne Savolainen <janne.savolainen@live.fi>