### PR TITLE
Fix PieChart tooltips

### DIFF
--- a/src/renderer/components/+cluster/cluster-pie-charts.tsx
+++ b/src/renderer/components/+cluster/cluster-pie-charts.tsx
@@ -156,15 +156,15 @@ const NonInjectedClusterPieCharts = observer(({ clusterOverviewStore }: Dependen
           ],
           id: "podUsage",
           label: "Usage",
+          tooltipLabels: [
+            (percent) => `Usage: ${percent}`,
+            (percent) => `Available: ${percent}`,
+          ],
         },
       ],
       labels: [
         `Usage: ${podUsage || 0}`,
         `Capacity: ${podAllocatableCapacity}`,
-      ],
-      tooltipLabels: [
-        (percent) => `Usage: ${percent}`,
-        (percent) => `Available: ${percent}`,
       ],
     };
 

--- a/src/renderer/components/+cluster/cluster-pie-charts.tsx
+++ b/src/renderer/components/+cluster/cluster-pie-charts.tsx
@@ -12,7 +12,7 @@ import { MetricNodeRole } from "./cluster-overview-store/cluster-overview-store"
 import { Spinner } from "../spinner";
 import { Icon } from "../icon";
 import { nodesStore } from "../+nodes/nodes.store";
-import type { ChartData } from "../chart";
+import type { PieChartData } from "../chart";
 import { PieChart } from "../chart";
 import { ClusterNoMetrics } from "./cluster-no-metrics";
 import { bytesToUnits, cssNames } from "../../utils";
