### PR TITLE
Remove deprecated nodeSelectorTerms from cluster metrics manifests

### DIFF
--- a/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/03-statefulset.yml.hb
@@ -24,11 +24,6 @@ spec:
                   operator: In
                   values:
                   - linux
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
       # <%- if config.node_selector -%>
       # nodeSelector:
       # <%- node_selector.to_h.each do |key, value| -%>

--- a/extensions/metrics-cluster-feature/resources/10-node-exporter-ds.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/10-node-exporter-ds.yml.hb
@@ -30,11 +30,6 @@ spec:
                   operator: In
                   values:
                   - linux
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/extensions/metrics-cluster-feature/resources/14-kube-state-metrics-deployment.yml.hb
+++ b/extensions/metrics-cluster-feature/resources/14-kube-state-metrics-deployment.yml.hb
@@ -23,11 +23,6 @@ spec:
                   operator: In
                   values:
                   - linux
-              - matchExpressions:
-                - key: beta.kubernetes.io/os
-                  operator: In
-                  values:
-                  - linux
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics


### PR DESCRIPTION
This PR removes `beta.kubernetes.io` node selector terms from cluster metrics manifests, since those are deprecated since k8s v1.14 and some admission controllers are already actively blocking those (for example gke policy controller) preventing metrics stack to be deployed properly.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>