### PR TITLE
Electron v15.5.7

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,8 +16,8 @@ jobs:
       vmImage: windows-2019
     strategy:
       matrix:
-        node_14.x:
-          node_version: 14.x
+        node:
+          node_version: 16.x
     steps:
       - powershell: |
           $CI_BUILD_TAG = git describe --tags
@@ -64,8 +64,8 @@ jobs:
       vmImage: macOS-11
     strategy:
       matrix:
-        node_14.x:
-          node_version: 14.x
+        node:
+          node_version: 16.x
     steps:
       - script: CI_BUILD_TAG=`git describe --tags` && echo "##vso[task.setvariable variable=CI_BUILD_TAG]$CI_BUILD_TAG"
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"
@@ -128,8 +128,8 @@ jobs:
       vmImage: ubuntu-18.04
     strategy:
       matrix:
-        node_14.x:
-          node_version: 14.x
+        node:
+          node_version: 16.x
     steps:
       - script: CI_BUILD_TAG=`git describe --tags` && echo "##vso[task.setvariable variable=CI_BUILD_TAG]$CI_BUILD_TAG"
         condition: "and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))"

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/documentation') }}
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Checkout Release from lens
         uses: actions/checkout@v2

--- a/.github/workflows/electronegativity.yml
+++ b/.github/workflows/electronegativity.yml
@@ -14,12 +14,12 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
 
       - uses: doyensec/electronegativity-action@v1.1
         with:
           input: src/
-          electron-version: "14.2.4"
+          electron-version: "15.5.7"
           severity: medium
 
       - name: Upload sarif

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Checkout Release from lens
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     needs: verify-docs
     steps:
       - name: Set up Python 3.7

--- a/.github/workflows/mkdocs-manual.yml
+++ b/.github/workflows/mkdocs-manual.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2

--- a/.github/workflows/publish-master-npm.yml
+++ b/.github/workflows/publish-master-npm.yml
@@ -14,7 +14,7 @@ jobs:
       ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'area/extension') }}
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Checkout Release
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release-npm.yml
+++ b/.github/workflows/publish-release-npm.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Checkout Release
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-11, windows-2019]
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Checkout Release from lens
         uses: actions/checkout@v2

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "14.2.4"
+target "15.5.0"
 runtime "electron"

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "@types/md5-file": "^4.0.2",
     "@types/mini-css-extract-plugin": "^2.4.0",
     "@types/mock-fs": "^4.13.1",
-    "@types/node": "14.18.18",
+    "@types/node": "^16.11.38",
     "@types/node-fetch": "^2.6.1",
     "@types/npm": "^2.0.32",
     "@types/proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sentryDsn": ""
   },
   "engines": {
-    "node": ">=14 <15"
+    "node": ">=16 <17"
   },
   "jest": {
     "collectCoverage": false,
@@ -250,7 +250,7 @@
     "monaco-editor": "^0.29.1",
     "monaco-editor-webpack-plugin": "^5.0.0",
     "node-fetch": "lensapp/node-fetch#2.x",
-    "node-pty": "^0.10.1",
+    "node-pty": "^0.11.0-beta19",
     "npm": "^6.14.17",
     "p-limit": "^3.1.0",
     "path-to-regexp": "^6.2.0",
@@ -355,7 +355,7 @@
     "css-loader": "^6.7.1",
     "deepdash": "^5.3.9",
     "dompurify": "^2.3.8",
-    "electron": "^14.2.9",
+    "electron": "^15.5.7",
     "electron-builder": "^23.0.3",
     "electron-notarize": "^0.3.0",
     "esbuild": "^0.14.38",

--- a/src/main/helm/exec.ts
+++ b/src/main/helm/exec.ts
@@ -4,7 +4,7 @@
  */
 
 import { promiseExecFile } from "../../common/utils/promise-exec";
-import type { BaseEncodingOptions } from "fs";
+import type { ObjectEncodingOptions } from "fs";
 import type { ExecFileOptions, ExecFileOptionsWithStringEncoding } from "child_process";
 import { helmBinaryPath } from "../../common/vars";
 import { UserStore } from "../../common/user-store";
@@ -14,7 +14,7 @@ import { isChildProcessError } from "../../common/utils";
  * ExecFile the bundled helm CLI
  * @returns STDOUT
  */
-export async function execHelm(args: string[], { encoding, ...rest }: BaseEncodingOptions & ExecFileOptions = {}): Promise<string> {
+export async function execHelm(args: string[], { encoding, ...rest }: ObjectEncodingOptions & ExecFileOptions = {}): Promise<string> {
   const options: ExecFileOptionsWithStringEncoding = {
     encoding: encoding ?? "utf-8",
     ...rest,

--- a/src/renderer/components/test-utils/get-application-builder.tsx
+++ b/src/renderer/components/test-utils/get-application-builder.tsx
@@ -209,6 +209,7 @@ export const getApplicationBuilder = () => {
           {
             menu: null as never,
             commandId: 0,
+            userAccelerator: null,
             ...menuItem,
           } as MenuItem,
           undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,7 +473,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@electron/get@^1.0.1":
+"@electron/get@^1.13.0":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
   integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
@@ -4989,12 +4989,12 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^14.2.9:
-  version "14.2.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.9.tgz#9e1e95643ec3847592a186e8115d1ddb2e4921ee"
-  integrity sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==
+electron@^15.5.7:
+  version "15.5.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.5.7.tgz#aadb0081c504f2c2d8f81ea5fd23e38881afe86a"
+  integrity sha512-n4mVlxoMc4eYx07wWFWGficL+iOMz5xZEf5dBtE/wwLm0fQpYVyW4AlknMFG9F8Css0MM0JSwNMOyRg5e1vDtg==
   dependencies:
-    "@electron/get" "^1.0.1"
+    "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 
@@ -9477,10 +9477,10 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-pty@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.1.tgz#cd05d03a2710315ec40221232ec04186f6ac2c6d"
-  integrity sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==
+node-pty@^0.11.0-beta19:
+  version "0.11.0-beta9"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta9.tgz#38a899d62b1c5c395ca466dfac5203eff989d350"
+  integrity sha512-bU/2zYV6xBMVMHaMe+yr4WEw36PCA0hyZ7A0IBQFWy5l1vjsD52sZ9sGJk+dH7bw3xpuBLHMh9Eq4Di8rJz4IQ==
   dependencies:
     nan "^2.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,15 +1847,20 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
   integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
 
-"@types/node@14.18.18", "@types/node@^14.6.2":
-  version "14.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
-  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
-
 "@types/node@^10.12.0":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+
+"@types/node@^14.6.2":
+  version "14.18.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
+  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+
+"@types/node@^16.13.1":
+  version "16.11.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.38.tgz#be0edd097b23eace6c471c525a74b3f98803017f"
+  integrity sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,7 +1857,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
   integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
 
-"@types/node@^16.13.1":
+"@types/node@^16.11.38":
   version "16.11.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.38.tgz#be0edd097b23eace6c471c525a74b3f98803017f"
   integrity sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==


### PR DESCRIPTION
- bumps Electron to 15.x series which is currently supported version (14.x is not)
- bumps node-pty because current stable version does not work with newer Electron versions
- changes nodejs version to 16 (because Electron 15.x has nodejs 16)