### PR TITLE
Fix returning to specific catalog tab and removing a hotbar item

### DIFF
--- a/src/renderer/components/hotbar/hotbar-menu.tsx
+++ b/src/renderer/components/hotbar/hotbar-menu.tsx
@@ -73,17 +73,17 @@ class NonInjectedHotbarMenu extends React.Component<Dependencies & HotbarMenuPro
     this.props.hotbarStore.restackItems(from, to);
   }
 
-  removeItem(uid: string) {
+  removeItem = (uid: string) => {
     const hotbar = this.props.hotbarStore;
 
     hotbar.removeFromHotbar(uid);
-  }
+  };
 
-  addItem(entity: CatalogEntity, index = -1) {
+  addItem = (entity: CatalogEntity, index = -1) => {
     const hotbar = this.props.hotbarStore;
 
     hotbar.addToHotbar(entity, index);
-  }
+  };
 
   getMoveAwayDirection(entityId: string, cellIndex: number) {
     const draggableItemIndex = this.hotbar.items.findIndex(item => item?.entity.uid == entityId);


### PR DESCRIPTION
This a hotfix which imitates the previous stateful solution.

Proper fix would mean redesign of hotbar items which operate at wrong level of abstraction and inherit a lot instead of composition.

Fixes #5192 

Also fixes removing of hotbar items which caused an error because of unexpected `this`.