### PR TITLE
Fix Kubectl.checkBinary() to be compatible with kubectl@1.24

### DIFF
--- a/src/main/kubectl/kubectl.ts
+++ b/src/main/kubectl/kubectl.ts
@@ -155,7 +155,7 @@ export class Kubectl {
       try {
         const args = [
           "version",
-          "--client", "true",
+          "--client",
           "--output", "json",
         ];
         const { stdout } = await promiseExecFile(path, args);


### PR DESCRIPTION
- This is a backwards compatible change with versions of kubectl going
  back to at least 1.16

Signed-off-by: Sebastian Malton <sebastian@malton.name>