### PR TITLE
Tweak timing of starting and stopping kubeconfig sync

### DIFF
--- a/src/main/start-main-application/runnables/kube-config-sync/start-kube-config-sync.injectable.ts
+++ b/src/main/start-main-application/runnables/kube-config-sync/start-kube-config-sync.injectable.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import { afterRootFrameIsReadyInjectionToken } from "../../runnable-tokens/after-root-frame-is-ready-injection-token";
+import { afterApplicationIsLoadedInjectionToken } from "../../runnable-tokens/after-application-is-loaded-injection-token";
 import directoryForKubeConfigsInjectable from "../../../../common/app-paths/directory-for-kube-configs/directory-for-kube-configs.injectable";
 import ensureDirInjectable from "../../../../common/fs/ensure-dir.injectable";
 import kubeconfigSyncManagerInjectable from "../../../catalog-sources/kubeconfig-sync/manager.injectable";
@@ -27,7 +27,7 @@ const startKubeConfigSyncInjectable = getInjectable({
 
   causesSideEffects: true,
 
-  injectionToken: afterRootFrameIsReadyInjectionToken,
+  injectionToken: afterApplicationIsLoadedInjectionToken,
 });
 
 export default startKubeConfigSyncInjectable;

--- a/src/main/start-main-application/runnables/kube-config-sync/stop-kube-config-sync.injectable.ts
+++ b/src/main/start-main-application/runnables/kube-config-sync/stop-kube-config-sync.injectable.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import { beforeQuitOfFrontEndInjectionToken } from "../../runnable-tokens/before-quit-of-front-end-injection-token";
+import { beforeQuitOfBackEndInjectionToken } from "../../runnable-tokens/before-quit-of-back-end-injection-token";
 import kubeconfigSyncManagerInjectable from "../../../catalog-sources/kubeconfig-sync/manager.injectable";
 
 const stopKubeConfigSyncInjectable = getInjectable({
@@ -19,7 +19,7 @@ const stopKubeConfigSyncInjectable = getInjectable({
     };
   },
 
-  injectionToken: beforeQuitOfFrontEndInjectionToken,
+  injectionToken: beforeQuitOfBackEndInjectionToken,
 });
 
 export default stopKubeConfigSyncInjectable;


### PR DESCRIPTION
It doesn't make sense to wait till window is there.

This will tackle a task in #5968 

Signed-off-by: Janne Savolainen <janne.savolainen@live.fi>