### PR TITLE
Fix cluster connection failing after execHelm

### DIFF
--- a/src/main/helm/exec.ts
+++ b/src/main/helm/exec.ts
@@ -17,7 +17,7 @@ export async function execHelm(args: string[], options?: BaseEncodingOptions & E
   try {
     const opts = { ...options };
 
-    opts.env ??= process.env;
+    opts.env ??= { ...process.env };
 
     if (!opts.env.HTTPS_PROXY && UserStore.getInstance().httpsProxy) {
       opts.env.HTTPS_PROXY = UserStore.getInstance().httpsProxy;


### PR DESCRIPTION
- The bug was that we were only assigning a reference to the global process.env instead of cloning it, so we were accidentally modifying the global

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #5423 