### PR TITLE
Revert "Bump type-fest from 2.14.0 to 2.17.0 (#5864)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     "tar-stream": "^2.2.0",
     "ts-loader": "^9.3.1",
     "ts-node": "^10.8.1",
-    "type-fest": "^2.17.0",
+    "type-fest": "^2.14.0",
     "typed-emitter": "^1.4.0",
     "typedoc": "0.23.8",
     "typedoc-plugin-markdown": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12613,10 +12613,10 @@ type-fest@^1.0.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-fest@^2.12.2, type-fest@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
-  integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
+type-fest@^2.12.2, type-fest@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.14.0.tgz#f990e19169517d689c98e16d128b231022b27e12"
+  integrity sha512-hQnTQkFjL5ik6HF2fTAM8ycbr94UbQXK364wF930VHb0dfBJ5JBP8qwrR8TaK9zwUEk7meruo2JAUDMwvuxd/w==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
This reverts commit be9ed13e089f6ed39b50101ad4f7f2b0e21e97cc.