### PR TITLE
Fix IPv6 missing brackets in httpProxy.ServerOptions

### DIFF
--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -155,10 +155,12 @@ export class ContextHandler implements ClusterContextHandler {
 
     if (this.clusterUrl.hostname) {
       headers.Host = this.clusterUrl.hostname;
-    }
 
-    if (headers.Host.includes(":")) {
-      headers.Host = "[" + headers.Host + "]";
+      // fix current IPv6 inconsistency in url.Parse() and httpProxy.
+      // with url.Parse the IPv6 Hostname has no Square brackets but httpProxy needs the Square brackets to work.
+      if (headers.Host.includes(":")) {
+        headers.Host = `[${headers.Host}]`;
+      }
     }
 
     return {

--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -157,6 +157,10 @@ export class ContextHandler implements ClusterContextHandler {
       headers.Host = this.clusterUrl.hostname;
     }
 
+    if (headers.Host.includes(":")) {
+      headers.Host = "[" + headers.Host + "]";
+    }
+
     return {
       target: {
         protocol: "https:",


### PR DESCRIPTION
This pull request should fix: #5743
Signed-off-by: dominic_dl <me@dominic.link>