### PR TITLE
Fix <Switch/> checked callback attribute value

### DIFF
--- a/src/renderer/components/switch/__tests__/switch.test.tsx
+++ b/src/renderer/components/switch/__tests__/switch.test.tsx
@@ -48,4 +48,24 @@ describe("<Switch/>", () => {
 
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it("returns true checked attribute in a onChange callback", () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(<Switch onChange={onClick} checked={true}/>);
+    const switcher = getByTestId("switch");
+
+    fireEvent.click(switcher);
+
+    expect(onClick).toHaveBeenCalledWith(false, expect.any(Object));
+  });
+
+  it("returns false checked attribute in a onChange callback", () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(<Switch onChange={onClick}/>);
+    const switcher = getByTestId("switch");
+
+    fireEvent.click(switcher);
+
+    expect(onClick).toHaveBeenCalledWith(true, expect.any(Object));
+  });
 });

--- a/src/renderer/components/switch/switch.tsx
+++ b/src/renderer/components/switch/switch.tsx
@@ -17,7 +17,13 @@ export function Switch({ children, disabled, onChange, ...props }: SwitchProps) 
   return (
     <label className={cssNames(styles.Switch, { [styles.disabled]: disabled })} data-testid="switch">
       {children}
-      <input type="checkbox" role="switch" disabled={disabled} onChange={(event) => onChange?.(props.checked, event)} {...props}/>
+      <input
+        type="checkbox"
+        role="switch"
+        disabled={disabled}
+        onChange={(event) => onChange?.(!props.checked, event)}
+        {...props}
+      />
     </label>
   );
 }

--- a/src/renderer/components/switch/switch.tsx
+++ b/src/renderer/components/switch/switch.tsx
@@ -21,7 +21,7 @@ export function Switch({ children, disabled, onChange, ...props }: SwitchProps) 
         type="checkbox"
         role="switch"
         disabled={disabled}
-        onChange={(event) => onChange?.(!props.checked, event)}
+        onChange={(event) => onChange?.(event.target.checked, event)}
         {...props}
       />
     </label>


### PR DESCRIPTION
Fixing `checked` value from `onChange` callback to be consistent what `event.target.checked` natively returns.

To avoid things like https://github.com/lensapp/lenscloud-lens-extension/pull/1654#discussion_r866658781

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>