### PR TITLE
reverting flushHeaders() fix to restore auto-refresh

### DIFF
--- a/src/main/lens-proxy.ts
+++ b/src/main/lens-proxy.ts
@@ -173,15 +173,6 @@ export class LensProxy extends Singleton {
         this.retryCounters.delete(retryCounterId);
       }
 
-      if (!res.headersSent && req.url) {
-        const url = new URL(req.url, "http://localhost");
-
-        if (url.searchParams.has("watch")) {
-          res.statusCode = proxyRes.statusCode;
-          res.flushHeaders();
-        }
-      }
-
       proxyRes.on("aborted", () => { // happens when proxy target aborts connection
         res.end();
       });


### PR DESCRIPTION
revert work from https://github.com/lensapp/lens/pull/2229 which was causing auto-refresh to fail for some (https://github.com/lensapp/lens/issues/3821)

fixes #3821 
reopens #1988