### PR TITLE
Align hotbar selector elements with status bar items

### DIFF
--- a/src/renderer/components/hotbar/hotbar-selector.module.scss
+++ b/src/renderer/components/hotbar/hotbar-selector.module.scss
@@ -6,9 +6,10 @@
 .HotbarSelector {
   display: flex;
   align-items: center;
-  height: 26px;
+  height: 25px;
   background-color: var(--layoutBackground);
   position: relative;
+  justify-content: center;
 
   &:before {
     content: " ";
@@ -21,8 +22,7 @@
 
   .HotbarIndex {
     display: flex;
-    flex-grow: 1;
-    align-items: center;
+    width: 3ch;
   }
 
   .Badge {
@@ -30,21 +30,17 @@
     background: var(--secondaryBackground);
     width: 100%;
     color: var(--settingsColor);
-    padding-top: 3px;
+    padding: 0px calc(var(--padding) / 2);
   }
 
   .Icon {
-    --size: 16px;
-    padding: 0 4px 0 0px;
-    margin: 0px 4px;
-
     &:hover {
       box-shadow: none;
       background-color: transparent;
     }
 
-    &.previous {
-      transform: rotateY(180deg);
+    &:focus-visible {
+      z-index: 1;
     }
   }
 }

--- a/src/renderer/components/hotbar/hotbar-selector.tsx
+++ b/src/renderer/components/hotbar/hotbar-selector.tsx
@@ -58,7 +58,7 @@ const NonInjectedHotbarSelector = observer(({ hotbar, hotbarStore, openCommandOv
   return (
     <div className={styles.HotbarSelector}>
       <Icon
-        material="play_arrow"
+        material="arrow_left"
         className={cssNames(styles.Icon, styles.previous)}
         onClick={onPrevClick}/>
       <div className={styles.HotbarIndex}>
@@ -80,7 +80,7 @@ const NonInjectedHotbarSelector = observer(({ hotbar, hotbarStore, openCommandOv
         </Tooltip>
       </div>
       <Icon
-        material="play_arrow"
+        material="arrow_right"
         className={styles.Icon}
         onClick={onNextClick}
       />

--- a/src/renderer/components/status-bar/status-bar.module.scss
+++ b/src/renderer/components/status-bar/status-bar.module.scss
@@ -19,17 +19,19 @@
 .leftSide {
   display: flex;
   align-items: center;
+  padding-inline-start: calc(var(--padding) / 2);
 }
 
 .rightSide {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  padding-inline-end: calc(var(--padding) / 2);
 }
 
 .item {
   height: 100%;
-  padding: 0 4px;
+  padding-inline: calc(var(--padding) / 4);
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
Before:
![misaligned status bar items](https://user-images.githubusercontent.com/9607060/176401692-d15e5809-ee2f-4c83-848a-933136789e31.png)

After:

![good aligned status bar items](https://user-images.githubusercontent.com/9607060/176401792-bfc3871b-59f4-472b-8e5f-959712c20e46.png)
![status bar light](https://user-images.githubusercontent.com/9607060/176401796-634efd51-c094-4aa4-a56f-bf7aacfbd75c.png)



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>