### PR TITLE
Fix light or dark flash while connecting to cluster

### DIFF
--- a/src/renderer/components/app.scss
+++ b/src/renderer/components/app.scss
@@ -72,7 +72,6 @@ html, body {
 
 body {
   color: var(--textColorPrimary);
-  background-color: var(--mainBackground);
   font-size: var(--font-size);
   font-family: var(--font-main);
 }
@@ -89,6 +88,11 @@ body {
 #app {
   height: 100%;
   min-height: 100%;
+  background-color: var(--mainBackground);
+
+  &:empty {
+    background-color: transparent;
+  }
 
   > * {
     height: inherit;
@@ -181,7 +185,7 @@ a {
 }
 
 iframe {
-  color-scheme: auto;
+  color-scheme: auto; // Remove default white background on iframes
 }
 
 // colors


### PR DESCRIPTION
Cluster `body` element has a background color defined in `var(--mainBackground)` custom property. After opening a cluster for the first time for about a second, app theme still not ready for the cluster frame so there no `--mainBackground` value. This forces the browser show some default background color (light or dark regarding to system theme).

Before:

https://user-images.githubusercontent.com/9607060/185935142-ad613ed9-becf-45c7-8981-84e38e3c36e2.mov

After:

https://user-images.githubusercontent.com/9607060/185935229-21735708-64a0-44ff-9bdd-09421bef3e8e.mov

Fixes #4408 



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>