### PR TITLE
Proposal: Add ContextProviders support to the Extension API

### DIFF
--- a/src/extensions/extension-loader/extension-loader.ts
+++ b/src/extensions/extension-loader/extension-loader.ts
@@ -250,6 +250,7 @@ export class ExtensionLoader {
         registries.GlobalPageRegistry.getInstance().add(extension.globalPages, extension),
         registries.EntitySettingRegistry.getInstance().add(extension.entitySettings),
         registries.CatalogEntityDetailRegistry.getInstance().add(extension.catalogEntityDetailItems),
+        ...(extension.getContextProviders ? [registries.ContextProviderRegistry.getInstance().add(await extension.getContextProviders())] : []),
       ];
 
       this.events.on("remove", (removedExtension: LensRendererExtension) => {
@@ -277,6 +278,7 @@ export class ExtensionLoader {
         registries.ClusterPageRegistry.getInstance().add(extension.clusterPages, extension),
         registries.ClusterPageMenuRegistry.getInstance().add(extension.clusterPageMenus, extension),
         registries.KubeObjectDetailRegistry.getInstance().add(extension.kubeObjectDetailItems),
+        ...(extension.getContextProviders ? [registries.ContextProviderRegistry.getInstance().add(await extension.getContextProviders())] : []),
       ];
 
       this.events.on("remove", (removedExtension: LensRendererExtension) => {

--- a/src/extensions/lens-renderer-extension.ts
+++ b/src/extensions/lens-renderer-extension.ts
@@ -41,6 +41,7 @@ export class LensRendererExtension extends LensExtension {
   topBarItems: TopBarRegistration[] = [];
   additionalCategoryColumns: AdditionalCategoryColumnRegistration[] = [];
   customCategoryViews: CustomCategoryViewRegistration[] = [];
+  getContextProviders?: () => Promise<registries.ContextProviderRegistration[]>;
 
   async navigate<P extends object>(pageId?: string, params?: P) {
     const { navigate } = await import("../renderer/navigation");

--- a/src/extensions/registries/context-provider-registry.ts
+++ b/src/extensions/registries/context-provider-registry.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type React from "react";
+import { BaseRegistry } from "./base-registry";
+
+export interface ContextProviderProps {
+}
+
+export interface ContextProviderComponents {
+  Provider: React.ComponentType<ContextProviderProps>;
+}
+
+export interface ContextProviderRegistration {
+  components: ContextProviderComponents;
+}
+
+export interface RegisteredContextProvider extends ContextProviderRegistration {
+  id: string;
+}
+
+export class ContextProviderRegistry extends BaseRegistry<ContextProviderRegistration, RegisteredContextProvider> {
+}

--- a/src/extensions/registries/index.ts
+++ b/src/extensions/registries/index.ts
@@ -10,4 +10,5 @@ export * from "./page-menu-registry";
 export * from "./kube-object-detail-registry";
 export * from "./entity-setting-registry";
 export * from "./catalog-entity-detail-registry";
+export * from "./context-provider-registry";
 export * from "./protocol-handler";

--- a/src/renderer/initializers/registries.ts
+++ b/src/renderer/initializers/registries.ts
@@ -12,4 +12,5 @@ export function initRegistries() {
   registries.EntitySettingRegistry.createInstance();
   registries.GlobalPageRegistry.createInstance();
   registries.KubeObjectDetailRegistry.createInstance();
+  registries.ContextProviderRegistry.createInstance();
 }


### PR DESCRIPTION
* Draft PR for discussion of adding a new Extension API which allows extensions to register a React Context Provider
* At the moment this is not feasible as an Extension exports/configures multiple "entry points" that are rendered by the Lens
* The use case here is to support using React Context in extensions, which will reduce boilerplate / prop drilling
* Draft PR, missing documentation and tests
* More information about Context and it's use cases: https://reactjs.org/docs/context.html
* If the value of the Provider changes, only the components under the Consumer(s) are re-rendered
* Performance consideration: the whole app's root might be re-rendered during loading multiple extensions when the application is being loaded
* Note: each extension can provide a single component that contains multiple Providers

Example code in an extension (in renderer):
```
  getContextProviders = async () => {
    return [{
      components: {
        Provider: LensPlatformStoreProvider
      }
    }];
  };
```

The interface is similar to entity settings for consistency.