### PR TITLE
Fix `<Select/>` text overflow below baseline

### DIFF
--- a/src/renderer/components/+namespaces/namespace-select-filter.scss
+++ b/src/renderer/components/+namespaces/namespace-select-filter.scss
@@ -20,6 +20,7 @@
       padding-left: 8px;
       margin-right: -8px;
       padding-right: 8px;
+      line-height: 1.1;
 
       &::-webkit-scrollbar {
         display: none;

--- a/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
@@ -166,6 +166,8 @@ export const ClusterLocalTerminalSetting = observer(({ cluster }: ClusterLocalTe
                     material="close"
                     title="Clear"
                     onClick={() => setAndCommitDirectory("")}
+                    smallest
+                    style={{ marginRight: "var(--margin)"}}
                   />
                 )
               }
@@ -173,6 +175,7 @@ export const ClusterLocalTerminalSetting = observer(({ cluster }: ClusterLocalTe
                 material="folder"
                 title="Pick from filesystem"
                 onClick={openFilePicker}
+                smallest
               />
             </>
           )}

--- a/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
@@ -167,7 +167,7 @@ export const ClusterLocalTerminalSetting = observer(({ cluster }: ClusterLocalTe
                     title="Clear"
                     onClick={() => setAndCommitDirectory("")}
                     smallest
-                    style={{ marginRight: "var(--margin)"}}
+                    style={{ marginRight: "var(--margin)" }}
                   />
                 )
               }

--- a/src/renderer/components/select/select.scss
+++ b/src/renderer/components/select/select.scss
@@ -49,6 +49,7 @@ html {
 
     &__single-value {
       color: var(--textColorSecondary);
+      overflow: visible;
     }
 
     &__indicator {


### PR DESCRIPTION
Some of the characters inside `<Select/>` value container get cropped for couple of pixels below the baseline. Example - notice the `g` and `y` tails.
<img width="522" alt="selector crop 1" src="https://user-images.githubusercontent.com/9607060/186090491-c783c5b6-8ee1-4df8-bdf9-fc70343688f9.png">
<img width="525" alt="selector crop 2" src="https://user-images.githubusercontent.com/9607060/186090501-6a6dbdd5-d325-4aa2-956f-ba69ba925ec7.png">

Fix adding `overflow: visible` to such values to prevent this.

<img width="521" alt="selector no crop" src="https://user-images.githubusercontent.com/9607060/186090894-af6392e2-6383-43d7-87e2-ae2c4bc1a0ce.png">



In addition, 2 tiny fixes for the namespace selector and `Working directory` input within cluster settings
