### PR TITLE
Fix slackLink in catalog becoming out of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.5.0-alpha.0",
+  "version": "5.5.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.5.0-alpha.1",
+  "version": "5.5.0-alpha.0",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -131,6 +131,13 @@ export const issuesTrackerUrl = "https://github.com/lensapp/lens/issues" as stri
 export const slackUrl = "https://join.slack.com/t/k8slens/shared_invite/zt-wcl8jq3k-68R5Wcmk1o95MLBE5igUDQ" as string;
 export const supportUrl = "https://docs.k8slens.dev/latest/support/" as string;
 
+export const lensWebsiteWeblinkId = "lens-website-link";
+export const lensDocumentationWeblinkId = "lens-documentation-link";
+export const lensSlackWeblinkId = "lens-slack-link";
+export const lensTwitterWeblinkId = "lens-twitter-link";
+export const lensBlogWeblinkId = "lens-blog-link";
+export const kubernetesDocumentationWeblinkId = "kubernetes-documentation-link";
+
 export const appSemVer = new SemVer(packageInfo.version);
 export const docsUrl = "https://docs.k8slens.dev/main/" as string;
 

--- a/src/common/weblink-store.ts
+++ b/src/common/weblink-store.ts
@@ -54,12 +54,11 @@ export class WeblinkStore extends BaseStore<WeblinkStoreModel> {
       name,
       url,
     } = data;
+    const weblink: WeblinkData = { id, name, url };
 
-    const weblink = { id, name, url };
+    this.weblinks.push(weblink);
 
-    this.weblinks.push(weblink as WeblinkData);
-
-    return weblink as WeblinkData;
+    return weblink;
   }
 
   @action

