### PR TITLE
Make terminal tab icon the same as the menu item icon

### DIFF
--- a/src/renderer/components/dock/dock.tsx
+++ b/src/renderer/components/dock/dock.tsx
@@ -166,11 +166,7 @@ class NonInjectedDock extends React.Component<DockProps & Dependencies> {
                 closeOnScroll={false}
               >
                 <MenuItem className="create-terminal-tab" onClick={() => this.props.createTerminalTab()}>
-                  <Icon
-                    small
-                    svg="terminal"
-                    size={15} 
-                  />
+                  <Icon small material="terminal" />
                   Terminal session
                 </MenuItem>
                 <MenuItem className="create-resource-tab" onClick={() => this.props.createResourceTab()}>

--- a/src/renderer/components/dock/terminal/dock-tab.tsx
+++ b/src/renderer/components/dock/terminal/dock-tab.tsx
@@ -77,12 +77,7 @@ class NonInjectedTerminalTab<Props extends TerminalTabProps & Dependencies> exte
       <DockTab
         {...tabProps}
         className={className}
-        icon={(
-          <Icon
-            svg="terminal"
-            smallest
-          />
-        )}
+        icon={<Icon material="terminal" />}
         moreActions={this.isDisconnected && (
           <Icon
             small

--- a/src/renderer/components/dock/terminal/dock-tab.tsx
+++ b/src/renderer/components/dock/terminal/dock-tab.tsx
@@ -67,7 +67,6 @@ class NonInjectedTerminalTab<Props extends TerminalTabProps & Dependencies> exte
   }
 
   render() {
-    const tabIcon = <Icon material="terminal"/>;
     const className = cssNames("TerminalTab", this.props.className, {
       disconnected: this.isDisconnected,
     });
@@ -78,7 +77,12 @@ class NonInjectedTerminalTab<Props extends TerminalTabProps & Dependencies> exte
       <DockTab
         {...tabProps}
         className={className}
-        icon={tabIcon}
+        icon={(
+          <Icon
+            svg="terminal"
+            smallest
+          />
+        )}
         moreActions={this.isDisconnected && (
           <Icon
             small


### PR DESCRIPTION
Just something off than I noticed.

Signed-off-by: Sebastian Malton <sebastian@malton.name>

before:
![Screen Shot 2022-05-25 at 3 33 43 PM](https://user-images.githubusercontent.com/8225332/170353055-561e0e61-0e98-4454-b26b-b89825d0de6a.png)

after:
![Screen Shot 2022-05-25 at 3 32 07 PM](https://user-images.githubusercontent.com/8225332/170353082-aec3cd06-fe34-4f11-881f-2fc297166415.png)
