### PR TITLE
Fix: do not use paddings for empty top bar items

### DIFF
--- a/src/renderer/components/layout/top-bar/top-bar.module.scss
+++ b/src/renderer/components/layout/top-bar/top-bar.module.scss
@@ -26,7 +26,7 @@
   &:first-of-type {
     padding-left: 1.5rem;
 
-    & > * {
+    & > *:not(:empty) {
       margin-right: 1rem;
     }
   }
@@ -34,7 +34,7 @@
   &:last-of-type {
     padding-right: 1.5rem;
 
-    & > * {
+    & > *:not(:empty) {
       margin-left: 1rem;
     }
   }


### PR DESCRIPTION
Fixing styles a bit to hide any paddings for empty top bar elements.

#### Why this is needed?

Extension sometimes can add empty invisible elements in TopBar area such as dialogs, modals etc which doesn't actually gets viewed in top bar area. This elements, however, create their own `div`s with unnecessary paddings.

Example:
<img width="743" alt="topbar unnecessary padding" src="https://user-images.githubusercontent.com/9607060/163976270-d6799a3e-925d-4e9f-8cd4-dcdc6bcca6e1.png">

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>