### PR TITLE
fix jsonnet error with kube-prometheus >= v0.8

### DIFF
--- a/jsonnet/lens/custom-prometheus.jsonnet
+++ b/jsonnet/lens/custom-prometheus.jsonnet
@@ -24,7 +24,7 @@
       },
     },
   },
-  prometheus+:: {
+  kubernetesControlPlane+:: {
     serviceMonitorKubelet+: {
       spec+: {
         endpoints: std.map(function(endpoint)

--- a/troubleshooting/custom-prometheus.md
+++ b/troubleshooting/custom-prometheus.md
@@ -31,14 +31,15 @@ metricRelabelings:
 
 ### Jsonnet
 
-The required label replacements are bundled in [jsonnet/lens/custom-prometheus](../jsonnet/lens/custom-prometheus.jsonnet). To install it copy the file or use
-[Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler).
+The required label replacements are bundled in [jsonnet/lens/custom-prometheus](../jsonnet/lens/custom-prometheus.jsonnet).
+This file is currently for jsonnet versions >= 0.8.0
+To install it copy the file or use [Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler).
 
 ```bash
 jb init && jb install https://github.com/lensapp/lens/jsonnet/lens@master
 ```
 
-When the installation was successful include it into your definitions. Using the [example](https://github.com/coreos/kube-prometheus#compiling) 
+When the installation was successful include it into your definitions. Using the [example](https://github.com/coreos/kube-prometheus#compiling)
 of kube-prometheus, e.g.:
 
 ```
@@ -60,4 +61,3 @@ local kp =
 ```
 helm upgrade --set server.global.scrape_interval=30s prometheus stable/prometheus
 ```
-


### PR DESCRIPTION
kubelet ServiceMonitor moved to kubernetesControlPlane starting from v0.8
