### PR TITLE
Rename injection token for clarity

### DIFF
--- a/src/behaviours/cluster/sidebar-and-tab-navigation-for-core.test.tsx
+++ b/src/behaviours/cluster/sidebar-and-tab-navigation-for-core.test.tsx
@@ -14,7 +14,7 @@ import { sidebarItemsInjectionToken } from "../../renderer/components/layout/sid
 import { computed } from "mobx";
 import { noop } from "lodash/fp";
 import routeIsActiveInjectable from "../../renderer/routes/route-is-active.injectable";
-import { routeInjectionToken } from "../../common/front-end-routing/route-injection-token";
+import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import writeJsonFileInjectable from "../../common/fs/write-json-file.injectable";
@@ -337,7 +337,7 @@ const testRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 const testRouteComponentInjectable = getInjectable({

--- a/src/behaviours/cluster/visibility-of-sidebar-items.test.tsx
+++ b/src/behaviours/cluster/visibility-of-sidebar-items.test.tsx
@@ -10,7 +10,7 @@ import { computed } from "mobx";
 import { routeSpecificComponentInjectionToken } from "../../renderer/routes/route-specific-component-injection-token";
 import React from "react";
 import isAllowedResourceInjectable from "../../common/utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../common/front-end-routing/route-injection-token";
+import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { navigateToRouteInjectionToken } from "../../common/front-end-routing/navigate-to-route-injection-token";
@@ -83,7 +83,7 @@ const testRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 const testRouteComponentInjectable = getInjectable({

--- a/src/behaviours/navigating-between-routes.test.tsx
+++ b/src/behaviours/navigating-between-routes.test.tsx
@@ -9,8 +9,8 @@ import { computed } from "mobx";
 import type { RenderResult } from "@testing-library/react";
 import { routeSpecificComponentInjectionToken } from "../renderer/routes/route-specific-component-injection-token";
 import { observer } from "mobx-react";
-import type { Route } from "../common/front-end-routing/route-injection-token";
-import { routeInjectionToken } from "../common/front-end-routing/route-injection-token";
+import type { Route } from "../common/front-end-routing/front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../common/front-end-routing/front-end-route-injection-token";
 import type { ApplicationBuilder } from "../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../renderer/components/test-utils/get-application-builder";
 import currentRouteInjectable from "../renderer/routes/current-route.injectable";
@@ -192,7 +192,7 @@ describe("navigating between routes", () => {
 
 const testRouteWithoutPathParametersInjectable = getInjectable({
   id: "some-route",
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 
   instantiate: () => ({
     path: "/some-path",
@@ -214,7 +214,7 @@ const testRouteWithoutPathParametersComponentInjectable = getInjectable({
 
 const routeWithOptionalPathParametersInjectable = getInjectable({
   id: "some-route",
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 
   instantiate: (): Route<{ someParameter?: string; someOtherParameter?: string }> => ({
     path: "/some-path/:someParameter?/:someOtherParameter?",

--- a/src/behaviours/preferences/closing-preferences.test.tsx
+++ b/src/behaviours/preferences/closing-preferences.test.tsx
@@ -8,7 +8,7 @@ import type { RenderResult } from "@testing-library/react";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import currentPathInjectable from "../../renderer/routes/current-path.injectable";
-import { routeInjectionToken } from "../../common/front-end-routing/route-injection-token";
+import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import { computed } from "mobx";
 import { preferenceNavigationItemInjectionToken } from "../../renderer/components/+preferences/preferences-navigation/preference-navigation-items.injectable";
 import routeIsActiveInjectable from "../../renderer/routes/route-is-active.injectable";
@@ -202,7 +202,7 @@ const testPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 const testPreferencesRouteComponentInjectable = getInjectable({
@@ -225,7 +225,7 @@ const testFrontPageRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 const testFrontPageRouteComponentInjectable = getInjectable({

--- a/src/common/front-end-routing/front-end-route-injection-token.ts
+++ b/src/common/front-end-routing/front-end-route-injection-token.ts
@@ -6,8 +6,8 @@ import { getInjectionToken } from "@ogre-tools/injectable";
 import type { IComputedValue } from "mobx";
 import type { LensRendererExtension } from "../../extensions/lens-renderer-extension";
 
-export const routeInjectionToken = getInjectionToken<Route<unknown>>({
-  id: "route-injection-token",
+export const frontEndRouteInjectionToken = getInjectionToken<Route<unknown>>({
+  id: "front-end-route-injection-token",
 });
 
 export interface Route<TParameter = void> {

--- a/src/common/front-end-routing/navigate-to-route-injection-token.ts
+++ b/src/common/front-end-routing/navigate-to-route-injection-token.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectionToken } from "@ogre-tools/injectable";
-import type { Route } from "./route-injection-token";
+import type { Route } from "./front-end-route-injection-token";
 
 type InferParametersFrom<TRoute> = TRoute extends Route<infer TParameters>
   ? TParameters

--- a/src/common/front-end-routing/routes/add-cluster/add-cluster-route.injectable.ts
+++ b/src/common/front-end-routing/routes/add-cluster/add-cluster-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 const addClusterRouteInjectable = getInjectable({
   id: "add-cluster-route",
@@ -15,7 +15,7 @@ const addClusterRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default addClusterRouteInjectable;

--- a/src/common/front-end-routing/routes/catalog/catalog-route.injectable.ts
+++ b/src/common/front-end-routing/routes/catalog/catalog-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../route-injection-token";
-import { routeInjectionToken } from "../../route-injection-token";
+import type { Route } from "../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 export interface CatalogPathParameters {
   group?: string;
@@ -21,7 +21,7 @@ const catalogRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default catalogRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster-view/cluster-view-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster-view/cluster-view-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 const clusterViewRouteInjectable = getInjectable({
   id: "cluster-view-route",
@@ -15,7 +15,7 @@ const clusterViewRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default clusterViewRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/config-maps/config-maps-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/config-maps/config-maps-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const configMapsRouteInjectable = getInjectable({
   id: "config-maps-route",
@@ -19,7 +19,7 @@ const configMapsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default configMapsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/horizontal-pod-autoscalers/horizontal-pod-autoscalers-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/horizontal-pod-autoscalers/horizontal-pod-autoscalers-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const horizontalPodAutoscalersRouteInjectable = getInjectable({
   id: "horizontal-pod-autoscalers-route",
@@ -19,7 +19,7 @@ const horizontalPodAutoscalersRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default horizontalPodAutoscalersRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/limit-ranges/limit-ranges-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/limit-ranges/limit-ranges-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const limitRangesRouteInjectable = getInjectable({
   id: "limit-ranges-route",
@@ -22,7 +22,7 @@ const limitRangesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default limitRangesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/pod-disruption-budgets/pod-disruption-budgets-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/pod-disruption-budgets/pod-disruption-budgets-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const podDisruptionBudgetsRouteInjectable = getInjectable({
   id: "pod-disruption-budgets-route",
@@ -19,7 +19,7 @@ const podDisruptionBudgetsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default podDisruptionBudgetsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/resource-quotas/resource-quotas-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/resource-quotas/resource-quotas-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const resourceQuotasRouteInjectable = getInjectable({
   id: "resource-quotas-route",
@@ -19,7 +19,7 @@ const resourceQuotasRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default resourceQuotasRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/config/secrets/secrets-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/config/secrets/secrets-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const secretsRouteInjectable = getInjectable({
   id: "secrets-route",
@@ -19,7 +19,7 @@ const secretsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default secretsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/custom-resources/crd-list/crd-list-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/custom-resources/crd-list/crd-list-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const crdListRouteInjectable = getInjectable({
   id: "crd-list-route",
@@ -15,7 +15,7 @@ const crdListRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default crdListRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/custom-resources/custom-resources/custom-resources-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/custom-resources/custom-resources/custom-resources-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../../../route-injection-token";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import type { Route } from "../../../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 export interface CustomResourcesPathParameters {
   group?: string;
@@ -21,7 +21,7 @@ const customResourcesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default customResourcesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/events/events-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/events/events-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const eventsRouteInjectable = getInjectable({
   id: "events-route",
@@ -19,7 +19,7 @@ const eventsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default eventsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/helm/charts/helm-charts-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/helm/charts/helm-charts-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../../../route-injection-token";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import type { Route } from "../../../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 export interface HelmChartsPathParameters {
   repo?: string;
@@ -21,7 +21,7 @@ const helmChartsRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default helmChartsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/helm/releases/helm-releases-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/helm/releases/helm-releases-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../../../route-injection-token";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import type { Route } from "../../../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 export interface HelmReleasesPathParameters {
   namespace?: string;
@@ -21,7 +21,7 @@ const helmReleasesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default helmReleasesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/namespaces/namespaces-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/namespaces/namespaces-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const namespacesRouteInjectable = getInjectable({
   id: "namespaces-route",
@@ -19,7 +19,7 @@ const namespacesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default namespacesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/network/endpoints/endpoints-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/network/endpoints/endpoints-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const endpointsRouteInjectable = getInjectable({
   id: "endpoints-route",
@@ -19,7 +19,7 @@ const endpointsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default endpointsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/network/ingresses/ingresses-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/network/ingresses/ingresses-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const ingressesRouteInjectable = getInjectable({
   id: "ingresses-route",
@@ -19,7 +19,7 @@ const ingressesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default ingressesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/network/network-policies/network-policies-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/network/network-policies/network-policies-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const networkPoliciesRouteInjectable = getInjectable({
   id: "network-policies-route",
@@ -19,7 +19,7 @@ const networkPoliciesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default networkPoliciesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/network/port-forwards/port-forwards-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/network/port-forwards/port-forwards-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../../../route-injection-token";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import type { Route } from "../../../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 export interface PortForwardsPathParameters {
   forwardport?: string;
@@ -20,7 +20,7 @@ const portForwardsRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default portForwardsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/network/services/services-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/network/services/services-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const servicesRouteInjectable = getInjectable({
   id: "services-route",
@@ -19,7 +19,7 @@ const servicesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default servicesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/nodes/nodes-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/nodes/nodes-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const nodesRouteInjectable = getInjectable({
   id: "nodes-route",
@@ -19,7 +19,7 @@ const nodesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default nodesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/overview/cluster-overview-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/overview/cluster-overview-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const clusterOverviewRouteInjectable = getInjectable({
   id: "cluster-overview-route",
@@ -19,7 +19,7 @@ const clusterOverviewRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default clusterOverviewRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/storage/persistent-volume-claims/persistent-volume-claims-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/storage/persistent-volume-claims/persistent-volume-claims-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const persistentVolumeClaimsRouteInjectable = getInjectable({
   id: "persistent-volume-claims-route",
@@ -19,7 +19,7 @@ const persistentVolumeClaimsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default persistentVolumeClaimsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/storage/persistent-volumes/persistent-volumes-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/storage/persistent-volumes/persistent-volumes-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const persistentVolumesRouteInjectable = getInjectable({
   id: "persistent-volumes-route",
@@ -19,7 +19,7 @@ const persistentVolumesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default persistentVolumesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/storage/storage-classes/storage-classes-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/storage/storage-classes/storage-classes-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const storageClassesRouteInjectable = getInjectable({
   id: "storage-classes-route",
@@ -19,7 +19,7 @@ const storageClassesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default storageClassesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/cluster-role-bindings/cluster-role-bindings-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/cluster-role-bindings/cluster-role-bindings-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const clusterRoleBindingsRouteInjectable = getInjectable({
   id: "cluster-role-bindings-route",
@@ -19,7 +19,7 @@ const clusterRoleBindingsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default clusterRoleBindingsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/cluster-roles/cluster-roles-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/cluster-roles/cluster-roles-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const clusterRolesRouteInjectable = getInjectable({
   id: "cluster-roles-route",
@@ -19,7 +19,7 @@ const clusterRolesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default clusterRolesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/pod-security-policies/pod-security-policies-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/pod-security-policies/pod-security-policies-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const podSecurityPoliciesRouteInjectable = getInjectable({
   id: "pod-security-policies-route",
@@ -19,7 +19,7 @@ const podSecurityPoliciesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default podSecurityPoliciesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/role-bindings/role-bindings-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/role-bindings/role-bindings-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const roleBindingsRouteInjectable = getInjectable({
   id: "role-bindings-route",
@@ -19,7 +19,7 @@ const roleBindingsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default roleBindingsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/roles/roles-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/roles/roles-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const rolesRouteInjectable = getInjectable({
   id: "roles-route",
@@ -19,7 +19,7 @@ const rolesRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default rolesRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/user-management/service-accounts/service-accounts-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/user-management/service-accounts/service-accounts-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const serviceAccountsRouteInjectable = getInjectable({
   id: "service-accounts-route",
@@ -19,7 +19,7 @@ const serviceAccountsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default serviceAccountsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/cron-jobs/cron-jobs-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/cron-jobs/cron-jobs-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const cronJobsRouteInjectable = getInjectable({
   id: "cron-jobs-route",
@@ -19,7 +19,7 @@ const cronJobsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default cronJobsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/daemonsets/daemonsets-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/daemonsets/daemonsets-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const daemonsetsRouteInjectable = getInjectable({
   id: "daemonsets-route",
@@ -19,7 +19,7 @@ const daemonsetsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default daemonsetsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/deployments/deployments-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/deployments/deployments-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const deploymentsRouteInjectable = getInjectable({
   id: "deployments-route",
@@ -19,7 +19,7 @@ const deploymentsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default deploymentsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/jobs/jobs-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/jobs/jobs-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const jobsRouteInjectable = getInjectable({
   id: "jobs-route",
@@ -19,7 +19,7 @@ const jobsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default jobsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/overview/workloads-overview-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/overview/workloads-overview-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const workloadsOverviewRouteInjectable = getInjectable({
   id: "workloads-overview-route",
@@ -15,7 +15,7 @@ const workloadsOverviewRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default workloadsOverviewRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/pods/pods-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/pods/pods-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const podsRouteInjectable = getInjectable({
   id: "pods-route",
@@ -19,7 +19,7 @@ const podsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default podsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/replicasets/replicasets-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/replicasets/replicasets-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const replicasetsRouteInjectable = getInjectable({
   id: "replicasets-route",
@@ -19,7 +19,7 @@ const replicasetsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default replicasetsRouteInjectable;

--- a/src/common/front-end-routing/routes/cluster/workloads/statefulsets/statefulsets-route.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/workloads/statefulsets/statefulsets-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import isAllowedResourceInjectable from "../../../../../utils/is-allowed-resource.injectable";
-import { routeInjectionToken } from "../../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../front-end-route-injection-token";
 
 const statefulsetsRouteInjectable = getInjectable({
   id: "statefulsets-route",
@@ -19,7 +19,7 @@ const statefulsetsRouteInjectable = getInjectable({
     };
   },
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default statefulsetsRouteInjectable;

--- a/src/common/front-end-routing/routes/entity-settings/entity-settings-route.injectable.ts
+++ b/src/common/front-end-routing/routes/entity-settings/entity-settings-route.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import type { Route } from "../../route-injection-token";
-import { routeInjectionToken } from "../../route-injection-token";
+import type { Route } from "../../front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 export interface EntitySettingsPathParameters {
   entityId: string;
@@ -20,7 +20,7 @@ const entitySettingsRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default entitySettingsRouteInjectable;

--- a/src/common/front-end-routing/routes/extensions/extensions-route.injectable.ts
+++ b/src/common/front-end-routing/routes/extensions/extensions-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 const extensionsRouteInjectable = getInjectable({
   id: "extensions-route",
@@ -15,7 +15,7 @@ const extensionsRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default extensionsRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/app/app-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/app/app-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const appPreferencesRouteInjectable = getInjectable({
   id: "app-preferences-route",
@@ -15,7 +15,7 @@ const appPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default appPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/editor/editor-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/editor/editor-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const editorPreferencesRouteInjectable = getInjectable({
   id: "editor-preferences-route",
@@ -15,7 +15,7 @@ const editorPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default editorPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/extension/extension-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/extension/extension-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const extensionPreferencesRouteInjectable = getInjectable({
   id: "extension-preferences-route",
@@ -15,7 +15,7 @@ const extensionPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default extensionPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/kubernetes/kubernetes-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/kubernetes/kubernetes-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const kubernetesPreferencesRouteInjectable = getInjectable({
   id: "kubernetes-preferences-route",
@@ -15,7 +15,7 @@ const kubernetesPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default kubernetesPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/proxy/proxy-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/proxy/proxy-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const proxyPreferencesRouteInjectable = getInjectable({
   id: "proxy-preferences-route",
@@ -15,7 +15,7 @@ const proxyPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default proxyPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/telemetry/telemetry-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/telemetry/telemetry-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const telemetryPreferencesRouteInjectable = getInjectable({
   id: "telemetry-preferences-route",
@@ -15,7 +15,7 @@ const telemetryPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default telemetryPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/preferences/terminal/terminal-preferences-route.injectable.ts
+++ b/src/common/front-end-routing/routes/preferences/terminal/terminal-preferences-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../front-end-route-injection-token";
 
 const terminalPreferencesRouteInjectable = getInjectable({
   id: "terminal-preferences-route",
@@ -15,7 +15,7 @@ const terminalPreferencesRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default terminalPreferencesRouteInjectable;

--- a/src/common/front-end-routing/routes/welcome/welcome-route.injectable.ts
+++ b/src/common/front-end-routing/routes/welcome/welcome-route.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../route-injection-token";
+import { frontEndRouteInjectionToken } from "../../front-end-route-injection-token";
 
 const welcomeRouteInjectable = getInjectable({
   id: "welcome-route",
@@ -15,7 +15,7 @@ const welcomeRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 export default welcomeRouteInjectable;

--- a/src/common/front-end-routing/verify-that-all-routes-have-route-component.test.ts
+++ b/src/common/front-end-routing/verify-that-all-routes-have-route-component.test.ts
@@ -4,7 +4,7 @@
  */
 import { getDiForUnitTesting } from "../../renderer/getDiForUnitTesting";
 import { routeSpecificComponentInjectionToken } from "../../renderer/routes/route-specific-component-injection-token";
-import { routeInjectionToken } from "./route-injection-token";
+import { frontEndRouteInjectionToken } from "./front-end-route-injection-token";
 import { filter, map, matches } from "lodash/fp";
 import clusterStoreInjectable from "../cluster-store/cluster-store.injectable";
 import type { ClusterStore } from "../cluster-store/cluster-store";
@@ -18,7 +18,7 @@ describe("verify-that-all-routes-have-component", () => {
       getById: () => null,
     } as unknown as ClusterStore));
 
-    const routes = rendererDi.injectMany(routeInjectionToken);
+    const routes = rendererDi.injectMany(frontEndRouteInjectionToken);
     const routeComponents = rendererDi.injectMany(
       routeSpecificComponentInjectionToken,
     );

--- a/src/extensions/lens-extension-set-dependencies.ts
+++ b/src/extensions/lens-extension-set-dependencies.ts
@@ -6,7 +6,7 @@
 import type { IComputedValue } from "mobx";
 import type { CatalogCategoryRegistry } from "../common/catalog";
 import type { NavigateToRoute } from "../common/front-end-routing/navigate-to-route-injection-token";
-import type { Route } from "../common/front-end-routing/route-injection-token";
+import type { Route } from "../common/front-end-routing/front-end-route-injection-token";
 import type { CatalogEntityRegistry as MainCatalogEntityRegistry } from "../main/catalog";
 import type { CatalogEntityRegistry as RendererCatalogEntityRegistry } from "../renderer/api/catalog/entity/registry";
 import type { GetExtensionPageParameters } from "../renderer/routes/get-extension-page-parameters.injectable";

--- a/src/renderer/components/+preferences/preferences-navigation/navigate-to-preference-tab.injectable.ts
+++ b/src/renderer/components/+preferences/preferences-navigation/navigate-to-preference-tab.injectable.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import type { Route } from "../../../../common/front-end-routing/route-injection-token";
+import type { Route } from "../../../../common/front-end-routing/front-end-route-injection-token";
 import { navigateToRouteInjectionToken } from "../../../../common/front-end-routing/navigate-to-route-injection-token";
 
 const navigateToPreferenceTabInjectable = getInjectable({

--- a/src/renderer/components/delete-cluster-dialog/__tests__/delete-cluster-dialog.test.tsx
+++ b/src/renderer/components/delete-cluster-dialog/__tests__/delete-cluster-dialog.test.tsx
@@ -20,7 +20,7 @@ import storesAndApisCanBeCreatedInjectable from "../../../stores-apis-can-be-cre
 import createKubeconfigManagerInjectable from "../../../../main/kubeconfig-manager/create-kubeconfig-manager.injectable";
 import type { ApplicationBuilder } from "../../test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../test-utils/get-application-builder";
-import { routeInjectionToken } from "../../../../common/front-end-routing/route-injection-token";
+import { frontEndRouteInjectionToken } from "../../../../common/front-end-routing/front-end-route-injection-token";
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
 import { routeSpecificComponentInjectionToken } from "../../../routes/route-specific-component-injection-token";
@@ -319,7 +319,7 @@ const testRouteInjectable = getInjectable({
     isEnabled: computed(() => true),
   }),
 
-  injectionToken: routeInjectionToken,
+  injectionToken: frontEndRouteInjectionToken,
 });
 
 const testRouteComponentInjectable = getInjectable({

--- a/src/renderer/routes/all-routes.injectable.ts
+++ b/src/renderer/routes/all-routes.injectable.ts
@@ -7,8 +7,8 @@ import { overSome } from "lodash/fp";
 import { computed } from "mobx";
 import rendererExtensionsInjectable from "../../extensions/renderer-extensions.injectable";
 import type { LensRendererExtension } from "../../extensions/lens-renderer-extension";
-import type { Route } from "../../common/front-end-routing/route-injection-token";
-import { routeInjectionToken } from "../../common/front-end-routing/route-injection-token";
+import type { Route } from "../../common/front-end-routing/front-end-route-injection-token";
+import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 
 const allRoutesInjectable = getInjectable({
   id: "all-routes",
@@ -20,7 +20,7 @@ const allRoutesInjectable = getInjectable({
       const enabledExtensions = extensions.get();
 
       return di
-        .injectMany(routeInjectionToken)
+        .injectMany(frontEndRouteInjectionToken)
         .filter((route) =>
           overSome([
             isNonExtensionRoute,

--- a/src/renderer/routes/extension-route-registrator.injectable.tsx
+++ b/src/renderer/routes/extension-route-registrator.injectable.tsx
@@ -15,7 +15,7 @@ import { SiblingsInTabLayout } from "../components/layout/siblings-in-tab-layout
 import extensionPageParametersInjectable from "./extension-page-parameters.injectable";
 import { routeSpecificComponentInjectionToken } from "./route-specific-component-injection-token";
 import { computed } from "mobx";
-import { routeInjectionToken } from "../../common/front-end-routing/route-injection-token";
+import { frontEndRouteInjectionToken } from "../../common/front-end-routing/front-end-route-injection-token";
 import { getExtensionRoutePath } from "./for-extension";
 
 const extensionRouteRegistratorInjectable = getInjectable({
@@ -62,7 +62,7 @@ const toRouteInjectableFor =
             extension,
           }),
 
-          injectionToken: routeInjectionToken,
+          injectionToken: frontEndRouteInjectionToken,
         });
 
         const normalizedParams = di.inject(extensionPageParametersInjectable, {

--- a/src/renderer/routes/route-is-active.injectable.ts
+++ b/src/renderer/routes/route-is-active.injectable.ts
@@ -5,7 +5,7 @@
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { computed } from "mobx";
 import currentRouteInjectable from "./current-route.injectable";
-import type { Route } from "../../common/front-end-routing/route-injection-token";
+import type { Route } from "../../common/front-end-routing/front-end-route-injection-token";
 
 const routeIsActiveInjectable = getInjectable({
   id: "route-is-active",

--- a/src/renderer/routes/route-path-parameters.injectable.ts
+++ b/src/renderer/routes/route-path-parameters.injectable.ts
@@ -6,7 +6,7 @@ import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { computed } from "mobx";
 import { matchPath } from "react-router";
 import currentPathInjectable from "./current-path.injectable";
-import type { Route } from "../../common/front-end-routing/route-injection-token";
+import type { Route } from "../../common/front-end-routing/front-end-route-injection-token";
 
 const routePathParametersInjectable = getInjectable({
   id: "route-path-parameters",

--- a/src/renderer/routes/route-specific-component-injection-token.ts
+++ b/src/renderer/routes/route-specific-component-injection-token.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectionToken } from "@ogre-tools/injectable";
-import type { Route } from "../../common/front-end-routing/route-injection-token";
+import type { Route } from "../../common/front-end-routing/front-end-route-injection-token";
 
 export const routeSpecificComponentInjectionToken = getInjectionToken<{
   route: Route<unknown>;


### PR DESCRIPTION
Notice that the base branch is #5635. 

This PR doesn't do anything else than rename `routeInjectionToken` to `frontEndRouteInjectionToken`. This is done to make it easier to distinguish back-end routes from front-end routes.