--- a/src/migrations/helpers.ts
+++ b/src/migrations/helpers.ts
@@ -20,7 +20,7 @@ export interface MigrationDeclaration {
 }
 
 export function joinMigrations(...declarations: MigrationDeclaration[]): Migrations<any> {
-  const migrations = new Map<string, ((store: Conf<any>) => void)[]>();
+  const migrations = new Map<string, MigrationDeclaration["run"][]>();
 
   for (const decl of declarations) {
     getOrInsert(migrations, decl.version, []).push(decl.run);

--- a/src/migrations/weblinks-store/5.1.4.ts
+++ b/src/migrations/weblinks-store/5.1.4.ts
@@ -7,6 +7,13 @@ import { docsUrl, slackUrl } from "../../common/vars";
 import type { WeblinkData } from "../../common/weblink-store";
 import type { MigrationDeclaration } from "../helpers";
 
+export const lensWebsiteLinkName = "Lens Website";
+export const lensDocumentationWeblinkName = "Lens Documentation";
+export const lensSlackWeblinkName = "Lens Community Slack";
+export const lensTwitterWeblinkName = "Lens on Twitter";
+export const lensBlogWeblinkName = "Lens Official Blog";
+export const kubernetesDocumentationWeblinkName = "Kubernetes Documentation";
+
 export default {
   version: "5.1.4",
   run(store) {
@@ -14,12 +21,12 @@ export default {
     const weblinks = (Array.isArray(weblinksRaw) ? weblinksRaw : []) as WeblinkData[];
 
     weblinks.push(
-      { id: "https://k8slens.dev", name: "Lens Website", url: "https://k8slens.dev" },
-      { id: docsUrl, name: "Lens Documentation", url: docsUrl },
-      { id: slackUrl, name: "Lens Community Slack", url: slackUrl },
-      { id: "https://kubernetes.io/docs/home/", name: "Kubernetes Documentation", url: "https://kubernetes.io/docs/home/" },
-      { id: "https://twitter.com/k8slens", name: "Lens on Twitter", url: "https://twitter.com/k8slens" },
-      { id: "https://medium.com/k8slens", name: "Lens Official Blog", url: "https://medium.com/k8slens" },
+      { id: "https://k8slens.dev", name: lensWebsiteLinkName, url: "https://k8slens.dev" },
+      { id: docsUrl, name: lensDocumentationWeblinkName, url: docsUrl },
+      { id: slackUrl, name: lensSlackWeblinkName, url: slackUrl },
+      { id: "https://twitter.com/k8slens", name: lensTwitterWeblinkName, url: "https://twitter.com/k8slens" },
+      { id: "https://medium.com/k8slens", name: lensBlogWeblinkName, url: "https://medium.com/k8slens" },
+      { id: "https://kubernetes.io/docs/home/", name: kubernetesDocumentationWeblinkName, url: "https://kubernetes.io/docs/home/" },
     );
 
     store.set("weblinks", weblinks);

--- a/src/migrations/weblinks-store/5.4.5-beta.1.ts
+++ b/src/migrations/weblinks-store/5.4.5-beta.1.ts
@@ -14,8 +14,6 @@ export default {
     const weblinksRaw: any = store.get("weblinks");
     const weblinks = (Array.isArray(weblinksRaw) ? weblinksRaw : []) as WeblinkData[];
 
-    console.log("weblinks in 5.4.5-beta.1 migration", weblinks);
-
     const lensWebsiteLink = weblinks.find(weblink => weblink.name === lensWebsiteLinkName);
 
     if (lensWebsiteLink) {

--- a/src/migrations/weblinks-store/5.4.5-beta.1.ts
+++ b/src/migrations/weblinks-store/5.4.5-beta.1.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { kubernetesDocumentationWeblinkId, lensBlogWeblinkId, lensDocumentationWeblinkId, lensSlackWeblinkId, lensTwitterWeblinkId, lensWebsiteWeblinkId } from "../../common/vars";
+import type { WeblinkData } from "../../common/weblink-store";
+import type { MigrationDeclaration } from "../helpers";
+import { kubernetesDocumentationWeblinkName, lensBlogWeblinkName, lensDocumentationWeblinkName, lensSlackWeblinkName, lensTwitterWeblinkName, lensWebsiteLinkName } from "./5.1.4";
+
+export default {
+  version: "5.4.5-beta.1 || 5.5.0-alpha.1",
+  run(store) {
+    const weblinksRaw: any = store.get("weblinks");
+    const weblinks = (Array.isArray(weblinksRaw) ? weblinksRaw : []) as WeblinkData[];
+
+    console.log("weblinks in 5.4.5-beta.1 migration", weblinks);
+
+    const lensWebsiteLink = weblinks.find(weblink => weblink.name === lensWebsiteLinkName);
+
+    if (lensWebsiteLink) {
+      lensWebsiteLink.id = lensWebsiteWeblinkId;
+    }
+
+    const lensDocumentationWeblinkLink = weblinks.find(weblink => weblink.name === lensDocumentationWeblinkName);
+
+    if (lensDocumentationWeblinkLink) {
+      lensDocumentationWeblinkLink.id = lensDocumentationWeblinkId;
+    }
+
+    const lensSlackWeblinkLink = weblinks.find(weblink => weblink.name === lensSlackWeblinkName);
+
+    if (lensSlackWeblinkLink) {
+      lensSlackWeblinkLink.id = lensSlackWeblinkId;
+    }
+
+    const lensTwitterWeblinkLink = weblinks.find(weblink => weblink.name === lensTwitterWeblinkName);
+
+    if (lensTwitterWeblinkLink) {
+      lensTwitterWeblinkLink.id = lensTwitterWeblinkId;
+    }
+
+    const lensBlogWeblinkLink = weblinks.find(weblink => weblink.name === lensBlogWeblinkName);
+
+    if (lensBlogWeblinkLink) {
+      lensBlogWeblinkLink.id = lensBlogWeblinkId;
+    }
+
+    const kubernetesDocumentationWeblinkLink = weblinks.find(weblink => weblink.name === kubernetesDocumentationWeblinkName);
+
+    if (kubernetesDocumentationWeblinkLink) {
+      kubernetesDocumentationWeblinkLink.id = kubernetesDocumentationWeblinkId;
+    }
+
+    store.set("weblinks", weblinks);
+  },
+} as MigrationDeclaration;

--- a/src/migrations/weblinks-store/5.4.5-beta.1.ts
+++ b/src/migrations/weblinks-store/5.4.5-beta.1.ts
@@ -9,7 +9,7 @@ import type { MigrationDeclaration } from "../helpers";
 import { kubernetesDocumentationWeblinkName, lensBlogWeblinkName, lensDocumentationWeblinkName, lensSlackWeblinkName, lensTwitterWeblinkName, lensWebsiteLinkName } from "./5.1.4";
 
 export default {
-  version: "5.4.5-beta.1 || 5.5.0-alpha.1",
+  version: "5.4.5-beta.1 || >=5.5.0-alpha.0",
   run(store) {
     const weblinksRaw: any = store.get("weblinks");
     const weblinks = (Array.isArray(weblinksRaw) ? weblinksRaw : []) as WeblinkData[];

--- a/src/migrations/weblinks-store/currentVersion.ts
+++ b/src/migrations/weblinks-store/currentVersion.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getAppVersion } from "../../common/utils";
+import { lensSlackWeblinkId, slackUrl } from "../../common/vars";
+import type { WeblinkData } from "../../common/weblink-store";
+import type { MigrationDeclaration } from "../helpers";
+
+export default {
+  version: getAppVersion(), // Run always after upgrade
+  run(store) {
+    const weblinksRaw: any = store.get("weblinks");
+    const weblinks = (Array.isArray(weblinksRaw) ? weblinksRaw : []) as WeblinkData[];
+    const slackWeblink = weblinks.find(weblink => weblink.id === lensSlackWeblinkId);
+
+    if (slackWeblink) {
+      slackWeblink.url = slackUrl;
+    }
+
+    store.set("weblinks", weblinks);
+  },
+} as MigrationDeclaration;

--- a/src/migrations/weblinks-store/index.ts
+++ b/src/migrations/weblinks-store/index.ts
@@ -6,7 +6,11 @@
 import { joinMigrations } from "../helpers";
 
 import version514 from "./5.1.4";
+import version545Beta1 from "./5.4.5-beta.1";
+import currentVersion from "./currentVersion";
 
 export default joinMigrations(
   version514,
+  version545Beta1,
+  currentVersion,
 );


### PR DESCRIPTION
- Add migration to make default weblinks' ids not their URLs

- Add migration to always update the slack weblink if still present

Signed-off-by: Sebastian Malton <sebastian@malton.name>

