### PR TITLE
Prevent duplicate app windows

### DIFF
--- a/src/behaviours/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
+++ b/src/behaviours/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
@@ -86,6 +86,18 @@ describe("opening application window using tray", () => {
           expectWindowsToBeOpen([]);
         });
 
+        describe("given opening of splash window has not finished yet, but another attempt to open the application is made", () => {
+          beforeEach(() => {
+            createElectronWindowMock.mockClear();
+
+            applicationBuilder.tray.click("open-app");
+          });
+
+          it("does not open any new windows", () => {
+            expect(createElectronWindowMock).not.toHaveBeenCalled();
+          });
+        });
+
         describe("when opening of splash window resolves", () => {
           beforeEach(async () => {
             await resolveOpeningOfWindow("splash");
@@ -101,7 +113,7 @@ describe("opening application window using tray", () => {
             expectWindowsToBeOpen(["only-application-window"]);
           });
 
-          describe("given opening has not finished yet, but another attempt to open the application is made", () => {
+          describe("given opening of application window has not finished yet, but another attempt to open the application is made", () => {
             beforeEach(() => {
               createElectronWindowMock.mockClear();
 

--- a/src/behaviours/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
+++ b/src/behaviours/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
+import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
+import { lensWindowInjectionToken } from "../../main/start-main-application/lens-window/application-window/lens-window-injection-token";
+import applicationWindowInjectable from "../../main/start-main-application/lens-window/application-window/application-window.injectable";
+import createElectronWindowForInjectable from "../../main/start-main-application/lens-window/application-window/create-electron-window-for.injectable";
+import type { AsyncFnMock } from "@async-fn/jest";
+import asyncFn from "@async-fn/jest";
+
+import type {
+  ElectronWindow,
+  LensWindowConfiguration,
+} from "../../main/start-main-application/lens-window/application-window/create-lens-window.injectable";
+
+import { flushPromises } from "../../common/test-utils/flush-promises";
+import type { DiContainer } from "@ogre-tools/injectable";
+
+describe("opening application window using tray", () => {
+  describe("given application has started", () => {
+    let applicationBuilder: ApplicationBuilder;
+
+    let createElectronWindowMock: AsyncFnMock<
+      (configuration: LensWindowConfiguration) => ElectronWindow
+    >;
+
+    let expectWindowsToBeOpen: (windowIds: string[]) => void;
+    let resolveOpeningOfWindow: (windowId: string) => Promise<void>;
+
+    beforeEach(async () => {
+      applicationBuilder = getApplicationBuilder().beforeApplicationStart(
+        ({ mainDi }) => {
+          createElectronWindowMock = asyncFn();
+
+          mainDi.override(
+            createElectronWindowForInjectable,
+
+            () => (configuration) => () =>
+              createElectronWindowMock(configuration),
+          );
+
+          expectWindowsToBeOpen = expectWindowsToBeOpenFor(mainDi);
+
+          resolveOpeningOfWindow = resolveOpeningOfWindowFor(
+            createElectronWindowMock,
+          );
+        },
+      );
+
+      const renderPromise = applicationBuilder.render();
+
+      await flushPromises();
+
+      await resolveOpeningOfWindow("splash");
+      await resolveOpeningOfWindow("only-application-window");
+
+      await renderPromise;
+    });
+
+    it("only an application window is open", () => {
+      expectWindowsToBeOpen(["only-application-window"]);
+    });
+
+    describe("when the application window is closed", () => {
+      beforeEach(() => {
+        const applicationWindow = applicationBuilder.dis.mainDi.inject(
+          applicationWindowInjectable,
+        );
+
+        applicationWindow.close();
+      });
+
+      it("no windows are open", () => {
+        expectWindowsToBeOpen([]);
+      });
+
+      describe("when an application window is reopened using tray", () => {
+        beforeEach(() => {
+          applicationBuilder.tray.click("open-app");
+        });
+
+        it("still no windows are open", () => {
+          expectWindowsToBeOpen([]);
+        });
+
+        describe("when opening of splash window resolves", () => {
+          beforeEach(async () => {
+            await resolveOpeningOfWindow("splash");
+          });
+
+          it("still only splash window is open", () => {
+            expectWindowsToBeOpen(["splash"]);
+          });
+
+          it("when opening finishes, only an application window is open", async () => {
+            await resolveOpeningOfWindow("only-application-window");
+
+            expectWindowsToBeOpen(["only-application-window"]);
+          });
+
+          describe("given opening has not finished yet, but another attempt to open the application is made", () => {
+            beforeEach(() => {
+              createElectronWindowMock.mockClear();
+
+              applicationBuilder.tray.click("open-app");
+            });
+
+            it("does not open any new windows", () => {
+              expect(createElectronWindowMock).not.toHaveBeenCalled();
+            });
+
+            it("when opening finishes, only an application window is open", async () => {
+              await resolveOpeningOfWindow("only-application-window");
+
+              expectWindowsToBeOpen(["only-application-window"]);
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+const expectWindowsToBeOpenFor = (di: DiContainer) => (windowIds: string[]) => {
+  const windows = di.injectMany(lensWindowInjectionToken);
+
+  expect(
+    windows.filter((window) => window.visible).map((window) => window.id),
+  ).toEqual(windowIds);
+};
+
+const resolveOpeningOfWindowFor =
+  (
+    createElectronWindowMock: AsyncFnMock<
+      (configuration: LensWindowConfiguration) => ElectronWindow
+    >,
+  ) =>
+    async (windowId: string) => {
+      await createElectronWindowMock.resolveSpecific(
+        [{ id: windowId }],
+
+        {
+          send: () => {},
+          close: () => {},
+          show: () => {},
+        },
+      );
+    };

--- a/src/behaviours/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
+++ b/src/behaviours/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
+import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
+import type { ClusterManager } from "../../main/cluster-manager";
+import { lensWindowInjectionToken } from "../../main/start-main-application/lens-window/application-window/lens-window-injection-token";
+import exitAppInjectable from "../../main/electron-app/features/exit-app.injectable";
+import clusterManagerInjectable from "../../main/cluster-manager.injectable";
+import stopServicesAndExitAppInjectable from "../../main/stop-services-and-exit-app.injectable";
+
+describe("quitting the app using application menu", () => {
+  describe("given application has started", () => {
+    let applicationBuilder: ApplicationBuilder;
+    let clusterManagerStub: ClusterManager;
+    let exitAppMock: jest.Mock;
+
+    beforeEach(async () => {
+      jest.useFakeTimers();
+
+      applicationBuilder = getApplicationBuilder().beforeApplicationStart(
+        ({ mainDi }) => {
+          mainDi.unoverride(stopServicesAndExitAppInjectable);
+
+          clusterManagerStub = { stop: jest.fn() } as unknown as ClusterManager;
+          mainDi.override(clusterManagerInjectable, () => clusterManagerStub);
+
+          exitAppMock = jest.fn();
+          mainDi.override(exitAppInjectable, () => exitAppMock);
+        },
+      );
+
+      await applicationBuilder.render();
+    });
+
+    it("only an application window is open", () => {
+      const windows = applicationBuilder.dis.mainDi.injectMany(
+        lensWindowInjectionToken,
+      );
+
+      expect(
+        windows.map((window) => ({ id: window.id, visible: window.visible })),
+      ).toEqual([
+        { id: "only-application-window", visible: true },
+        { id: "splash", visible: false },
+      ]);
+    });
+
+    describe("when application is quit", () => {
+      beforeEach(async () => {
+        await applicationBuilder.applicationMenu.click("root.quit");
+      });
+
+      it("closes all windows", () => {
+        const windows = applicationBuilder.dis.mainDi.injectMany(
+          lensWindowInjectionToken,
+        );
+
+        expect(
+          windows.map((window) => ({ id: window.id, visible: window.visible })),
+        ).toEqual([
+          { id: "only-application-window", visible: false },
+          { id: "splash", visible: false },
+        ]);
+      });
+
+      it("disconnects all clusters", () => {
+        expect(clusterManagerStub.stop).toHaveBeenCalled();
+      });
+
+      it("after insufficient time passes, does not terminate application yet", () => {
+        jest.advanceTimersByTime(999);
+
+        expect(exitAppMock).not.toHaveBeenCalled();
+      });
+
+      describe("after sufficient time passes", () => {
+        beforeEach(() => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        it("terminates application", () => {
+          expect(exitAppMock).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/main/getDiForUnitTesting.ts
+++ b/src/main/getDiForUnitTesting.ts
@@ -225,7 +225,7 @@ const overrideElectronFeatures = (di: DiContainer) => {
   di.override(getCommandLineSwitchInjectable, () => () => "irrelevant");
   di.override(requestSingleInstanceLockInjectable, () => () => true);
   di.override(disableHardwareAccelerationInjectable, () => () => {});
-  di.override(shouldStartHiddenInjectable, () => true);
+  di.override(shouldStartHiddenInjectable, () => false);
   di.override(showMessagePopupInjectable, () => () => {});
   di.override(waitForElectronToBeReadyInjectable, () => () => Promise.resolve());
   di.override(ipcMainInjectable, () => ({}));

--- a/src/main/start-main-application/lens-window/application-window/create-electron-window-for.injectable.ts
+++ b/src/main/start-main-application/lens-window/application-window/create-electron-window-for.injectable.ts
@@ -9,7 +9,7 @@ import { BrowserWindow } from "electron";
 import { openBrowser } from "../../../../common/utils";
 import type { SendToViewArgs } from "./lens-window-injection-token";
 import sendToChannelInElectronBrowserWindowInjectable from "./send-to-channel-in-electron-browser-window.injectable";
-import type { LensWindow } from "./create-lens-window.injectable";
+import type { ElectronWindow } from "./create-lens-window.injectable";
 
 export type ElectronWindowTitleBarStyle = "hiddenInset" | "hidden" | "default" | "customButtonsOnHover";
 
@@ -30,7 +30,7 @@ export interface ElectronWindowConfiguration {
   onDomReady?: () => void;
 }
 
-export type CreateElectronWindow = () => Promise<LensWindow>;
+export type CreateElectronWindow = () => Promise<ElectronWindow>;
 export type CreateElectronWindowFor = (config: ElectronWindowConfiguration) => CreateElectronWindow;
 
 const createElectronWindowFor = getInjectable({

--- a/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
+++ b/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
@@ -3,11 +3,11 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import type { SendToViewArgs } from "./lens-window-injection-token";
+import type { LensWindow, SendToViewArgs } from "./lens-window-injection-token";
 import type { ElectronWindowTitleBarStyle } from "./create-electron-window-for.injectable";
 import createElectronWindowForInjectable from "./create-electron-window-for.injectable";
 
-export interface LensWindow {
+export interface ElectronWindow {
   show: () => void;
   close: () => void;
   send: (args: SendToViewArgs) => void;
@@ -35,13 +35,14 @@ const createLensWindowInjectable = getInjectable({
   instantiate: (di) => {
     const createElectronWindowFor = di.inject(createElectronWindowForInjectable);
 
-    return (configuration: LensWindowConfiguration) => {
-      let browserWindow: LensWindow | undefined;
+    return (configuration: LensWindowConfiguration): LensWindow => {
+      let browserWindow: ElectronWindow | undefined;
 
       const createElectronWindow = createElectronWindowFor(Object.assign(
         {
           onClose: () => browserWindow = undefined,
         },
+
         configuration,
       ));
 
@@ -49,6 +50,7 @@ const createLensWindowInjectable = getInjectable({
         get visible() {
           return !!browserWindow;
         },
+
         show: async () => {
           if (!browserWindow) {
             browserWindow = await createElectronWindow();
@@ -56,10 +58,12 @@ const createLensWindowInjectable = getInjectable({
 
           browserWindow.show();
         },
+
         close: () => {
           browserWindow?.close();
           browserWindow = undefined;
         },
+
         send: (args: SendToViewArgs) => {
           if (!browserWindow) {
             throw new Error(`Tried to send message to window "${configuration.id}" but the window was closed`);

--- a/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
+++ b/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
@@ -46,6 +46,8 @@ const createLensWindowInjectable = getInjectable({
         configuration,
       ));
 
+      let windowIsOpening = false;
+
       return {
         id: configuration.id,
 
@@ -53,12 +55,18 @@ const createLensWindowInjectable = getInjectable({
           return !!browserWindow;
         },
 
+        get opening() {
+          return windowIsOpening;
+        },
+
         show: async () => {
           if (!browserWindow) {
+            windowIsOpening = true;
             browserWindow = await createElectronWindow();
           }
 
           browserWindow.show();
+          windowIsOpening = false;
         },
 
         close: () => {

--- a/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
+++ b/src/main/start-main-application/lens-window/application-window/create-lens-window.injectable.ts
@@ -13,7 +13,7 @@ export interface ElectronWindow {
   send: (args: SendToViewArgs) => void;
 }
 
-interface LensWindowConfiguration {
+export interface LensWindowConfiguration {
   id: string;
   title: string;
   defaultHeight: number;
@@ -47,6 +47,8 @@ const createLensWindowInjectable = getInjectable({
       ));
 
       return {
+        id: configuration.id,
+
         get visible() {
           return !!browserWindow;
         },

--- a/src/main/start-main-application/lens-window/application-window/lens-window-injection-token.ts
+++ b/src/main/start-main-application/lens-window/application-window/lens-window-injection-token.ts
@@ -17,6 +17,7 @@ export interface LensWindow {
   close: () => void;
   send: (args: SendToViewArgs) => void;
   visible: boolean;
+  opening: boolean;
 }
 
 export const lensWindowInjectionToken = getInjectionToken<LensWindow>({

--- a/src/main/start-main-application/lens-window/application-window/lens-window-injection-token.ts
+++ b/src/main/start-main-application/lens-window/application-window/lens-window-injection-token.ts
@@ -12,6 +12,7 @@ export interface SendToViewArgs {
 }
 
 export interface LensWindow {
+  id: string;
   show: () => Promise<void>;
   close: () => void;
   send: (args: SendToViewArgs) => void;

--- a/src/main/start-main-application/lens-window/show-application-window.injectable.ts
+++ b/src/main/start-main-application/lens-window/show-application-window.injectable.ts
@@ -17,7 +17,7 @@ const showApplicationWindowInjectable = getInjectable({
     );
 
     return async () => {
-      if (applicationWindow.visible) {
+      if (applicationWindow.visible || splashWindow.visible) {
         return;
       }
 

--- a/src/main/start-main-application/lens-window/show-application-window.injectable.ts
+++ b/src/main/start-main-application/lens-window/show-application-window.injectable.ts
@@ -5,6 +5,8 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import splashWindowInjectable from "./splash-window/splash-window.injectable";
 import applicationWindowInjectable from "./application-window/application-window.injectable";
+import { identity, some } from "lodash/fp";
+const someIsTruthy = some(identity);
 
 const showApplicationWindowInjectable = getInjectable({
   id: "show-application-window",
@@ -12,12 +14,17 @@ const showApplicationWindowInjectable = getInjectable({
   instantiate: (di) => {
     const applicationWindow = di.inject(applicationWindowInjectable);
 
-    const splashWindow = di.inject(
-      splashWindowInjectable,
-    );
+    const splashWindow = di.inject(splashWindowInjectable);
 
     return async () => {
-      if (applicationWindow.visible || splashWindow.visible) {
+      const windowIsAlreadyBeingShown = someIsTruthy([
+        applicationWindow.visible,
+        applicationWindow.opening,
+        splashWindow.visible,
+        splashWindow.opening,
+      ]);
+
+      if (windowIsAlreadyBeingShown) {
         return;
       }
 


### PR DESCRIPTION
Note: base-branch of this PR is #5433 instead of master, because the requirements of unit testing are introduced in the branch.

Note: this fixes bug about multiple application windows opening if user reopens Lens using tray while the splash screen was still visible. The bug was reproduced in a unit test and some behaviours around starting and stopping Lens where created.

Relevant test:
`opening application window using tray › given application has started › when the application window is closed › when an application window is reopened using tray › given opening of splash window has not finished yet, but another attempt to open the application is made › does not open any new windows`