### PR TITLE
Export ReactDOM globally, and ensure in-tree extension to use the same instance

### DIFF
--- a/extensions/kube-object-event-status/webpack.config.js
+++ b/extensions/kube-object-event-status/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = [
       {
         "@k8slens/extensions": "var global.LensExtensions",
         "react": "var global.React",
+        "react-dom": "var global.ReactDOM",
         "mobx": "var global.Mobx",
         "mobx-react": "var global.MobxReact",
       },

--- a/extensions/metrics-cluster-feature/webpack.config.js
+++ b/extensions/metrics-cluster-feature/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = [
       {
         "@k8slens/extensions": "var global.LensExtensions",
         "react": "var global.React",
+        "react-dom": "var global.ReactDOM",
         "mobx": "var global.Mobx",
         "mobx-react": "var global.MobxReact",
       },

--- a/extensions/node-menu/webpack.config.js
+++ b/extensions/node-menu/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = [
       {
         "@k8slens/extensions": "var global.LensExtensions",
         "react": "var global.React",
+        "react-dom": "var global.ReactDOM",
         "mobx": "var global.Mobx",
         "mobx-react": "var global.MobxReact",
       },

--- a/extensions/pod-menu/webpack.config.js
+++ b/extensions/pod-menu/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = [
       {
         "@k8slens/extensions": "var global.LensExtensions",
         "react": "var global.React",
+        "react-dom": "var global.ReactDOM",
         "mobx": "var global.Mobx",
         "mobx-react": "var global.MobxReact",
       },

--- a/src/renderer/bootstrap.tsx
+++ b/src/renderer/bootstrap.tsx
@@ -6,6 +6,7 @@
 import "./components/app.scss";
 
 import React from "react";
+import ReactDOM from "react-dom";
 import * as Mobx from "mobx";
 import * as MobxReact from "mobx-react";
 import * as ReactRouter from "react-router";
@@ -187,6 +188,7 @@ const LensExtensions = {
 
 export {
   React,
+  ReactDOM,
   ReactRouter,
   ReactRouterDom,
   Mobx,


### PR DESCRIPTION
Previously it was possible that in-tree extensions are using different instances of React/ReactDOM