### PR TITLE
Fix styles for topbar window buttons on linux

### DIFF
--- a/src/renderer/components/layout/top-bar/top-bar.module.scss
+++ b/src/renderer/components/layout/top-bar/top-bar.module.scss
@@ -79,10 +79,10 @@
 
   &.linuxButtons {
     > div {
-      width: 16px;
-      height: 16px;
+      width: 18px;
+      height: 18px;
       border-radius: 50%;
-      margin-right: calc(var(--padding) * -1.5);
+      margin-right: var(--padding);
       color: var(--textColorAccent);
 
       svg {


### PR DESCRIPTION

<img width="421" alt="linux window buttons" src="https://user-images.githubusercontent.com/9607060/180400991-f08c5b08-db61-4d3f-ad81-8a1f24c3f198.png">

Fixes #5836

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>