### PR TITLE
Disable fail-fast on the testing CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
         node-version: [16.x]


### PR DESCRIPTION
- There are several reasons why these might fail that are irrelavent to
  the other pipelines. So we should just let them continue

Signed-off-by: Sebastian Malton <sebastian@malton.name>