### PR TITLE
Fix completely overriding PATH in shellSync

### DIFF
--- a/src/common/utils/__tests__/union-env-path.test.ts
+++ b/src/common/utils/__tests__/union-env-path.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import path from "path";
+import { unionPATHs } from "../union-env-path";
+
+describe("unionPATHs", () => {
+  it("return the same path if given only one with no double delimiters", () => {
+    expect(unionPATHs(`/bin/bar${path.delimiter}/usr/bin`)).toBe(`/bin/bar${path.delimiter}/usr/bin`);
+  });
+
+  it("return equivalent path if given only one with no double delimiters", () => {
+    expect(unionPATHs(`/bin/bar${path.delimiter}${path.delimiter}/usr/bin`)).toBe(`/bin/bar${path.delimiter}/usr/bin`);
+  });
+
+  it("should remove duplicate entries, appending non duplicates in order received", () => {
+    expect(unionPATHs(
+      `/bin/bar${path.delimiter}/usr/bin`,
+      `/bin/bar${path.delimiter}/usr/lens/bat`,
+    )).toBe(`/bin/bar${path.delimiter}/usr/bin${path.delimiter}/usr/lens/bat`);
+  });
+
+  it("should remove duplicate entries, appending non duplicates in order received, 3", () => {
+    expect(unionPATHs(
+      `/bin/bar${path.delimiter}/usr/bin`,
+      `/bin/bar${path.delimiter}/usr/lens/bat`,
+      `/usr/local/lens${path.delimiter}/usr/bin`,
+    )).toBe(`/bin/bar${path.delimiter}/usr/bin${path.delimiter}/usr/lens/bat${path.delimiter}/usr/local/lens`);
+  });
+});

--- a/src/common/utils/iter.ts
+++ b/src/common/utils/iter.ts
@@ -233,3 +233,18 @@ export function every<T>(src: Iterable<T>, fn: (val: T) => any): boolean {
 
   return true;
 }
+
+/**
+ * Takes two iterators and creates a new iterator over both in sequence.
+ * @param first The first iterable to iterate over
+ * @param second The second iterable to iterate over
+ */
+export function* chain<T>(first: Iterable<T>, second: Iterable<T>): Iterable<T> {
+  for (const item of first) {
+    yield item;
+  }
+
+  for (const item of second) {
+    yield item;
+  }
+}

--- a/src/common/utils/iter.ts
+++ b/src/common/utils/iter.ts
@@ -233,18 +233,3 @@ export function every<T>(src: Iterable<T>, fn: (val: T) => any): boolean {
 
   return true;
 }
-
-/**
- * Takes two iterators and creates a new iterator over both in sequence.
- * @param first The first iterable to iterate over
- * @param second The second iterable to iterate over
- */
-export function* chain<T>(first: Iterable<T>, second: Iterable<T>): Iterable<T> {
-  for (const item of first) {
-    yield item;
-  }
-
-  for (const item of second) {
-    yield item;
-  }
-}

--- a/src/common/utils/union-env-path.ts
+++ b/src/common/utils/union-env-path.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import path from "path";
+import * as iter from "./iter";
+
+/**
+ * Join all entires with a PATH env var delimated string together
+ * @param PATHs Any number of PATH env variables
+ *
+ * NOTE: This function does not attempt to handle any sort of escape sequences since after testing
+ * it was found that `zsh` (at least on `macOS`) does not when trying to find programs
+ */
+export function unionPATHs(...PATHs: string[]): string {
+  const entries = new Set(iter.filterFlatMap(PATHs, PATH => PATH.split(path.delimiter)));
+
+  return iter.join(entries.values(), path.delimiter);
+}

--- a/src/main/shell-sync.ts
+++ b/src/main/shell-sync.ts
@@ -8,6 +8,7 @@ import os from "os";
 import { app } from "electron";
 import logger from "./logger";
 import { isSnap } from "../common/vars";
+import { unionPATHs } from "../common/utils/union-env-path";
 
 /**
  * shellSync loads what would have been the environment if this application was
@@ -25,7 +26,8 @@ export async function shellSync() {
   }
 
   if (!isSnap) {
-    process.env.PATH = env.PATH;
+    // Prefer the synced PATH over the initial one
+    process.env.PATH = unionPATHs(env.PATH ?? "",  process.env.PATH ?? "");
   }
 
   // The spread operator allows joining of objects. The precedence is last to first.

--- a/src/main/utils/shell-env.ts
+++ b/src/main/utils/shell-env.ts
@@ -6,7 +6,7 @@
 import shellEnvironment from "shell-env";
 import logger from "../logger";
 
-export type EnvironmentVariables = Record<string, string>;
+export type EnvironmentVariables = Partial<Record<string, string>>;
 
 let shellSyncFailed = false;
 


### PR DESCRIPTION
- This allows local changes to PATH in the shell that is used to open
  lens to persist after shellSync.

- This helps with using python virtual environments

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #4931 