### PR TITLE
TopBar Update button

### DIFF
--- a/src/renderer/components/layout/top-bar/top-bar.tsx
+++ b/src/renderer/components/layout/top-bar/top-bar.tsx
@@ -11,7 +11,7 @@ import { Icon } from "../../icon";
 import { observable } from "mobx";
 import { ipcRendererOn } from "../../../../common/ipc";
 import { watchHistoryState } from "../../../remote-helpers/history-updater";
-import { cssNames } from "../../../utils";
+import { cssNames, noop } from "../../../utils";
 import topBarItemsInjectable from "./top-bar-items/top-bar-items.injectable";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import type { TopBarRegistration } from "./top-bar-registration";
@@ -23,6 +23,7 @@ import type { NavigateToCatalog } from "../../../../common/front-end-routing/rou
 import navigateToCatalogInjectable from "../../../../common/front-end-routing/routes/catalog/navigate-to-catalog.injectable";
 import catalogRouteInjectable from "../../../../common/front-end-routing/routes/catalog/catalog-route.injectable";
 import routeIsActiveInjectable from "../../../routes/route-is-active.injectable";
+import { UpdateButton } from "../../update-button";
 
 interface Dependencies {
   navigateToCatalog: NavigateToCatalog;
@@ -114,6 +115,7 @@ const NonInjectedTopBar = observer(({ items, navigateToCatalog, catalogRouteIsAc
           onClick={goForward}
           disabled={!nextEnabled.get()}
         />
+        <UpdateButton update={noop} warningLevel="light" />
       </div>
       <div className={styles.items}>
         {renderRegisteredItems(items.get())}

--- a/src/renderer/components/layout/top-bar/top-bar.tsx
+++ b/src/renderer/components/layout/top-bar/top-bar.tsx
@@ -115,7 +115,7 @@ const NonInjectedTopBar = observer(({ items, navigateToCatalog, catalogRouteIsAc
           onClick={goForward}
           disabled={!nextEnabled.get()}
         />
-        <UpdateButton update={noop} warningLevel="light" />
+        <UpdateButton update={noop} />
       </div>
       <div className={styles.items}>
         {renderRegisteredItems(items.get())}

--- a/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
+++ b/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<UpdateButton/> should render if warning level prop passed 1`] = `
+<button
+  class="updateButton"
+  data-testid="update-button"
+  id="update_button_2"
+>
+  Update
+  <i
+    class="Icon material focusable"
+  >
+    <span
+      class="icon"
+      data-icon-name="update"
+    >
+      update
+    </span>
+  </i>
+</button>
+`;

--- a/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
+++ b/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<UpdateButton/> should render if warning level prop passed 1`] = `
 <button
   class="updateButton"
   data-testid="update-button"
+  data-warning-level="light"
   id="update-lens-button"
 >
   Update

--- a/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
+++ b/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
@@ -4,27 +4,18 @@ exports[`<UpdateButton/> should render if warning level prop passed 1`] = `
 <button
   class="updateButton"
   data-testid="update-button"
-  id="update_button_2"
+  id="update-lens-button"
 >
   Update
-  <svg
-    height="12"
-    shape-rendering="crispEdges"
-    viewBox="0 0 12 12"
-    width="12"
+  <i
+    class="Icon icon material focusable"
   >
-    <path
-      d="M0,8.5h12v1H0V8.5z"
-      fill="currentColor"
-    />
-    <path
-      d="M0,5.5h12v1H0V5.5z"
-      fill="currentColor"
-    />
-    <path
-      d="M0,2.5h12v1H0V2.5z"
-      fill="currentColor"
-    />
-  </svg>
+    <span
+      class="icon"
+      data-icon-name="arrow_drop_down"
+    >
+      arrow_drop_down
+    </span>
+  </i>
 </button>
 `;

--- a/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
+++ b/src/renderer/components/update-button/__tests__/__snapshots__/update-button.test.tsx.snap
@@ -7,15 +7,24 @@ exports[`<UpdateButton/> should render if warning level prop passed 1`] = `
   id="update_button_2"
 >
   Update
-  <i
-    class="Icon material focusable"
+  <svg
+    height="12"
+    shape-rendering="crispEdges"
+    viewBox="0 0 12 12"
+    width="12"
   >
-    <span
-      class="icon"
-      data-icon-name="update"
-    >
-      update
-    </span>
-  </i>
+    <path
+      d="M0,8.5h12v1H0V8.5z"
+      fill="currentColor"
+    />
+    <path
+      d="M0,5.5h12v1H0V5.5z"
+      fill="currentColor"
+    />
+    <path
+      d="M0,2.5h12v1H0V2.5z"
+      fill="currentColor"
+    />
+  </svg>
 </button>
 `;

--- a/src/renderer/components/update-button/__tests__/update-button.test.tsx
+++ b/src/renderer/components/update-button/__tests__/update-button.test.tsx
@@ -5,7 +5,7 @@
 
 import { render } from "@testing-library/react";
 import React from "react";
-import { UpdateButton } from "..";
+import { UpdateButton } from "../update-button";
 import "@testing-library/jest-dom/extend-expect";
 
 const update = jest.fn();

--- a/src/renderer/components/update-button/__tests__/update-button.test.tsx
+++ b/src/renderer/components/update-button/__tests__/update-button.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { render } from "@testing-library/react";
+import React from "react";
+import { UpdateButton } from "..";
+import "@testing-library/jest-dom/extend-expect";
+
+const update = jest.fn();
+
+describe("<UpdateButton/>", () => {
+  it("should not render if no warning level prop passed", () => {
+    const { queryByTestId } = render(<UpdateButton update={update} />);
+
+    expect(queryByTestId("update-button")).not.toBeInTheDocument();
+  });
+
+  it("should render if warning level prop passed", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="light" />);
+
+    expect(getByTestId("update-button")).toMatchSnapshot();
+  });
+
+  it("should open menu when clicked", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="light" />);
+
+    const button = getByTestId("update-button");
+
+    button.click();
+
+    expect(getByTestId("update-lens-menu-item")).toBeInTheDocument();
+  });
+
+  it("should call update function when menu item clicked", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="light" />);
+
+    const button = getByTestId("update-button");
+
+    button.click();
+
+    const menuItem = getByTestId("update-lens-menu-item");
+
+    menuItem.click();
+
+    expect(update).toHaveBeenCalled();
+  });
+
+  it("should have class name with medium warning level", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="medium" />);
+
+    const button = getByTestId("update-button");
+
+    expect(button.className.toLowerCase().includes("medium")).toBeTruthy();
+  });
+
+  it("should have class name with high warning level", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="high" />);
+
+    const button = getByTestId("update-button");
+
+    expect(button.className.toLowerCase().includes("high")).toBeTruthy();
+  });
+});

--- a/src/renderer/components/update-button/__tests__/update-button.test.tsx
+++ b/src/renderer/components/update-button/__tests__/update-button.test.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import React from "react";
 import { UpdateButton } from "../update-button";
 import "@testing-library/jest-dom/extend-expect";
@@ -27,12 +27,12 @@ describe("<UpdateButton/>", () => {
     expect(getByTestId("update-button")).toMatchSnapshot();
   });
 
-  it("should open menu when clicked", () => {
+  it("should open menu when clicked", async () => {
     const { getByTestId } = render(<UpdateButton update={update} warningLevel="light" />);
 
     const button = getByTestId("update-button");
 
-    button.click();
+    act(() => button.click());
 
     expect(getByTestId("update-lens-menu-item")).toBeInTheDocument();
   });
@@ -42,7 +42,7 @@ describe("<UpdateButton/>", () => {
 
     const button = getByTestId("update-button");
 
-    button.click();
+    act(() => button.click());
 
     const menuItem = getByTestId("update-lens-menu-item");
 

--- a/src/renderer/components/update-button/__tests__/update-button.test.tsx
+++ b/src/renderer/components/update-button/__tests__/update-button.test.tsx
@@ -51,19 +51,27 @@ describe("<UpdateButton/>", () => {
     expect(update).toHaveBeenCalled();
   });
 
-  it("should have class name with medium warning level", () => {
+  it("should have light warning level", () => {
+    const { getByTestId } = render(<UpdateButton update={update} warningLevel="light" />);
+
+    const button = getByTestId("update-button");
+
+    expect(button.dataset.warningLevel).toBe("light");
+  });
+
+  it("should have medium warning level", () => {
     const { getByTestId } = render(<UpdateButton update={update} warningLevel="medium" />);
 
     const button = getByTestId("update-button");
 
-    expect(button.className.toLowerCase().includes("medium")).toBeTruthy();
+    expect(button.dataset.warningLevel).toBe("medium");
   });
 
-  it("should have class name with high warning level", () => {
+  it("should have high warning level", () => {
     const { getByTestId } = render(<UpdateButton update={update} warningLevel="high" />);
 
     const button = getByTestId("update-button");
 
-    expect(button.className.toLowerCase().includes("high")).toBeTruthy();
+    expect(button.dataset.warningLevel).toBe("high");
   });
 });

--- a/src/renderer/components/update-button/__tests__/update-button.test.tsx
+++ b/src/renderer/components/update-button/__tests__/update-button.test.tsx
@@ -11,6 +11,10 @@ import "@testing-library/jest-dom/extend-expect";
 const update = jest.fn();
 
 describe("<UpdateButton/>", () => {
+  beforeEach(() => {
+    update.mockClear();
+  });
+
   it("should not render if no warning level prop passed", () => {
     const { queryByTestId } = render(<UpdateButton update={update} />);
 

--- a/src/renderer/components/update-button/index.ts
+++ b/src/renderer/components/update-button/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+export * from "./update-button";

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -3,7 +3,30 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-.updateButton {}
+.updateButton {
+  --active-color-hsl: 122deg 39% 49%;
+  --active-color: hsl(var(--active-color-hsl));
+
+  border: 1px solid var(--active-color);
+  border-radius: 4px;
+  background: hsl(var(--active-color-hsl) / 15%);
+  color: var(--active-color);
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  gap: 8px;
+  cursor: default;
+  transition: background-color 0.1s;
+
+  &:hover {
+    background: hsl(var(--active-color-hsl) / 5%);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--blue);
+    border-color: transparent;
+  }
+}
 
 .warningHigh {}
 

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -35,3 +35,8 @@
 .warningMedium {
   --active-color-hsl: 36deg 100% 50%;
 }
+
+:global(.theme-light) .warningMedium {
+  // Making medium color a bit darker for light theme
+  --active-color-hsl: 36deg 100% 46%;
+}

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -28,6 +28,10 @@
   }
 }
 
-.warningHigh {}
+.warningHigh {
+  --active-color-hsl: 0deg 76% 62%;
+}
 
-.warningMedium {}
+.warningMedium {
+  --active-color-hsl: 36deg 100% 50%;
+}

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -28,6 +28,11 @@
   }
 }
 
+.icon {
+  width: 16px;
+  height: 16px;
+}
+
 .warningHigh {
   --active-color-hsl: 0deg 76% 62%;
 }

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+.updateButton {}
+
+.warningHigh {}
+
+.warningMedium {}

--- a/src/renderer/components/update-button/styles.module.scss
+++ b/src/renderer/components/update-button/styles.module.scss
@@ -4,27 +4,37 @@
  */
 
 .updateButton {
-  --active-color-hsl: 122deg 39% 49%;
-  --active-color: hsl(var(--active-color-hsl));
+  --accent-color: var(--colorOk);
 
-  border: 1px solid var(--active-color);
+  border: 1px solid var(--accent-color);
   border-radius: 4px;
-  background: hsl(var(--active-color-hsl) / 15%);
-  color: var(--active-color);
+  color: var(--accent-color);
   display: flex;
   align-items: center;
   padding: 4px 8px;
-  gap: 8px;
+  gap: 6px;
   cursor: default;
-  transition: background-color 0.1s;
+  position: relative;
 
-  &:hover {
-    background: hsl(var(--active-color-hsl) / 5%);
+  &:hover::before{
+    opacity: 0.25;
   }
 
   &:focus-visible {
     box-shadow: 0 0 0 2px var(--blue);
     border-color: transparent;
+  }
+
+  &::before {
+    content: " ";
+    position: absolute;
+    background: var(--accent-color);
+    width: 100%;
+    height: 100%;
+    left: 0;
+    opacity: 0.15;
+    z-index: -1;
+    transition: opacity 0.1s;
   }
 }
 
@@ -33,15 +43,10 @@
   height: 16px;
 }
 
-.warningHigh {
-  --active-color-hsl: 0deg 76% 62%;
-}
-
 .warningMedium {
-  --active-color-hsl: 36deg 100% 50%;
+  --accent-color: var(--colorWarning);
 }
 
-:global(.theme-light) .warningMedium {
-  // Making medium color a bit darker for light theme
-  --active-color-hsl: 36deg 100% 46%;
+.warningHigh {
+  --accent-color: var(--colorSoftError);
 }

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -50,7 +50,11 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
         close={toggle}
         open={toggle}
       >
-        <MenuItem icon={menuIconProps} onClick={update} data-testid="update-lens-menu-item">
+        <MenuItem
+          icon={menuIconProps}
+          onClick={update}
+          data-testid="update-lens-menu-item"
+        >
           Relaunch to Update Lens
         </MenuItem>
       </Menu>

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -62,7 +62,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
         close={toggle}
         open={noop}
       >
-        <MenuItem onClick={update} data-testid="update-lens-menu-item">
+        <MenuItem icon="update" onClick={update} data-testid="update-lens-menu-item">
           Relaunch to Update Lens
         </MenuItem>
       </Menu>

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -50,7 +50,6 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
         isOpen={opened}
         close={toggle}
         open={toggle}
-        aria-expanded={opened}
       >
         <MenuItem
           icon={menuIconProps}

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -6,7 +6,6 @@
 import styles from "./styles.module.scss";
 
 import React, { useState } from "react";
-import { Icon } from "../icon";
 import { Menu, MenuItem } from "../menu";
 import uniqueId from "lodash/uniqueId";
 import { noop } from "lodash";
@@ -48,7 +47,11 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
         onKeyDown={onKeyDown}
       >
         Update
-        <Icon material="update"/>
+        <svg width="12" height="12" viewBox="0 0 12 12" shapeRendering="crispEdges">
+          <path fill="currentColor" d="M0,8.5h12v1H0V8.5z"/>
+          <path fill="currentColor" d="M0,5.5h12v1H0V5.5z"/>
+          <path fill="currentColor" d="M0,2.5h12v1H0V2.5z"/>
+        </svg>
       </button>
       <Menu
         usePortal

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -10,6 +10,8 @@ import { Menu, MenuItem } from "../menu";
 import uniqueId from "lodash/uniqueId";
 import { noop } from "lodash";
 import { cssNames } from "../../utils";
+import type { IconProps } from "../icon";
+import { Icon } from "../icon";
 
 interface UpdateButtonProps {
   warningLevel?: "light" | "medium" | "high";
@@ -18,6 +20,7 @@ interface UpdateButtonProps {
 
 export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
   const id = uniqueId("update_button_");
+  const menuIconProps: IconProps = { material: "update", small: true };
   const [opened, setOpened] = useState(false);
 
   const onKeyDown = (evt: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -48,11 +51,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
         onKeyDown={onKeyDown}
       >
         Update
-        <svg width="12" height="12" viewBox="0 0 12 12" shapeRendering="crispEdges">
-          <path fill="currentColor" d="M0,8.5h12v1H0V8.5z"/>
-          <path fill="currentColor" d="M0,5.5h12v1H0V5.5z"/>
-          <path fill="currentColor" d="M0,2.5h12v1H0V2.5z"/>
-        </svg>
+        <Icon material="arrow_drop_down" className={styles.icon}/>
       </button>
       <Menu
         usePortal
@@ -61,7 +60,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
         close={toggle}
         open={noop}
       >
-        <MenuItem icon="update" onClick={update} data-testid="update-lens-menu-item">
+        <MenuItem icon={menuIconProps} onClick={update} data-testid="update-lens-menu-item">
           Relaunch to Update Lens
         </MenuItem>
       </Menu>

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -50,6 +50,7 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
         isOpen={opened}
         close={toggle}
         open={toggle}
+        aria-expanded={opened}
       >
         <MenuItem
           icon={menuIconProps}

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -8,7 +8,6 @@ import styles from "./styles.module.scss";
 import type { HTMLAttributes } from "react";
 import React, { useState } from "react";
 import { Menu, MenuItem } from "../menu";
-import { noop } from "lodash";
 import { cssNames } from "../../utils";
 import type { IconProps } from "../icon";
 import { Icon } from "../icon";
@@ -22,13 +21,6 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
   const buttonId = id ?? "update-lens-button";
   const menuIconProps: IconProps = { material: "update", small: true };
   const [opened, setOpened] = useState(false);
-
-  const onKeyDown = (evt: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (evt.code == "Space") {
-      evt.preventDefault();
-      toggle();
-    }
-  };
 
   const toggle = () => {
     setOpened(!opened);
@@ -47,8 +39,6 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
           [styles.warningHigh]: warningLevel === "high",
           [styles.warningMedium]: warningLevel === "medium",
         })}
-        onClick={toggle}
-        onKeyDown={onKeyDown}
       >
         Update
         <Icon material="arrow_drop_down" className={styles.icon}/>
@@ -58,7 +48,7 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
         htmlFor={buttonId}
         isOpen={opened}
         close={toggle}
-        open={noop}
+        open={toggle}
       >
         <MenuItem icon={menuIconProps} onClick={update} data-testid="update-lens-menu-item">
           Relaunch to Update Lens

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -5,21 +5,21 @@
 
 import styles from "./styles.module.scss";
 
+import type { HTMLAttributes} from "react";
 import React, { useState } from "react";
 import { Menu, MenuItem } from "../menu";
-import uniqueId from "lodash/uniqueId";
 import { noop } from "lodash";
 import { cssNames } from "../../utils";
 import type { IconProps } from "../icon";
 import { Icon } from "../icon";
 
-interface UpdateButtonProps {
+interface UpdateButtonProps extends HTMLAttributes<HTMLButtonElement> {
   warningLevel?: "light" | "medium" | "high";
   update: () => void;
 }
 
-export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
-  const id = uniqueId("update_button_");
+export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
+  const buttonId = id ?? "update-lens-button";
   const menuIconProps: IconProps = { material: "update", small: true };
   const [opened, setOpened] = useState(false);
 
@@ -42,7 +42,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
     <>
       <button
         data-testid="update-button"
-        id="update-lens-button"
+        id={buttonId}
         className={cssNames(styles.updateButton, {
           [styles.warningHigh]: warningLevel === "high",
           [styles.warningMedium]: warningLevel === "medium",
@@ -55,7 +55,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
       </button>
       <Menu
         usePortal
-        htmlFor="update-lens-button"
+        htmlFor={buttonId}
         isOpen={opened}
         close={toggle}
         open={noop}

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -42,7 +42,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
     <>
       <button
         data-testid="update-button"
-        id={id}
+        id="update-lens-button"
         className={cssNames(styles.updateButton, {
           [styles.warningHigh]: warningLevel === "high",
           [styles.warningMedium]: warningLevel === "medium",
@@ -55,7 +55,7 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
       </button>
       <Menu
         usePortal
-        htmlFor={id}
+        htmlFor="update-lens-button"
         isOpen={opened}
         close={toggle}
         open={noop}

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -21,7 +21,8 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
   const [opened, setOpened] = useState(false);
 
   const onKeyDown = (evt: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (evt.code == "Space" || evt.code == "Enter") {
+    if (evt.code == "Space") {
+      evt.preventDefault();
       toggle();
     }
   };
@@ -57,8 +58,6 @@ export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
         usePortal
         htmlFor={id}
         isOpen={opened}
-        closeOnClickItem
-        closeOnClickOutside
         close={toggle}
         open={noop}
       >

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -5,7 +5,7 @@
 
 import styles from "./styles.module.scss";
 
-import type { HTMLAttributes} from "react";
+import type { HTMLAttributes } from "react";
 import React, { useState } from "react";
 import { Menu, MenuItem } from "../menu";
 import { noop } from "lodash";

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -34,6 +34,7 @@ export function UpdateButton({ warningLevel, update, id }: UpdateButtonProps) {
     <>
       <button
         data-testid="update-button"
+        data-warning-level={warningLevel}
         id={buttonId}
         className={cssNames(styles.updateButton, {
           [styles.warningHigh]: warningLevel === "high",

--- a/src/renderer/components/update-button/update-button.tsx
+++ b/src/renderer/components/update-button/update-button.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import styles from "./styles.module.scss";
+
+import React, { useState } from "react";
+import { Icon } from "../icon";
+import { Menu, MenuItem } from "../menu";
+import uniqueId from "lodash/uniqueId";
+import { noop } from "lodash";
+import { cssNames } from "../../utils";
+
+interface UpdateButtonProps {
+  warningLevel?: "light" | "medium" | "high";
+  update: () => void;
+}
+
+export function UpdateButton({ warningLevel, update }: UpdateButtonProps) {
+  const id = uniqueId("update_button_");
+  const [opened, setOpened] = useState(false);
+
+  const onKeyDown = (evt: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (evt.code == "Space" || evt.code == "Enter") {
+      toggle();
+    }
+  };
+
+  const toggle = () => {
+    setOpened(!opened);
+  };
+
+  if (!warningLevel) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        data-testid="update-button"
+        id={id}
+        className={cssNames(styles.updateButton, {
+          [styles.warningHigh]: warningLevel === "high",
+          [styles.warningMedium]: warningLevel === "medium",
+        })}
+        onClick={toggle}
+        onKeyDown={onKeyDown}
+      >
+        Update
+        <Icon material="update"/>
+      </button>
+      <Menu
+        usePortal
+        htmlFor={id}
+        isOpen={opened}
+        closeOnClickItem
+        closeOnClickOutside
+        close={toggle}
+        open={noop}
+      >
+        <MenuItem onClick={update} data-testid="update-lens-menu-item">
+          Relaunch to Update Lens
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}


### PR DESCRIPTION
UI Part of #5214 

Update button with 3 warning levels, each of them changes button color. Clicking 'Update' button will show menu with `Relaunch Lens to Update` item.

Dark theme:

https://user-images.githubusercontent.com/9607060/168063398-dbb1a94c-d110-455a-8006-8ca3f5ec69e8.mov

<img width="823" alt="update medium dark" src="https://user-images.githubusercontent.com/9607060/168063435-087c24eb-611e-405f-b54f-6a68fb7f754c.png">
<img width="821" alt="update high dark" src="https://user-images.githubusercontent.com/9607060/168063487-cf29d579-e21d-46a3-84f1-16c3a49dc798.png">

Light theme:
<img width="825" alt="update high light" src="https://user-images.githubusercontent.com/9607060/168063557-c39269e9-ca32-466f-9504-61ad73c7790c.png">
<img width="823" alt="update medium light" src="https://user-images.githubusercontent.com/9607060/168063584-c8721ca0-8811-4463-b4a6-120f86f1bd0e.png">
<img width="823" alt="update light light" src="https://user-images.githubusercontent.com/9607060/168063645-232a2520-74e0-418d-b7d4-5b03fe6a25d3.png">

Update button is isolated and currently completely hidden. It will show up when some `warningLevel` prop will be passed.
<img width="825" alt="no update button" src="https://user-images.githubusercontent.com/9607060/168063857-607fce9b-7b4b-4258-9332-80bdf17e81e6.png">


