### PR TITLE
Fix *.modules.scss that don't get correctly typed

### DIFF
--- a/src/renderer/components/+add-cluster/add-cluster.module.scss
+++ b/src/renderer/components/+add-cluster/add-cluster.module.scss
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+@import "../../components/mixins.scss";
+
 .AddClusters {
   --flex-gap: calc(var(--unit) * 2);
 

--- a/src/renderer/components/kubeconfig-dialog/kubeconfig-dialog.module.scss
+++ b/src/renderer/components/kubeconfig-dialog/kubeconfig-dialog.module.scss
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+@import "../../components/mixins.scss";
+
 .KubeConfigDialog {
   :global(.Wizard) {
     width: 50vw;

--- a/src/renderer/components/switch/switch.module.scss
+++ b/src/renderer/components/switch/switch.module.scss
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+@import "../../components/mixins.scss";
+
 .Switch {
   --thumb-size: 2rem;
   --thumb-color: hsl(0 0% 100%);

--- a/types/mocks.d.ts
+++ b/types/mocks.d.ts
@@ -10,6 +10,14 @@ declare module "@hapi/subtext"
 
 // Support import for custom module extensions
 // https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations
+declare module "*.module.scss" {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+declare module "*.module.css" {
+  const classes: { [key: string]: string };
+  export default classes;
+}
 declare module "*.scss" {
   const content: string;
   export = content;

--- a/types/mocks.d.ts
+++ b/types/mocks.d.ts
@@ -10,14 +10,6 @@ declare module "@hapi/subtext"
 
 // Support import for custom module extensions
 // https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations
-declare module "*.module.scss" {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-declare module "*.module.css" {
-  const classes: { [key: string]: string };
-  export default classes;
-}
 declare module "*.scss" {
   const content: string;
   export = content;


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This was only a problem within vscode (and maybe other editors) which is why I marked it as a `chore`.