### PR TITLE
Fix subclasses of BaseStore<T> not be able to overrride cwd()

### DIFF
--- a/src/common/base-store.ts
+++ b/src/common/base-store.ts
@@ -10,7 +10,7 @@ import { ipcMain, ipcRenderer } from "electron";
 import type { IEqualsComparer } from "mobx";
 import { makeObservable, reaction, runInAction } from "mobx";
 import type { Disposer } from "./utils";
-import { getAppVersion, Singleton, toJS } from "./utils";
+import { Singleton, toJS } from "./utils";
 import logger from "../main/logger";
 import { broadcastMessage, ipcMainOn, ipcRendererOn } from "./ipc";
 import isEqual from "lodash/isEqual";
@@ -19,6 +19,7 @@ import { kebabCase } from "lodash";
 import { getLegacyGlobalDiForExtensionApi } from "../extensions/as-legacy-globals-for-extension-api/legacy-global-di-for-extension-api";
 import directoryForUserDataInjectable from "./app-paths/directory-for-user-data/directory-for-user-data.injectable";
 import getConfigurationFileModelInjectable from "./get-configuration-file-model/get-configuration-file-model.injectable";
+import appVersionInjectable from "./get-configuration-file-model/app-version/app-version.injectable";
 
 export interface BaseStoreParams<T> extends ConfOptions<T> {
   syncOptions?: {
@@ -60,7 +61,7 @@ export abstract class BaseStore<T> extends Singleton {
     this.storeConfig = getConfigurationFileModel({
       ...this.params,
       projectName: "lens",
-      projectVersion: getAppVersion(),
+      projectVersion: di.inject(appVersionInjectable),
       cwd: this.cwd(),
     });
 

--- a/src/common/get-configuration-file-model/get-configuration-file-model.injectable.ts
+++ b/src/common/get-configuration-file-model/get-configuration-file-model.injectable.ts
@@ -5,21 +5,10 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import Config from "conf";
 import type { BaseStoreParams } from "../base-store";
-import appVersionInjectable from "./app-version/app-version.injectable";
-import directoryForUserDataInjectable from "../app-paths/directory-for-user-data/directory-for-user-data.injectable";
 
 const getConfigurationFileModelInjectable = getInjectable({
   id: "get-configuration-file-model",
-  instantiate:
-    (di) =>
-    <ConfigurationContent>(content: BaseStoreParams<ConfigurationContent>) =>
-        new Config({
-          ...content,
-          projectName: "lens",
-          projectVersion: di.inject(appVersionInjectable),
-          cwd: di.inject(directoryForUserDataInjectable),
-        }),
-
+  instantiate: () => <ConfigurationContent>(content: BaseStoreParams<ConfigurationContent>) => new Config(content),
   causesSideEffects: true,
 });
 


### PR DESCRIPTION
- The cwd field was being overridden unconditionally by the new getConfigurationFileModelInjectable

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #5296 

This was a regression from #5084 