### PR TITLE
release 6.0.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "5.6.0-alpha.7",
+  "version": "6.0.0-alpha.0",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",

--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -83,7 +83,6 @@ if (basename(process.cwd()) === "scripts") {
 
 
 const currentVersion = new SemVer(readJsonSync("./package.json").version);
-const currentVersionMilestone = `${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch}`;
 
 console.log(`current version: ${currentVersion.format()}`);
 console.log("fetching tags...");
@@ -111,6 +110,9 @@ npmVersionArgs.push("--git-tag-version false");
 execSync(npmVersionArgs.join(" "), { stdio: "ignore" });
 
 const newVersion = new SemVer(readJsonSync("./package.json").version);
+const newVersionMilestone = `${newVersion.major}.${newVersion.minor}.${newVersion.patch}`;
+
+console.log(`new version: ${newVersion.format()}`);
 
 const getMergedPrsArgs = [
   "gh",
@@ -124,7 +126,7 @@ const getMergedPrsArgs = [
 
 console.log("retreiving last 500 PRs to create release PR body...");
 const mergedPrs = JSON.parse(execSync(getMergedPrsArgs.join(" "), { encoding: "utf-8" }));
-const milestoneRelevantPrs = mergedPrs.filter(pr => pr.milestone && pr.milestone.title === currentVersionMilestone);
+const milestoneRelevantPrs = mergedPrs.filter(pr => pr.milestone?.title === newVersionMilestone);
 const relaventPrsQuery = await Promise.all(
   milestoneRelevantPrs.map(async pr => ({
     pr,


### PR DESCRIPTION
## Changes since 5.6.0-alpha.7

## 🚀 Features

- feat: New view for PriorityClasses under Config menu (**[#5816](https://github.com/lensapp/lens/pull/5816)**) https://github.com/dex4er

## 🐛 Bug Fixes

- use intended(?) node-pty version (**[#5880](https://github.com/lensapp/lens/pull/5880)**) https://github.com/jim-docker
- Fix edit kube resource tab not respecting changes to current draft (**[#5878](https://github.com/lensapp/lens/pull/5878)**) https://github.com/Nokel81
- Add guards to prevent activation errors slipping through (**[#5845](https://github.com/lensapp/lens/pull/5845)**) https://github.com/Nokel81
- Fix installation of helm charts (**[#5841](https://github.com/lensapp/lens/pull/5841)**) https://github.com/jansav
- Remove old workaround to append clusterUrl in resolveAuthProxyUrl() (**[#5833](https://github.com/lensapp/lens/pull/5833)**) https://github.com/jim-docker
- Fix open CommandDialog (**[#5818](https://github.com/lensapp/lens/pull/5818)**) https://github.com/Nokel81
- Fix terminal fit errors (**[#5811](https://github.com/lensapp/lens/pull/5811)**) https://github.com/Nokel81

## 🧰 Maintenance

- Revert "Bump type-fest from 2.14.0 to 2.17.0 (#5864)" (**[#5882](https://github.com/lensapp/lens/pull/5882)**) https://github.com/Nokel81
- Bump marked from 4.0.17 to 4.0.18 (**[#5869](https://github.com/lensapp/lens/pull/5869)**) https://github.com/dependabot
- Bump jest-mock-extended from 2.0.6 to 2.0.7 (**[#5866](https://github.com/lensapp/lens/pull/5866)**) https://github.com/dependabot
- Bump concurrently from 7.2.2 to 7.3.0 (**[#5865](https://github.com/lensapp/lens/pull/5865)**) https://github.com/dependabot
- Bump type-fest from 2.14.0 to 2.17.0 (**[#5864](https://github.com/lensapp/lens/pull/5864)**) https://github.com/dependabot
- Bump mobx-react from 7.5.1 to 7.5.2 (**[#5861](https://github.com/lensapp/lens/pull/5861)**) https://github.com/dependabot
- Bump terser from 5.13.1 to 5.14.2 (**[#5860](https://github.com/lensapp/lens/pull/5860)**) https://github.com/dependabot
- Bump typedoc from 0.23.6 to 0.23.8 (**[#5858](https://github.com/lensapp/lens/pull/5858)**) https://github.com/dependabot
- Bump react-refresh from 0.13.0 to 0.14.0 (**[#5857](https://github.com/lensapp/lens/pull/5857)**) https://github.com/dependabot
- Bump @swc/jest from 0.2.21 to 0.2.22 (**[#5856](https://github.com/lensapp/lens/pull/5856)**) https://github.com/dependabot
- Bump jest-environment-jsdom from 28.1.2 to 28.1.3 (**[#5853](https://github.com/lensapp/lens/pull/5853)**) https://github.com/dependabot
- Bump eslint from 8.19.0 to 8.20.0 (**[#5848](https://github.com/lensapp/lens/pull/5848)**) https://github.com/dependabot
- Bump react-refresh-typescript from 2.0.5 to 2.0.7 (**[#5847](https://github.com/lensapp/lens/pull/5847)**) https://github.com/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.29.0 to 5.30.7 (**[#5846](https://github.com/lensapp/lens/pull/5846)**) https://github.com/dependabot
- Bump @swc/core from 1.2.210 to 1.2.218 (**[#5843](https://github.com/lensapp/lens/pull/5843)**) https://github.com/dependabot
- Bump tailwindcss from 3.1.5 to 3.1.6 (**[#5842](https://github.com/lensapp/lens/pull/5842)**) https://github.com/dependabot
- Do not show Version on welcome screen (**[#5840](https://github.com/lensapp/lens/pull/5840)**) https://github.com/msa0311
- Bump playwright from 1.23.1 to 1.23.4 (**[#5839](https://github.com/lensapp/lens/pull/5839)**) https://github.com/dependabot
- Bump esbuild from 0.14.48 to 0.14.49 (**[#5823](https://github.com/lensapp/lens/pull/5823)**) https://github.com/dependabot
- Bump nodemon from 2.0.18 to 2.0.19 (**[#5822](https://github.com/lensapp/lens/pull/5822)**) https://github.com/dependabot
