### PR TITLE
Tweak timing of starting and stopping periodical checking for updates

### DIFF
--- a/src/main/application-update/periodical-check-for-updates/start-checking-for-updates.injectable.ts
+++ b/src/main/application-update/periodical-check-for-updates/start-checking-for-updates.injectable.ts
@@ -4,8 +4,8 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import periodicalCheckForUpdatesInjectable from "./periodical-check-for-updates.injectable";
-import { afterRootFrameIsReadyInjectionToken } from "../../start-main-application/runnable-tokens/after-root-frame-is-ready-injection-token";
 import updatingIsEnabledInjectable from "../updating-is-enabled.injectable";
+import { afterApplicationIsLoadedInjectionToken } from "../../start-main-application/runnable-tokens/after-application-is-loaded-injection-token";
 
 const startCheckingForUpdatesInjectable = getInjectable({
   id: "start-checking-for-updates",
@@ -23,7 +23,7 @@ const startCheckingForUpdatesInjectable = getInjectable({
     };
   },
 
-  injectionToken: afterRootFrameIsReadyInjectionToken,
+  injectionToken: afterApplicationIsLoadedInjectionToken,
 });
 
 export default startCheckingForUpdatesInjectable;

--- a/src/main/application-update/periodical-check-for-updates/stop-checking-for-updates.injectable.ts
+++ b/src/main/application-update/periodical-check-for-updates/stop-checking-for-updates.injectable.ts
@@ -3,8 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import { beforeQuitOfFrontEndInjectionToken } from "../../start-main-application/runnable-tokens/before-quit-of-front-end-injection-token";
 import periodicalCheckForUpdatesInjectable from "./periodical-check-for-updates.injectable";
+import { beforeQuitOfBackEndInjectionToken } from "../../start-main-application/runnable-tokens/before-quit-of-back-end-injection-token";
 
 const stopCheckingForUpdatesInjectable = getInjectable({
   id: "stop-checking-for-updates",
@@ -21,7 +21,7 @@ const stopCheckingForUpdatesInjectable = getInjectable({
     };
   },
 
-  injectionToken: beforeQuitOfFrontEndInjectionToken,
+  injectionToken: beforeQuitOfBackEndInjectionToken,
 });
 
 export default stopCheckingForUpdatesInjectable;


### PR DESCRIPTION
Since we are no longer showing the notifications for updates, it doesn't make sense to wait till window is present.

Tackles one task from #5968

Signed-off-by: Janne Savolainen <janne.savolainen@live.fi>