### PR TITLE
Remove listener for online event

### DIFF
--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -10,10 +10,9 @@ import { Notifications } from "../../../components/notifications";
 import type { AppEvent } from "../../../../common/app-event-bus/event-bus";
 import type { CatalogEntity } from "../../../../common/catalog";
 import { when } from "mobx";
-import { unmountComponentAtNode } from "react-dom";
 import type { ClusterFrameContext } from "../../../cluster-frame-context/cluster-frame-context";
 import { KubeObjectStore } from "../../../../common/k8s-api/kube-object.store";
-import { requestSetClusterFrameId } from "../../../ipc";
+import { requestClusterDisconnection, requestSetClusterFrameId } from "../../../ipc";
 
 interface Dependencies {
   hostedCluster: Cluster;
@@ -30,7 +29,7 @@ const logPrefix = "[CLUSTER-FRAME]:";
 
 export const initClusterFrame =
   ({ hostedCluster, loadExtensions, catalogEntityRegistry, frameRoutingId, emitEvent, clusterFrameContext }: Dependencies) =>
-    async (rootElem: HTMLElement) => {
+    async () => {
 
       // TODO: Make catalogEntityRegistry already initialized when passed as dependency
       catalogEntityRegistry.init();
@@ -84,7 +83,7 @@ export const initClusterFrame =
           `${logPrefix} Unload dashboard, clusterId=${(hostedCluster.id)}, frameId=${frameRoutingId}`,
         );
 
-        unmountComponentAtNode(rootElem);
+        requestClusterDisconnection(hostedCluster.id);
       };
 
       // TODO: Make context dependency of KubeObjectStore

--- a/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -10,9 +10,10 @@ import { Notifications } from "../../../components/notifications";
 import type { AppEvent } from "../../../../common/app-event-bus/event-bus";
 import type { CatalogEntity } from "../../../../common/catalog";
 import { when } from "mobx";
+import { unmountComponentAtNode } from "react-dom";
 import type { ClusterFrameContext } from "../../../cluster-frame-context/cluster-frame-context";
 import { KubeObjectStore } from "../../../../common/k8s-api/kube-object.store";
-import { requestClusterDisconnection, requestSetClusterFrameId } from "../../../ipc";
+import { requestSetClusterFrameId } from "../../../ipc";
 
 interface Dependencies {
   hostedCluster: Cluster;
@@ -29,7 +30,7 @@ const logPrefix = "[CLUSTER-FRAME]:";
 
 export const initClusterFrame =
   ({ hostedCluster, loadExtensions, catalogEntityRegistry, frameRoutingId, emitEvent, clusterFrameContext }: Dependencies) =>
-    async () => {
+    async (rootElem: HTMLElement) => {
 
       // TODO: Make catalogEntityRegistry already initialized when passed as dependency
       catalogEntityRegistry.init();
@@ -74,16 +75,12 @@ export const initClusterFrame =
         });
       });
 
-      window.addEventListener("online", () => {
-        window.location.reload();
-      });
-
       window.onbeforeunload = () => {
         logger.info(
           `${logPrefix} Unload dashboard, clusterId=${(hostedCluster.id)}, frameId=${frameRoutingId}`,
         );
 
-        requestClusterDisconnection(hostedCluster.id);
+        unmountComponentAtNode(rootElem);
       };
 
       // TODO: Make context dependency of KubeObjectStore


### PR DESCRIPTION
On Windows only, as a result of the system sleeping, `window.onbeforeunload()` is called for the visible cluster dashboard (not sure why). The behaviour before this PR was to simply remove the root element of the cluster frame. This leaves Lens in limbo as the cluster is still connected but the dashboard is gone. This PR initiates a cluster disconnect instead of removing the root element. So when the windows system is awakened the user is greeted with the catalog rather than a blank dashboard.

Fixes #2434 

Might still want to investigate why `window.onbeforeunload()` is getting called during sleep.

UPDATE:
- restored the `window.onbeforeunload()` behaviour as it was relied upon during user reloads (View menu -> Reload)
- removed the listener for online event, verifying that
  - it doesn't impact cluster loading behaviour (doesn't appear to be necessary given other listeners)
  - it did get triggered on windows during sleep/resume and is responsible for triggering the problematic call to `window.onbeforeunload()`

This should soak in case I missed any reload behaviour being impacted.