### PR TITLE
Fix Badge.props.expandable's default being switched to false 

### DIFF
--- a/src/renderer/components/badge/badge.tsx
+++ b/src/renderer/components/badge/badge.tsx
@@ -33,7 +33,7 @@ export const Badge = withTooltip(observer(({
   small,
   flat,
   label,
-  expandable = false,
+  expandable = true,
   disabled,
   scrollable,
   className,


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/5894