### PR TITLE
adding https_proxy to execHelm env

### DIFF
--- a/src/main/helm/exec.ts
+++ b/src/main/helm/exec.ts
@@ -17,9 +17,7 @@ export async function execHelm(args: string[], options?: BaseEncodingOptions & E
   try {
     const opts = { ...options };
 
-    if (!opts.env) {
-      opts.env = process.env
-    }
+    opts.env ??= process.env;
 
     if (!opts.env.HTTPS_PROXY && UserStore.getInstance().httpsProxy) {
       opts.env.HTTPS_PROXY = UserStore.getInstance().httpsProxy;

--- a/src/main/helm/exec.ts
+++ b/src/main/helm/exec.ts
@@ -7,6 +7,7 @@ import { promiseExecFile } from "../../common/utils/promise-exec";
 import type { BaseEncodingOptions } from "fs";
 import type { ExecFileOptions } from "child_process";
 import { helmBinaryPath } from "../../common/vars";
+import { UserStore } from "../../common/user-store";
 
 /**
  * ExecFile the bundled helm CLI
@@ -14,7 +15,17 @@ import { helmBinaryPath } from "../../common/vars";
  */
 export async function execHelm(args: string[], options?: BaseEncodingOptions & ExecFileOptions): Promise<string> {
   try {
-    const { stdout } = await promiseExecFile(helmBinaryPath.get(), args, options);
+    const opts = { ...options };
+
+    if (!opts.env) {
+      opts.env = process.env
+    }
+
+    if (!opts.env.HTTPS_PROXY && UserStore.getInstance().httpsProxy) {
+      opts.env.HTTPS_PROXY = UserStore.getInstance().httpsProxy;
+    }
+
+    const { stdout } = await promiseExecFile(helmBinaryPath.get(), args, opts);
 
     return stdout;
   } catch (error) {


### PR DESCRIPTION
applies the https_proxy env var to all `execHelm` calls, for simplicity and to be certain it is set when needed for helm (could instead set it for specific invocations where http access is certain)

This code needs conversion to DI, but beyond the scope of this bug fix(?)

Fixes #3787