### PR TITLE
release 5.6.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.0",
+  "version": "5.6.0-alpha.1",
   "main": "static/build/main.js",
   "copyright": "© 2021 OpenLens Authors",
   "license": "MIT",

--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -133,7 +133,8 @@ const relaventPrsQuery = await Promise.all(
 );
 const relaventPrs = relaventPrsQuery
   .filter(query => query.stdout)
-  .map(query => query.pr);
+  .map(query => query.pr)
+  .filter(pr => pr.labels.every(label => label.name !== "skip-changelog"));
 
 const enhancementPrLabelName = "enhancement";
 const bugfixPrLabelName = "bug";

--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -152,11 +152,15 @@ const prBodyLines = [
   "",
 ];
 
+function getPrEntry(pr) {
+  return `- ${pr.title} (**[#${pr.number}](https://github.com/lensapp/lens/pull/${pr.number})**) https://github.com/${pr.author.login}`;
+}
+
 if (enhancementPrs.length > 0) {
   prBodyLines.push(
     "## 🚀 Features",
     "",
-    ...enhancementPrs.map(pr => `- ${pr.title} (**#${pr.number}**) https://github.com/${pr.author.login}`),
+    ...enhancementPrs.map(getPrEntry),
     "",
   );
 }
@@ -165,7 +169,7 @@ if (bugfixPrs.length > 0) {
   prBodyLines.push(
     "## 🐛 Bug Fixes",
     "",
-    ...bugfixPrs.map(pr => `- ${pr.title} (**#${pr.number}**) https://github.com/${pr.author.login}`),
+    ...bugfixPrs.map(getPrEntry),
     "",
   );
 }
@@ -174,7 +178,7 @@ if (maintenencePrs.length > 0) {
   prBodyLines.push(
     "## 🧰 Maintenance",
     "",
-    ...maintenencePrs.map(pr => `- ${pr.title} (**#${pr.number}**) https://github.com/${pr.author.login}`),
+    ...maintenencePrs.map(getPrEntry),
     "",
   );
 }


### PR DESCRIPTION
## Changes since 5.5.4

## 🚀 Features

