### PR TITLE
"kubectl version --client" doesn't have extra values

### DIFF
--- a/src/main/kubectl/kubectl.ts
+++ b/src/main/kubectl/kubectl.ts
@@ -155,7 +155,7 @@ export class Kubectl {
       try {
         const args = [
           "version",
-          "--client", "true",
+          "--client",
           "--output", "json",
         ];
         const { stdout } = await promiseExecFile(path, args);


### PR DESCRIPTION
`--client true` has been working with previous versions, but not with 1.24