### PR TITLE
Allow using custom https.Agent instance

### DIFF
--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -170,9 +170,12 @@ export interface IRemoteKubeApiConfig {
     clientKeyData?: string;
   };
   /**
-   * Custom instance of https.agent
+   * Custom instance of https.agent to use for the requests
+   * 
+   * @remarks the custom agent replaced default agent, options skipTLSVerify,
+   * clientCertificateData, clientKeyData and caData are ignored.
    */
-  agent?: Agent;
+   agent?: Agent;
 }
 
 export function forCluster<
@@ -245,7 +248,7 @@ export function forRemoteCluster<
   }
 
   if (config.agent) {
-    reqInit.agent = config.agent.constructor(agentOptions);
+    reqInit.agent = config.agent;
   }
 
   const token = config.user.token;

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -169,6 +169,13 @@ export interface IRemoteKubeApiConfig {
     clientCertificateData?: string;
     clientKeyData?: string;
   };
+  /**
+   * Custom instance of https.agent to use for the requests
+   * 
+   * @remarks the custom agent replaced default agent, options skipTLSVerify,
+   * clientCertificateData, clientKeyData and caData are ignored.
+   */
+  agent?: Agent;
 }
 
 export function forCluster<
@@ -238,6 +245,10 @@ export function forRemoteCluster<
 
   if (Object.keys(agentOptions).length > 0) {
     reqInit.agent = new Agent(agentOptions);
+  }
+
+  if (config.agent) {
+    reqInit.agent = config.agent;
   }
 
   const token = config.user.token;

--- a/src/common/k8s-api/kube-api.ts
+++ b/src/common/k8s-api/kube-api.ts
@@ -170,10 +170,7 @@ export interface IRemoteKubeApiConfig {
     clientKeyData?: string;
   };
   /**
-   * Custom instance of https.agent to use for the requests
-   * 
-   * @remarks the custom agent replaced default agent, options skipTLSVerify,
-   * clientCertificateData, clientKeyData and caData are ignored.
+   * Custom instance of https.agent
    */
   agent?: Agent;
 }
@@ -248,7 +245,7 @@ export function forRemoteCluster<
   }
 
   if (config.agent) {
-    reqInit.agent = config.agent;
+    reqInit.agent = config.agent.constructor(agentOptions);
   }
 
   const token = config.user.token;


### PR DESCRIPTION
This PR add "agent" option to "forRemoteCluster", so user can use their own instance of https.Agent.