### PR TITLE
Fix edit kube resource tab not respecting changes to current draft

### DIFF
--- a/src/renderer/components/dock/edit-resource/view.tsx
+++ b/src/renderer/components/dock/edit-resource/view.tsx
@@ -154,7 +154,7 @@ class NonInjectedEditResource extends React.Component<EditResourceProps & Depend
           value={draft}
           onChange={draft => {
             this.error = "";
-            tabData.draft = draft;
+            this.draft = tabData.draft = draft;
           }}
           onError={error => this.error = String(error)}
         />


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

Fixes https://github.com/lensapp/lens/issues/5876
closes https://github.com/lensapp/lens/pull/5877