### PR TITLE
fix(ci): make appBundleId configurable.

### DIFF
--- a/build/notarize.js
+++ b/build/notarize.js
@@ -18,7 +18,7 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productFilename;
 
   return await notarize({
-    appBundleId: "io.kontena.lens-app",
+    appBundleId: process.env.APPBUNDLEID || "io.kontena.lens-app",
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,


### PR DESCRIPTION
Allow to notarize 3rd party builds without manually patch build files.