### PR TITLE
Fix api-manager kubeobject types

### DIFF
--- a/src/common/k8s-api/api-manager.ts
+++ b/src/common/k8s-api/api-manager.ts
@@ -79,7 +79,7 @@ export class ApiManager {
     return this.stores.get(this.resolveApi(api)?.apiBase) as S;
   }
 
-  lookupApiLink<T extends KubeObject = KubeObject>(ref: IKubeObjectRef, parentObject?: T): string {
+  lookupApiLink(ref: IKubeObjectRef, parentObject?: KubeObject): string {
     const {
       kind, apiVersion, name,
       namespace = parentObject?.getNs(),

--- a/src/common/k8s-api/api-manager.ts
+++ b/src/common/k8s-api/api-manager.ts
@@ -69,7 +69,7 @@ export class ApiManager<TKubeObject extends KubeObject = any> {
   }
 
   @action
-  registerStore(store: KubeObjectStore<any>, apis: KubeApi<any>[] = [store.api]) {
+  registerStore(store: KubeObjectStore<TKubeObject>, apis: KubeApi<TKubeObject>[] = [store.api]) {
     apis.filter(Boolean).forEach(api => {
       if (api.apiBase) this.stores.set(api.apiBase, store);
     });

--- a/src/common/k8s-api/api-manager.ts
+++ b/src/common/k8s-api/api-manager.ts
@@ -11,16 +11,16 @@ import type { KubeApi } from "./kube-api";
 import type { KubeObject } from "./kube-object";
 import { IKubeObjectRef, parseKubeApi, createKubeApiURL } from "./kube-api-parse";
 
-export class ApiManager {
-  private apis = observable.map<string, KubeApi<any>>();
-  private stores = observable.map<string, KubeObjectStore<any>>();
+export class ApiManager<TKubeObject extends KubeObject = any> {
+  private apis = observable.map<string, KubeApi<TKubeObject>>();
+  private stores = observable.map<string, KubeObjectStore<TKubeObject>>();
 
   constructor() {
     makeObservable(this);
     autoBind(this);
   }
 
-  getApi(pathOrCallback: string | ((api: KubeApi<any>) => boolean)) {
+  getApi(pathOrCallback: string | ((api: KubeApi<TKubeObject>) => boolean)) {
     if (typeof pathOrCallback === "string") {
       return this.apis.get(pathOrCallback) || this.apis.get(parseKubeApi(pathOrCallback).apiBase);
     }
@@ -32,7 +32,7 @@ export class ApiManager {
     return iter.find(this.apis.values(), api => api.kind === kind && api.apiVersionWithGroup === apiVersion);
   }
 
-  registerApi(apiBase: string, api: KubeApi<any>) {
+  registerApi(apiBase: string, api: KubeApi<TKubeObject>) {
     if (!api.apiBase) return;
 
     if (!this.apis.has(apiBase)) {
@@ -46,13 +46,13 @@ export class ApiManager {
     }
   }
 
-  protected resolveApi<K extends KubeObject>(api?: string | KubeApi<K>): KubeApi<K> | undefined {
+  protected resolveApi(api?: string | KubeApi<TKubeObject>): KubeApi<TKubeObject> | undefined {
     if (!api) {
       return undefined;
     }
 
     if (typeof api === "string") {
-      return this.getApi(api) as KubeApi<K>;
+      return this.getApi(api) as KubeApi<TKubeObject>;
     }
 
     return api;
@@ -75,7 +75,7 @@ export class ApiManager {
     });
   }
 
-  getStore<S extends KubeObjectStore<any>>(api: string | KubeApi<KubeObject>): S | undefined {
+  getStore<S extends KubeObjectStore<TKubeObject>>(api: string | KubeApi<TKubeObject>): S | undefined {
     return this.stores.get(this.resolveApi(api)?.apiBase) as S;
   }
 

--- a/src/common/k8s-api/api-manager.ts
+++ b/src/common/k8s-api/api-manager.ts
@@ -12,15 +12,15 @@ import type { KubeObject } from "./kube-object";
 import { IKubeObjectRef, parseKubeApi, createKubeApiURL } from "./kube-api-parse";
 
 export class ApiManager {
-  private apis = observable.map<string, KubeApi<KubeObject>>();
-  private stores = observable.map<string, KubeObjectStore<KubeObject>>();
+  private apis = observable.map<string, KubeApi<any>>();
+  private stores = observable.map<string, KubeObjectStore<any>>();
 
   constructor() {
     makeObservable(this);
     autoBind(this);
   }
 
-  getApi(pathOrCallback: string | ((api: KubeApi<KubeObject>) => boolean)) {
+  getApi(pathOrCallback: string | ((api: KubeApi<any>) => boolean)) {
     if (typeof pathOrCallback === "string") {
       return this.apis.get(pathOrCallback) || this.apis.get(parseKubeApi(pathOrCallback).apiBase);
     }
@@ -32,7 +32,7 @@ export class ApiManager {
     return iter.find(this.apis.values(), api => api.kind === kind && api.apiVersionWithGroup === apiVersion);
   }
 
-  registerApi(apiBase: string, api: KubeApi<KubeObject>) {
+  registerApi(apiBase: string, api: KubeApi<any>) {
     if (!api.apiBase) return;
 
     if (!this.apis.has(apiBase)) {
@@ -58,7 +58,7 @@ export class ApiManager {
     return api;
   }
 
-  unregisterApi(api: string | KubeApi<KubeObject>) {
+  unregisterApi(api: string | KubeApi<any>) {
     if (typeof api === "string") this.apis.delete(api);
     else {
       const apis = Array.from(this.apis.entries());
@@ -69,17 +69,17 @@ export class ApiManager {
   }
 
   @action
-  registerStore(store: KubeObjectStore<KubeObject>, apis: KubeApi<KubeObject>[] = [store.api]) {
+  registerStore(store: KubeObjectStore<any>, apis: KubeApi<any>[] = [store.api]) {
     apis.filter(Boolean).forEach(api => {
       if (api.apiBase) this.stores.set(api.apiBase, store);
     });
   }
 
-  getStore<S extends KubeObjectStore<KubeObject>>(api: string | KubeApi<KubeObject>): S | undefined {
+  getStore<S extends KubeObjectStore<any>>(api: string | KubeApi<KubeObject>): S | undefined {
     return this.stores.get(this.resolveApi(api)?.apiBase) as S;
   }
 
-  lookupApiLink(ref: IKubeObjectRef, parentObject?: KubeObject): string {
+  lookupApiLink<T extends KubeObject = KubeObject>(ref: IKubeObjectRef, parentObject?: T): string {
     const {
       kind, apiVersion, name,
       namespace = parentObject?.getNs(),


### PR DESCRIPTION
Currently it's not possible to have a `MyClass extends KubeObject` with additional methods because `ApiManager` requires objects to be exactly `KubeObject`. ~`ApiManager` should not care about `KubeObject` types within `KubeApi` / `KubeObjectStore` because it's not possible to create those classes with invalid types.~


Needs a separate backport PR to `release/5.4` branch once merged.