### PR TITLE
Fix for issue where non-explicit namespaces in a chart's manifest breaks helm release viewing

### DIFF
--- a/src/main/helm/helm-release-manager.ts
+++ b/src/main/helm/helm-release-manager.ts
@@ -194,6 +194,7 @@ async function getResources(name: string, namespace: string, kubeconfigPath: str
     "--kubeconfig", kubeconfigPath,
     "-f", "-",
     "--output", "json",
+    "--namespace", namespace,
   ];
 
   try {


### PR DESCRIPTION
Add namespace to our kubectl command as not all helm manifests include explicit namespaces for their resources

Fixes #6031