### PR TITLE
modify app test rendering to include status bar

### DIFF
--- a/src/behaviours/__snapshots__/extension-special-characters-in-page-registrations.test.tsx.snap
+++ b/src/behaviours/__snapshots__/extension-special-characters-in-page-registrations.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`extension special characters in page registrations renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`extension special characters in page registrations renders 1`] = `
 
 exports[`extension special characters in page registrations when navigating to route with ID having special characters renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     Some page
   </div>

--- a/src/behaviours/__snapshots__/navigate-to-extension-page.test.tsx.snap
+++ b/src/behaviours/__snapshots__/navigate-to-extension-page.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`navigate to extension page renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`navigate to extension page renders 1`] = `
 
 exports[`navigate to extension page when extension navigates to child route renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     Child page
   </div>
@@ -21,6 +41,16 @@ exports[`navigate to extension page when extension navigates to child route rend
 
 exports[`navigate to extension page when extension navigates to route with parameters renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     <ul>
       <li>
@@ -48,6 +78,16 @@ exports[`navigate to extension page when extension navigates to route with param
 
 exports[`navigate to extension page when extension navigates to route without parameters renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     <ul>
       <li>
@@ -75,6 +115,16 @@ exports[`navigate to extension page when extension navigates to route without pa
 
 exports[`navigate to extension page when extension navigates to route without parameters when changing page parameters renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     <ul>
       <li>

--- a/src/behaviours/__snapshots__/navigating-between-routes.test.tsx.snap
+++ b/src/behaviours/__snapshots__/navigating-between-routes.test.tsx.snap
@@ -2,6 +2,16 @@
 
 exports[`navigating between routes given route with optional path parameters when navigating to route with path parameters renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <pre>
     {
   "someParameter": "some-value",
@@ -16,6 +26,16 @@ exports[`navigating between routes given route with optional path parameters whe
 
 exports[`navigating between routes given route without path parameters when navigating to route renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     Some component
   </div>

--- a/src/behaviours/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
+++ b/src/behaviours/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`add-cluster - navigation using application menu renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`add-cluster - navigation using application menu renders 1`] = `
 
 exports[`add-cluster - navigation using application menu when navigating to add cluster using application menu renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout AddClusters"
     data-testid="add-cluster-page"

--- a/src/behaviours/application-update/__snapshots__/installing-update-using-tray.test.ts.snap
+++ b/src/behaviours/application-update/__snapshots__/installing-update-using-tray.test.ts.snap
@@ -4,6 +4,16 @@ exports[`installing update using tray when started renders 1`] = `
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -13,6 +23,16 @@ exports[`installing update using tray when started renders 1`] = `
 exports[`installing update using tray when started when user checks for updates using tray renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >
@@ -64,6 +84,16 @@ exports[`installing update using tray when started when user checks for updates 
 exports[`installing update using tray when started when user checks for updates using tray when new update is discovered renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >
@@ -155,6 +185,16 @@ exports[`installing update using tray when started when user checks for updates 
 exports[`installing update using tray when started when user checks for updates using tray when new update is discovered when download fails renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >
@@ -286,6 +326,16 @@ exports[`installing update using tray when started when user checks for updates 
 exports[`installing update using tray when started when user checks for updates using tray when new update is discovered when download succeeds renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >
@@ -447,6 +497,16 @@ Lens should restart automatically, if it doesn't please restart manually. Instal
 exports[`installing update using tray when started when user checks for updates using tray when no new update is discovered renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >

--- a/src/behaviours/application-update/__snapshots__/installing-update.test.ts.snap
+++ b/src/behaviours/application-update/__snapshots__/installing-update.test.ts.snap
@@ -4,6 +4,16 @@ exports[`installing update when started renders 1`] = `
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -13,6 +23,16 @@ exports[`installing update when started renders 1`] = `
 exports[`installing update when started when user checks for updates renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     />
@@ -24,6 +44,16 @@ exports[`installing update when started when user checks for updates when new up
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -33,6 +63,16 @@ exports[`installing update when started when user checks for updates when new up
 exports[`installing update when started when user checks for updates when new update is discovered when download fails renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     />
@@ -44,6 +84,16 @@ exports[`installing update when started when user checks for updates when new up
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -53,6 +103,16 @@ exports[`installing update when started when user checks for updates when new up
 exports[`installing update when started when user checks for updates when new update is discovered when download succeeds when user answers not to install the update renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     />
@@ -64,6 +124,16 @@ exports[`installing update when started when user checks for updates when new up
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -73,6 +143,16 @@ exports[`installing update when started when user checks for updates when new up
 exports[`installing update when started when user checks for updates when no new update is discovered renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     />

--- a/src/behaviours/application-update/__snapshots__/periodical-checking-of-updates.test.ts.snap
+++ b/src/behaviours/application-update/__snapshots__/periodical-checking-of-updates.test.ts.snap
@@ -4,6 +4,16 @@ exports[`periodical checking of updates given updater is enabled and configurati
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>

--- a/src/behaviours/application-update/__snapshots__/selection-of-update-stability.test.ts.snap
+++ b/src/behaviours/application-update/__snapshots__/selection-of-update-stability.test.ts.snap
@@ -4,6 +4,16 @@ exports[`selection of update stability when started renders 1`] = `
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>

--- a/src/behaviours/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/src/behaviours/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`extensions - navigation using application menu renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`extensions - navigation using application menu renders 1`] = `
 
 exports[`extensions - navigation using application menu when navigating to extensions using application menu renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout DropFileInput Extensions"
     data-testid="extensions-page"

--- a/src/behaviours/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -4,6 +4,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -472,6 +482,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -946,6 +966,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve when selecting to add custom repository renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -1530,6 +1560,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -2011,6 +2051,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve when selecting to add custom repository when inputted minimal options for the repository renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -2594,6 +2644,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve when selecting to add custom repository when inputted minimal options for the repository when showing the maximal options renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -3354,6 +3414,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -3936,6 +4006,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve when selecting to add custom repository when inputted minimal options for the repository when showing the maximal options when inputted maximal options renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -4696,6 +4776,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -5279,6 +5369,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -5761,6 +5861,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -6237,6 +6347,16 @@ exports[`add custom helm repository in preferences when navigating to preference
 exports[`add custom helm repository in preferences when navigating to preferences containing helm repositories when active repositories resolve when selecting to add custom repository when inputted minimal options for the repository when submitted and some time passes when activation resolves with success when adding custom repository again renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"

--- a/src/behaviours/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
@@ -4,6 +4,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -472,6 +482,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -946,6 +966,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve when select for adding public repositories is clicked renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -1474,6 +1504,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -1947,6 +1987,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve when select for adding public repositories is clicked when deactive public repository is selected when adding rejects renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -2422,6 +2472,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -2890,6 +2950,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve when select for adding public repositories is clicked when deactive public repository is selected when adding resolves when active repositories resolve again renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -3392,6 +3462,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve when select for adding public repositories is clicked when deactive public repository is selected when adding resolves when active repositories resolve again when select for selecting active repositories is clicked renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -3958,6 +4038,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -4459,6 +4549,16 @@ exports[`add helm repository from list in preferences when navigating to prefere
 exports[`add helm repository from list in preferences when navigating to preferences containing helm repositories when both active and public repositories resolve when select for adding public repositories is clicked when deactive public repository is selected when adding resolves when active repositories resolve again when select for selecting active repositories is clicked when active repository is selected when removing resolves renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"

--- a/src/behaviours/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
@@ -4,6 +4,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -472,6 +482,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 exports[`listing active helm repositories in preferences when navigating to preferences containing helm repositories when configuration resolves renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -942,6 +962,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -1302,6 +1332,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 exports[`listing active helm repositories in preferences when navigating to preferences containing helm repositories when configuration resolves when updating repositories reject with error about no existing repositories renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -1772,6 +1812,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -2132,6 +2182,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 exports[`listing active helm repositories in preferences when navigating to preferences containing helm repositories when configuration resolves when updating repositories reject with error about no existing repositories when adding of default repository resolves renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -2601,6 +2661,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 exports[`listing active helm repositories in preferences when navigating to preferences containing helm repositories when configuration resolves when updating repositories resolve when repositories resolves renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -3104,6 +3174,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -3465,6 +3545,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -3825,6 +3915,16 @@ exports[`listing active helm repositories in preferences when navigating to pref
 exports[`listing active helm repositories in preferences when navigating to preferences containing helm repositories when getting configuration rejects renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"

--- a/src/behaviours/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
@@ -4,6 +4,16 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -472,6 +482,16 @@ exports[`remove helm repository from list of active repositories in preferences 
 exports[`remove helm repository from list of active repositories in preferences when navigating to preferences containing helm repositories when active repositories resolve renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
@@ -947,6 +967,16 @@ exports[`remove helm repository from list of active repositories in preferences 
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"
     >
@@ -1420,6 +1450,16 @@ exports[`remove helm repository from list of active repositories in preferences 
 exports[`remove helm repository from list of active repositories in preferences when navigating to preferences containing helm repositories when active repositories resolve when removing repository when removing resolves renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="kubernetes-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/closing-preferences.test.tsx.snap
+++ b/src/behaviours/preferences/__snapshots__/closing-preferences.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`preferences - closing-preferences given accessing preferences directly renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -544,6 +554,16 @@ exports[`preferences - closing-preferences given accessing preferences directly 
 exports[`preferences - closing-preferences given accessing preferences directly when navigating to a tab in preferences renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
   >
     <nav
@@ -688,6 +708,16 @@ exports[`preferences - closing-preferences given accessing preferences directly 
 
 exports[`preferences - closing-preferences given accessing preferences directly when navigating to a tab in preferences when preferences are closed renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     Some front page
   </div>
@@ -699,6 +729,16 @@ exports[`preferences - closing-preferences given accessing preferences directly 
 
 exports[`preferences - closing-preferences given accessing preferences directly when preferences are closed renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div>
     Some front page
   </div>
@@ -710,6 +750,16 @@ exports[`preferences - closing-preferences given accessing preferences directly 
 
 exports[`preferences - closing-preferences given already in a page and then navigated to preferences renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
@@ -1252,6 +1302,16 @@ exports[`preferences - closing-preferences given already in a page and then navi
 exports[`preferences - closing-preferences given already in a page and then navigated to preferences when navigating to a tab in preferences renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
   >
     <nav
@@ -1397,6 +1457,16 @@ exports[`preferences - closing-preferences given already in a page and then navi
 exports[`preferences - closing-preferences given already in a page and then navigated to preferences when navigating to a tab in preferences when preferences are closed renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
   >
     <nav
@@ -1541,6 +1611,16 @@ exports[`preferences - closing-preferences given already in a page and then navi
 
 exports[`preferences - closing-preferences given already in a page and then navigated to preferences when preferences are closed renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
   >

--- a/src/behaviours/preferences/__snapshots__/navigation-to-application-preferences.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-application-preferences.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to application preferences given in some child page of preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="proxy-preferences-page"
   >
@@ -207,6 +217,16 @@ exports[`preferences - navigation to application preferences given in some child
 
 exports[`preferences - navigation to application preferences given in some child page of preferences, when rendered when navigating to application preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-editor-preferences.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-editor-preferences.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to editor preferences given in preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -531,6 +541,16 @@ exports[`preferences - navigation to editor preferences given in preferences, wh
 
 exports[`preferences - navigation to editor preferences given in preferences, when rendered when navigating to editor preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="editor-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-extension-specific-preferences.test.tsx.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-extension-specific-preferences.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to extension specific preferences given in preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -531,6 +541,16 @@ exports[`preferences - navigation to extension specific preferences given in pre
 
 exports[`preferences - navigation to extension specific preferences given in preferences, when rendered when extension with specific preferences is enabled renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
@@ -1072,6 +1092,16 @@ exports[`preferences - navigation to extension specific preferences given in pre
 
 exports[`preferences - navigation to extension specific preferences given in preferences, when rendered when extension with specific preferences is enabled when navigating to extension preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="extension-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-kubernetes-preferences.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to kubernetes preferences given in preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -531,6 +541,16 @@ exports[`preferences - navigation to kubernetes preferences given in preferences
 
 exports[`preferences - navigation to kubernetes preferences given in preferences, when rendered when navigating to kubernetes preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="kubernetes-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-proxy-preferences.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-proxy-preferences.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to proxy preferences given in preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -531,6 +541,16 @@ exports[`preferences - navigation to proxy preferences given in preferences, whe
 
 exports[`preferences - navigation to proxy preferences given in preferences, when rendered when navigating to proxy preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="proxy-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-telemetry-preferences.test.tsx.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-telemetry-preferences.test.tsx.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to telemetry preferences given URL for Sentry DNS, when navigating to preferences when navigating to telemetry preferences renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="telemetry-preferences-page"
   >
@@ -193,6 +203,16 @@ exports[`preferences - navigation to telemetry preferences given URL for Sentry 
 
 exports[`preferences - navigation to telemetry preferences given in preferences, when rendered renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
@@ -722,6 +742,16 @@ exports[`preferences - navigation to telemetry preferences given in preferences,
 
 exports[`preferences - navigation to telemetry preferences given in preferences, when rendered when extension with telemetry preference items gets enabled renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
@@ -1264,6 +1294,16 @@ exports[`preferences - navigation to telemetry preferences given in preferences,
 exports[`preferences - navigation to telemetry preferences given in preferences, when rendered when extension with telemetry preference items gets enabled when clicking link to telemetry preferences from navigation renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="telemetry-preferences-page"
   >
@@ -1442,6 +1482,16 @@ exports[`preferences - navigation to telemetry preferences given in preferences,
 
 exports[`preferences - navigation to telemetry preferences given no URL for Sentry DNS, when navigating to telemetry preferences renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="telemetry-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-to-terminal-preferences.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-to-terminal-preferences.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation to terminal preferences given in preferences, when rendered renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"
   >
@@ -531,6 +541,16 @@ exports[`preferences - navigation to terminal preferences given in preferences, 
 
 exports[`preferences - navigation to terminal preferences given in preferences, when rendered when navigating to terminal preferences using navigation renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="terminal-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`preferences - navigation using application menu renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`preferences - navigation using application menu renders 1`] = `
 
 exports[`preferences - navigation using application menu when navigating to preferences using application menu renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="SettingLayout showNavigation Preferences"
     data-testid="application-preferences-page"

--- a/src/behaviours/preferences/__snapshots__/navigation-using-tray.test.ts.snap
+++ b/src/behaviours/preferences/__snapshots__/navigation-using-tray.test.ts.snap
@@ -4,6 +4,16 @@ exports[`show-about-using-tray renders 1`] = `
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -13,6 +23,16 @@ exports[`show-about-using-tray renders 1`] = `
 exports[`show-about-using-tray when navigating using tray renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="SettingLayout showNavigation Preferences"
       data-testid="application-preferences-page"

--- a/src/behaviours/welcome/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/src/behaviours/welcome/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -3,6 +3,16 @@
 exports[`welcome - navigation using application menu renders 1`] = `
 <div>
   <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
+  <div
     class="Notifications flex column align-flex-end"
   />
 </div>
@@ -10,6 +20,16 @@ exports[`welcome - navigation using application menu renders 1`] = `
 
 exports[`welcome - navigation using application menu when navigating to welcome using application menu renders 1`] = `
 <div>
+  <div
+    class="StatusBar"
+  >
+    <div
+      class="leftSide"
+    />
+    <div
+      class="rightSide"
+    />
+  </div>
   <div
     class="flex justify-center Welcome align-center"
     data-testid="welcome-page"

--- a/src/main/ask-boolean/__snapshots__/ask-boolean.test.ts.snap
+++ b/src/main/ask-boolean/__snapshots__/ask-boolean.test.ts.snap
@@ -4,6 +4,16 @@ exports[`ask-boolean given started when asking multiple questions renders 1`] = 
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     >
       <div
@@ -151,6 +161,16 @@ exports[`ask-boolean given started when asking multiple questions when answering
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     >
       <div
@@ -229,6 +249,16 @@ exports[`ask-boolean given started when asking multiple questions when answering
 exports[`ask-boolean given started when asking question renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     >
@@ -309,6 +339,16 @@ exports[`ask-boolean given started when asking question when user answers "no" r
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -319,6 +359,16 @@ exports[`ask-boolean given started when asking question when user answers "yes" 
 <body>
   <div>
     <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
+    <div
       class="Notifications flex column align-flex-end"
     />
   </div>
@@ -328,6 +378,16 @@ exports[`ask-boolean given started when asking question when user answers "yes" 
 exports[`ask-boolean given started when asking question when user closes notification without answering the question renders 1`] = `
 <body>
   <div>
+    <div
+      class="StatusBar"
+    >
+      <div
+        class="leftSide"
+      />
+      <div
+        class="rightSide"
+      />
+    </div>
     <div
       class="Notifications flex column align-flex-end"
     />

--- a/src/renderer/components/test-utils/get-application-builder.tsx
+++ b/src/renderer/components/test-utils/get-application-builder.tsx
@@ -55,6 +55,7 @@ import trayIconPathsInjectable from "../../../main/tray/tray-icon-path.injectabl
 import assert from "assert";
 import { openMenu } from "react-select-event";
 import userEvent from "@testing-library/user-event";
+import { StatusBar } from "../status-bar/status-bar";
 
 type Callback = (dis: DiContainers) => void | Promise<void>;
 
@@ -102,6 +103,7 @@ interface DiContainers {
 
 interface Environment {
   renderSidebar: () => React.ReactNode;
+  renderStatusBar: () => React.ReactNode;
   beforeRender: () => void;
   onAllowKubeResource: () => void;
 }
@@ -141,6 +143,8 @@ export const getApplicationBuilder = () => {
     application: {
       renderSidebar: () => null,
 
+      renderStatusBar: () => <StatusBar />,
+
       beforeRender: () => {
         const nofifyThatRootFrameIsRendered = rendererDi.inject(broadcastThatRootFrameIsRenderedInjectable);
 
@@ -156,6 +160,7 @@ export const getApplicationBuilder = () => {
 
     clusterFrame: {
       renderSidebar: () => <Sidebar />,
+      renderStatusBar: () => null,
       beforeRender: () => {},
       onAllowKubeResource: () => {},
     } as Environment,
@@ -422,6 +427,7 @@ export const getApplicationBuilder = () => {
       rendered = render(
         <Router history={history}>
           {environment.renderSidebar()}
+          {environment.renderStatusBar()}
 
           <Observer>
             {() => {


### PR DESCRIPTION
With some auto-upate info moving to the status bar from notifications, the snapshots will need to include the status bar in order to reflect this change. 