### PR TITLE
Fix: make dock tab close button smaller

### DIFF
--- a/src/renderer/components/dock/dock-tab.module.scss
+++ b/src/renderer/components/dock/dock-tab.module.scss
@@ -81,7 +81,7 @@
 .close {
   position: absolute;
   right: 0px;
-  width: 5ch;
+  width: 4ch;
   opacity: 0;
   text-align: center;
   background: linear-gradient(90deg, transparent 0%, var(--color-active) 25%);


### PR DESCRIPTION
A tiny fix which solves small shadow overflow above the tab text.

Before:
![terminal before](https://user-images.githubusercontent.com/9607060/160391966-4856048d-322a-45f0-94da-47454d5c0d2d.png)

(its visible that `Terminal` character a bit "shadowed" in the end).

After:
![terminal after](https://user-images.githubusercontent.com/9607060/160391997-e0f2f342-cc2d-4336-b1b0-4f73f6b35570.png)



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>