### PR TITLE
Remove Tabs hover line width transition

### DIFF
--- a/src/renderer/components/tabs/tabs.scss
+++ b/src/renderer/components/tabs/tabs.scss
@@ -54,11 +54,10 @@
       position: absolute;
       right: 0;
       bottom: 0;
-      width: 0;
-      height: $unit * 0.5;
-      transition: width 150ms;
+      height: 3px;
+      transition: opacity 150ms;
       background: currentColor;
-      color: var(--halfGray)
+      opacity: 0;
     }
 
     &:focus {
@@ -76,6 +75,7 @@
         left: 0;
         right: auto;
         color: var(--line-color-active);
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
Removing Cumulative Layout Shift devtools warnings following the recommendation https://web.dev/cls/

Currently `Tab` component hover effect causing its `:after` pseudo-element to jump around and creating CLS. Removing `width` transition fixes this issue.

Before:
<img width="1233" alt="tab cls" src="https://user-images.githubusercontent.com/9607060/184103551-bd01a108-bb50-4ad1-8a27-0ab6e9fa3c44.png">

After:

https://user-images.githubusercontent.com/9607060/184103570-0646457b-f686-4ef6-a5d9-828faafae9dd.mov



Fixes #4511



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>