### PR TITLE
Remove old workaround to append clusterUrl in resolveAuthProxyUrl()

### DIFF
--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -131,9 +131,8 @@ export class ContextHandler implements ClusterContextHandler {
 
   async resolveAuthProxyUrl(): Promise<string> {
     const kubeAuthProxy = await this.ensureServerHelper();
-    const path = this.clusterUrl.path !== "/" ? this.clusterUrl.path : "";
 
-    return `https://127.0.0.1:${kubeAuthProxy.port}${kubeAuthProxy.apiPrefix}${path}`;
+    return `https://127.0.0.1:${kubeAuthProxy.port}${kubeAuthProxy.apiPrefix}`;
   }
 
   resolveAuthProxyCa() {


### PR DESCRIPTION
A similar code fragment was removed in #5550. It's not clear why this code was needed. @jakolehm can you confirm if this is part of the same workaround that is no longer needed? (as stated here: https://github.com/lensapp/lens/pull/5550#pullrequestreview-998752200)

fixes #5663
also may fix #5658 and fix #5628

Before this fix this was the kind of pathname going through the auth proxy:
```
/a412d1bafa4a0722/k8s/clusters/local/api/v1/namespaces/default/pods/nginx-deployment-9456bbbf9-6fc7k/portforward
```
The clusterUrl, `k8s/clusters/local` being extraneous and causing a Bad Gateway response.

~~needs more testing to confirm it doesn't cause regression~~ tried local, spaces, aws clusters, no issues. Others should test...