### PR TITLE
Add optional badge to Catalog Category label

### DIFF
--- a/src/common/__tests__/catalog-entity.test.tsx
+++ b/src/common/__tests__/catalog-entity.test.tsx
@@ -3,15 +3,18 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import React from "react";
 import { CatalogCategory, CatalogCategorySpec } from "../catalog";
 
-class TestCatalogCategory extends CatalogCategory {
+class TestCatalogCategoryWithoutBadge extends CatalogCategory {
   public readonly apiVersion = "catalog.k8slens.dev/v1alpha1";
   public readonly kind = "CatalogCategory";
+
   public metadata = {
     name: "Test Category",
     icon: "",
   };
+
   public spec: CatalogCategorySpec = {
     group: "entity.k8slens.dev",
     versions: [],
@@ -21,10 +24,28 @@ class TestCatalogCategory extends CatalogCategory {
   };
 }
 
+class TestCatalogCategoryWithBadge extends TestCatalogCategoryWithoutBadge {
+  getBadge() {
+    return (<div>Test Badge</div>);
+  }
+}
+
 describe("CatalogCategory", () => {
   it("returns name", () => {
-    const category = new TestCatalogCategory();
+    const category = new TestCatalogCategoryWithoutBadge();
 
     expect(category.getName()).toEqual("Test Category");
+  });
+
+  it("doesn't return badge by default", () => {
+    const category = new TestCatalogCategoryWithoutBadge();
+
+    expect(category.getBadge()).toEqual(null);
+  });
+
+  it("returns a badge", () => {
+    const category = new TestCatalogCategoryWithBadge();
+
+    expect(category.getBadge()).toBeTruthy();
   });
 });

--- a/src/common/catalog/catalog-entity.ts
+++ b/src/common/catalog/catalog-entity.ts
@@ -181,6 +181,15 @@ export abstract class CatalogCategory extends (EventEmitter as new () => TypedEm
   }
 
   /**
+   * Get the badge of this category.
+   * Defaults to no badge.
+   * The badge is displayed next to the Category name in the Catalog Category menu
+   */
+  public getBadge(): React.ReactNode {
+    return null;
+  }
+
+  /**
    * Add a filter for menu items of catalogAddMenu
    * @param fn The function that should return a truthy value if that menu item should be displayed
    * @returns A function to remove that filter

--- a/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
+++ b/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { CatalogCategory, CatalogCategorySpec } from "../../../../common/catalog";
+import { CatalogCategoryLabel } from "../catalog-category-label";
+
+class CatalogCategoryWithoutBadge extends CatalogCategory {
+  public readonly apiVersion = "catalog.k8slens.dev/v1alpha1";
+  public readonly kind = "CatalogCategory";
+
+  public metadata = {
+    name: "Test Category",
+    icon: "",
+  };
+
+  public spec: CatalogCategorySpec = {
+    group: "entity.k8slens.dev",
+    versions: [],
+    names: {
+      kind: "Test",
+    },
+  };
+}
+
+class CatalogCategoryWithBadge extends CatalogCategoryWithoutBadge {
+  getBadge() {
+    return (<div>Test Badge</div>);
+  }
+}
+
+describe("CatalogCategoryLabel", () => {
+  it("renders without a badge", async () => {
+    const category = new CatalogCategoryWithoutBadge();
+
+    render(<CatalogCategoryLabel category={category}/>);
+
+    expect(await screen.findByText("Test Category")).toBeInTheDocument();
+  });
+
+  it("renders with a badge", async () => {
+    const category = new CatalogCategoryWithBadge();
+
+    render(<CatalogCategoryLabel category={category}/>);
+
+    expect(await screen.findByText("Test Category")).toBeInTheDocument();
+    expect(await screen.findByText("Test Badge")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
+++ b/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
@@ -37,7 +37,7 @@ describe("CatalogCategoryLabel", () => {
   it("renders without a badge", async () => {
     const category = new CatalogCategoryWithoutBadge();
 
-    render(<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()}/>);
+    render(<CatalogCategoryLabel category={category}/>);
 
     expect(await screen.findByText("Test Category")).toBeInTheDocument();
   });
@@ -45,7 +45,7 @@ describe("CatalogCategoryLabel", () => {
   it("renders with a badge", async () => {
     const category = new CatalogCategoryWithBadge();
 
-    render(<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()}/>);
+    render(<CatalogCategoryLabel category={category}/>);
 
     expect(await screen.findByText("Test Category")).toBeInTheDocument();
     expect(await screen.findByText("Test Badge")).toBeInTheDocument();

--- a/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
+++ b/src/renderer/components/+catalog/__tests__/catalog-category-label.test.tsx
@@ -37,7 +37,7 @@ describe("CatalogCategoryLabel", () => {
   it("renders without a badge", async () => {
     const category = new CatalogCategoryWithoutBadge();
 
-    render(<CatalogCategoryLabel category={category}/>);
+    render(<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()}/>);
 
     expect(await screen.findByText("Test Category")).toBeInTheDocument();
   });
@@ -45,7 +45,7 @@ describe("CatalogCategoryLabel", () => {
   it("renders with a badge", async () => {
     const category = new CatalogCategoryWithBadge();
 
-    render(<CatalogCategoryLabel category={category}/>);
+    render(<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()}/>);
 
     expect(await screen.findByText("Test Category")).toBeInTheDocument();
     expect(await screen.findByText("Test Badge")).toBeInTheDocument();

--- a/src/renderer/components/+catalog/catalog-category-label.tsx
+++ b/src/renderer/components/+catalog/catalog-category-label.tsx
@@ -3,19 +3,22 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import React from "react";
+import type { CatalogCategory } from "../../../common/catalog/catalog-entity";
 
 interface CatalogCategoryLabelProps {
-  label: string | React.ReactNode;
-  badge?: React.ReactNode;
+  category: CatalogCategory;
 }
 
 /**
  * Display label for Catalog Category for the Catalog menu
  */
-export const CatalogCategoryLabel = ({ label, badge }: CatalogCategoryLabelProps) =>
-  (
+export const CatalogCategoryLabel = ({ category }: CatalogCategoryLabelProps) => {
+  const badge = category.getBadge();
+
+  return (
     <div className="flex">
-      <div>{label}</div>
+      <div>{category.metadata.name}</div>
       {badge ? (<div className="flex items-center">{badge}</div>) : null}
     </div>
   );
+};

--- a/src/renderer/components/+catalog/catalog-category-label.tsx
+++ b/src/renderer/components/+catalog/catalog-category-label.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import React from "react";
+import type { CatalogCategory } from "../../../common/catalog/catalog-entity";
+
+interface CatalogCategoryLabelProps {
+  category: CatalogCategory;
+}
+
+/**
+ * Display label for Catalog Category for the Catalog menu
+ */
+export const CatalogCategoryLabel = ({ category }: CatalogCategoryLabelProps) =>
+  (
+    <div className="flex">
+      <div>{category.metadata.name}</div>
+      <div className="flex items-center">{category.getBadge()}</div>
+    </div>
+  );

--- a/src/renderer/components/+catalog/catalog-category-label.tsx
+++ b/src/renderer/components/+catalog/catalog-category-label.tsx
@@ -3,19 +3,19 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import React from "react";
-import type { CatalogCategory } from "../../../common/catalog/catalog-entity";
 
 interface CatalogCategoryLabelProps {
-  category: CatalogCategory;
+  label: string | React.ReactNode;
+  badge?: React.ReactNode;
 }
 
 /**
  * Display label for Catalog Category for the Catalog menu
  */
-export const CatalogCategoryLabel = ({ category }: CatalogCategoryLabelProps) =>
+export const CatalogCategoryLabel = ({ label, badge }: CatalogCategoryLabelProps) =>
   (
     <div className="flex">
-      <div>{category.metadata.name}</div>
-      <div className="flex items-center">{category.getBadge()}</div>
+      <div>{label}</div>
+      {badge ? (<div className="flex items-center">{badge}</div>) : null}
     </div>
   );

--- a/src/renderer/components/+catalog/catalog-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-menu.tsx
@@ -14,6 +14,7 @@ import { StylesProvider } from "@material-ui/core";
 import { cssNames } from "../../utils";
 import type { CatalogCategory } from "../../api/catalog-entity";
 import { observer } from "mobx-react";
+import { CatalogCategoryLabel } from "./catalog-category-label";
 
 export interface CatalogMenuProps {
   activeItem: string;
@@ -66,7 +67,7 @@ export const CatalogMenu = observer((props: CatalogMenuProps) => {
                   icon={getCategoryIcon(category)}
                   key={category.getId()}
                   nodeId={category.getId()}
-                  label={category.metadata.name}
+                  label={<CatalogCategoryLabel category={category} />}
                   data-testid={`${category.getId()}-tab`}
                   onClick={() => props.onItemClick(category.getId())}
                 />

--- a/src/renderer/components/+catalog/catalog-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-menu.tsx
@@ -67,7 +67,7 @@ export const CatalogMenu = observer((props: CatalogMenuProps) => {
                   icon={getCategoryIcon(category)}
                   key={category.getId()}
                   nodeId={category.getId()}
-                  label={<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()} />}
+                  label={<CatalogCategoryLabel category={category}/>}
                   data-testid={`${category.getId()}-tab`}
                   onClick={() => props.onItemClick(category.getId())}
                 />

--- a/src/renderer/components/+catalog/catalog-menu.tsx
+++ b/src/renderer/components/+catalog/catalog-menu.tsx
@@ -67,7 +67,7 @@ export const CatalogMenu = observer((props: CatalogMenuProps) => {
                   icon={getCategoryIcon(category)}
                   key={category.getId()}
                   nodeId={category.getId()}
-                  label={<CatalogCategoryLabel category={category} />}
+                  label={<CatalogCategoryLabel label={category.metadata.name} badge={category.getBadge()} />}
                   data-testid={`${category.getId()}-tab`}
                   onClick={() => props.onItemClick(category.getId())}
                 />

--- a/src/renderer/themes/lens-dark.json
+++ b/src/renderer/themes/lens-dark.json
@@ -29,6 +29,7 @@
     "sidebarActiveColor": "#ffffff",
     "sidebarSubmenuActiveColor": "#ffffff",
     "sidebarItemHoverBackground": "#3a3e44",
+    "badgeBackgroundColor": "#ffba44",
     "buttonPrimaryBackground": "#3d90ce",
     "buttonDefaultBackground": "#414448",
     "buttonLightBackground": "#f1f1f1",

--- a/src/renderer/themes/lens-light.json
+++ b/src/renderer/themes/lens-light.json
@@ -29,6 +29,7 @@
     "sidebarSubmenuActiveColor": "#3d90ce",
     "sidebarBackground": "#e8e8e8",
     "sidebarItemHoverBackground": "#f0f2f5",
+    "badgeBackgroundColor": "#ffba44",
     "buttonPrimaryBackground": "#3d90ce",
     "buttonDefaultBackground": "#414448",
     "buttonLightBackground": "#f1f1f1",

--- a/src/renderer/themes/theme-vars.css
+++ b/src/renderer/themes/theme-vars.css
@@ -29,6 +29,7 @@
 --sidebarActiveColor: #ffffff;
 --sidebarSubmenuActiveColor: #ffffff;
 --sidebarItemHoverBackground: #3a3e44;
+--badgeBackgroundColor: #ffba44;
 --buttonPrimaryBackground: #3d90ce;
 --buttonDefaultBackground: #414448;
 --buttonLightBackground: #f1f1f1;
@@ -73,6 +74,8 @@
 --dockEditorComment: #808080;
 --dockEditorActiveLineBackground: #3a3d41;
 --dockBadgeBackground: #36393e;
+--dockTabBorderColor: #43424d;
+--dockTabActiveBackground: #3a3e45;
 --logsBackground: #000000;
 --logsForeground: #ffffff;
 --logRowHoverBackground: #35373a;
@@ -125,7 +128,7 @@
 --inputControlHoverBorder: #474a4f;
 --lineProgressBackground: #414448;
 --radioActiveBackground: #36393e;
---menuActiveBackground: #36393e;
+--menuActiveBackground: #3d90ce;
 --menuSelectedOptionBgc: #36393e;
 --canvasBackground: #24292e;
 --scrollBarColor: #5f6064;


### PR DESCRIPTION
* Fixes https://github.com/lensapp/lens/issues/5146
* Makes it possible for extensions to specify a badge for a custom Catalog Category
* Add `badgeBackgroundColor` CSS variable for extension use

Example use by an extension:
![Screenshot 2022-03-31 at 16 17 35](https://user-images.githubusercontent.com/2162413/161071797-9bc75f2e-6e73-4748-865f-d148645501c0.png)

