### PR TITLE
Fix: overlapped pod logs

### DIFF
--- a/src/renderer/components/dock/logs/store.ts
+++ b/src/renderer/components/dock/logs/store.ts
@@ -120,7 +120,7 @@ export class LogStore {
       previous: showPrevious,
     });
 
-    return result.trimEnd().split("\n");
+    return result.trimEnd().replace(/\r/g, "\n").split("\n");
   }
 
   /**


### PR DESCRIPTION
For some reason some loggers uses CR `\r` symbol for the new lines. Before this PR lens splits logs only by the LF `\n` symbol. This caused overlapped logs rendering.

Here we replace CR with LF new line characters in logs.

Before:
<img width="1183" alt="overlapped logs" src="https://user-images.githubusercontent.com/9607060/158802481-dcb83750-e8c0-4992-bd14-a2b73f028f84.png">

After:
<img width="1173" alt="non-overlapped logs" src="https://user-images.githubusercontent.com/9607060/158802430-d845311a-36a9-45f8-8011-9382acb673d5.png">



The difference between CR LF symbols https://stackoverflow.com/a/9260158/17505870

Fixes https://github.com/lensapp/lens/issues/3591
Fixes https://github.com/lensapp/lens/issues/4003
Fixes https://github.com/lensapp/lens/issues/3233

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>