### PR TITLE
Export getAppVersion in the extension API

### DIFF
--- a/src/extensions/common-api/utils.ts
+++ b/src/extensions/common-api/utils.ts
@@ -3,6 +3,6 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-export { Singleton, openExternal, openBrowser } from "../../common/utils";
+export { Singleton, openExternal, openBrowser, getAppVersion } from "../../common/utils";
 export { prevDefault, stopPropagation } from "../../renderer/utils/prevDefault";
 export { cssNames } from "../../renderer/utils/cssNames";


### PR DESCRIPTION
Extensions can use this to get the Lens application version.