### PR TITLE
Fix: replace all list items on store.loadAll()

### DIFF
--- a/src/renderer/kube-watch-api/kube-watch-api.ts
+++ b/src/renderer/kube-watch-api/kube-watch-api.ts
@@ -96,7 +96,7 @@ export class KubeWatchApi {
 
     const loadThenSubscribe = async (namespaces: string[]) => {
       try {
-        await store.loadAll({ namespaces, reqInit: { signal: childController.signal }, onLoadFailure });
+        await store.loadAll({ namespaces, merge: false, reqInit: { signal: childController.signal }, onLoadFailure });
         unsubscribe.push(store.subscribe({ onLoadFailure, abortController: childController }));
       } catch (error) {
         if (!(error instanceof DOMException)) {


### PR DESCRIPTION
Adding `merge: false` rule on KubeObjectListLayout mount causing all store items to be replaces with loaded ones.

https://user-images.githubusercontent.com/9607060/162903929-73dae1bb-4419-465d-ba05-df4e163afb83.mov


Fixes #4897 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>