### PR TITLE
release 5.6.0-alpha.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.4",
+  "version": "5.6.0-alpha.5",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.3",
+  "version": "5.6.0-alpha.4",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",

--- a/src/behaviours/application-update/installing-update-using-tray.test.ts
+++ b/src/behaviours/application-update/installing-update-using-tray.test.ts
@@ -14,7 +14,6 @@ import asyncFn from "@async-fn/jest";
 import type { DownloadPlatformUpdate } from "../../main/application-update/download-platform-update/download-platform-update.injectable";
 import downloadPlatformUpdateInjectable from "../../main/application-update/download-platform-update/download-platform-update.injectable";
 import showApplicationWindowInjectable from "../../main/start-main-application/lens-window/show-application-window.injectable";
-import progressOfUpdateDownloadInjectable from "../../common/application-update/progress-of-update-download/progress-of-update-download.injectable";
 import type { TrayIconPaths } from "../../main/tray/tray-icon-path.injectable";
 import trayIconPathsInjectable from "../../main/tray/tray-icon-path.injectable";
 
@@ -87,13 +86,13 @@ describe("installing update using tray", () => {
 
       it("user cannot check for updates again", () => {
         expect(
-          applicationBuilder.tray.get("check-for-updates")?.enabled.get(),
+          applicationBuilder.tray.get("check-for-updates")?.enabled,
         ).toBe(false);
       });
 
       it("name of tray item for checking updates indicates that checking is happening", () => {
         expect(
-          applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+          applicationBuilder.tray.get("check-for-updates")?.label,
         ).toBe("Checking for updates...");
       });
 
@@ -128,13 +127,13 @@ describe("installing update using tray", () => {
 
         it("user can check for updates again", () => {
           expect(
-            applicationBuilder.tray.get("check-for-updates")?.enabled.get(),
+            applicationBuilder.tray.get("check-for-updates")?.enabled,
           ).toBe(true);
         });
 
         it("name of tray item for checking updates no longer indicates that checking is happening", () => {
           expect(
-            applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+            applicationBuilder.tray.get("check-for-updates")?.label,
           ).toBe("Check for updates");
         });
 
@@ -163,25 +162,21 @@ describe("installing update using tray", () => {
 
         it("user cannot check for updates again yet", () => {
           expect(
-            applicationBuilder.tray.get("check-for-updates")?.enabled.get(),
+            applicationBuilder.tray.get("check-for-updates")?.enabled,
           ).toBe(false);
         });
 
         it("name of tray item for checking updates indicates that downloading is happening", () => {
           expect(
-            applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+            applicationBuilder.tray.get("check-for-updates")?.label,
           ).toBe("Downloading update some-version (0%)...");
         });
 
         it("when download progresses with decimals, percentage increases as integers", () => {
-          const progressOfUpdateDownload = applicationBuilder.dis.mainDi.inject(
-            progressOfUpdateDownloadInjectable,
-          );
-
-          progressOfUpdateDownload.set({ percentage: 42.424242 });
+          downloadPlatformUpdateMock.mock.calls[0][0]({ percentage: 42.424242 });
 
           expect(
-            applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+            applicationBuilder.tray.get("check-for-updates")?.label,
           ).toBe("Downloading update some-version (42%)...");
         });
 
@@ -210,13 +205,13 @@ describe("installing update using tray", () => {
 
           it("user can check for updates again", () => {
             expect(
-              applicationBuilder.tray.get("check-for-updates")?.enabled.get(),
+              applicationBuilder.tray.get("check-for-updates")?.enabled,
             ).toBe(true);
           });
 
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
-              applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+              applicationBuilder.tray.get("check-for-updates")?.label,
             ).toBe("Check for updates");
           });
 
@@ -232,7 +227,7 @@ describe("installing update using tray", () => {
 
           it("user can install update", () => {
             expect(
-              applicationBuilder.tray.get("install-update")?.label?.get(),
+              applicationBuilder.tray.get("install-update")?.label,
             ).toBe("Install update some-version");
           });
 
@@ -242,13 +237,13 @@ describe("installing update using tray", () => {
 
           it("user can check for updates again", () => {
             expect(
-              applicationBuilder.tray.get("check-for-updates")?.enabled.get(),
+              applicationBuilder.tray.get("check-for-updates")?.enabled,
             ).toBe(true);
           });
 
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
-              applicationBuilder.tray.get("check-for-updates")?.label?.get(),
+              applicationBuilder.tray.get("check-for-updates")?.label,
             ).toBe("Check for updates");
           });
 

--- a/src/main/tray/electron-tray/electron-tray.injectable.ts
+++ b/src/main/tray/electron-tray/electron-tray.injectable.ts
@@ -9,15 +9,24 @@ import showApplicationWindowInjectable from "../../start-main-application/lens-w
 import isWindowsInjectable from "../../../common/vars/is-windows.injectable";
 import loggerInjectable from "../../../common/logger.injectable";
 import trayIconPathsInjectable from "../tray-icon-path.injectable";
-import type { TrayMenuItem } from "../tray-menu-item/tray-menu-item-injection-token";
 import { convertToElectronMenuTemplate } from "../reactive-tray-menu-items/converters";
 
 const TRAY_LOG_PREFIX = "[TRAY]";
 
+export interface MinimalTrayMenuItem {
+  id: string;
+  parentId: string | null;
+  enabled: boolean;
+  label?: string;
+  click?: () => Promise<void> | void;
+  tooltip?: string;
+  separator?: boolean;
+}
+
 export interface ElectronTray {
   start(): void;
   stop(): void;
-  setMenuItems(menuItems: TrayMenuItem[]): void;
+  setMenuItems(menuItems: MinimalTrayMenuItem[]): void;
   setIconPath(iconPath: string): void;
 }
 

--- a/src/main/tray/reactive-tray-menu-items/converters.ts
+++ b/src/main/tray/reactive-tray-menu-items/converters.ts
@@ -2,13 +2,13 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import type { TrayMenuItem } from "../tray-menu-item/tray-menu-item-injection-token";
+import type { MinimalTrayMenuItem } from "../electron-tray/electron-tray.injectable";
 
-export function convertToElectronMenuTemplate(trayMenuItems: TrayMenuItem[]): Electron.MenuItemConstructorOptions[] {
+export function convertToElectronMenuTemplate(trayMenuItems: MinimalTrayMenuItem[]): Electron.MenuItemConstructorOptions[] {
   const toTrayMenuOptions = (parentId: string | null) => (
     trayMenuItems
       .filter((item) => item.parentId === parentId)
-      .map((trayMenuItem: TrayMenuItem): Electron.MenuItemConstructorOptions => {
+      .map((trayMenuItem): Electron.MenuItemConstructorOptions => {
         if (trayMenuItem.separator) {
           return { id: trayMenuItem.id, type: "separator" };
         }
@@ -17,8 +17,8 @@ export function convertToElectronMenuTemplate(trayMenuItems: TrayMenuItem[]): El
 
         return {
           id: trayMenuItem.id,
-          label: trayMenuItem.label?.get(),
-          enabled: trayMenuItem.enabled.get(),
+          label: trayMenuItem.label,
+          enabled: trayMenuItem.enabled,
           toolTip: trayMenuItem.tooltip,
 
           ...(childItems.length === 0


### PR DESCRIPTION
## Changes since 5.6.0-alpha.3

## 🚀 Features

- Show extension preferences in separate page (**[#5284](https://github.com/lensapp/lens/pull/5284)**) https://github.com/aleksfront

## 🐛 Bug Fixes

- Fix cluster frame display issue (**[#5518](https://github.com/lensapp/lens/pull/5518)**) https://github.com/Nokel81

## 🧰 Maintenance

- Bump @types/node from 16.11.40 to 16.11.41 (**[#5686](https://github.com/lensapp/lens/pull/5686)**) https://github.com/dependabot
- Bump @side/jest-runtime from 1.0.0 to 1.0.1 (**[#5685](https://github.com/lensapp/lens/pull/5685)**) https://github.com/dependabot
- Bump typescript from 4.7.3 to 4.7.4 (**[#5684](https://github.com/lensapp/lens/pull/5684)**) https://github.com/dependabot
- Bump @hapi/subtext from 7.0.3 to 7.0.4 (**[#5683](https://github.com/lensapp/lens/pull/5683)**) https://github.com/dependabot
- Trivial tweaks accidentally left from other PR (**[#5679](https://github.com/lensapp/lens/pull/5679)**) https://github.com/jansav
- Update README.md (**[#5675](https://github.com/lensapp/lens/pull/5675)**) https://github.com/abserari
- Simplify logic for injecting many instances which can reactively change e.g. based on extension being enabled or disabled (**[#5662](https://github.com/lensapp/lens/pull/5662)**) https://github.com/jansav
- Bump tailwindcss from 3.0.24 to 3.1.3 (**[#5650](https://github.com/lensapp/lens/pull/5650)**) https://github.com/dependabot
- Bump mini-css-extract-plugin from 2.6.0 to 2.6.1 (**[#5649](https://github.com/lensapp/lens/pull/5649)**) https://github.com/dependabot
- Bump @typescript-eslint/parser from 5.27.0 to 5.28.0 (**[#5648](https://github.com/lensapp/lens/pull/5648)**) https://github.com/dependabot
- Bump @types/node-fetch from 2.6.1 to 2.6.2 (**[#5647](https://github.com/lensapp/lens/pull/5647)**) https://github.com/dependabot
