### PR TITLE
Fix remove and edit buttons not updating

### DIFF
--- a/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
+++ b/src/renderer/components/kube-object-menu/__snapshots__/kube-object-menu.test.tsx.snap
@@ -132,6 +132,132 @@ exports[`kube-object-menu given kube object when removing kube object renders 1`
 </body>
 `;
 
+exports[`kube-object-menu given kube object when rerendered with different kube object renders 1`] = `
+<body>
+  <div>
+    <div>
+      <ul
+        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+      >
+        <li
+          class="MenuItem"
+          data-testid="menu-action-delete"
+          tabindex="0"
+        >
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+            tooltip="Delete"
+          >
+            <span
+              class="icon"
+              data-icon-name="delete"
+            >
+              delete
+            </span>
+          </i>
+          <span
+            class="title"
+          >
+            Delete
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`kube-object-menu given kube object when rerendered with different kube object when removing new kube object renders 1`] = `
+<body>
+  <div>
+    <div>
+      <ul
+        class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
+      >
+        <li
+          class="MenuItem"
+          data-testid="menu-action-delete"
+          tabindex="0"
+        >
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+            tooltip="Delete"
+          >
+            <span
+              class="icon"
+              data-icon-name="delete"
+            >
+              delete
+            </span>
+          </i>
+          <span
+            class="title"
+          >
+            Delete
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    class="Dialog flex center ConfirmDialog modal"
+    data-testid="confirmation-dialog"
+  >
+    <div
+      class="box"
+    >
+      <div
+        class="confirm-content"
+      >
+        <i
+          class="Icon material focusable big"
+        >
+          <span
+            class="icon"
+            data-icon-name="warning"
+          >
+            warning
+          </span>
+        </i>
+         
+        <p>
+          Remove 
+          some-other-kind
+           
+          <b>
+            some-other-namespace/some-other-name
+          </b>
+           from 
+          <b>
+            Some name
+          </b>
+          ?
+        </p>
+      </div>
+      <div
+        class="confirm-buttons"
+      >
+        <button
+          class="Button cancel plain"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="Button ok primary"
+          data-testid="confirm"
+          type="button"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`kube-object-menu given kube object with namespace when removing kube object, renders confirmation dialog with namespace 1`] = `
 <body>
   <div>

--- a/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -3,6 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import React from "react";
+import type { RenderResult } from "@testing-library/react";
 import { screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { KubeObject } from "../../../common/k8s-api/kube-object";
@@ -127,7 +128,7 @@ describe("kube-object-menu", () => {
   });
 
   describe("given kube object", () => {
-    let baseElement: Element;
+    let result: RenderResult;
     let removeActionMock: AsyncFnMock<() => void>;
 
     beforeEach(async () => {
@@ -143,8 +144,7 @@ describe("kube-object-menu", () => {
       });
 
       removeActionMock = asyncFn();
-
-      ({ baseElement } = render(
+      result = render((
         <div>
           <ConfirmDialog animated={false} />
 
@@ -153,16 +153,58 @@ describe("kube-object-menu", () => {
             toolbar={true}
             removeAction={removeActionMock}
           />
-        </div>,
+        </div>
       ));
     });
 
     it("renders", () => {
-      expect(baseElement).toMatchSnapshot();
+      expect(result.baseElement).toMatchSnapshot();
     });
 
     it("does not open a confirmation dialog yet", () => {
       expect(screen.queryByTestId("confirmation-dialog")).toBeNull();
+    });
+
+    describe("when rerendered with different kube object", () => {
+      beforeEach(() => {
+        const newObjectStub = KubeObject.create({
+          apiVersion: "some-other-api-version",
+          kind: "some-other-kind",
+          metadata: {
+            uid: "some-other-uid",
+            name: "some-other-name",
+            resourceVersion: "some-other-resource-version",
+            namespace: "some-other-namespace",
+          },
+        });
+
+        result.rerender(
+          <div>
+            <ConfirmDialog animated={false} />
+
+            <KubeObjectMenu
+              object={newObjectStub}
+              toolbar={true}
+              removeAction={removeActionMock}
+            />
+          </div>,
+        );
+      });
+
+      it("renders", () => {
+        expect(result.baseElement).toMatchSnapshot();
+      });
+
+      describe("when removing new kube object", () => {
+        beforeEach(async () => {
+          userEvent.click(await screen.findByTestId("menu-action-delete"));
+        });
+
+        it("renders", async () => {
+          await screen.findByTestId("confirmation-dialog");
+          expect(result.baseElement).toMatchSnapshot();
+        });
+      });
     });
 
     describe("when removing kube object", () => {
@@ -172,7 +214,7 @@ describe("kube-object-menu", () => {
 
       it("renders", async () => {
         await screen.findByTestId("confirmation-dialog");
-        expect(baseElement).toMatchSnapshot();
+        expect(result.baseElement).toMatchSnapshot();
       });
 
       describe("when remove is confirmed", () => {

--- a/src/renderer/components/kube-object-menu/kube-object-menu.tsx
+++ b/src/renderer/components/kube-object-menu/kube-object-menu.tsx
@@ -48,6 +48,12 @@ interface Dependencies {
 class NonInjectedKubeObjectMenu<Kube extends KubeObject> extends React.Component<KubeObjectMenuProps<Kube> & Dependencies> {
   private menuItems = observable.array<KubeObjectContextMenuItem>();
 
+  componentDidUpdate(prevProps: Readonly<KubeObjectMenuProps<Kube> & Dependencies>): void {
+    if (prevProps.object !== this.props.object && this.props.object) {
+      this.emitOnContextMenuOpen(this.props.object);
+    }
+  }
+
   private renderRemoveMessage(object: KubeObject) {
     const breadcrumbParts = [object.getNs(), object.getName()];
     const breadcrumb = breadcrumbParts.filter(identity).join("/");


### PR DESCRIPTION
- KubeObjectMenu buttons failed to update during rerender

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #5492 

