### PR TITLE
Ensure the cluster dashboard start url is valid

### DIFF
--- a/src/renderer/frames/cluster-frame/start-url.injectable.ts
+++ b/src/renderer/frames/cluster-frame/start-url.injectable.ts
@@ -4,8 +4,6 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { KubeResource } from "../../../common/rbac";
-import isAllowedResourceInjectable from "../../../common/utils/is-allowed-resource.injectable";
 import clusterOverviewRouteInjectable from "../../../common/front-end-routing/routes/cluster/overview/cluster-overview-route.injectable";
 import workloadsOverviewRouteInjectable from "../../../common/front-end-routing/routes/cluster/workloads/overview/workloads-overview-route.injectable";
 import { buildURL } from "../../../common/utils/buildUrl";
@@ -14,17 +12,13 @@ const startUrlInjectable = getInjectable({
   id: "start-url",
 
   instantiate: (di) => {
-    const isAllowedResource = (resourceName: any) => di.inject(isAllowedResourceInjectable, resourceName);
-
     const clusterOverviewRoute = di.inject(clusterOverviewRouteInjectable);
     const workloadOverviewRoute = di.inject(workloadsOverviewRouteInjectable);
     const clusterOverviewUrl = buildURL(clusterOverviewRoute.path);
     const workloadOverviewUrl = buildURL(workloadOverviewRoute.path);
 
     return computed(() => {
-      const resources: KubeResource[] = ["events", "nodes", "pods"];
-
-      return resources.every((resourceName) => isAllowedResource(resourceName))
+      return clusterOverviewRoute.isEnabled.get()
         ? clusterOverviewUrl
         : workloadOverviewUrl;
     });


### PR DESCRIPTION
ensure the start url is the workloads overview when the cluster overview is not available due to rbac restrictions

fixes #5487
fixes #5459
fixes #5462

~~This may also fix #5459 / #5462 though there is a separate PR coming for that. I think that PR should duplicate these changes to `start-url.injectable.ts`.~~