### PR TITLE
release 5.6.0-alpha.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.4",
+  "version": "5.6.0-alpha.5",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since 5.6.0-alpha.4

## 🚀 Features

- Helper to resolve proxy from URL in any environment, or using extension-API (**[#5690](https://github.com/lensapp/lens/pull/5690)**) https://github.com/Iku-turso
- Change update warning level over time (**[#5445](https://github.com/lensapp/lens/pull/5445)**) https://github.com/aleksfront

## 🐛 Bug Fixes

- Remove 'Update Now' notification (**[#5750](https://github.com/lensapp/lens/pull/5750)**) https://github.com/Nokel81
- Fix: do not affect browsing history while navigating to extension preferences (**[#5741](https://github.com/lensapp/lens/pull/5741)**) https://github.com/aleksfront
- Re-export types for notifications store to revert accidental breaking… (**[#5715](https://github.com/lensapp/lens/pull/5715)**) https://github.com/jansav
- Revert accidental breaking change (**[#5703](https://github.com/lensapp/lens/pull/5703)**) https://github.com/jansav

## 🧰 Maintenance

- Bump playwright from 1.22.2 to 1.23.0 (**[#5748](https://github.com/lensapp/lens/pull/5748)**) https://github.com/dependabot
- Bump typedoc from 0.22.17 to 0.23.2 (**[#5746](https://github.com/lensapp/lens/pull/5746)**) https://github.com/dependabot
- Bump nodemon from 2.0.16 to 2.0.18 (**[#5745](https://github.com/lensapp/lens/pull/5745)**) https://github.com/dependabot
- Bump mobx from 6.6.0 to 6.6.1 (**[#5744](https://github.com/lensapp/lens/pull/5744)**) https://github.com/dependabot
- Bump @types/jest from 28.1.1 to 28.1.3 (**[#5734](https://github.com/lensapp/lens/pull/5734)**) https://github.com/dependabot
- Bump winston from 3.7.2 to 3.8.0 (**[#5733](https://github.com/lensapp/lens/pull/5733)**) https://github.com/dependabot
- Bump sharp from 0.30.6 to 0.30.7 (**[#5732](https://github.com/lensapp/lens/pull/5732)**) https://github.com/dependabot
- Bump type-fest from 2.13.1 to 2.14.0 (**[#5726](https://github.com/lensapp/lens/pull/5726)**) https://github.com/dependabot
- Bump sass from 1.52.3 to 1.53.0 (**[#5721](https://github.com/lensapp/lens/pull/5721)**) https://github.com/dependabot
- Bump eslint-plugin-react from 7.30.0 to 7.30.1 (**[#5720](https://github.com/lensapp/lens/pull/5720)**) https://github.com/dependabot
- Bump electron-builder from 23.0.3 to 23.1.0 (**[#5719](https://github.com/lensapp/lens/pull/5719)**) https://github.com/dependabot
- Bump esbuild from 0.14.43 to 0.14.47 (**[#5718](https://github.com/lensapp/lens/pull/5718)**) https://github.com/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.28.0 to 5.29.0 (**[#5710](https://github.com/lensapp/lens/pull/5710)**) https://github.com/dependabot
- Bump ts-loader from 9.3.0 to 9.3.1 (**[#5709](https://github.com/lensapp/lens/pull/5709)**) https://github.com/dependabot
- Bump @typescript-eslint/parser from 5.28.0 to 5.29.0 (**[#5708](https://github.com/lensapp/lens/pull/5708)**) https://github.com/dependabot
- Bump eslint from 8.17.0 to 8.18.0 (**[#5696](https://github.com/lensapp/lens/pull/5696)**) https://github.com/dependabot
- Bump tailwindcss from 3.1.3 to 3.1.4 (**[#5694](https://github.com/lensapp/lens/pull/5694)**) https://github.com/dependabot
- Bump @types/semver from 7.3.9 to 7.3.10 (**[#5693](https://github.com/lensapp/lens/pull/5693)**) https://github.com/dependabot
- Reenable generating of .js files for extension api package (**[#5431](https://github.com/lensapp/lens/pull/5431)**) https://github.com/Nokel81
