### PR TITLE
supply github workflow for generating openlens release files.

### DIFF
--- a/.github/workflows/build-openlens-binaries-release.yml
+++ b/.github/workflows/build-openlens-binaries-release.yml
@@ -1,0 +1,97 @@
+name: Build OpenLens (release)
+
+on:
+  release:
+    types:
+      - published
+          
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]        
+        node-version: [16.x]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+    
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+        
+      - name: Export version to variable
+        run: |
+            export VERSION_STRING=$(cat package.json | jq '.version' -r | xargs printf "%s")
+            echo "VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
+        shell: bash
+        
+      - uses: actions/setup-node@v3        
+        with:
+          node-version: ${{ matrix.node-version }}
+          
+      - name: Build Lens
+        run: |
+          mkdir releasefiles
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            choco install visualstudio2019buildtools visualstudio2019-workload-vctools
+          fi
+          make build
+          if [ "$RUNNER_OS" == "macOS" ]; then
+                ls -la dist
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.dmg releasefiles/OpenLens-${{ env.VERSION_STRING }}.dmg
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.zip releasefiles/OpenLens-${{ env.VERSION_STRING }}.zip
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+                ls -la dist
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.x86_64.AppImage releasefiles/OpenLens-${{ env.VERSION_STRING }}.AppImage
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.amd64.deb releasefiles/OpenLens-${{ env.VERSION_STRING }}.deb
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.x86_64.rpm releasefiles/OpenLens-${{ env.VERSION_STRING }}.rpm
+          else
+                cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.VERSION_STRING }}.exe
+          fi
+        shell: bash
+        working-directory: .
+        
+      - name: Calculate SHA256 checksum
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            certutil -hashfile OpenLens-${{ env.VERSION_STRING }}.exe SHA256 > OpenLens-${{ env.VERSION_STRING }}.exe.sha256
+          else
+            for filename in OpenLens-${{ env.VERSION_STRING }}.*; do shasum -a 256 ${filename} > ${filename}.sha256 ; done
+          fi
+        shell: bash
+        working-directory: releasefiles
+        
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          tag_name: v${{ env.VERSION_STRING }}
+          files: | 
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.dmg
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.AppImage
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.deb
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.rpm
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.zip
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.exe
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.*.sha256
+              
+      - name: Clean latest tag
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ github.token }}
+          tag: Latest
+          fail-if-no-assets: false
+          fail-if-no-release: false
+          assets: | 
+            *.*
+      
+      - name: Release Latest
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          tag_name: Latest
+          files: | 
+              dist/OpenLens*.dmg
+              dist/OpenLens*.AppImage
+              dist/OpenLens*.deb
+              dist/OpenLens*.rpm
+              dist/OpenLens*.exe
+              dist/OpenLens*.zip
+              dist/lates*.yml

--- a/.github/workflows/build-openlens-binaries-stable.yml
+++ b/.github/workflows/build-openlens-binaries-stable.yml
@@ -1,0 +1,74 @@
+name: Build OpenLens (stable)
+
+on:
+  push:
+    branches:
+      - master
+          
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]        
+        node-version: [16.x]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+    
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+        
+      - name: Export version to variable
+        run: |
+            export VERSION_STRING=$(cat package.json | jq '.version' -r | xargs printf "%s")
+            echo "VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
+        shell: bash
+        
+      - uses: actions/setup-node@v3        
+        with:
+          node-version: ${{ matrix.node-version }}
+          
+      - name: Build Lens
+        run: |
+          mkdir releasefiles
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            choco install visualstudio2019buildtools visualstudio2019-workload-vctools
+          fi
+          make build
+          if [ "$RUNNER_OS" == "macOS" ]; then
+                ls -la dist
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.dmg releasefiles/OpenLens-${{ env.VERSION_STRING }}.dmg
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.zip releasefiles/OpenLens-${{ env.VERSION_STRING }}.zip
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+                ls -la dist
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.x86_64.AppImage releasefiles/OpenLens-${{ env.VERSION_STRING }}.AppImage
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.amd64.deb releasefiles/OpenLens-${{ env.VERSION_STRING }}.deb
+                cp dist/OpenLens-${{ env.VERSION_STRING }}.*.x86_64.rpm releasefiles/OpenLens-${{ env.VERSION_STRING }}.rpm
+          else
+                cp dist/OpenLens*.exe releasefiles/OpenLens-${{ env.VERSION_STRING }}.exe
+          fi
+        shell: bash
+        working-directory: .
+        
+      - name: Calculate SHA256 checksum
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            certutil -hashfile OpenLens-${{ env.VERSION_STRING }}.exe SHA256 > OpenLens-${{ env.VERSION_STRING }}.exe.sha256
+          else
+            for filename in OpenLens-${{ env.VERSION_STRING }}.*; do shasum -a 256 ${filename} > ${filename}.sha256 ; done
+          fi
+        shell: bash
+        working-directory: releasefiles
+        
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          tag_name: v${{ env.VERSION_STRING }}
+          files: | 
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.dmg
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.AppImage
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.deb
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.rpm
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.zip
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.exe
+              releasefiles/OpenLens-${{ env.VERSION_STRING }}.*.sha256

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
     "runtime": "@side/jest-runtime"
   },
   "build": {
+    "publish": {
+      "url": "https://github.com/lensapp/lens/releases/download/Latest",
+      "provider": "generic"
+    },
     "generateUpdatesFilesForAllChannels": true,
     "files": [
       "static/build/main.js"


### PR DESCRIPTION
The workflows contain the ideas of [@ykursadkaya](https://github.com/ykursadkaya/homebrew-openlens) and [@MuhammedKalkan](https://github.com/MuhammedKalkan/OpenLens). I also peeked at the existing workflows [publish-master-npm](https://github.com/lensapp/lens/blob/master/.github/workflows/publish-master-npm.yml#L2-L5) and [publish-release-npm](https://github.com/lensapp/lens/blob/master/.github/workflows/publish-release-npm.yml#L2-L5)

#### what does this PR do?
- checkout
- build packages for windows, mac and ubuntu
- calculate SHA256 
- push to /releases subsite
- if type: release: update /releases/latest

#### what does this PR not do?
- it does no code signing since this is an open source and not proprietary software
- it doesn't do any tests since this does not affect the source code.
- it does not include any additional code or proprietary plugins
- it does not introduce an EULA that is not part of this repo.

#### what does this solve?
- the mess created with issue https://github.com/lensapp/lens/issues/5444
- it automatically creates binary files for the OpenLens project and links these to the release page.
- it provides a pre-compiled community FOSS alternative to the enterprise version that can be downloaded on https://k8slens.dev/
- it supply a pull request to continue more productive discussions

#### limitations:
- although build process for windows, ubuntu and mac succeeds, I was only able to verify the ubuntu version since I lack the necessary hardware. The low number of issues and problems reported with the repository of [@MuhammedKalkan](https://github.com/MuhammedKalkan/OpenLens) indicate that this is not a proplem.
- I successfully tested functionality of the workflows in [my repository on wip branch](https://github.com/PhilippKuntschik/lens/tree/wip). But: I was not able to fully understand when the release-type event is called so that [on release type: published](https://github.com/PhilippKuntschik/lens/blob/wip/.github/workflows/build-openlens-binaries-release.yml#L3-L6) is triggered. I just copied the trigger from the workflows existing in this repository.