### PR TITLE
Get DI cleaner

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,11 +58,11 @@ import userStoreInjectable from "../common/user-store/user-store.injectable";
 import trayMenuItemsInjectable from "./tray/tray-menu-items.injectable";
 import { broadcastNativeThemeOnUpdate } from "./native-theme";
 
-const di = getDi();
-
 app.setName(appName);
 
 app.on("ready", async () => {
+  const di = getDi();
+
   await di.runSetups();
 
   injectSystemCAs();


### PR DESCRIPTION
We only need the di inside the callback, so it's cleaner to get it there. This function also has side effect (which might be removed later, though).