### PR TITLE
Updated typescript target to ES2019

### DIFF
--- a/src/common/getTSLoader.ts
+++ b/src/common/getTSLoader.ts
@@ -23,7 +23,7 @@ const getTSLoader = (options: Partial<TSLoaderOptions> = {}, testRegExp?: RegExp
       loader: "esbuild-loader",
       options: {
         loader: "tsx",
-        target: "es2015",
+        target: "ES2019", // supported by >= electron@14
         implementation: esbuild,
       },
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "jsx": "react",
-    "target": "ES2017",
+    "target": "ES2019",
     "module": "ESNext",
     "lib": [
       "ESNext",


### PR DESCRIPTION
Seems like fully supported by `electron@14` _(currently used version)_
