### PR TITLE
Release 5.5.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.5.0-beta.1",
+  "version": "5.5.0-beta.2",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since 5.5.0-beta.1

## 🐛 Bug Fixes
- Fix master node classification for kubernetes >1.20 (**[#5416](5416)**) https://github.com/Nokel81
- Fix downloading cluster specific kubectl (**[#5413](5413)**) https://github.com/Nokel81
- Fix Kubectl.checkBinary() to be compatible with kubectl@1.24 (**[#5415](5415)**) https://github.com/Nokel81
-  Fix cluster connection failing after execHelm (**[#5432](5432)**) https://github.com/Nokel81
