### PR TITLE
Increase max memory usage when running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
 
       - run: make test
         name: Run tests
+        shell: bash
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        if: runner.os == 'Linux'
 
       - run: make test-extensions
         name: Run In-tree Extension tests


### PR DESCRIPTION
Temporary fix for max memory hit errors when running tests on github

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>