### PR TITLE
Fix cluster.k8s.io/v1alpha1/clusters CRD not being marked as Namespaced 

### DIFF
--- a/src/common/k8s-api/endpoints/cluster.api.ts
+++ b/src/common/k8s-api/endpoints/cluster.api.ts
@@ -10,7 +10,14 @@ import type { DerivedKubeApiOptions, IgnoredKubeApiOptions } from "../kube-api";
 import { KubeApi } from "../kube-api";
 
 export class ClusterApi extends KubeApi<Cluster> {
+  /**
+   * @deprecated This field is legacy and never used.
+   */
   static kind = "Cluster";
+
+  /**
+   * @deprecated This field is legacy and never used.
+   */
   static namespaced = true;
 
   constructor(opts: DerivedKubeApiOptions & IgnoredKubeApiOptions = {}) {
@@ -104,6 +111,7 @@ export interface Cluster {
 export class Cluster extends KubeObject {
   static kind = "Cluster";
   static apiBase = "/apis/cluster.k8s.io/v1alpha1/clusters";
+  static namespaced = true;
 
   getStatus() {
     if (this.metadata.deletionTimestamp) return ClusterStatus.REMOVING;


### PR DESCRIPTION
- This type is completely unused within Lens itself

Signed-off-by: Sebastian Malton <sebastian@malton.name>

This fixes an issue reported on slack where this specific CRD (which is a mainstay of MCC) couldn't be edited within Lens.