- Add reactive tray icon for when update is available (**[#5567](https://github.com/lensapp/lens/pull/5567)**) https://github.com/Nokel81
- Allow using custom https.Agent instance (**[#5564](https://github.com/lensapp/lens/pull/5564)**) https://github.com/chenhunghan
- Electron v15.5.7 (**[#5562](https://github.com/lensapp/lens/pull/5562)**) https://github.com/jakolehm
- Change update default to update on quit (**[#5390](https://github.com/lensapp/lens/pull/5390)**) https://github.com/Nokel81
- TopBar Update button (**[#5376](https://github.com/lensapp/lens/pull/5376)**) https://github.com/aleksfront
- Change engines.lens signature to only respect minimums (**[#5290](https://github.com/lensapp/lens/pull/5290)**) https://github.com/ixrock

## 🐛 Bug Fixes

- Disable nativeWindowOpen on webviews (**[#5582](https://github.com/lensapp/lens/pull/5582)**) https://github.com/jakolehm
- Make terminal tab icon the same as the menu item icon (**[#5449](https://github.com/lensapp/lens/pull/5449)**) https://github.com/Nokel81
- Fix Catalog displaying wrong number of items per category (**[#5427](https://github.com/lensapp/lens/pull/5427)**) https://github.com/Nokel81
- Fix error in legacyRegisterApi on main (**[#5426](https://github.com/lensapp/lens/pull/5426)**) https://github.com/Nokel81
- Fix splash window having window control buttons (**[#5418](https://github.com/lensapp/lens/pull/5418)**) https://github.com/Nokel81

## 🧰 Maintenance

- Bump injectable for faster unit tests (**[#5587](https://github.com/lensapp/lens/pull/5587)**) https://github.com/jansav
- Bump @types/node from 16.11.38 to 16.11.39 (**[#5577](https://github.com/lensapp/lens/pull/5577)**) https://github.com/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.27.0 to 5.27.1 (**[#5569](https://github.com/lensapp/lens/pull/5569)**) https://github.com/dependabot
- Bump sass from 1.52.1 to 1.52.2 (**[#5561](https://github.com/lensapp/lens/pull/5561)**) https://github.com/dependabot
- Bump webpack from 5.72.1 to 5.73.0 (**[#5560](https://github.com/lensapp/lens/pull/5560)**) https://github.com/dependabot
- Bump ws from 8.6.0 to 8.7.0 (**[#5559](https://github.com/lensapp/lens/pull/5559)**) https://github.com/dependabot
- Bump react-refresh from 0.12.0 to 0.13.0 (**[#5558](https://github.com/lensapp/lens/pull/5558)**) https://github.com/dependabot
- Bump react-refresh-typescript from 2.0.4 to 2.0.5 (**[#5554](https://github.com/lensapp/lens/pull/5554)**) https://github.com/dependabot
- Bump @typescript-eslint/parser from 5.23.0 to 5.27.0 (**[#5553](https://github.com/lensapp/lens/pull/5553)**) https://github.com/dependabot
- Bump playwright from 1.21.1 to 1.22.2 (**[#5552](https://github.com/lensapp/lens/pull/5552)**) https://github.com/dependabot
- Bump typedoc from 0.22.16 to 0.22.17 (**[#5551](https://github.com/lensapp/lens/pull/5551)**) https://github.com/dependabot
- Fix type error in kube-object-menu.test.tsx (**[#5540](https://github.com/lensapp/lens/pull/5540)**) https://github.com/Nokel81
- Fix ERR_FAILED for splash screen on windows sometimes (**[#5539](https://github.com/lensapp/lens/pull/5539)**) https://github.com/Nokel81
- Fix failing kube-object-menu.test.tsx test (**[#5538](https://github.com/lensapp/lens/pull/5538)**) https://github.com/Nokel81
- Fix *.modules.scss that don't get correctly typed (**[#5532](https://github.com/lensapp/lens/pull/5532)**) https://github.com/Nokel81
- Bump got from 11.8.3 to 11.8.5 (**[#5525](https://github.com/lensapp/lens/pull/5525)**) https://github.com/dependabot
- Bump typedoc from 0.22.15 to 0.22.16 (**[#5524](https://github.com/lensapp/lens/pull/5524)**) https://github.com/dependabot
- Bump sharp from 0.30.4 to 0.30.6 (**[#5523](https://github.com/lensapp/lens/pull/5523)**) https://github.com/dependabot
- Bump webpack-dev-server from 4.9.0 to 4.9.1 (**[#5522](https://github.com/lensapp/lens/pull/5522)**) https://github.com/dependabot
- Update slack invite link (**[#5515](https://github.com/lensapp/lens/pull/5515)**) https://github.com/Nokel81
- Bump dompurify from 2.3.6 to 2.3.8 (**[#5509](https://github.com/lensapp/lens/pull/5509)**) https://github.com/dependabot
- Bump postcss from 8.4.13 to 8.4.14 (**[#5508](https://github.com/lensapp/lens/pull/5508)**) https://github.com/dependabot
- Bump esbuild-loader from 2.18.0 to 2.19.0 (**[#5507](https://github.com/lensapp/lens/pull/5507)**) https://github.com/dependabot
- Bump eslint-plugin-react from 7.29.4 to 7.30.0 (**[#5506](https://github.com/lensapp/lens/pull/5506)**) https://github.com/dependabot
- Remove legacy renderBooleans prop (**[#5483](https://github.com/lensapp/lens/pull/5483)**) https://github.com/Nokel81
- Bump @types/webpack-env from 1.16.4 to 1.17.0 (**[#5472](https://github.com/lensapp/lens/pull/5472)**) https://github.com/dependabot
- Bump type-fest from 2.12.2 to 2.13.0 (**[#5471](https://github.com/lensapp/lens/pull/5471)**) https://github.com/dependabot
- Bump marked from 4.0.15 to 4.0.16 (**[#5470](https://github.com/lensapp/lens/pull/5470)**) https://github.com/dependabot
- Bump sass from 1.51.0 to 1.52.1 (**[#5469](https://github.com/lensapp/lens/pull/5469)**) https://github.com/dependabot
- Improve readability (**[#5468](https://github.com/lensapp/lens/pull/5468)**) https://github.com/ryanrussell
- Bump concurrently from 7.1.0 to 7.2.1 (**[#5464](https://github.com/lensapp/lens/pull/5464)**) https://github.com/dependabot
- Bump @types/node from 14.18.17 to 14.18.18 (**[#5454](https://github.com/lensapp/lens/pull/5454)**) https://github.com/dependabot
- Bump react-router-dom from 5.3.1 to 5.3.3 (**[#5452](https://github.com/lensapp/lens/pull/5452)**) https://github.com/dependabot
- Bump eslint from 8.15.0 to 8.16.0 (**[#5446](https://github.com/lensapp/lens/pull/5446)**) https://github.com/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.23.0 to 5.26.0 (**[#5437](https://github.com/lensapp/lens/pull/5437)**) https://github.com/dependabot
- Bump @pmmmwh/react-refresh-webpack-plugin from 0.5.5 to 0.5.7 (**[#5436](https://github.com/lensapp/lens/pull/5436)**) https://github.com/dependabot
- Introduce way to install update directly from tray. Make application updater unit testable... (**[#5433](https://github.com/lensapp/lens/pull/5433)**) https://github.com/jansav
- Cherry Pick bug fixes from v5.5.0-beta.2 (**[#5429](https://github.com/lensapp/lens/pull/5429)**) https://github.com/Nokel81
- Switch to always using latest minikube in CI (**[#5408](https://github.com/lensapp/lens/pull/5408)**) https://github.com/Nokel81
- Increase version to v5.6.0-alpha.0 for master (**[#5404](https://github.com/lensapp/lens/pull/5404)**) https://github.com/Nokel81
- Fix downloading cluster specific kubectl (**[#5399](https://github.com/lensapp/lens/pull/5399)**) https://github.com/Nokel81
- Refactoring extension-app compatibility checks (**[#5389](https://github.com/lensapp/lens/pull/5389)**) https://github.com/ixrock
- Bump immer from 9.0.12 to 9.0.14 (**[#5377](https://github.com/lensapp/lens/pull/5377)**) https://github.com/dependabot
- Bump fork-ts-checker-webpack-plugin from 6.5.0 to 6.5.2 (**[#5372](https://github.com/lensapp/lens/pull/5372)**) https://github.com/dependabot
- Make starting of application modular and unit testable (**[#5324](https://github.com/lensapp/lens/pull/5324)**) https://github.com/jansav
- Turn on strict mode in tsconfig.json, some helpful lints, and required cleanup where strictness necessitates it (**[#5195](https://github.com/lensapp/lens/pull/5195)**) https://github.com/Nokel81