@@ -49,7 +49,7 @@ const NonInjectedClusterPieCharts = observer(({ clusterOverviewStore }: Dependen
     const defaultColor = ThemeStore.getInstance().activeTheme.colors.pieChartDefaultColor;
 
     if (!memoryCapacity || !cpuCapacity || !podCapacity || !memoryAllocatableCapacity || !cpuAllocatableCapacity || !podAllocatableCapacity) return null;
-    const cpuData: ChartData = {
+    const cpuData: PieChartData = {
       datasets: [
         {
           data: [
@@ -96,7 +96,7 @@ const NonInjectedClusterPieCharts = observer(({ clusterOverviewStore }: Dependen
         ["Capacity", cpuCapacity],
       ]),
     };
-    const memoryData: ChartData = {
+    const memoryData: PieChartData = {
       datasets: [
         {
           data: [
@@ -143,7 +143,7 @@ const NonInjectedClusterPieCharts = observer(({ clusterOverviewStore }: Dependen
         `Capacity: ${bytesToUnits(memoryCapacity)}`,
       ],
     };
-    const podsData: ChartData = {
+    const podsData: PieChartData = {
       datasets: [
         {
           data: [

--- a/src/renderer/components/+cluster/cluster-pie-charts.tsx
+++ b/src/renderer/components/+cluster/cluster-pie-charts.tsx
@@ -162,6 +162,10 @@ const NonInjectedClusterPieCharts = observer(({ clusterOverviewStore }: Dependen
         `Usage: ${podUsage || 0}`,
         `Capacity: ${podAllocatableCapacity}`,
       ],
+      tooltipLabels: [
+        (percent) => `Usage: ${percent}`,
+        (percent) => `Available: ${percent}`,
+      ],
     };
 
     return (

--- a/src/renderer/components/+workloads-overview/overview-workload-status.scss
+++ b/src/renderer/components/+workloads-overview/overview-workload-status.scss
@@ -13,10 +13,4 @@
   --workload-status-failed: #{$pod-status-failed-color};
   --workload-status-terminated: #{$pod-status-terminated-color};
   --workload-status-unknown: #{$pod-status-unknown-color};
-
-  .PieChart {
-    .chart-container {
-      width: 110px
-    }
-  }
 }

--- a/src/renderer/components/+workloads-overview/overview-workload-status.tsx
+++ b/src/renderer/components/+workloads-overview/overview-workload-status.tsx
@@ -8,9 +8,9 @@ import "./overview-workload-status.scss";
 import React from "react";
 import capitalize from "lodash/capitalize";
 import { observer } from "mobx-react";
+import type { ChartData, ChartTooltipLabel } from "../chart";
 import { PieChart } from "../chart";
 import { cssVar } from "../../utils";
-import type { ChartData } from "chart.js";
 import { ThemeStore } from "../../theme.store";
 
 export interface OverviewWorkloadStatusProps {
@@ -43,10 +43,12 @@ export class OverviewWorkloadStatus extends React.Component<OverviewWorkloadStat
     } else {
       const data: number[] = [];
       const backgroundColor: string[] = [];
+      const tooltipLabels: ChartTooltipLabel[] = [];
 
       for (const [status, value] of statuses) {
         data.push(value);
         backgroundColor.push(cssVars.get(`--workload-status-${status.toLowerCase()}`).toString());
+        tooltipLabels.push(percent => `${capitalize(status)}: ${percent}`);
         chartData.labels.push(`${capitalize(status)}: ${value}`);
       }
 
@@ -54,6 +56,7 @@ export class OverviewWorkloadStatus extends React.Component<OverviewWorkloadStat
         data,
         backgroundColor,
         label: "Status",
+        tooltipLabels,
       });
     }
 

--- a/src/renderer/components/+workloads-overview/overview-workload-status.tsx
+++ b/src/renderer/components/+workloads-overview/overview-workload-status.tsx
@@ -8,7 +8,7 @@ import "./overview-workload-status.scss";
 import React from "react";
 import capitalize from "lodash/capitalize";
 import { observer } from "mobx-react";
-import type { ChartData, ChartTooltipLabel } from "../chart";
+import type { DatasetTooltipLabel, PieChartData } from "../chart";
 import { PieChart } from "../chart";
 import { cssVar } from "../../utils";
 import { ThemeStore } from "../../theme.store";
@@ -27,7 +27,7 @@ export class OverviewWorkloadStatus extends React.Component<OverviewWorkloadStat
     }
 
     const cssVars = cssVar(this.elem);
-    const chartData: Required<ChartData> = {
+    const chartData: Required<PieChartData> = {
       labels: [],
       datasets: [],
     };
@@ -43,7 +43,7 @@ export class OverviewWorkloadStatus extends React.Component<OverviewWorkloadStat
     } else {
       const data: number[] = [];
       const backgroundColor: string[] = [];
-      const tooltipLabels: ChartTooltipLabel[] = [];
+      const tooltipLabels: DatasetTooltipLabel[] = [];
 
       for (const [status, value] of statuses) {
         data.push(value);

--- a/src/renderer/components/chart/chart.tsx
+++ b/src/renderer/components/chart/chart.tsx
@@ -18,7 +18,6 @@ export interface ChartData extends ChartJS.ChartData {
 export interface ChartDataSets extends ChartJS.ChartDataSets {
   id?: string;
   tooltip?: string;
-  tooltipLabels?: ChartTooltipLabel[];
 }
 
 export interface ChartProps {
@@ -36,8 +35,6 @@ export interface ChartProps {
   title?: string;
   className?: string;
 }
-
-export type ChartTooltipLabel = (percent: string) => string | string;
 
 export enum ChartKind {
   PIE = "pie",

--- a/src/renderer/components/chart/chart.tsx
+++ b/src/renderer/components/chart/chart.tsx
@@ -13,12 +13,12 @@ import { Badge } from "../badge";
 
 export interface ChartData extends ChartJS.ChartData {
   datasets?: ChartDataSets[];
-  tooltipLabels?: ChartTooltipLabel[];
 }
 
 export interface ChartDataSets extends ChartJS.ChartDataSets {
   id?: string;
   tooltip?: string;
+  tooltipLabels?: ChartTooltipLabel[];
 }
 
 export interface ChartProps {
@@ -37,7 +37,7 @@ export interface ChartProps {
   className?: string;
 }
 
-type ChartTooltipLabel = (percent: string) => string | string;
+export type ChartTooltipLabel = (percent: string) => string | string;
 
 export enum ChartKind {
   PIE = "pie",

--- a/src/renderer/components/chart/chart.tsx
+++ b/src/renderer/components/chart/chart.tsx
@@ -13,6 +13,7 @@ import { Badge } from "../badge";
 
 export interface ChartData extends ChartJS.ChartData {
   datasets?: ChartDataSets[];
+  tooltipLabels?: ChartTooltipLabel[];
 }
 
 export interface ChartDataSets extends ChartJS.ChartDataSets {
@@ -35,6 +36,8 @@ export interface ChartProps {
   title?: string;
   className?: string;
 }
+
+type ChartTooltipLabel = (percent: string) => string | string;
 
 export enum ChartKind {
   PIE = "pie",

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -34,7 +34,7 @@ export class PieChart extends React.Component<PieChartProps> {
             const total = datasetData.reduce((acc, cur) => acc + cur, 0);
             const percent = Math.round((dataset.data[tooltipItem["index"]] as number / total) * 100);
             const percentLabel = isNaN(percent) ? "N/A" : `${percent}%`;
-            const tooltipLabel = data.tooltipLabels?.[tooltipItem["index"]];
+            const tooltipLabel = dataset.tooltipLabels?.[tooltipItem["index"]];
             let tooltip = `${dataset["label"]}: ${percentLabel}`;
 
             if (tooltipLabel) {

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -17,13 +17,13 @@ export interface PieChartProps extends ChartProps {
 }
 
 export interface PieChartData extends ChartJS.ChartData {
-  id?: string;
   datasets?: PieChartDataSets[];
 }
 
 export type DatasetTooltipLabel = (percent: string) => string | string;
 
 interface PieChartDataSets extends ChartJS.ChartDataSets {
+  id?: string;
   tooltipLabels?: DatasetTooltipLabel[];
 }
 

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -17,6 +17,7 @@ export interface PieChartProps extends ChartProps {
 }
 
 export interface PieChartData extends ChartJS.ChartData {
+  id?: string;
   datasets?: PieChartDataSets[];
 }
 

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -23,7 +23,6 @@ export interface PieChartData extends ChartJS.ChartData {
 export type DatasetTooltipLabel = (percent: string) => string | string;
 
 interface PieChartDataSets extends ChartJS.ChartDataSets {
-  id?: string;
   tooltipLabels?: DatasetTooltipLabel[];
 }
 
@@ -43,10 +42,10 @@ export class PieChart extends React.Component<PieChartProps> {
             const dataset = data.datasets[tooltipItem.datasetIndex];
             const datasetData = dataset.data as number[];
             const total = datasetData.reduce((acc, cur) => acc + cur, 0);
-            const percent = Math.round((dataset.data[tooltipItem["index"]] as number / total) * 100);
+            const percent = Math.round((dataset.data[tooltipItem.index] as number / total) * 100);
             const percentLabel = isNaN(percent) ? "N/A" : `${percent}%`;
-            const tooltipLabel = dataset.tooltipLabels?.[tooltipItem["index"]];
-            let tooltip = `${dataset["label"]}: ${percentLabel}`;
+            const tooltipLabel = dataset.tooltipLabels?.[tooltipItem.index];
+            let tooltip = `${dataset.label}: ${percentLabel}`;
 
             if (tooltipLabel) {
               if (typeof tooltipLabel === "function") {

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -8,12 +8,23 @@ import React from "react";
 import { observer } from "mobx-react";
 import type { ChartOptions } from "chart.js";
 import ChartJS from "chart.js";
-import type { ChartData, ChartProps } from "./chart";
+import type { ChartProps } from "./chart";
 import { Chart } from "./chart";
 import { cssNames } from "../../utils";
 import { ThemeStore } from "../../theme.store";
 
 export interface PieChartProps extends ChartProps {
+}
+
+export interface PieChartData extends ChartJS.ChartData {
+  datasets?: PieChartDataSets[];
+}
+
+export type DatasetTooltipLabel = (percent: string) => string | string;
+
+interface PieChartDataSets extends ChartJS.ChartDataSets {
+  id?: string;
+  tooltipLabels?: DatasetTooltipLabel[];
 }
 
 @observer
@@ -28,7 +39,7 @@ export class PieChart extends React.Component<PieChartProps> {
         mode: "index",
         callbacks: {
           title: () => "",
-          label: (tooltipItem, data: ChartData) => {
+          label: (tooltipItem, data: PieChartData) => {
             const dataset = data.datasets[tooltipItem.datasetIndex];
             const datasetData = dataset.data as number[];
             const total = datasetData.reduce((acc, cur) => acc + cur, 0);

--- a/src/renderer/components/chart/pie-chart.tsx
+++ b/src/renderer/components/chart/pie-chart.tsx
@@ -43,7 +43,7 @@ export class PieChart extends React.Component<PieChartProps> {
             const dataset = data.datasets[tooltipItem.datasetIndex];
             const datasetData = dataset.data as number[];
             const total = datasetData.reduce((acc, cur) => acc + cur, 0);
-            const percent = Math.round((dataset.data[tooltipItem.index] as number / total) * 100);
+            const percent = Math.round((datasetData[tooltipItem.index] as number / total) * 100);
             const percentLabel = isNaN(percent) ? "N/A" : `${percent}%`;
             const tooltipLabel = dataset.tooltipLabels?.[tooltipItem.index];
             let tooltip = `${dataset.label}: ${percentLabel}`;


### PR DESCRIPTION
Fixing PieChart labelling using new `tooltipLabels` field within datasets.

Before that, only `dataset` `label` was used for every part part of the graph. Example:

![image](https://user-images.githubusercontent.com/9607060/162388931-79372911-4ba6-4fcb-9b6e-f4bd047b5082.png)


https://user-images.githubusercontent.com/9607060/162387620-0f22d8a4-4a8e-4700-8625-ce906bc17f8e.mov


Now PieChart provide callback function with `percents` argument. It can be used in a following way:

```typescript
const podsData: PieChartData = {
      datasets: [
        {
          data: [
            podUsage,
            podUsage ? podAllocatableCapacity - podUsage : 1,
          ],
          backgroundColor: [
            "#4caf50",
            defaultColor,
          ],
          id: "podUsage",
          label: "Usage",
          tooltipLabels: [
            (percent) => `Usage: ${percent}`,
            (percent) => `Available: ${percent}`,
          ],
        },
      ],
      labels: [
        `Usage: ${podUsage || 0}`,
        `Capacity: ${podAllocatableCapacity}`,
      ],
    };
``` 

https://user-images.githubusercontent.com/9607060/162387782-5da1d0a0-d0f3-4759-aa75-c9d90b53996c.mov


https://user-images.githubusercontent.com/9607060/162387800-e895aa08-7d2d-48cb-937e-5ee5342e426b.mov


