### PR TITLE
Allow bundled extensions to use codesign

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -94,9 +94,25 @@ jobs:
           GH_TOKEN: $(LENS_IDE_GH_TOKEN)
         displayName: Customize config
 
-      - script: make build
+      - bash: |
+          set -e
+
+          echo "Importing codesign certificate ..."
+          echo $CSC_LINK | base64 -D > certificate.p12
+          security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security import certificate.p12 -k build.keychain -P $CSC_KEY_PASSWORD -T /usr/bin/codesign -T /usr/bin/security -A
+          security set-key-partition-list -S apple-tool:,apple: -k $KEYCHAIN_PASSWORD build.keychain
+
+          rm certificate.p12
+          echo "Codesign certificate imported!"
+
+          make build
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
         env:
+          KEYCHAIN_PASSWORD: secretz
           APPLEID: $(APPLEID)
           APPLEIDPASS: $(APPLEIDPASS)
           CSC_LINK: $(CSC_LINK)


### PR DESCRIPTION
Allows bundled extensions to bundle binaries and sign them with codesign for example during prepack. This is a macOS requirement, even binaries within npm tgz needs to be signed properly.