### PR TITLE
Always preload app fonts at earliest stages

### DIFF
--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -7,9 +7,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@import "~flex.box"; // todo: replace with tailwind's flexbox classes
-@import "./fonts";
+@import "~flex.box";
 @import "../themes/theme-vars";
+@import "./fonts";
 
 :root {
   --unit: 8px;

--- a/src/renderer/components/dock/terminal/terminal-dock-tab.scss
+++ b/src/renderer/components/dock/terminal/terminal-dock-tab.scss
@@ -4,7 +4,4 @@
  */
 
 .TerminalTab {
-  @include font-preload {
-    font-family: "RobotoMono", monospace;
-  }
 }

--- a/src/renderer/components/fonts.scss
+++ b/src/renderer/components/fonts.scss
@@ -4,7 +4,8 @@
  */
 
 // Custom fonts
-@import "~typeface-roboto/index.css";
+@import "~typeface-roboto";
+@import "./mixins";
 
 // Material Design Icons, used primarily in icon.tsx
 // Latest: https://github.com/google/material-design-icons/tree/master/font
@@ -23,4 +24,14 @@
   font-family: 'RobotoMono';
   font-display: block;
   src: local('RobotoMono'), url('./fonts/roboto-mono-nerd.ttf') format('truetype');
+}
+
+#fonts-preloading {
+  > .icons {
+    @include font-preload("Material Icons");
+  }
+
+  > .terminal {
+    @include font-preload("RobotoMono");
+  }
 }

--- a/src/renderer/components/fonts.scss
+++ b/src/renderer/components/fonts.scss
@@ -4,8 +4,7 @@
  */
 
 // Custom fonts
-@import "~typeface-roboto";
-@import "./mixins";
+@import "~typeface-roboto/index.css";
 
 // Material Design Icons, used primarily in icon.tsx
 // Latest: https://github.com/google/material-design-icons/tree/master/font

--- a/src/renderer/components/mixins.scss
+++ b/src/renderer/components/mixins.scss
@@ -60,14 +60,19 @@
   }
 }
 
-// Makes custom font available at earlier stages (start preloading)
-// Element must be in DOM and contain some text of loading font.
-@mixin font-preload() {
+// Makes custom @font-family available at earlier stages.
+// Element must exist in DOM as soon as possible to initiate preloading.
+@mixin font-preload($fontFamily: "RobotoMono") {
+  position: absolute;
+  visibility: hidden;
+  height: 0;
+
   &:before {
     width: 0;
     display: block;
     overflow: hidden;
-    content: "x"; // required
-    @content; // must contain `font-family`
+    content: "x"; // some text required to start applying font in document
+    font-family: $fontFamily; // imported name in @font-face declaration
+    @content;
   }
 }

--- a/src/renderer/components/mixins.scss
+++ b/src/renderer/components/mixins.scss
@@ -62,7 +62,7 @@
 
 // Makes custom @font-family available at earlier stages.
 // Element must exist in DOM as soon as possible to initiate preloading.
-@mixin font-preload($fontFamily: "RobotoMono") {
+@mixin font-preload($fontFamily) {
   position: absolute;
   visibility: hidden;
   height: 0;

--- a/src/renderer/template.html
+++ b/src/renderer/template.html
@@ -2,13 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="preload" href="<%= assetPath %>/MaterialIcons-Regular.ttf" as="font" crossorigin>
-  <link rel="preload" href="<%= assetPath %>/roboto-mono-nerd.ttf" as="font" crossorigin>
 </head>
 <body>
 
 <div id="app"></div>
 <div id="terminal-init"></div>
+
+<div id="fonts-preloading">
+  <i class="icons"><!--material icons--></i>
+  <i class="terminal"><!--roboto mono--></i>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
Terminal font wasn't loaded in some specific conditions of app working.
Reproduced: after disconnect  & connect to active cluster with opened terminal tab.
From now all fonts used in app must be manually declared in `template.html` and enabled for preloading in `fonts.scss`

fix #5019