### PR TITLE
link update for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lens IDE a standalone application for MacOS, Windows and Linux operating systems
 
 ## Installation
 
-See [Getting Started](https://docs.k8slens.dev/latest/getting-started/) page.
+See [Getting Started](https://docs.k8slens.dev/latest/getting-started/install-lens/) page.
 
 ## Development
 


### PR DESCRIPTION
The current link i.e: https://docs.k8slens.dev/latest/getting-started/ seems to be broken and shows a 404 Not Found error.

I've updated the link to https://docs.k8slens.dev/latest/getting-started/install-lens/ that redirects to another link i.e. https://docs.k8slens.dev/main/getting-started/install-lens/ which is a working page.

Thanks