### PR TITLE
Fix not starting with sentryDSN configured

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,7 @@ const di = getDi();
 
 const startApplication = di.inject(startMainApplicationInjectable);
 
-startApplication();
+void startApplication();
 
 /**
  * Exports for virtual package "@k8slens/extensions" for main-process.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,9 +15,7 @@ const di = getDi();
 
 const startApplication = di.inject(startMainApplicationInjectable);
 
-(async () => {
-  await startApplication();
-})();
+startApplication();
 
 /**
  * Exports for virtual package "@k8slens/extensions" for main-process.

--- a/src/main/start-main-application/runnables/setup-sentry.injectable.ts
+++ b/src/main/start-main-application/runnables/setup-sentry.injectable.ts
@@ -5,7 +5,7 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { initializeSentryReporting } from "../../../common/sentry";
 import { init } from "@sentry/electron/main";
-import { beforeApplicationIsLoadingInjectionToken } from "../runnable-tokens/before-application-is-loading-injection-token";
+import { beforeElectronIsReadyInjectionToken } from "../runnable-tokens/before-electron-is-ready-injection-token";
 
 const setupSentryInjectable = getInjectable({
   id: "setup-sentry",
@@ -18,7 +18,7 @@ const setupSentryInjectable = getInjectable({
 
   causesSideEffects: true,
 
-  injectionToken: beforeApplicationIsLoadingInjectionToken,
+  injectionToken: beforeElectronIsReadyInjectionToken,
 });
 
 export default setupSentryInjectable;

--- a/src/main/start-main-application/start-main-application.injectable.ts
+++ b/src/main/start-main-application/start-main-application.injectable.ts
@@ -43,7 +43,7 @@ const startMainApplicationInjectable = getInjectable({
       // https://github.com/electron/electron/issues/21370
       beforeElectronIsReady();
 
-      (async () => {
+      return (async () => {
         await waitForElectronToBeReady();
 
         await beforeApplicationIsLoading();

--- a/src/main/start-main-application/start-main-application.injectable.ts
+++ b/src/main/start-main-application/start-main-application.injectable.ts
@@ -38,34 +38,36 @@ const startMainApplicationInjectable = getInjectable({
     const onLoadOfApplication = runMany(onLoadOfApplicationInjectionToken);
     const afterApplicationIsLoaded = runMany(afterApplicationIsLoadedInjectionToken);
 
-    return async () => {
+    return () => {
       // Stuff happening before application is ready needs to be synchronous because of
       // https://github.com/electron/electron/issues/21370
       beforeElectronIsReady();
 
-      await waitForElectronToBeReady();
+      (async () => {
+        await waitForElectronToBeReady();
 
-      await beforeApplicationIsLoading();
+        await beforeApplicationIsLoading();
 
-      if (!shouldStartHidden) {
-        await splashWindow.show();
-      }
-
-      await onLoadOfApplication();
-
-      if (!shouldStartHidden) {
-        const deepLinkUrl = getDeepLinkUrl(commandLineArguments);
-
-        if (deepLinkUrl) {
-          await openDeepLink(deepLinkUrl);
-        } else {
-          await applicationWindow.show();
+        if (!shouldStartHidden) {
+          await splashWindow.show();
         }
 
-        splashWindow.close();
-      }
+        await onLoadOfApplication();
 
-      await afterApplicationIsLoaded();
+        if (!shouldStartHidden) {
+          const deepLinkUrl = getDeepLinkUrl(commandLineArguments);
+
+          if (deepLinkUrl) {
+            await openDeepLink(deepLinkUrl);
+          } else {
+            await applicationWindow.show();
+          }
+
+          splashWindow.close();
+        }
+
+        await afterApplicationIsLoaded();
+      })();
     };
   },
 });


### PR DESCRIPTION
- Make sure that all beforeElectronIsReady runables are run completely
  syncronously

- Fix when setupSentry is to be run (namely before electron is ready)

Signed-off-by: Sebastian Malton <sebastian@malton.name>