### PR TITLE
Add Service Account in pods details

### DIFF
--- a/src/common/k8s-api/endpoints/pod.api.ts
+++ b/src/common/k8s-api/endpoints/pod.api.ts
@@ -840,6 +840,10 @@ export class Pod extends KubeObject<
     return this.spec?.priorityClassName || "";
   }
 
+  getServiceAccountName() {
+    return this.spec?.serviceAccountName || "";
+  }
+
   getStatus(): PodStatusPhase {
     const phase = this.getStatusPhase();
     const reason = this.getReason();

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -116,6 +116,9 @@ export class PodDetails extends React.Component<PodDetailsProps> {
         >
           {podIPs.map(label => <Badge key={label} label={label} />)}
         </DrawerItem>
+        <DrawerItem name="Service Account">
+          {pod.getServiceAccountName()}
+        </DrawerItem>
         <DrawerItem name="Priority Class">
           {pod.getPriorityClassName()}
         </DrawerItem>


### PR DESCRIPTION
Hi. This is a small patch which adds a Service Account in pod details.

I wish I could add a clickable link for Service Account and Priority Class but this is beyond my knowledge of React development and Lens internals.

Screenshot:

![image](https://user-images.githubusercontent.com/174367/185374615-4fdab381-6ac1-4188-8622-3a82c42da8f7.png)
