### PR TITLE
Set focus on port field when port-forward-dialog opens

### DIFF
--- a/src/renderer/port-forward/port-forward-dialog.tsx
+++ b/src/renderer/port-forward/port-forward-dialog.tsx
@@ -127,6 +127,7 @@ class NonInjectedPortForwardDialog extends Component<PortForwardDialogProps & De
                 value={this.desiredPort === 0 ? "" : String(this.desiredPort)}
                 placeholder={"Random"}
                 onChange={this.changePort}
+                autoFocus
               />
             </div>
             <Checkbox


### PR DESCRIPTION
This makes the the port-forward-dialog more convenient to use.

Signed-off-by: Stefan Woehrer <stefan.woehrer@lean-coders.at>