### PR TITLE
Switch to always using latest minikube in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,9 @@ jobs:
 
       - name: Install integration test dependencies
         id: minikube
-        uses: medyagh/setup-minikube@5a9a7104d7322fa40424de8855c84685e89cefd7
+        uses: medyagh/setup-minikube@master
+        with:
+          minikube-version: latest
         if: runner.os == 'Linux'
 
       - run: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' make integration


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This PR fixes the issue seen at https://github.com/lensapp/lens/runs/6472618905?check_suite_focus=true where if there is a minikube upgrade then CI on ubuntu will fail because there is an interactive prompt which never gets resolved.