### PR TITLE
Fix issue where releases are not reloaded when new release is added e…

### DIFF
--- a/src/renderer/components/+helm-releases/release-secrets.injectable.ts
+++ b/src/renderer/components/+helm-releases/release-secrets.injectable.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import { computed, onBecomeObserved, onBecomeUnobserved } from "mobx";
+import subscribeStoresInjectable from "../../kube-watch-api/subscribe-stores.injectable";
+import secretStoreInjectable from "../+config-secrets/store.injectable";
+
+const releaseSecretsInjectable = getInjectable({
+  id: "release-secrets",
+
+  instantiate: (di) => {
+    const subscribeStores = di.inject(subscribeStoresInjectable);
+    const secretStore = di.inject(secretStoreInjectable);
+
+    const releaseSecrets = computed(() =>
+      secretStore.contextItems.filter((secret) =>
+        secret.type.startsWith("helm.sh/release"),
+      ),
+    );
+
+    let unsubscribe: () => void;
+
+    onBecomeObserved(releaseSecrets, () => {
+      unsubscribe = subscribeStores([secretStore]);
+    });
+
+    onBecomeUnobserved(releaseSecrets, () => {
+      unsubscribe?.();
+    });
+
+    return releaseSecrets;
+  },
+});
+
+export default releaseSecretsInjectable;

--- a/src/renderer/components/+helm-releases/releases.injectable.ts
+++ b/src/renderer/components/+helm-releases/releases.injectable.ts
@@ -7,6 +7,7 @@ import { asyncComputed } from "@ogre-tools/injectable-react";
 import namespaceStoreInjectable from "../+namespaces/store.injectable";
 import { listReleases } from "../../../common/k8s-api/endpoints/helm-releases.api";
 import clusterFrameContextInjectable from "../../cluster-frame-context/cluster-frame-context.injectable";
+import releaseSecretsInjectable from "./release-secrets.injectable";
 
 const releasesInjectable = getInjectable({
   id: "releases",
@@ -14,9 +15,12 @@ const releasesInjectable = getInjectable({
   instantiate: (di) => {
     const clusterContext = di.inject(clusterFrameContextInjectable);
     const namespaceStore = di.inject(namespaceStoreInjectable);
+    const releaseSecrets = di.inject(releaseSecretsInjectable);
 
     return asyncComputed(async () => {
       const contextNamespaces = namespaceStore.contextNamespaces || [];
+
+      void releaseSecrets.get();
 
       const isLoadingAll =
         clusterContext.allNamespaces?.length > 1 &&


### PR DESCRIPTION
…xternally (e.g. from terminal)

Notice:

There should be behaviour for this, but adding it would lead to cascade of refactorings so I chose not do it for now. 


How to test:

1. Open Releases
2. Open Terminal
3. `$ helm install --generate-name bitnami/consul`
4. Make sure that releases are reloaded (this is the part that wasn't working before)
5. `$ helm list` and `$ helm uninstall X`
6. Make sure that releases are reloaded (Notice how the release which is uninstalled will stay in the list with status "Uninstalling". If this is not intended behaviour, then it's separate bug somewhere in `SecretStore`)

Signed-off-by: Janne Savolainen <janne.savolainen@live.fi>