### PR TITLE
Set dock tab contrast bg color

### DIFF
--- a/src/renderer/components/dock/dock.scss
+++ b/src/renderer/components/dock/dock.scss
@@ -69,6 +69,7 @@
     flex: 1;
     overflow: hidden;
     transition: flex-basis 25ms ease-in;
+    background: var(--dockInfoBackground);
 
     &.terminal {
       background: var(--terminalBackground);


### PR DESCRIPTION
Set contrast background color for the spinner area to separate tabs from dock contents.

Before:

https://user-images.githubusercontent.com/9607060/160835896-94ebb432-f24f-404f-80fa-666c1e3ba959.mov

After:


https://user-images.githubusercontent.com/9607060/160835911-0ad141e2-4c93-4519-876a-ba3aa9de0b74.mov



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>