### PR TITLE
Move devserver to different port

### DIFF
--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -136,4 +136,4 @@ export const docsUrl = "https://docs.k8slens.dev/main/" as string;
 
 export const sentryDsn = packageInfo.config?.sentryDsn ?? "";
 
-export const webpackDevServerPort: number = +process.env.WEBPACK_DEV_SERVER_PORT || 9191;
+export const webpackDevServerPort: number = Number(process.env.WEBPACK_DEV_SERVER_PORT) || 9191;

--- a/src/common/vars.ts
+++ b/src/common/vars.ts
@@ -135,3 +135,5 @@ export const appSemVer = new SemVer(packageInfo.version);
 export const docsUrl = "https://docs.k8slens.dev/main/" as string;
 
 export const sentryDsn = packageInfo.config?.sentryDsn ?? "";
+
+export const webpackDevServerPort: number = +process.env.WEBPACK_DEV_SERVER_PORT || 9191;

--- a/src/main/routes/static-file-route.injectable.ts
+++ b/src/main/routes/static-file-route.injectable.ts
@@ -74,7 +74,7 @@ const handleStaticFileInDevelopment =
       }
 
       proxy.web(req, res, {
-        target: "http://127.0.0.1:8080",
+        target: "http://127.0.0.1:9191",
       });
 
       return { proxy };

--- a/src/main/routes/static-file-route.injectable.ts
+++ b/src/main/routes/static-file-route.injectable.ts
@@ -8,7 +8,7 @@ import type { SupportedFileExtension } from "../router/router-content-types";
 import { contentTypes } from "../router/router-content-types";
 import logger from "../logger";
 import { routeInjectionToken } from "../router/router.injectable";
-import { appName, publicPath } from "../../common/vars";
+import { appName, publicPath, webpackDevServerPort } from "../../common/vars";
 import path from "path";
 import isDevelopmentInjectable from "../../common/vars/is-development.injectable";
 import httpProxy from "http-proxy";
@@ -74,7 +74,7 @@ const handleStaticFileInDevelopment =
       }
 
       proxy.web(req, res, {
-        target: "http://127.0.0.1:9191",
+        target: `http://127.0.0.1:${webpackDevServerPort}`,
       });
 
       return { proxy };

--- a/webpack.dev-server.ts
+++ b/webpack.dev-server.ts
@@ -6,7 +6,7 @@
 import Webpack from "webpack";
 import WebpackDevServer from "webpack-dev-server";
 import { webpackLensRenderer } from "./webpack.renderer";
-import { buildDir } from "./src/common/vars";
+import { buildDir, webpackDevServerPort } from "./src/common/vars";
 import logger from "./src/common/logger";
 
 /**
@@ -26,7 +26,7 @@ function createDevServer(): WebpackDevServer {
     },
     allowedHosts: "all",
     host: "localhost",
-    port: 9191,
+    port: webpackDevServerPort,
     static: buildDir, // aka `devServer.contentBase` in webpack@4
     hot: "only", // use HMR only without errors
     liveReload: false,

--- a/webpack.dev-server.ts
+++ b/webpack.dev-server.ts
@@ -26,6 +26,7 @@ function createDevServer(): WebpackDevServer {
     },
     allowedHosts: "all",
     host: "localhost",
+    port: 9191,
     static: buildDir, // aka `devServer.contentBase` in webpack@4
     hot: "only", // use HMR only without errors
     liveReload: false,


### PR DESCRIPTION
Port 8080 is pretty common and often used. Currently, if something is running on 8080, ``make dev`` fails with unavailable port error.

``
Exception:
Error: connect ECONNREFUSED 127.0.0.1:8080
at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)
``