### PR TITLE
Fix: allow to load images with data:base64 urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "bundledKubectlVersion": "1.23.3",
     "bundledHelmVersion": "3.7.2",
     "sentryDsn": "",
-    "contentSecurityPolicy": "script-src 'unsafe-eval' 'self'; frame-src http://*.localhost:*/; img-src *"
+    "contentSecurityPolicy": "script-src 'unsafe-eval' 'self'; frame-src http://*.localhost:*/; img-src * data:"
   },
   "engines": {
     "node": ">=16 <17"


### PR DESCRIPTION
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/6377066/173045004-83cfe33c-0bd7-456f-a2a1-c4cd36f03abd.png">