### PR TITLE
revert node-pty to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "monaco-editor": "^0.29.1",
     "monaco-editor-webpack-plugin": "^5.0.0",
     "node-fetch": "lensapp/node-fetch#2.x",
-    "node-pty": "0.11.0-beta19",
+    "node-pty": "0.10.1",
     "npm": "^6.14.17",
     "p-limit": "^3.1.0",
     "path-to-regexp": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9469,10 +9469,10 @@ node-loader@^2.0.0:
   dependencies:
     loader-utils "^2.0.0"
 
-node-pty@0.11.0-beta19:
-  version "0.11.0-beta19"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta19.tgz#cb09fcd2ac984365af7f770df900fc0c8c587dcd"
-  integrity sha512-1cdUx15rCVYEcvOvqNRO4S52vYM9mnFyTAceut+lW8/+YWcYQl1TQ3naDqtWHDcVjZI/FbDX1j4iQFwypmJSLQ==
+node-pty@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.1.tgz#cd05d03a2710315ec40221232ec04186f6ac2c6d"
+  integrity sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==
   dependencies:
     nan "^2.14.0"
 


### PR DESCRIPTION
fixes https://github.com/lensapp/lens/issues/5835

@jakolehm said of node-pty that the "current stable version does not work with newer Electron versions"(https://github.com/lensapp/lens/pull/5562#issue-1261575055) but it appears to work on windows, linux, and macos (maybe because node-gyp was bumped [here](https://github.com/lensapp/lens/pull/5880)?)

This needs to be tested...