### PR TITLE
Fix: preloading fonts for terminal

### DIFF
--- a/src/renderer/components/dock/terminal/dock-tab.tsx
+++ b/src/renderer/components/dock/terminal/dock-tab.tsx
@@ -3,6 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import "./terminal-dock-tab.scss";
 import React from "react";
 import { observer } from "mobx-react";
 import { boundMethod, cssNames } from "../../../utils";

--- a/src/renderer/components/dock/terminal/terminal-dock-tab.scss
+++ b/src/renderer/components/dock/terminal/terminal-dock-tab.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+.TerminalTab {
+  @include font-preload {
+    font-family: "RobotoMono", monospace;
+  }
+}

--- a/src/renderer/components/fonts.scss
+++ b/src/renderer/components/fonts.scss
@@ -22,5 +22,6 @@
 // https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/RobotoMono
 @font-face {
   font-family: 'RobotoMono';
+  font-display: block;
   src: local('RobotoMono'), url('./fonts/roboto-mono-nerd.ttf') format('truetype');
 }

--- a/src/renderer/components/mixins.scss
+++ b/src/renderer/components/mixins.scss
@@ -59,3 +59,15 @@
     @content; // css-modules (*.module.scss)
   }
 }
+
+// Makes custom font available at earlier stages (start preloading)
+// Element must be in DOM and contain some text of loading font.
+@mixin font-preload() {
+  &:before {
+    width: 0;
+    display: block;
+    overflow: hidden;
+    content: "x"; // required
+    @content; // must contain `font-family`
+  }
+}

--- a/src/renderer/template.html
+++ b/src/renderer/template.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <link rel="preload" href="<%= assetPath %>/MaterialIcons-Regular.ttf" as="font" crossorigin>
+  <link rel="preload" href="<%= assetPath %>/roboto-mono-nerd.ttf" as="font" crossorigin>
 </head>
 <body>
 

--- a/webpack.renderer.ts
+++ b/webpack.renderer.ts
@@ -17,14 +17,8 @@ import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 export function webpackLensRenderer(): webpack.Configuration {
   console.info("WEBPACK:renderer", vars);
 
-  const {
-    appName,
-    buildDir,
-    htmlTemplate,
-    isDevelopment,
-    publicPath,
-    rendererDir,
-  } = vars;
+  const assetsFolderName = "assets";
+  const { appName, buildDir, htmlTemplate, isDevelopment, publicPath, rendererDir } = vars;
 
   return {
     target: "electron-renderer",
@@ -42,7 +36,7 @@ export function webpackLensRenderer(): webpack.Configuration {
       path: buildDir,
       filename: "[name].js",
       chunkFilename: "chunks/[name].js",
-      assetModuleFilename: "assets/[name][ext][query]",
+      assetModuleFilename: `${assetsFolderName}/[name][ext][query]`,
     },
     watchOptions: {
       ignored: /node_modules/, // https://webpack.js.org/configuration/watch/
@@ -97,6 +91,9 @@ export function webpackLensRenderer(): webpack.Configuration {
         template: htmlTemplate,
         inject: true,
         hash: true,
+        templateParameters: {
+          assetPath: `${publicPath}${assetsFolderName}`,
+        },
       }),
 
       new CircularDependencyPlugin({


### PR DESCRIPTION
_Before:_
<img width="574" alt="Screenshot 2022-02-15 at 17 12 38" src="https://user-images.githubusercontent.com/6377066/154090997-5d45d8f3-f450-44d9-84a6-6eec34b6932b.png">

_After:_
<img width="573" alt="Screenshot 2022-02-15 at 17 13 43" src="https://user-images.githubusercontent.com/6377066/154091005-e663d756-29d4-4172-a25c-4d6bbf7e20d6.png">

Note: this behaviour happened only with initial tab opening after page loaded.

follow up #4725