### PR TITLE
Allowing to copy text from About dialog

### DIFF
--- a/src/main/menu/application-menu-items.injectable.ts
+++ b/src/main/menu/application-menu-items.injectable.ts
@@ -10,10 +10,7 @@ import { broadcastMessage } from "../../common/ipc";
 import { openBrowser } from "../../common/utils";
 import { showAbout } from "./menu";
 import windowManagerInjectable from "../window-manager.injectable";
-import type {
-  BrowserWindow,
-  MenuItem,
-  MenuItemConstructorOptions } from "electron";
+import type { MenuItemConstructorOptions } from "electron";
 import {
   webContents,
 } from "electron";
@@ -69,8 +66,8 @@ const applicationMenuItemsInjectable = getInjectable({
           {
             label: `About ${productName}`,
             id: "about",
-            click(menuItem: MenuItem, browserWindow: BrowserWindow) {
-              showAbout(browserWindow);
+            click() {
+              showAbout();
             },
           },
           ...ignoreIf(autoUpdateDisabled, [
@@ -286,8 +283,8 @@ const applicationMenuItemsInjectable = getInjectable({
             {
               label: `About ${productName}`,
               id: "about",
-              click(menuItem: MenuItem, browserWindow: BrowserWindow) {
-                showAbout(browserWindow);
+              click() {
+                showAbout();
               },
             },
             ...ignoreIf(autoUpdateDisabled, [

--- a/src/main/menu/menu.ts
+++ b/src/main/menu/menu.ts
@@ -2,7 +2,6 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import type { BrowserWindow } from "electron";
 import { app, dialog, Menu } from "electron";
 import type { IComputedValue } from "mobx";
 import { autorun } from "mobx";
@@ -20,7 +19,7 @@ export function initMenu(
   });
 }
 
-export function showAbout(browserWindow: BrowserWindow) {
+export function showAbout() {
   const appInfo = [
     `${appName}: ${app.getVersion()}`,
     `Electron: ${process.versions.electron}`,
@@ -29,7 +28,7 @@ export function showAbout(browserWindow: BrowserWindow) {
     packageJson.copyright,
   ];
 
-  dialog.showMessageBoxSync(browserWindow, {
+  dialog.showMessageBoxSync({
     title: `${isWindows ? " ".repeat(2) : ""}${appName}`,
     type: "info",
     buttons: ["Close"],


### PR DESCRIPTION
Another solution to fix #5177 instead of this one #5185 

It shows About dialog in separate modal window where all contents can be copied.

<img width="313" alt="about openlens" src="https://user-images.githubusercontent.com/9607060/166931104-0b535c37-d97a-4714-8e81-7ef0e635d774.png">

https://user-images.githubusercontent.com/9607060/166931109-116232dc-aa86-472b-9e42-04060ceb7671.mov



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>