### PR TITLE
Replace individual mocks for withTooltip with global mock

### DIFF
--- a/src/behaviours/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
+++ b/src/behaviours/add-cluster/__snapshots__/navigation-using-application-menu.test.tsx.snap
@@ -288,7 +288,11 @@ exports[`add-cluster - navigation using application menu when navigating to add 
             </p>
             <div
               class="flex column"
-            />
+            >
+              <textarea
+                data-testid="monaco-editor-for-undefined"
+              />
+            </div>
             <div
               class="actions-panel"
             >
@@ -299,6 +303,7 @@ exports[`add-cluster - navigation using application menu when navigating to add 
               >
                 Add clusters
               </button>
+              <div />
             </div>
           </div>
           <div

--- a/src/behaviours/add-cluster/navigation-using-application-menu.test.tsx
+++ b/src/behaviours/add-cluster/navigation-using-application-menu.test.tsx
@@ -6,16 +6,6 @@
 import type { RenderResult } from "@testing-library/react";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
-import React from "react";
-
-// TODO: Make components free of side effects by making them deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (Target: any) => ({ tooltip, tooltipOverrideDisabled, ...props }: any) => <Target {...props} />,
-}));
-
-jest.mock("../../renderer/components/monaco-editor/monaco-editor", () => ({
-  MonacoEditor: () => null,
-}));
 
 describe("add-cluster - navigation using application menu", () => {
   let applicationBuilder: ApplicationBuilder;

--- a/src/behaviours/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
+++ b/src/behaviours/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
@@ -503,7 +503,6 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_14"
                         tabindex="0"
                       >
                         <span
@@ -512,8 +511,10 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -537,12 +538,13 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_16"
               tabindex="0"
             >
               <span
@@ -551,11 +553,12 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_17"
               tabindex="0"
             >
               <span
@@ -564,8 +567,10 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1135,7 +1140,6 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_52"
                         tabindex="0"
                       >
                         <span
@@ -1144,8 +1148,10 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1169,12 +1175,13 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_54"
               tabindex="0"
             >
               <span
@@ -1183,11 +1190,12 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_55"
               tabindex="0"
             >
               <span
@@ -1196,8 +1204,10 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>

--- a/src/behaviours/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
+++ b/src/behaviours/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
@@ -472,7 +472,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_177"
                         tabindex="0"
                       >
                         <span
@@ -481,8 +480,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -506,12 +507,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_179"
               tabindex="0"
             >
               <span
@@ -520,11 +522,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_180"
               tabindex="0"
             >
               <span
@@ -533,8 +536,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1015,7 +1020,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_215"
                         tabindex="0"
                       >
                         <span
@@ -1024,8 +1028,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1049,12 +1055,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_217"
               tabindex="0"
             >
               <span
@@ -1063,11 +1070,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_218"
               tabindex="0"
             >
               <span
@@ -1076,8 +1084,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1580,7 +1590,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_272"
                         tabindex="0"
                       >
                         <span
@@ -1589,8 +1598,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1614,12 +1625,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_274"
               tabindex="0"
             >
               <span
@@ -1628,11 +1640,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_275"
               tabindex="0"
             >
               <span
@@ -1641,8 +1654,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -2026,7 +2041,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_332"
                         tabindex="0"
                       >
                         <span
@@ -2035,8 +2049,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2060,12 +2076,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_334"
               tabindex="0"
             >
               <span
@@ -2074,11 +2091,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_335"
               tabindex="0"
             >
               <span
@@ -2087,8 +2105,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -2449,7 +2469,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_14"
                         tabindex="0"
                       >
                         <span
@@ -2458,8 +2477,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2483,12 +2504,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_16"
               tabindex="0"
             >
               <span
@@ -2497,11 +2519,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_17"
               tabindex="0"
             >
               <span
@@ -2510,8 +2533,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -3014,7 +3039,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_82"
                         tabindex="0"
                       >
                         <span
@@ -3023,8 +3047,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3048,12 +3074,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_84"
               tabindex="0"
             >
               <span
@@ -3062,11 +3089,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_85"
               tabindex="0"
             >
               <span
@@ -3075,8 +3103,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -3557,7 +3587,6 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_139"
                         tabindex="0"
                       >
                         <span
@@ -3566,8 +3595,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3591,12 +3622,13 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_141"
               tabindex="0"
             >
               <span
@@ -3605,11 +3637,12 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_142"
               tabindex="0"
             >
               <span
@@ -3618,8 +3651,10 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>

--- a/src/behaviours/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
+++ b/src/behaviours/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
@@ -473,7 +473,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -482,6 +481,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -498,7 +500,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -507,11 +508,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -520,10 +523,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -532,6 +537,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1013,7 +1021,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -1022,6 +1029,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1038,7 +1048,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -1047,11 +1056,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -1060,10 +1071,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -1072,6 +1085,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1593,7 +1609,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -1602,6 +1617,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1618,7 +1636,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -1627,11 +1644,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -1640,10 +1659,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -1652,6 +1673,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -2093,7 +2117,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -2102,6 +2125,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2118,7 +2144,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -2127,11 +2152,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -2140,10 +2167,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -2152,6 +2181,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -2593,7 +2625,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -2602,6 +2633,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2618,7 +2652,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -2627,11 +2660,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -2640,10 +2675,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -2652,6 +2689,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -3052,7 +3092,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -3061,6 +3100,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3077,7 +3119,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -3086,11 +3127,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -3099,10 +3142,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -3111,6 +3156,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -3632,7 +3680,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -3641,6 +3688,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -3657,7 +3707,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -3666,11 +3715,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -3679,10 +3730,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -3691,6 +3744,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -4172,7 +4228,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                       <i
                         class="Icon material interactive focusable small"
                         tabindex="0"
-                        tooltip="Close ⌘+W"
                       >
                         <span
                           class="icon"
@@ -4181,6 +4236,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                           close
                         </span>
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -4197,7 +4255,6 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 class="Icon new-dock-tab material interactive focusable"
                 id="menu-actions-for-dock"
                 tabindex="0"
-                tooltip="New tab"
               >
                 <span
                   class="icon"
@@ -4206,11 +4263,13 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                   add
                 </span>
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Fit to window"
             >
               <span
                 class="icon"
@@ -4219,10 +4278,12 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 fullscreen
               </span>
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Open"
             >
               <span
                 class="icon"
@@ -4231,6 +4292,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 keyboard_arrow_up
               </span>
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>

--- a/src/behaviours/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
+++ b/src/behaviours/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
@@ -442,7 +442,6 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_13"
                         tabindex="0"
                       >
                         <span
@@ -451,8 +450,10 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -476,12 +477,13 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_15"
               tabindex="0"
             >
               <span
@@ -490,11 +492,12 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_16"
               tabindex="0"
             >
               <span
@@ -503,8 +506,10 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -999,7 +1004,6 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_49"
                         tabindex="0"
                       >
                         <span
@@ -1008,8 +1012,10 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1033,12 +1039,13 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_51"
               tabindex="0"
             >
               <span
@@ -1047,11 +1054,12 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_52"
               tabindex="0"
             >
               <span
@@ -1060,8 +1068,10 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>

--- a/src/behaviours/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
@@ -324,7 +324,6 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_129"
                           tabindex="0"
                         >
                           <span
@@ -333,8 +332,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -358,12 +359,13 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_131"
                 tabindex="0"
               >
                 <span
@@ -372,11 +374,12 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_132"
                 tabindex="0"
               >
                 <span
@@ -385,8 +388,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -839,7 +844,6 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_71"
                           tabindex="0"
                         >
                           <span
@@ -848,8 +852,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -873,12 +879,13 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_73"
                 tabindex="0"
               >
                 <span
@@ -887,11 +894,12 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_74"
                 tabindex="0"
               >
                 <span
@@ -900,8 +908,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1354,7 +1364,6 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1363,8 +1372,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1388,12 +1399,13 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1402,11 +1414,12 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1415,8 +1428,10 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -463,7 +463,6 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_129"
                           tabindex="0"
                         >
                           <span
@@ -472,8 +471,10 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -497,12 +498,13 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_131"
                 tabindex="0"
               >
                 <span
@@ -511,11 +513,12 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_132"
                 tabindex="0"
               >
                 <span
@@ -524,8 +527,10 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -978,7 +983,6 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_71"
                           tabindex="0"
                         >
                           <span
@@ -987,8 +991,10 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1012,12 +1018,13 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_73"
                 tabindex="0"
               >
                 <span
@@ -1026,11 +1033,12 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_74"
                 tabindex="0"
               >
                 <span
@@ -1039,8 +1047,10 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1493,7 +1503,6 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1502,8 +1511,10 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1527,12 +1538,13 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1541,11 +1553,12 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1554,8 +1567,10 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -281,7 +281,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 some-kind: some-name
                 <i
                   class="Icon material interactive focusable"
-                  id="tooltip_target_161"
                   tabindex="0"
                 >
                   <span
@@ -290,8 +289,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   >
                     content_copy
                   </span>
-                  <div />
                 </i>
+                <div>
+                  Copy
+                </div>
               </div>
               <ul
                 class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
@@ -299,7 +300,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               />
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_162"
                 tabindex="0"
               >
                 <span
@@ -308,8 +308,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   close
                 </span>
-                <div />
               </i>
+              <div>
+                Close
+              </div>
             </div>
             <div
               class="drawer-content flex column box grow"
@@ -379,7 +381,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_153"
                           tabindex="0"
                         >
                           <span
@@ -388,8 +389,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -413,12 +416,13 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_155"
                 tabindex="0"
               >
                 <span
@@ -427,11 +431,12 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_156"
                 tabindex="0"
               >
                 <span
@@ -440,8 +445,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -732,7 +739,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 some-kind: some-name
                 <i
                   class="Icon material interactive focusable"
-                  id="tooltip_target_91"
                   tabindex="0"
                 >
                   <span
@@ -741,8 +747,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   >
                     content_copy
                   </span>
-                  <div />
                 </i>
+                <div>
+                  Copy
+                </div>
               </div>
               <ul
                 class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
@@ -750,7 +758,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               />
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_92"
                 tabindex="0"
               >
                 <span
@@ -759,8 +766,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   close
                 </span>
-                <div />
               </i>
+              <div>
+                Close
+              </div>
             </div>
             <div
               class="drawer-content flex column box grow"
@@ -868,7 +877,6 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_83"
                           tabindex="0"
                         >
                           <span
@@ -877,8 +885,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -902,12 +912,13 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_85"
                 tabindex="0"
               >
                 <span
@@ -916,11 +927,12 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_86"
                 tabindex="0"
               >
                 <span
@@ -929,8 +941,10 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1221,7 +1235,6 @@ exports[`disable kube object detail items when cluster is not relevant given not
                 some-kind: some-name
                 <i
                   class="Icon material interactive focusable"
-                  id="tooltip_target_21"
                   tabindex="0"
                 >
                   <span
@@ -1230,8 +1243,10 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   >
                     content_copy
                   </span>
-                  <div />
                 </i>
+                <div>
+                  Copy
+                </div>
               </div>
               <ul
                 class="Menu MenuActions flex KubeObjectMenu toolbar gaps right bottom"
@@ -1239,7 +1254,6 @@ exports[`disable kube object detail items when cluster is not relevant given not
               />
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_22"
                 tabindex="0"
               >
                 <span
@@ -1248,8 +1262,10 @@ exports[`disable kube object detail items when cluster is not relevant given not
                 >
                   close
                 </span>
-                <div />
               </i>
+              <div>
+                Close
+              </div>
             </div>
             <div
               class="drawer-content flex column box grow"
@@ -1357,7 +1373,6 @@ exports[`disable kube object detail items when cluster is not relevant given not
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1366,8 +1381,10 @@ exports[`disable kube object detail items when cluster is not relevant given not
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1391,12 +1408,13 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1405,11 +1423,12 @@ exports[`disable kube object detail items when cluster is not relevant given not
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1418,8 +1437,10 @@ exports[`disable kube object detail items when cluster is not relevant given not
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -329,7 +329,6 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_137"
                           tabindex="0"
                         >
                           <span
@@ -338,8 +337,10 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -363,12 +364,13 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_139"
                 tabindex="0"
               >
                 <span
@@ -377,11 +379,12 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_140"
                 tabindex="0"
               >
                 <span
@@ -390,8 +393,10 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -724,7 +729,6 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_75"
                           tabindex="0"
                         >
                           <span
@@ -733,8 +737,10 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -758,12 +764,13 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_77"
                 tabindex="0"
               >
                 <span
@@ -772,11 +779,12 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_78"
                 tabindex="0"
               >
                 <span
@@ -785,8 +793,10 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1119,7 +1129,6 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1128,8 +1137,10 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1153,12 +1164,13 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1167,11 +1179,12 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1180,8 +1193,10 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/cluster/kube-object-status-icon/__snapshots__/show-status-for-a-kube-object.test.tsx.snap
+++ b/src/behaviours/cluster/kube-object-status-icon/__snapshots__/show-status-for-a-kube-object.test.tsx.snap
@@ -319,7 +319,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -347,7 +346,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -363,7 +361,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -378,7 +375,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -758,7 +754,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -786,7 +781,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -802,7 +796,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -817,7 +810,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -1197,7 +1189,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1225,7 +1216,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1241,7 +1231,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1256,7 +1245,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -1596,7 +1584,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1624,7 +1611,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1640,7 +1626,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1655,7 +1640,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -1995,7 +1979,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2023,7 +2006,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2039,7 +2021,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -2054,7 +2035,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -2434,7 +2414,6 @@ exports[`show status for a kube object given application starts and in test page
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2462,7 +2441,6 @@ exports[`show status for a kube object given application starts and in test page
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2478,7 +2456,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -2493,7 +2470,6 @@ exports[`show status for a kube object given application starts and in test page
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"

--- a/src/behaviours/cluster/kube-object-status-icon/extension-api/__snapshots__/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/kube-object-status-icon/extension-api/__snapshots__/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx.snap
@@ -268,7 +268,6 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
         <i
           class="Icon KubeObjectStatusIcon error material focusable"
           data-testid="kube-object-status-icon-for-some-uid"
-          id="tooltip_target_156"
         >
           <span
             class="icon"
@@ -276,8 +275,35 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
           >
             error
           </span>
-          <div />
         </i>
+        <div
+          data-testid="tooltip-content-for-kube-object-status-icon-for-some-uid"
+        >
+          <div
+            class="KubeObjectStatusTooltip"
+          >
+            <div
+              class="level error"
+            >
+              <span
+                class="title"
+              >
+                Critical
+              </span>
+              <div
+                class="status msg"
+              >
+                - some-kube-object-status-text 
+                <span
+                  class="age"
+                >
+                   . 
+                  
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="footer"
@@ -332,7 +358,6 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_137"
                           tabindex="0"
                         >
                           <span
@@ -341,8 +366,10 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -366,12 +393,13 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_139"
                 tabindex="0"
               >
                 <span
@@ -380,11 +408,12 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_140"
                 tabindex="0"
               >
                 <span
@@ -393,8 +422,10 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -722,7 +753,6 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_75"
                           tabindex="0"
                         >
                           <span
@@ -731,8 +761,10 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -756,12 +788,13 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_77"
                 tabindex="0"
               >
                 <span
@@ -770,11 +803,12 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_78"
                 tabindex="0"
               >
                 <span
@@ -783,8 +817,10 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1112,7 +1148,6 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1121,8 +1156,10 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1146,12 +1183,13 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1160,11 +1198,12 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1173,8 +1212,10 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/cluster/kube-object-status-icon/show-status-for-a-kube-object.test.tsx
+++ b/src/behaviours/cluster/kube-object-status-icon/show-status-for-a-kube-object.test.tsx
@@ -21,31 +21,6 @@ import { observer } from "mobx-react";
 import { kubeObjectStatusTextInjectionToken } from "../../../renderer/components/kube-object-status-icon/kube-object-status-text-injection-token";
 import { KubeObjectStatusIcon } from "../../../renderer/components/kube-object-status-icon";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip:
-    (Target: any) =>
-      ({ tooltip, ...props }: any) => {
-        if (tooltip) {
-          const testId = props["data-testid"];
-
-          return (
-            <>
-              <Target
-                tooltip={tooltip.children ? undefined : tooltip}
-                {...props}
-              />
-              <div data-testid={testId && `tooltip-content-for-${testId}`}>
-                {tooltip.children || tooltip}
-              </div>
-            </>
-          );
-        }
-
-        return <Target {...props} />;
-      },
-}));
-
 describe("show status for a kube object", () => {
   let builder: ApplicationBuilder;
   let infoStatusIsShown: boolean;

--- a/src/behaviours/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/src/behaviours/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -489,7 +489,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -566,7 +565,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -594,7 +592,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -610,7 +607,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -625,7 +621,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -1145,7 +1140,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -1222,7 +1216,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1250,7 +1243,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1266,7 +1258,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1281,7 +1272,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -1806,7 +1796,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -1883,7 +1872,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1911,7 +1899,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1927,7 +1914,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1942,7 +1928,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -2536,7 +2521,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -2613,7 +2597,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2663,7 +2646,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2691,7 +2673,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2707,7 +2688,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -2722,7 +2702,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -3242,7 +3221,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -3319,7 +3297,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -3369,7 +3346,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -3397,7 +3373,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -3413,7 +3388,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -3428,7 +3402,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -4020,7 +3993,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -4097,7 +4069,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -4147,7 +4118,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -4175,7 +4145,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -4191,7 +4160,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -4206,7 +4174,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -4800,7 +4767,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -4877,7 +4843,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -4905,7 +4870,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -4921,7 +4885,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -4936,7 +4899,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -5001,10 +4963,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   >
                     <i
                       class="Icon material focusable"
-                      tooltip="YAMLException: end of the stream or a document separator is expected (1:1)
-
- 1 | @some-invalid-configuration@
------^"
                     >
                       <span
                         class="icon"
@@ -5548,7 +5506,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -5625,7 +5582,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -5653,7 +5609,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -5669,7 +5624,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -5684,7 +5638,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -6287,7 +6240,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -6364,7 +6316,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -6392,7 +6343,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -6408,7 +6358,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -6423,7 +6372,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -7017,7 +6965,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -7094,7 +7041,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -7122,7 +7068,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -7138,7 +7083,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -7153,7 +7097,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -7747,7 +7690,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -7824,7 +7766,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -7852,7 +7793,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -7868,7 +7808,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -7883,7 +7822,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -8477,7 +8415,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -8531,7 +8468,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -9042,7 +8978,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -9119,7 +9054,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -9147,7 +9081,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -9163,7 +9096,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -9178,7 +9110,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -9781,7 +9712,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -9835,7 +9765,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -10346,7 +10275,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -10400,7 +10328,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -10911,7 +10838,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                 >
                   <button
                     class="Button add-button primary big round"
-                    tooltip="Add Namespace"
                     type="button"
                   >
                     <i
@@ -10988,7 +10914,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -11016,7 +10941,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -11032,7 +10956,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -11047,7 +10970,6 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"

--- a/src/behaviours/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
+++ b/src/behaviours/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
@@ -471,7 +471,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -499,7 +498,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -515,7 +513,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -530,7 +527,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -1032,7 +1028,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1060,7 +1055,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1076,7 +1070,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1091,7 +1084,6 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"

--- a/src/behaviours/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/src/behaviours/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -8,7 +8,6 @@ import { fireEvent } from "@testing-library/react";
 import type { ApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 import navigateToNamespacesInjectable from "../../../common/front-end-routing/routes/cluster/namespaces/navigate-to-namespaces.injectable";
-import React from "react";
 import createEditResourceTabInjectable from "../../../renderer/components/dock/edit-resource/edit-resource-tab.injectable";
 import getRandomIdForEditResourceTabInjectable from "../../../renderer/components/dock/edit-resource/get-random-id-for-edit-resource-tab.injectable";
 import type { AsyncFnMock } from "@async-fn/jest";
@@ -25,30 +24,6 @@ import readJsonFileInjectable from "../../../common/fs/read-json-file.injectable
 import directoryForLensLocalStorageInjectable from "../../../common/directory-for-lens-local-storage/directory-for-lens-local-storage.injectable";
 import hostedClusterIdInjectable from "../../../renderer/cluster-frame-context/hosted-cluster-id.injectable";
 import { controlWhenStoragesAreReady } from "../../../renderer/utils/create-storage/storages-are-ready";
-
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip:
-    (Target: any) =>
-      ({ tooltip, ...props }: any) => {
-        if (tooltip) {
-          const testId = props["data-testid"];
-
-          return (
-            <>
-              <Target
-                tooltip={tooltip.children ? undefined : tooltip}
-                {...props}
-              />
-              <div data-testid={testId && `tooltip-content-for-${testId}`}>
-                {tooltip.children || tooltip}
-              </div>
-            </>
-          );
-        }
-
-        return <Target {...props} />;
-      },
-}));
 
 describe("cluster/namespaces - edit namespace from new tab", () => {
   let builder: ApplicationBuilder;

--- a/src/behaviours/cluster/namespaces/edit-namespace-from-previously-opened-tab.test.tsx
+++ b/src/behaviours/cluster/namespaces/edit-namespace-from-previously-opened-tab.test.tsx
@@ -6,7 +6,6 @@ import type { RenderResult } from "@testing-library/react";
 import { act } from "@testing-library/react";
 import type { ApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../../renderer/components/test-utils/get-application-builder";
-import React from "react";
 import type { AsyncFnMock } from "@async-fn/jest";
 import asyncFn from "@async-fn/jest";
 import type { CallForResource } from "../../../renderer/components/dock/edit-resource/edit-resource-model/call-for-resource/call-for-resource.injectable";
@@ -17,30 +16,6 @@ import { controlWhenStoragesAreReady } from "../../../renderer/utils/create-stor
 import writeJsonFileInjectable from "../../../common/fs/write-json-file.injectable";
 import { TabKind } from "../../../renderer/components/dock/dock/store";
 import { Namespace } from "../../../common/k8s-api/endpoints";
-
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip:
-    (Target: any) =>
-      ({ tooltip, ...props }: any) => {
-        if (tooltip) {
-          const testId = props["data-testid"];
-
-          return (
-            <>
-              <Target
-                tooltip={tooltip.children ? undefined : tooltip}
-                {...props}
-              />
-              <div data-testid={testId && `tooltip-content-for-${testId}`}>
-                {tooltip.children || tooltip}
-              </div>
-            </>
-          );
-        }
-
-        return <Target {...props} />;
-      },
-}));
 
 describe("cluster/namespaces - edit namespaces from previously opened tab", () => {
   let builder: ApplicationBuilder;

--- a/src/behaviours/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
+++ b/src/behaviours/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
@@ -23,11 +23,6 @@ import type { IObservableValue } from "mobx";
 import { runInAction, computed, observable } from "mobx";
 import storageSaveDelayInjectable from "../../renderer/utils/create-storage/storage-save-delay.injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("cluster - sidebar and tab navigation for extensions", () => {
   let applicationBuilder: ApplicationBuilder;
   let rendererDi: DiContainer;

--- a/src/behaviours/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/behaviours/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
@@ -448,7 +448,6 @@ exports[`disable workloads overview details when cluster is not relevant given e
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_129"
                           tabindex="0"
                         >
                           <span
@@ -457,8 +456,10 @@ exports[`disable workloads overview details when cluster is not relevant given e
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -482,12 +483,13 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_131"
                 tabindex="0"
               >
                 <span
@@ -496,11 +498,12 @@ exports[`disable workloads overview details when cluster is not relevant given e
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_132"
                 tabindex="0"
               >
                 <span
@@ -509,8 +512,10 @@ exports[`disable workloads overview details when cluster is not relevant given e
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -963,7 +968,6 @@ exports[`disable workloads overview details when cluster is not relevant given e
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_71"
                           tabindex="0"
                         >
                           <span
@@ -972,8 +976,10 @@ exports[`disable workloads overview details when cluster is not relevant given e
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -997,12 +1003,13 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_73"
                 tabindex="0"
               >
                 <span
@@ -1011,11 +1018,12 @@ exports[`disable workloads overview details when cluster is not relevant given e
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_74"
                 tabindex="0"
               >
                 <span
@@ -1024,8 +1032,10 @@ exports[`disable workloads overview details when cluster is not relevant given e
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1478,7 +1488,6 @@ exports[`disable workloads overview details when cluster is not relevant given n
                       >
                         <i
                           class="Icon material interactive focusable small"
-                          id="tooltip_target_13"
                           tabindex="0"
                         >
                           <span
@@ -1487,8 +1496,10 @@ exports[`disable workloads overview details when cluster is not relevant given n
                           >
                             close
                           </span>
-                          <div />
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1512,12 +1523,13 @@ exports[`disable workloads overview details when cluster is not relevant given n
                   >
                     add
                   </span>
-                  <div />
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_15"
                 tabindex="0"
               >
                 <span
@@ -1526,11 +1538,12 @@ exports[`disable workloads overview details when cluster is not relevant given n
                 >
                   fullscreen
                 </span>
-                <div />
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
-                id="tooltip_target_16"
                 tabindex="0"
               >
                 <span
@@ -1539,8 +1552,10 @@ exports[`disable workloads overview details when cluster is not relevant given n
                 >
                   keyboard_arrow_up
                 </span>
-                <div />
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>

--- a/src/behaviours/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/add-custom-helm-repository-in-preferences.test.ts.snap
@@ -1046,7 +1046,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1055,6 +1054,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -1631,7 +1635,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1640,6 +1643,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -1820,7 +1828,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -1829,6 +1836,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     add
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
             </div>
           </div>
@@ -2325,7 +2335,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -2334,6 +2343,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -2918,7 +2932,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -2927,6 +2940,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -3107,7 +3125,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -3116,6 +3133,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     add
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
             </div>
           </div>
@@ -3612,7 +3632,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -3621,6 +3640,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -3801,7 +3825,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -3810,6 +3833,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     remove
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
               <div
                 data-testid="maximal-options-for-custom-helm-repository-dialog"
@@ -3861,7 +3887,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -3870,6 +3895,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="flex gaps align-center"
@@ -3896,7 +3924,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -3905,6 +3932,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="flex gaps align-center"
@@ -3931,7 +3961,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -3940,6 +3969,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="SubTitle"
@@ -4482,7 +4514,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -4491,6 +4522,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -4671,7 +4707,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -4680,6 +4715,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     add
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
             </div>
           </div>
@@ -5176,7 +5214,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -5185,6 +5222,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -5365,7 +5407,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -5374,6 +5415,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     remove
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
               <div
                 data-testid="maximal-options-for-custom-helm-repository-dialog"
@@ -5425,7 +5469,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -5434,6 +5477,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="flex gaps align-center"
@@ -5460,7 +5506,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -5469,6 +5514,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="flex gaps align-center"
@@ -5495,7 +5543,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                   <i
                     class="Icon material interactive focusable"
                     tabindex="0"
-                    tooltip="Browse"
                   >
                     <span
                       class="icon"
@@ -5504,6 +5551,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                       folder
                     </span>
                   </i>
+                  <div>
+                    Browse
+                  </div>
                 </div>
                 <div
                   class="SubTitle"
@@ -6046,7 +6096,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -6055,6 +6104,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -6235,7 +6289,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -6244,6 +6297,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     add
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
             </div>
           </div>
@@ -6740,7 +6796,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -6749,6 +6804,11 @@ exports[`add custom helm repository in preferences when navigating to preference
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -8101,7 +8161,6 @@ exports[`add custom helm repository in preferences when navigating to preference
                 More
                 <i
                   class="Icon material focusable small"
-                  tooltip="More"
                 >
                   <span
                     class="icon"
@@ -8110,6 +8169,9 @@ exports[`add custom helm repository in preferences when navigating to preference
                     add
                   </span>
                 </i>
+                <div>
+                  More
+                </div>
               </button>
             </div>
           </div>

--- a/src/behaviours/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/add-helm-repository-from-list-in-preferences.test.ts.snap
@@ -1046,7 +1046,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1055,6 +1054,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -1633,7 +1637,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1642,6 +1645,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -2269,7 +2277,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -2278,6 +2285,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -2854,7 +2866,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -2863,6 +2874,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -4017,7 +4033,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -4026,6 +4041,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                         <div
                           class="item flex gaps align-center justify-space-between repo"
@@ -4047,7 +4067,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some to be added repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -4056,6 +4075,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some to be added repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -4634,7 +4658,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -4643,6 +4666,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                         <div
                           class="item flex gaps align-center justify-space-between repo"
@@ -4664,7 +4692,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some to be added repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -4673,6 +4700,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some to be added repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -5310,7 +5342,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some already active repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -5319,6 +5350,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some already active repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                         <div
                           class="item flex gaps align-center justify-space-between repo"
@@ -5340,7 +5376,6 @@ exports[`add helm repository from list in preferences when navigating to prefere
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-Some to be added repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -5349,6 +5384,11 @@ exports[`add helm repository from list in preferences when navigating to prefere
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-Some to be added repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />

--- a/src/behaviours/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/listing-active-helm-repositories-in-preferences.test.ts.snap
@@ -3720,7 +3720,6 @@ exports[`listing active helm repositories in preferences when navigating to pref
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-some-repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -3729,6 +3728,11 @@ exports[`listing active helm repositories in preferences when navigating to pref
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-some-repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                         <div
                           class="item flex gaps align-center justify-space-between repo"
@@ -3750,7 +3754,6 @@ exports[`listing active helm repositories in preferences when navigating to pref
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-some-other-repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -3759,6 +3762,11 @@ exports[`listing active helm repositories in preferences when navigating to pref
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-some-other-repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />

--- a/src/behaviours/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
+++ b/src/behaviours/helm-charts/__snapshots__/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts.snap
@@ -1046,7 +1046,6 @@ exports[`remove helm repository from list of active repositories in preferences 
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-some-active-repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1055,6 +1054,11 @@ exports[`remove helm repository from list of active repositories in preferences 
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-some-active-repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />
@@ -1631,7 +1635,6 @@ exports[`remove helm repository from list of active repositories in preferences 
                             class="Icon material interactive focusable"
                             data-testid="remove-helm-repository-some-active-repository"
                             tabindex="0"
-                            tooltip="Remove"
                           >
                             <span
                               class="icon"
@@ -1640,6 +1643,11 @@ exports[`remove helm repository from list of active repositories in preferences 
                               delete
                             </span>
                           </i>
+                          <div
+                            data-testid="tooltip-content-for-remove-helm-repository-some-active-repository"
+                          >
+                            Remove
+                          </div>
                         </div>
                       </div>
                       <div />

--- a/src/behaviours/helm-charts/add-custom-helm-repository-in-preferences.test.ts
+++ b/src/behaviours/helm-charts/add-custom-helm-repository-in-preferences.test.ts
@@ -18,11 +18,6 @@ import showSuccessNotificationInjectable from "../../renderer/components/notific
 import showErrorNotificationInjectable from "../../renderer/components/notifications/show-error-notification.injectable";
 import type { AsyncResult } from "../../common/utils/async-result";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("add custom helm repository in preferences", () => {
   let applicationBuilder: ApplicationBuilder;
   let showSuccessNotificationMock: jest.Mock;

--- a/src/behaviours/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
+++ b/src/behaviours/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
@@ -16,11 +16,6 @@ import showSuccessNotificationInjectable from "../../renderer/components/notific
 import showErrorNotificationInjectable from "../../renderer/components/notifications/show-error-notification.injectable";
 import type { AsyncResult } from "../../common/utils/async-result";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("add helm repository from list in preferences", () => {
   let applicationBuilder: ApplicationBuilder;
   let showSuccessNotificationMock: jest.Mock;

--- a/src/behaviours/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/src/behaviours/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -660,7 +660,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -669,6 +668,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -693,7 +695,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -702,11 +703,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -715,6 +718,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -1604,7 +1610,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1613,6 +1618,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1629,7 +1637,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1638,11 +1645,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1651,10 +1660,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -1663,6 +1674,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -2365,7 +2379,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2374,6 +2387,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2390,7 +2406,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2399,11 +2414,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -2412,10 +2429,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -2424,6 +2443,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -3370,7 +3392,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -3379,6 +3400,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -3395,7 +3419,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -3404,11 +3427,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -3417,10 +3442,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -3429,6 +3456,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -4349,7 +4379,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -4358,6 +4387,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -4374,7 +4406,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -4383,11 +4414,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -4396,10 +4429,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -4408,6 +4443,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -5323,7 +5361,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -5332,6 +5369,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -5348,7 +5388,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -5357,11 +5396,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -5370,10 +5411,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -5382,6 +5425,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -6297,7 +6343,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -6306,6 +6351,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -6322,7 +6370,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -6331,11 +6378,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -6344,10 +6393,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -6356,6 +6407,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -6564,10 +6618,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   >
                     <i
                       class="Icon material focusable"
-                      tooltip="YAMLException: end of the stream or a document separator is expected (1:1)
-
- 1 | @some-invalid-configuration@
------^"
                     >
                       <span
                         class="icon"
@@ -6576,6 +6626,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         error_outline
                       </span>
                     </i>
+                    <div>
+                      YAMLException: end of the stream or a document separator is expected (1:1)
+
+ 1 | @some-invalid-configuration@
+-----^
+                    </div>
                   </div>
                 </div>
                 <button
@@ -7291,7 +7347,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -7300,6 +7355,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -7316,7 +7374,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -7325,11 +7382,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -7338,10 +7397,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -7350,6 +7411,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -8296,7 +8360,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -8305,6 +8368,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -8321,7 +8387,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -8330,11 +8395,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -8343,10 +8410,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -8355,6 +8424,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -9270,7 +9342,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -9279,6 +9350,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -9295,7 +9369,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -9304,11 +9377,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -9317,10 +9392,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -9329,6 +9406,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -10299,7 +10379,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -10308,6 +10387,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -10324,7 +10406,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -10333,11 +10414,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -10346,10 +10429,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -10358,6 +10443,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -11115,7 +11203,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -11124,6 +11211,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -11151,7 +11241,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -11160,6 +11249,11 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -11907,7 +12001,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -11916,6 +12009,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -11932,7 +12028,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -11941,11 +12036,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -11954,10 +12051,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -11966,6 +12065,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -12761,7 +12863,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -12770,6 +12871,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -12786,7 +12890,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -12795,11 +12898,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -12808,10 +12913,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -12820,6 +12927,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -13066,7 +13176,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -13075,11 +13184,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -13088,6 +13199,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -13977,7 +14091,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -13986,6 +14099,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14024,7 +14140,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -14033,6 +14148,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14049,7 +14167,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -14058,11 +14175,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -14071,10 +14190,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -14083,6 +14204,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -14785,7 +14909,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -14794,6 +14917,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14832,7 +14958,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -14841,6 +14966,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14857,7 +14985,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -14866,11 +14993,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -14879,10 +15008,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -14891,6 +15022,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -15808,7 +15942,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -15817,6 +15950,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -15855,7 +15991,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -15864,6 +15999,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -15880,7 +16018,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -15889,11 +16026,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -15902,10 +16041,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -15914,6 +16055,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -16829,7 +16973,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -16838,6 +16981,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -16854,7 +17000,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -16863,11 +17008,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -16876,10 +17023,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -16888,6 +17037,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -17803,7 +17955,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -17812,6 +17963,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -17828,7 +17982,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -17837,11 +17990,13 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -17850,10 +18005,12 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -17862,6 +18019,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -18754,7 +18914,6 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -18763,6 +18922,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>

--- a/src/behaviours/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
+++ b/src/behaviours/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
@@ -444,7 +444,6 @@ exports[`installing helm chart from previously opened tab given tab for installi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -453,6 +452,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -469,7 +471,6 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -478,11 +479,13 @@ exports[`installing helm chart from previously opened tab given tab for installi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -491,10 +494,12 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -503,6 +508,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -966,7 +974,6 @@ exports[`installing helm chart from previously opened tab given tab for installi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -975,6 +982,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -991,7 +1001,6 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1000,11 +1009,13 @@ exports[`installing helm chart from previously opened tab given tab for installi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1013,10 +1024,12 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -1025,6 +1038,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div

--- a/src/behaviours/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
+++ b/src/behaviours/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
@@ -496,7 +496,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -505,6 +504,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -1175,7 +1177,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1184,6 +1185,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -1854,7 +1858,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1863,6 +1866,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -1887,7 +1893,6 @@ exports[`opening dock tab for installing helm chart given application is started
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -1896,11 +1901,13 @@ exports[`opening dock tab for installing helm chart given application is started
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -1909,6 +1916,9 @@ exports[`opening dock tab for installing helm chart given application is started
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -2586,7 +2596,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2595,6 +2604,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -2619,7 +2631,6 @@ exports[`opening dock tab for installing helm chart given application is started
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -2628,11 +2639,13 @@ exports[`opening dock tab for installing helm chart given application is started
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -2641,6 +2654,9 @@ exports[`opening dock tab for installing helm chart given application is started
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -3497,7 +3513,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -3506,6 +3521,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -3530,7 +3548,6 @@ exports[`opening dock tab for installing helm chart given application is started
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -3539,11 +3556,13 @@ exports[`opening dock tab for installing helm chart given application is started
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -3552,6 +3571,9 @@ exports[`opening dock tab for installing helm chart given application is started
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -4418,7 +4440,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -4427,6 +4448,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -4451,7 +4475,6 @@ exports[`opening dock tab for installing helm chart given application is started
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -4460,11 +4483,13 @@ exports[`opening dock tab for installing helm chart given application is started
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -4473,6 +4498,9 @@ exports[`opening dock tab for installing helm chart given application is started
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -5329,7 +5357,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -5338,6 +5365,9 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
             </div>
           </div>
@@ -5362,7 +5392,6 @@ exports[`opening dock tab for installing helm chart given application is started
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -5371,11 +5400,13 @@ exports[`opening dock tab for installing helm chart given application is started
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -5384,6 +5415,9 @@ exports[`opening dock tab for installing helm chart given application is started
             close
           </span>
         </i>
+        <div>
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -6273,7 +6307,6 @@ exports[`opening dock tab for installing helm chart given application is started
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -6282,6 +6315,9 @@ exports[`opening dock tab for installing helm chart given application is started
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -6298,7 +6334,6 @@ exports[`opening dock tab for installing helm chart given application is started
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -6307,11 +6342,13 @@ exports[`opening dock tab for installing helm chart given application is started
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -6320,10 +6357,12 @@ exports[`opening dock tab for installing helm chart given application is started
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -6332,6 +6371,9 @@ exports[`opening dock tab for installing helm chart given application is started
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div

--- a/src/behaviours/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
+++ b/src/behaviours/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
@@ -31,11 +31,6 @@ import dockStoreInjectable from "../../../renderer/components/dock/dock/store.in
 import readJsonFileInjectable from "../../../common/fs/read-json-file.injectable";
 import type { DiContainer } from "@ogre-tools/injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("installing helm chart from new tab", () => {
   let builder: ApplicationBuilder;
   let rendererDi: DiContainer;

--- a/src/behaviours/helm-charts/installing-chart/installing-helm-chart-from-previously-opened-tab.test.ts
+++ b/src/behaviours/helm-charts/installing-chart/installing-helm-chart-from-previously-opened-tab.test.ts
@@ -24,11 +24,6 @@ import { controlWhenStoragesAreReady } from "../../../renderer/utils/create-stor
 import type { DiContainer } from "@ogre-tools/injectable";
 import callForCreateHelmReleaseInjectable from "../../../renderer/components/+helm-releases/create-release/call-for-create-helm-release.injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("installing helm chart from previously opened tab", () => {
   let builder: ApplicationBuilder;
   let rendererDi: DiContainer;

--- a/src/behaviours/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
+++ b/src/behaviours/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
@@ -25,11 +25,6 @@ import hostedClusterIdInjectable from "../../../renderer/cluster-frame-context/h
 import dockStoreInjectable from "../../../renderer/components/dock/dock/store.injectable";
 import type { DiContainer } from "@ogre-tools/injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("opening dock tab for installing helm chart", () => {
   let builder: ApplicationBuilder;
   let rendererDi: DiContainer;

--- a/src/behaviours/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
+++ b/src/behaviours/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
@@ -17,11 +17,6 @@ import type { Logger } from "../../common/logger";
 import callForPublicHelmRepositoriesInjectable from "../../renderer/components/+preferences/kubernetes/helm-charts/adding-of-public-helm-repository/public-helm-repositories/call-for-public-helm-repositories.injectable";
 import showErrorNotificationInjectable from "../../renderer/components/notifications/show-error-notification.injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("listing active helm repositories in preferences", () => {
   let applicationBuilder: ApplicationBuilder;
   let rendered: RenderResult;

--- a/src/behaviours/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
+++ b/src/behaviours/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
@@ -15,11 +15,6 @@ import type { HelmRepo } from "../../common/helm/helm-repo";
 import callForPublicHelmRepositoriesInjectable from "../../renderer/components/+preferences/kubernetes/helm-charts/adding-of-public-helm-repository/public-helm-repositories/call-for-public-helm-repositories.injectable";
 import type { AsyncResult } from "../../common/utils/async-result";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("remove helm repository from list of active repositories in preferences", () => {
   let applicationBuilder: ApplicationBuilder;
   let rendered: RenderResult;

--- a/src/behaviours/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/src/behaviours/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -676,7 +676,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -685,6 +684,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -701,7 +703,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -710,11 +711,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -723,10 +726,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -735,6 +740,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -1425,7 +1433,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -1434,6 +1441,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1450,7 +1460,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -1459,11 +1468,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -1472,10 +1483,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -1484,6 +1497,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -2342,7 +2358,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -2351,6 +2366,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2367,7 +2385,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -2376,11 +2393,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -2389,10 +2408,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -2401,6 +2422,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -3259,7 +3283,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -3268,6 +3291,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -3284,7 +3310,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -3293,11 +3318,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -3306,10 +3333,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -3318,6 +3347,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -3344,7 +3376,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -3353,6 +3384,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -4219,7 +4255,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -4228,6 +4263,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -4244,7 +4282,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -4253,11 +4290,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -4266,10 +4305,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -4278,6 +4319,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -5136,7 +5180,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -5145,6 +5188,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -5161,7 +5207,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -5170,11 +5215,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -5183,10 +5230,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -5195,6 +5244,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -5221,7 +5273,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -5230,6 +5281,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -6096,7 +6152,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -6105,6 +6160,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -6121,7 +6179,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -6130,11 +6187,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -6143,10 +6202,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -6155,6 +6216,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -6181,7 +6245,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -6190,6 +6253,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -7056,7 +7124,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -7065,6 +7132,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -7081,7 +7151,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -7090,11 +7159,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -7103,10 +7174,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -7115,6 +7188,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -7139,7 +7215,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -7148,6 +7223,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -7160,7 +7238,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -7169,6 +7246,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -7183,7 +7263,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -7192,6 +7271,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -7203,7 +7285,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -7212,6 +7293,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -8276,7 +8362,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -8285,6 +8370,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -8301,7 +8389,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -8310,11 +8397,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -8323,10 +8412,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -8335,6 +8426,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -8359,7 +8453,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -8368,6 +8461,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -8380,7 +8476,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -8389,6 +8484,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -8403,7 +8501,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -8412,6 +8509,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -8423,7 +8523,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -8432,6 +8531,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -9496,7 +9600,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -9505,6 +9608,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -9521,7 +9627,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -9530,11 +9635,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -9543,10 +9650,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -9555,6 +9664,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -9579,7 +9691,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -9588,6 +9699,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -9600,7 +9714,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -9609,6 +9722,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -9623,7 +9739,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -9632,6 +9747,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -9643,7 +9761,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -9652,6 +9769,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -10543,7 +10665,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -10552,6 +10673,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -10568,7 +10692,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -10577,11 +10700,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -10590,10 +10715,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -10602,6 +10729,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -10626,7 +10756,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -10635,6 +10764,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -10647,7 +10779,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -10656,6 +10787,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -10670,7 +10804,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -10679,6 +10812,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -10690,7 +10826,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -10699,6 +10834,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -11590,7 +11730,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -11599,6 +11738,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -11615,7 +11757,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -11624,11 +11765,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -11637,10 +11780,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -11649,6 +11794,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -11673,7 +11821,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -11682,6 +11829,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -11694,7 +11844,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -11703,6 +11852,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -11717,7 +11869,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -11726,6 +11877,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -11737,7 +11891,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -11746,6 +11899,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -12812,7 +12970,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -12821,6 +12978,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -12837,7 +12997,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -12846,11 +13005,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -12859,10 +13020,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -12871,6 +13034,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -12895,7 +13061,6 @@ exports[`showing details for helm release given application is started when navi
           <i
             class="Icon material interactive focusable"
             tabindex="0"
-            tooltip="Copy"
           >
             <span
               class="icon"
@@ -12904,6 +13069,9 @@ exports[`showing details for helm release given application is started when navi
               content_copy
             </span>
           </i>
+          <div>
+            Copy
+          </div>
         </div>
         <ul
           class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
@@ -12916,7 +13084,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Upgrade"
             >
               <span
                 class="icon"
@@ -12925,6 +13092,9 @@ exports[`showing details for helm release given application is started when navi
                 refresh
               </span>
             </i>
+            <div>
+              Upgrade
+            </div>
             <span
               class="title"
             >
@@ -12939,7 +13109,6 @@ exports[`showing details for helm release given application is started when navi
             <i
               class="Icon material interactive focusable"
               tabindex="0"
-              tooltip="Delete"
             >
               <span
                 class="icon"
@@ -12948,6 +13117,9 @@ exports[`showing details for helm release given application is started when navi
                 delete
               </span>
             </i>
+            <div>
+              Delete
+            </div>
             <span
               class="title"
             >
@@ -12959,7 +13131,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -12968,6 +13139,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -14032,7 +14208,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -14041,6 +14216,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14079,7 +14257,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -14088,6 +14265,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -14104,7 +14284,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -14113,11 +14292,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -14126,10 +14307,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Minimize"
               >
                 <span
                   class="icon"
@@ -14138,6 +14321,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_down
                 </span>
               </i>
+              <div>
+                Minimize
+              </div>
             </div>
           </div>
           <div
@@ -15005,7 +15191,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -15014,6 +15199,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -15030,7 +15218,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -15039,11 +15226,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -15052,10 +15241,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -15064,6 +15255,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -15090,7 +15284,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -15099,6 +15292,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"
@@ -15965,7 +16163,6 @@ exports[`showing details for helm release given application is started when navi
                         <i
                           class="Icon material interactive focusable small"
                           tabindex="0"
-                          tooltip="Close ⌘+W"
                         >
                           <span
                             class="icon"
@@ -15974,6 +16171,9 @@ exports[`showing details for helm release given application is started when navi
                             close
                           </span>
                         </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -15990,7 +16190,6 @@ exports[`showing details for helm release given application is started when navi
                   class="Icon new-dock-tab material interactive focusable"
                   id="menu-actions-for-dock"
                   tabindex="0"
-                  tooltip="New tab"
                 >
                   <span
                     class="icon"
@@ -15999,11 +16198,13 @@ exports[`showing details for helm release given application is started when navi
                     add
                   </span>
                 </i>
+                <div>
+                  New tab
+                </div>
               </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Fit to window"
               >
                 <span
                   class="icon"
@@ -16012,10 +16213,12 @@ exports[`showing details for helm release given application is started when navi
                   fullscreen
                 </span>
               </i>
+              <div>
+                Fit to window
+              </div>
               <i
                 class="Icon material interactive focusable"
                 tabindex="0"
-                tooltip="Open"
               >
                 <span
                   class="icon"
@@ -16024,6 +16227,9 @@ exports[`showing details for helm release given application is started when navi
                   keyboard_arrow_up
                 </span>
               </i>
+              <div>
+                Open
+              </div>
             </div>
           </div>
         </div>
@@ -16050,7 +16256,6 @@ exports[`showing details for helm release given application is started when navi
           class="Icon material interactive focusable"
           data-testid="close-helm-release-detail"
           tabindex="0"
-          tooltip="Close"
         >
           <span
             class="icon"
@@ -16059,6 +16264,11 @@ exports[`showing details for helm release given application is started when navi
             close
           </span>
         </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
       </div>
       <div
         class="drawer-content flex column box grow"

--- a/src/behaviours/helm-releases/showing-details-for-helm-release.test.ts
+++ b/src/behaviours/helm-releases/showing-details-for-helm-release.test.ts
@@ -24,11 +24,6 @@ import showSuccessNotificationInjectable from "../../renderer/components/notific
 import showCheckedErrorInjectable from "../../renderer/components/notifications/show-checked-error.injectable";
 import getRandomUpgradeChartTabIdInjectable from "../../renderer/components/dock/upgrade-chart/get-random-upgrade-chart-tab-id.injectable";
 
-// TODO: Make tooltips free of side effects by making it deterministic
-jest.mock("../../renderer/components/tooltip/withTooltip", () => ({
-  withTooltip: (target: any) => target,
-}));
-
 describe("showing details for helm release", () => {
   let builder: ApplicationBuilder;
   let callForHelmReleasesMock: AsyncFnMock<CallForHelmReleases>;

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -44,3 +44,4 @@ global.ResizeObserver = class {
 };
 
 jest.mock("./renderer/components/monaco-editor/monaco-editor");
+jest.mock("./renderer/components/tooltip/withTooltip");

--- a/src/renderer/components/tooltip/__mocks__/withTooltip.tsx
+++ b/src/renderer/components/tooltip/__mocks__/withTooltip.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import React from "react";
+
+export const withTooltip =
+  (Target: any) =>
+    ({ tooltip, tooltipOverrideDisabled, ...props }: any) => {
+      if (tooltip) {
+        const testId = props["data-testid"];
+
+        return (
+          <>
+            <Target {...props} />
+            <div data-testid={testId && `tooltip-content-for-${testId}`}>
+              {tooltip.children || tooltip}
+            </div>
+          </>
+        );
+      }
+
+      return <Target {...props} />;
+    };

--- a/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
+++ b/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
@@ -403,7 +403,6 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_56"
                         tabindex="0"
                       >
                         <span
@@ -412,8 +411,10 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -437,12 +438,13 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_58"
               tabindex="0"
             >
               <span
@@ -451,11 +453,12 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_59"
               tabindex="0"
             >
               <span
@@ -464,8 +467,10 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -884,7 +889,6 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_16"
                         tabindex="0"
                       >
                         <span
@@ -893,8 +897,10 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -918,12 +924,13 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_18"
               tabindex="0"
             >
               <span
@@ -932,11 +939,12 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_19"
               tabindex="0"
             >
               <span
@@ -945,8 +953,10 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>
@@ -1424,7 +1434,6 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                     >
                       <i
                         class="Icon material interactive focusable small"
-                        id="tooltip_target_94"
                         tabindex="0"
                       >
                         <span
@@ -1433,8 +1442,10 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                         >
                           close
                         </span>
-                        <div />
                       </i>
+                      <div>
+                        Close ⌘+W
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1458,12 +1469,13 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                 >
                   add
                 </span>
-                <div />
               </i>
+              <div>
+                New tab
+              </div>
             </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_96"
               tabindex="0"
             >
               <span
@@ -1472,11 +1484,12 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
               >
                 fullscreen
               </span>
-              <div />
             </i>
+            <div>
+              Fit to window
+            </div>
             <i
               class="Icon material interactive focusable"
-              id="tooltip_target_97"
               tabindex="0"
             >
               <span
@@ -1485,8 +1498,10 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
               >
                 keyboard_arrow_up
               </span>
-              <div />
             </i>
+            <div>
+              Open
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
**Motivation**
1. Remove duplication
2. Prevent situation where you accidentally forgot to mock it, which leads to introduction of tests that fail for wrong reason.
3. One place to control how we want tooltips to show in unit tests

This PR contains changes only to tests.