### PR TITLE
Fix cluster server path being duplicated by proxy

### DIFF
--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -152,9 +152,6 @@ export class ContextHandler implements ClusterContextHandler {
 
   protected async newApiTarget(timeout: number): Promise<httpProxy.ServerOptions> {
     const kubeAuthProxy = await this.ensureServerHelper();
-    const ca = this.resolveAuthProxyCa();
-    const clusterPath = this.clusterUrl.path !== "/" ? this.clusterUrl.path : "";
-    const apiPrefix = `${kubeAuthProxy.apiPrefix}${clusterPath}`;
     const headers: Record<string, string> = {};
 
     if (this.clusterUrl.hostname) {
@@ -166,8 +163,8 @@ export class ContextHandler implements ClusterContextHandler {
         protocol: "https:",
         host: "127.0.0.1",
         port: kubeAuthProxy.port,
-        path: apiPrefix,
-        ca,
+        path: kubeAuthProxy.apiPrefix,
+        ca: this.resolveAuthProxyCa(),
       },
       changeOrigin: true,
       timeout,


### PR DESCRIPTION
- This resolves an issue with non-Rancher clusters that have been added to Rancher, for some reason this causes the server path to be duplicated in that case. Other connection types don't seem to be affected either way.

Signed-off-by: Sebastian Malton <sebastian@malton.name>