### PR TITLE
Fix iframes white background

### DIFF
--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -180,6 +180,10 @@ a {
   }
 }
 
+iframe {
+  color-scheme: auto;
+}
+
 // colors
 .success {
   color: var(--colorSuccess);


### PR DESCRIPTION
Using `color-scheme: auto` on all iframes drops theme-specific iframe background color. Before the fix, all iframes having white background regardless specified colors.

Before
![white iframes](https://user-images.githubusercontent.com/9607060/185890375-1b9d6a2e-56ba-402c-b483-21d64d946bf8.png)

After
![transparent iframes](https://user-images.githubusercontent.com/9607060/185890399-6cbaf60b-356a-4c06-bded-c2be9db8a065.png)

Fixes https://github.com/lensapp/lens-ide/issues/183

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>