### PR TITLE
quick fix for logs not showing in tabs after first tab

### DIFF
--- a/src/renderer/components/dock/logs/view.tsx
+++ b/src/renderer/components/dock/logs/view.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React, { createRef, useEffect } from "react";
+import React, { createRef, useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import { InfoPanel } from "../info-panel";
 import { LogResourceSelector } from "./resource-selector";
@@ -34,6 +34,12 @@ interface Dependencies {
 const NonInjectedLogsDockTab = observer(({ className, tab, model, subscribeStores }: Dependencies & LogsDockTabProps) => {
   const logListElement = createRef<LogList>();
   const data = model.logTabData.get();
+  const [tabIds, setTabIds] = useState([]);
+
+  if (!tabIds.find(id => tab.id === id)) {
+    setTabIds([...tabIds, tab.id]);
+    model.reloadLogs();
+  }
 
   useEffect(() => {
     model.reloadLogs();

--- a/src/renderer/components/dock/logs/view.tsx
+++ b/src/renderer/components/dock/logs/view.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import React, { createRef, useEffect, useState } from "react";
+import React, { createRef, useEffect } from "react";
 import { observer } from "mobx-react";
 import { InfoPanel } from "../info-panel";
 import { LogResourceSelector } from "./resource-selector";
@@ -34,18 +34,12 @@ interface Dependencies {
 const NonInjectedLogsDockTab = observer(({ className, tab, model, subscribeStores }: Dependencies & LogsDockTabProps) => {
   const logListElement = createRef<LogList>();
   const data = model.logTabData.get();
-  const [tabIds, setTabIds] = useState([]);
-
-  if (!tabIds.find(id => tab.id === id)) {
-    setTabIds([...tabIds, tab.id]);
-    model.reloadLogs();
-  }
 
   useEffect(() => {
     model.reloadLogs();
 
     return model.stopLoadingLogs;
-  }, []);
+  }, [tab.id]);
   useEffect(() => subscribeStores([
     podsStore,
   ], {


### PR DESCRIPTION
Fixes #4958 

When opening the first pods log tab a pod watch is started and the logs are successfully loaded:
```
[KUBE-API] watch (pod-7) started /api/v1/namespaces/lens-platform/pods?watch=1&resourceVersion=617360
```
But opening subsequent pods log tabs reports an error on (re)starting the watch:
```
[KUBE-API] watch (pod-7) aborted /api/v1/namespaces/lens-platform/pods?watch=1&resourceVersion=617360
[KUBE-API] watch (pod-7) throwed /api/v1/namespaces/lens-platform/pods?watch=1&resourceVersion=617360 The user aborted a request. 
AbortError {type: 'aborted', message: 'The user aborted a request.', stack: 'AbortError: The user aborted a request.\n    at abo…ld/OpenLensDev.js?dfc84d02244888fa6d21:518651:11)'}
KUBE-API] watch (pod-8) started /api/v1/namespaces/default/pods?watch=1&resourceVersion=617433
```
I don't know if this watch error is a factor but the result of this is that on subsequent log tab openings the logs are not loaded. The logs are meant to be loaded in `LogsDockTab` via a call to `model.reloadLogs()` in a react effect:
```
  useEffect(() => {
    model.reloadLogs();

    return model.stopLoadingLogs;
  }, []);
```
This is not being called for subsequent log tabs and is the root of the problem.
It looks like the pod watch is restarted also in an effect here, maybe this is related?
```
  useEffect(() => subscribeStores([
    podsStore,
  ], {
    namespaces: data ? [data.namespace] : [],
  }), [data?.namespace]);
```

~~In any case, I opted for a small kludge to ensure `model.reloadLogs()` gets called when the tab is first opened. I'm sure there's a better way...~~
@Nokel81 pointed to what I think is the proper fix.
