### PR TITLE
Fix UI for scaling ReplicaSets

### DIFF
--- a/src/renderer/components/+workloads-replicasets/scale-dialog/dialog.tsx
+++ b/src/renderer/components/+workloads-replicasets/scale-dialog/dialog.tsx
@@ -104,7 +104,7 @@ class NonInjectedReplicaSetScaleDialog extends Component<ReplicaSetScaleDialogPr
       <Wizard
         header={(
           <h5>
-            Scale Replica Set
+            {"Scale Replica Set "}
             <span>{replicaSet.getName()}</span>
           </h5>
         )}
@@ -132,14 +132,14 @@ class NonInjectedReplicaSetScaleDialog extends Component<ReplicaSetScaleDialogPr
             </div>
             <div className="plus-minus-container flex gaps">
               <Icon
-                material="add_circle_outline"
-                onClick={this.desiredReplicasUp}
-                data-testid="desired-replicas-up"
-              />
-              <Icon
                 material="remove_circle_outline"
                 onClick={this.desiredReplicasDown}
                 data-testid="desired-replicas-down"
+              />
+              <Icon
+                material="add_circle_outline"
+                onClick={this.desiredReplicasUp}
+                data-testid="desired-replicas-up"
               />
             </div>
           </div>


### PR DESCRIPTION
Signed-off-by: Carlos René Mederos Arias <krlosmederos@gmail.com>

Fixes #5924 

Adds space between the title and the name of the replica set in the header.
Changes the order of decrease and increase buttons.

Screenshot:

![CleanShot 2022-08-18 at 15 17 51](https://user-images.githubusercontent.com/7034429/185476490-022d90af-8474-49e0-bc8b-f4224a033bac.png)
