### PR TITLE
release 6.0.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.0.0",
+  "version": "6.0.1-beta.0",
   "main": "static/build/main.js",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",


### PR DESCRIPTION
## Changes since 6.0.0

## 🐛 Bug Fixes

- Fix incorrect links in workload overview page (**[#6002](https://github.com/lensapp/lens/pull/6002)**) https://github.com/jansav
- Fix focus not switching to new cluster frame (**[#5995](https://github.com/lensapp/lens/pull/5995)**) https://github.com/Nokel81
- Correctly handle HorizontalPodAutoscaler metrics with 0 usage (**[#5986](https://github.com/lensapp/lens/pull/5986)**) https://github.com/Nokel81
- Fix HorizontalPodAutoscaler metrics not displaying current values (**[#5956](https://github.com/lensapp/lens/pull/5956)**) https://github.com/Nokel81
- Fix KubeObjectDetails drawer not working for Cluster scoped resources (**[#5954](https://github.com/lensapp/lens/pull/5954)**) https://github.com/Nokel81
- Fix ingress list line heights (**[#5949](https://github.com/lensapp/lens/pull/5949)**) https://github.com/aleksfront
- Open application only if new update is available when using tray to check for updates (**[#5948](https://github.com/lensapp/lens/pull/5948)**) https://github.com/jansav
- Remove duplicate 'Controlled by' section on Jobs' details (**[#5943](https://github.com/lensapp/lens/pull/5943)**) https://github.com/Nokel81
- Fine-tune styles of Extensions page (**[#5921](https://github.com/lensapp/lens/pull/5921)**) https://github.com/aleksfront
- Fix Badge.props.expandable's default being switched to false  (**[#5911](https://github.com/lensapp/lens/pull/5911)**) https://github.com/Nokel81
- Fix ResourceQuotaDetails quotas display bugs (**[#5909](https://github.com/lensapp/lens/pull/5909)**) https://github.com/Nokel81
- Fix CPU spike when opening PodDetails from MonacoEditor (**[#5642](https://github.com/lensapp/lens/pull/5642)**) https://github.com/Nokel81
- Fix not being able to switch metrics if none are available (**[#5430](https://github.com/lensapp/lens/pull/5430)**) https://github.com/Nokel81
- Fix Pod Container sorting not correlating to visuals (**[#5175](https://github.com/lensapp/lens/pull/5175)**) https://github.com/Nokel81

## 🧰 Maintenance

- Bump eslint from 8.20.0 to 8.21.0 (**[#5993](https://github.com/lensapp/lens/pull/5993)**) https://github.com/dependabot
- Bump jest and @types/jest (**[#5992](https://github.com/lensapp/lens/pull/5992)**) https://github.com/dependabot
- Bump playwright from 1.24.1 to 1.24.2 (**[#5990](https://github.com/lensapp/lens/pull/5990)**) https://github.com/dependabot
- Bump electron-builder from 23.1.0 to 23.3.3 (**[#5989](https://github.com/lensapp/lens/pull/5989)**) https://github.com/dependabot
- Bump mock-fs from 5.1.2 to 5.1.4 (**[#5985](https://github.com/lensapp/lens/pull/5985)**) https://github.com/dependabot
- Bump sass from 1.53.0 to 1.54.2 (**[#5984](https://github.com/lensapp/lens/pull/5984)**) https://github.com/dependabot
- Bump esbuild from 0.14.49 to 0.14.53 (**[#5983](https://github.com/lensapp/lens/pull/5983)**) https://github.com/dependabot
- Bump @swc/core from 1.2.218 to 1.2.223 (**[#5978](https://github.com/lensapp/lens/pull/5978)**) https://github.com/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.30.7 to 5.32.0 (**[#5965](https://github.com/lensapp/lens/pull/5965)**) https://github.com/dependabot
- Bump @types/node from 16.11.45 to 16.11.47 (**[#5961](https://github.com/lensapp/lens/pull/5961)**) https://github.com/dependabot
- Bump ws from 8.8.0 to 8.8.1 (**[#5959](https://github.com/lensapp/lens/pull/5959)**) https://github.com/dependabot
- Bump webpack from 5.73.0 to 5.74.0 (**[#5929](https://github.com/lensapp/lens/pull/5929)**) https://github.com/dependabot
- Bump playwright from 1.23.4 to 1.24.1 (**[#5915](https://github.com/lensapp/lens/pull/5915)**) https://github.com/dependabot
- Bump @typescript-eslint/parser from 5.30.5 to 5.31.0 (**[#5899](https://github.com/lensapp/lens/pull/5899)**) https://github.com/dependabot
- Bump ts-node from 10.8.1 to 10.9.1 (**[#5871](https://github.com/lensapp/lens/pull/5871)**) https://github.com/dependabot
