### PR TITLE
Autofocus port field in port-forward-dialog

### DIFF
--- a/src/renderer/port-forward/port-forward-dialog.tsx
+++ b/src/renderer/port-forward/port-forward-dialog.tsx
@@ -127,6 +127,7 @@ class NonInjectedPortForwardDialog extends Component<PortForwardDialogProps & De
                 value={this.desiredPort === 0 ? "" : String(this.desiredPort)}
                 placeholder={"Random"}
                 onChange={this.changePort}
+                autoFocus
               />
             </div>
             <Checkbox


### PR DESCRIPTION
Added and tested setting the focus on the port field when the port-forward dialog opens to improve the convenience / user experience and speed of working with Lens.