### PR TITLE
release 5.6.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.1",
+  "version": "5.6.0-alpha.2",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since 5.6.0-alpha.1

## 🐛 Bug Fixes

- Fix not starting with sentryDSN configured (**[#5629](https://github.com/lensapp/lens/pull/5629)**) https://github.com/Nokel81

## 🧰 Maintenance

- Update copyright to 2022 (**[#5624](https://github.com/lensapp/lens/pull/5624)**) https://github.com/Nokel81
- Bump immer from 9.0.14 to 9.0.15 (**[#5621](https://github.com/lensapp/lens/pull/5621)**) https://github.com/dependabot
- Bump @types/sharp from 0.30.2 to 0.30.4 (**[#5620](https://github.com/lensapp/lens/pull/5620)**) https://github.com/dependabot
- Bump sass from 1.52.2 to 1.52.3 (**[#5619](https://github.com/lensapp/lens/pull/5619)**) https://github.com/dependabot
- Bump type-fest from 2.13.0 to 2.13.1 (**[#5616](https://github.com/lensapp/lens/pull/5616)**) https://github.com/dependabot
