### PR TITLE
Remove unused code in the telemetry preference.

### DIFF
--- a/src/common/user-store/preferences-helpers.ts
+++ b/src/common/user-store/preferences-helpers.ts
@@ -112,19 +112,6 @@ const allowUntrustedCAs: PreferenceDescription<boolean> = {
   },
 };
 
-const allowTelemetry: PreferenceDescription<boolean> = {
-  fromStore(val) {
-    return val ?? true;
-  },
-  toStore(val) {
-    if (val === true) {
-      return undefined;
-    }
-
-    return val;
-  },
-};
-
 const allowErrorReporting: PreferenceDescription<boolean> = {
   fromStore(val) {
     return val ?? true;
@@ -366,7 +353,6 @@ export const DESCRIPTORS = {
   terminalTheme,
   localeTimezone,
   allowUntrustedCAs,
-  allowTelemetry,
   allowErrorReporting,
   downloadMirror,
   downloadKubectlBinaries,

--- a/src/common/user-store/user-store.ts
+++ b/src/common/user-store/user-store.ts
@@ -46,7 +46,6 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
   @observable kubeConfigPath = kubeConfigDefaultPath;
   @observable seenContexts = observable.set<string>();
   @observable newContexts = observable.set<string>();
-  @observable allowTelemetry: boolean;
   @observable allowErrorReporting: boolean;
   @observable allowUntrustedCAs: boolean;
   @observable colorTheme: string;
@@ -97,11 +96,6 @@ export class UserStore extends BaseStore<UserStoreModel> /* implements UserStore
   }
 
   startMainReactions() {
-    // track telemetry availability
-    reaction(() => this.allowTelemetry, allowed => {
-      appEventBus.emit({ name: "telemetry", action: allowed ? "enabled" : "disabled" });
-    });
-
     // open at system start-up
     reaction(() => this.openAtLogin, openAtLogin => {
       app.setLoginItemSettings({


### PR DESCRIPTION
Telemetry setting is stored in the `telemetry` extension.

Related to https://github.com/lensapp/lens-ide/issues/117

Signed-off-by: Juho Heikka <juho.heikka@gmail.com>