### PR TITLE
Fix Pod Container sorting not correlating to visuals

### DIFF
--- a/src/common/utils/tuple.ts
+++ b/src/common/utils/tuple.ts
@@ -24,8 +24,9 @@ type TupleOfImpl<T, N extends number, R extends unknown[]> = R["length"] extends
  * @yields A tuple of the next element from each of the sources
  * @returns The tuple of all the sources as soon as at least one of the sources is exausted
  */
-export function zip<T>(src1: T[]): Iterator<[T], Tuple<T[], 1>>;
-export function zip<T>(src1: T[], src2: T[]): Iterator<[T, T], Tuple<T[], 2>>;
+export function zip<T>(...sources: Tuple<T[], 0>): Iterator<Tuple<T, 0>, Tuple<T[], 0>>;
+export function zip<T>(...sources: Tuple<T[], 1>): Iterator<Tuple<T, 1>, Tuple<T[], 1>>;
+export function zip<T>(...sources: Tuple<T[], 2>): Iterator<Tuple<T, 2>, Tuple<T[], 2>>;
 
 export function* zip<T, N extends number>(...sources: Tuple<T[], N>): Iterator<Tuple<T, N>, Tuple<T[], N>> {
   const maxSafeLength = Math.min(...sources.map(source => source.length));

--- a/src/renderer/components/+workloads-pods/pods.tsx
+++ b/src/renderer/components/+workloads-pods/pods.tsx
@@ -113,7 +113,7 @@ class NonInjectedPods extends React.Component<Dependencies> {
           sortingCallbacks={{
             [columnId.name]: pod => getConvertedParts(pod.getName()),
             [columnId.namespace]: pod => pod.getNs(),
-            [columnId.containers]: pod => pod.getContainers().length,
+            [columnId.containers]: pod => pod.getContainerStatuses().length,
             [columnId.restarts]: pod => pod.getRestartsCount(),
             [columnId.owners]: pod => pod.getOwnerRefs().map(ref => ref.kind),
             [columnId.qos]: pod => pod.getQosClass(),

--- a/src/renderer/components/table/__tests__/getSorted.test.ts
+++ b/src/renderer/components/table/__tests__/getSorted.test.ts
@@ -26,10 +26,10 @@ describe("Table tests", () => {
       expect(i).toStrictEqual([1, 2, 4, 3]);
     });
 
-    it("should sort numerically asc (by defaul) and not touch the original list", () => {
+    it("should sort numerically asc (by default) and not touch the original list", () => {
       const i = [1, 2, 4, 3];
 
-      expect(getSorted(i, v => v, "foobar")).toStrictEqual([1, 2, 3, 4]);
+      expect(getSorted(i, v => v)).toStrictEqual([1, 2, 3, 4]);
       expect(i).toStrictEqual([1, 2, 4, 3]);
     });
 

--- a/src/renderer/components/table/sorting.ts
+++ b/src/renderer/components/table/sorting.ts
@@ -3,15 +3,14 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import type { TableSortCallback } from "./table";
+import type { TableOrderBy, TableSortCallback } from "./table";
 import { Ordering, rectifyOrdering, sortCompare, tuple } from "../../utils";
 
-export function getSorted<T>(rawItems: T[], sortingCallback: TableSortCallback<T> | undefined, orderByRaw: string): T[] {
+export function getSorted<T>(rawItems: T[], sortingCallback: TableSortCallback<T> | undefined, orderBy: TableOrderBy = "asc"): T[] {
   if (typeof sortingCallback !== "function") {
     return rawItems;
   }
 
-  const orderBy = orderByRaw === "asc" || orderByRaw === "desc" ? orderByRaw : "asc";
   const sortData = rawItems.map((item, index) => ({
     index,
     sortBy: sortingCallback(item),


### PR DESCRIPTION
- Add some specific tuple.zip types

- Remove the `string` part of `TableOrderBy` to simplify implementation
  and because it removes any sort of intellisense

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #5165 