### PR TITLE
Ingress metrics fix for namespace

### DIFF
--- a/src/main/prometheus/lens.ts
+++ b/src/main/prometheus/lens.ts
@@ -118,9 +118,9 @@ export class PrometheusLens extends PrometheusProvider {
           case "bytesSentFailure":
             return this.bytesSent(opts.ingress, opts.namespace, "^5\\\\d*");
           case "requestDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
           case "responseDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
         }
         break;
     }

--- a/src/main/prometheus/operator.ts
+++ b/src/main/prometheus/operator.ts
@@ -118,9 +118,9 @@ export class PrometheusOperator extends PrometheusProvider {
           case "bytesSentFailure":
             return this.bytesSent(opts.ingress, opts.namespace, "^5\\\\d*");
           case "requestDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}", exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
           case "responseDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}", namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}", exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
         }
         break;
     }

--- a/src/main/prometheus/stacklight.ts
+++ b/src/main/prometheus/stacklight.ts
@@ -118,9 +118,9 @@ export class PrometheusStacklight extends PrometheusProvider {
           case "bytesSentFailure":
             return this.bytesSent(opts.ingress, opts.namespace, "^5\\\\d*");
           case "requestDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_request_duration_seconds_sum{ingress="${opts.ingress}",exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
           case "responseDurationSeconds":
-            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
+            return `sum(rate(nginx_ingress_controller_response_duration_seconds_sum{ingress="${opts.ingress}",exported_namespace="${opts.namespace}"}[${this.rateAccuracy}])) by (ingress, namespace)`;
         }
         break;
     }


### PR DESCRIPTION
https://github.com/lensapp/lens/issues/4348

The namespace label for ingress metrics is set to the controller namespace. The actual ingress namespace is in the exported_namespace label.