### PR TITLE
Fix PersistentVolumeClaims->StorageClass link details being blank

### DIFF
--- a/src/renderer/components/+storage-classes/storage-class-details.tsx
+++ b/src/renderer/components/+storage-classes/storage-class-details.tsx
@@ -38,6 +38,7 @@ class NonInjectedStorageClassDetails extends React.Component<StorageClassDetails
     disposeOnUnmount(this, [
       this.props.subscribeStores([
         this.props.persistentVolumeStore,
+        this.props.storageClassStore,
       ]),
     ]);
   }


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/5903