### PR TITLE
Fix catalog syncer long delay

### DIFF
--- a/src/main/catalog-pusher.ts
+++ b/src/main/catalog-pusher.ts
@@ -14,9 +14,13 @@ import { catalogInitChannel, catalogItemsChannel } from "../common/ipc/catalog";
 
 const broadcaster = debounce((items: CatalogEntity[]) => {
   broadcastMessage(catalogItemsChannel, items);
-}, 1_000, { leading: true, trailing: true });
+}, 100, { leading: true, trailing: true });
 
 export function pushCatalogToRenderer(catalog: CatalogEntityRegistry) {
+  broadcaster(toJS(catalog.items));
+}
+
+export function startCatalogSyncToRenderer(catalog: CatalogEntityRegistry) {
   return disposer(
     ipcMainOn(catalogInitChannel, () => broadcaster(toJS(catalog.items))),
     reaction(() => toJS(catalog.items), (items) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,7 @@ import { disposer, getAppVersion, getAppVersionFromProxyServer } from "../common
 import { ipcMainOn } from "../common/ipc";
 import { startUpdateChecking } from "./app-updater";
 import { IpcRendererNavigationEvents } from "../renderer/navigation/events";
-import { pushCatalogToRenderer } from "./catalog-pusher";
+import { startCatalogSyncToRenderer } from "./catalog-pusher";
 import { catalogEntityRegistry } from "./catalog";
 import { HelmRepoManager } from "./helm/helm-repo-manager";
 import { syncGeneralEntities, syncWeblinks } from "./catalog-sources";
@@ -244,7 +244,7 @@ di.runSetups().then(() => {
     }
 
     ipcMainOn(IpcRendererNavigationEvents.LOADED, async () => {
-      onCloseCleanup.push(pushCatalogToRenderer(catalogEntityRegistry));
+      onCloseCleanup.push(startCatalogSyncToRenderer(catalogEntityRegistry));
 
       const directoryForKubeConfigs = di.inject(directoryForKubeConfigsInjectable);
 


### PR DESCRIPTION
- debounce lowered from 1s to 0.1s
- fixed a bug where `cluster:set-frame-id` ipc event leaked reactions