### PR TITLE
Do not render Tooltip and Menu elements until needed

### DIFF
--- a/src/renderer/components/animate/animate.tsx
+++ b/src/renderer/components/animate/animate.tsx
@@ -90,9 +90,13 @@ export class Animate extends React.Component<AnimateProps> {
       "--leave-duration": `${leaveDuration}ms`,
     } as React.CSSProperties;
 
+    if (!this.isVisible) {
+      return null;
+    }
+
     return React.cloneElement(contentElem, {
       className: cssNames("Animate", name, contentElem.props.className, this.statusClassName),
-      children: this.isVisible ? contentElem.props.children : null,
+      children: contentElem.props.children,
       style: {
         ...contentElem.props.style,
         ...durations,

--- a/src/renderer/components/animate/animate.tsx
+++ b/src/renderer/components/animate/animate.tsx
@@ -83,23 +83,23 @@ export class Animate extends React.Component<AnimateProps> {
   }
 
   render() {
-    const { name, enterDuration, leaveDuration } = this.props;
-    const contentElem = this.contentElem;
-    const durations = {
-      "--enter-duration": `${enterDuration}ms`,
-      "--leave-duration": `${leaveDuration}ms`,
-    } as React.CSSProperties;
-
     if (!this.isVisible) {
       return null;
     }
+
+    const { name, enterDuration, leaveDuration } = this.props;
+    const contentElem = this.contentElem;
+    const cssVarsForAnimation = {
+      "--enter-duration": `${enterDuration}ms`,
+      "--leave-duration": `${leaveDuration}ms`,
+    } as React.CSSProperties;
 
     return React.cloneElement(contentElem, {
       className: cssNames("Animate", name, contentElem.props.className, this.statusClassName),
       children: contentElem.props.children,
       style: {
         ...contentElem.props.style,
-        ...durations,
+        ...cssVarsForAnimation,
       },
     });
   }

--- a/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
+++ b/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
@@ -37,10 +37,6 @@ exports[`kube-object-menu given kube object renders 1`] = `
       </ul>
     </div>
   </div>
-  <div
-    class="Animate opacity-scale Dialog flex center ConfirmDialog modal"
-    style="--enter-duration: 100ms; --leave-duration: 100ms;"
-  />
 </body>
 `;
 

--- a/src/renderer/components/kube-object-status-icon/__snapshots__/kube-object-status-icon.test.tsx.snap
+++ b/src/renderer/components/kube-object-status-icon/__snapshots__/kube-object-status-icon.test.tsx.snap
@@ -16,58 +16,6 @@ exports[`kube-object-status-icon given info and warning statuses are present, wh
       <div />
     </i>
   </div>
-  <div
-    class="Tooltip narrow formatter"
-  >
-    <div
-      class="KubeObjectStatusTooltip"
-    >
-      <div
-        class="level warning"
-      >
-        <span
-          class="title"
-        >
-          Warning
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some warning status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-      <div
-        class="level info"
-      >
-        <span
-          class="title"
-        >
-          Info
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some info status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
 </body>
 `;
 
@@ -86,36 +34,6 @@ exports[`kube-object-status-icon given level "critical" status, when rendered, r
       </span>
       <div />
     </i>
-  </div>
-  <div
-    class="Tooltip narrow formatter"
-  >
-    <div
-      class="KubeObjectStatusTooltip"
-    >
-      <div
-        class="level error"
-      >
-        <span
-          class="title"
-        >
-          Critical
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some critical status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-    </div>
   </div>
 </body>
 `;
@@ -136,36 +54,6 @@ exports[`kube-object-status-icon given level "info" status, when rendered, rende
       <div />
     </i>
   </div>
-  <div
-    class="Tooltip narrow formatter"
-  >
-    <div
-      class="KubeObjectStatusTooltip"
-    >
-      <div
-        class="level info"
-      >
-        <span
-          class="title"
-        >
-          Info
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some info status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
 </body>
 `;
 
@@ -184,36 +72,6 @@ exports[`kube-object-status-icon given level "warning" status, when rendered, re
       </span>
       <div />
     </i>
-  </div>
-  <div
-    class="Tooltip narrow formatter"
-  >
-    <div
-      class="KubeObjectStatusTooltip"
-    >
-      <div
-        class="level warning"
-      >
-        <span
-          class="title"
-        >
-          Warning
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some warning status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-    </div>
   </div>
 </body>
 `;
@@ -253,80 +111,6 @@ exports[`kube-object-status-icon given status for all levels is present, when re
       </span>
       <div />
     </i>
-  </div>
-  <div
-    class="Tooltip narrow formatter"
-  >
-    <div
-      class="KubeObjectStatusTooltip"
-    >
-      <div
-        class="level error"
-      >
-        <span
-          class="title"
-        >
-          Critical
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some critical status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-      <div
-        class="level warning"
-      >
-        <span
-          class="title"
-        >
-          Warning
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some warning status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-      <div
-        class="level info"
-      >
-        <span
-          class="title"
-        >
-          Info
-        </span>
-        <div
-          class="status msg"
-        >
-          - 
-          Some info status for some-name
-           
-          <span
-            class="age"
-          >
-             · 
-            2d
-          </span>
-        </div>
-      </div>
-    </div>
   </div>
 </body>
 `;

--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -93,7 +93,6 @@ export class Menu extends React.Component<MenuProps, State> {
       this.opener.addEventListener(this.props.toggleEvent, this.toggle);
       this.opener.addEventListener("keydown", this.onKeyDown);
     }
-    this.elem.addEventListener("keydown", this.onKeyDown);
     window.addEventListener("resize", this.onWindowResize);
     window.addEventListener("click", this.onClickOutside, true);
     window.addEventListener("scroll", this.onScrollOutside, true);
@@ -106,7 +105,6 @@ export class Menu extends React.Component<MenuProps, State> {
       this.opener.removeEventListener(this.props.toggleEvent, this.toggle);
       this.opener.removeEventListener("keydown", this.onKeyDown);
     }
-    this.elem.removeEventListener("keydown", this.onKeyDown);
     window.removeEventListener("resize", this.onWindowResize);
     window.removeEventListener("click", this.onClickOutside, true);
     window.removeEventListener("scroll", this.onScrollOutside, true);
@@ -218,7 +216,7 @@ export class Menu extends React.Component<MenuProps, State> {
     }
   }
 
-  onKeyDown(evt: KeyboardEvent) {
+  onKeyDown(evt: React.KeyboardEvent | KeyboardEvent) {
     if (!this.isOpen) return;
 
     switch (evt.code) {
@@ -330,6 +328,7 @@ export class Menu extends React.Component<MenuProps, State> {
               left: this.state?.menuStyle?.left,
               top: this.state?.menuStyle?.top,
             }}
+            onKeyDown={this.onKeyDown}
           >
             {menuItems}
           </ul>


### PR DESCRIPTION
Part of #2243

Before this PR the DOM was flooded with html elements produces by each `Menu` and `Tooltip` components visible on the screen. Every table scroll caused bunch of these elements removed and created in a crazy speed.


Before:

https://user-images.githubusercontent.com/9607060/161263049-980de65e-f743-4dac-9094-31c12ea43fef.mov



After:


https://user-images.githubusercontent.com/9607060/161263081-fb70ee99-8425-41ec-bc99-dd2e53871b87.mov


