### PR TITLE
Make opening of release details work properly when release has resources without namespace

### DIFF
--- a/src/common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable.ts
+++ b/src/common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable.ts
@@ -16,8 +16,7 @@ const navigateToHelmReleasesInjectable = getInjectable({
     const navigateToRoute = di.inject(navigateToRouteInjectionToken);
     const route = di.inject(helmReleasesRouteInjectable);
 
-    return (parameters) =>
-      navigateToRoute(route, { parameters });
+    return (parameters) => navigateToRoute(route, { parameters });
   },
 });
 

--- a/src/common/fs/exec-file.injectable.ts
+++ b/src/common/fs/exec-file.injectable.ts
@@ -3,20 +3,23 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
+import type { ExecFileOptions } from "child_process";
 import { execFile } from "child_process";
 import { promisify } from "util";
 
-export type ExecFile = (filePath: string, args: string[]) => Promise<string>;
+export type ExecFile = (filePath: string, args: string[], options: ExecFileOptions) => Promise<string>;
 
 const execFileInjectable = getInjectable({
   id: "exec-file",
 
-  instantiate: (): ExecFile => async (filePath, args) => {
+  instantiate: (): ExecFile => {
     const asyncExecFile = promisify(execFile);
 
-    const result = await asyncExecFile(filePath, args);
+    return async (filePath, args, options) => {
+      const result = await asyncExecFile(filePath, args, options);
 
-    return result.stdout;
+      return result.stdout;
+    };
   },
 
   causesSideEffects: true,

--- a/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
+++ b/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
@@ -167,6 +167,7 @@ describe("add custom helm repository in preferences", () => {
               expect(execFileMock).toHaveBeenCalledWith(
                 "some-helm-binary-path",
                 ["repo", "add", "some-custom-repository", "http://some.url"],
+                { "maxBuffer": 34359738368 },
               );
             });
 
@@ -365,6 +366,7 @@ describe("add custom helm repository in preferences", () => {
                     "--cert-file",
                     "some-cert-file",
                   ],
+                  { "maxBuffer": 34359738368 },
                 );
               });
             });

--- a/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
+++ b/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
@@ -119,6 +119,7 @@ describe("add helm repository from list in preferences", () => {
             expect(execFileMock).toHaveBeenCalledWith(
               "some-helm-binary-path",
               ["repo", "add", "Some to be added repository", "some-other-url"],
+              { "maxBuffer": 34359738368 },
             );
           });
 
@@ -227,6 +228,7 @@ describe("add helm repository from list in preferences", () => {
                     expect(execFileMock).toHaveBeenCalledWith(
                       "some-helm-binary-path",
                       ["repo", "remove", "Some already active repository"],
+                      { "maxBuffer": 34359738368 },
                     );
                   });
 

--- a/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -11496,7 +11496,21 @@ exports[`installing helm chart from new tab given tab for installing chart was n
         <div
           class="drawer-title-text flex gaps align-center"
         >
-          
+          some-release
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"

--- a/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
+++ b/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
@@ -29,6 +29,8 @@ import hostedClusterIdInjectable from "../../../renderer/cluster-frame-context/h
 import dockStoreInjectable from "../../../renderer/components/dock/dock/store.injectable";
 import readJsonFileInjectable from "../../../common/fs/read-json-file.injectable";
 import type { DiContainer } from "@ogre-tools/injectable";
+import callForHelmReleasesInjectable from "../../../renderer/components/+helm-releases/call-for-helm-releases/call-for-helm-releases.injectable";
+import callForHelmReleaseDetailsInjectable from "../../../renderer/components/+helm-releases/release-details/release-details-model/call-for-helm-release/call-for-helm-release-details/call-for-helm-release-details.injectable";
 
 describe("installing helm chart from new tab", () => {
   let builder: ApplicationBuilder;
@@ -50,6 +52,9 @@ describe("installing helm chart from new tab", () => {
     callForCreateHelmReleaseMock = asyncFn();
 
     builder.beforeWindowStart((windowDi) => {
+      windowDi.override(callForHelmReleasesInjectable, () => async () => []);
+      windowDi.override(callForHelmReleaseDetailsInjectable, () => () => new Promise(() => {}));
+
       windowDi.override(
         directoryForLensLocalStorageInjectable,
         () => "/some-directory-for-lens-local-storage",

--- a/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
+++ b/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
@@ -69,6 +69,7 @@ describe("listing active helm repositories in preferences", () => {
       expect(execFileMock).toHaveBeenCalledWith(
         "some-helm-binary-path",
         ["env"],
+        { "maxBuffer": 34359738368 },
       );
     });
 
@@ -76,6 +77,7 @@ describe("listing active helm repositories in preferences", () => {
       expect(execFileMock).not.toHaveBeenCalledWith(
         "some-helm-binary-path",
         ["repo", "update"],
+        { "maxBuffer": 34359738368 },
       );
     });
 
@@ -207,6 +209,7 @@ describe("listing active helm repositories in preferences", () => {
         expect(execFileMock).toHaveBeenCalledWith(
           "some-helm-binary-path",
           ["repo", "update"],
+          { "maxBuffer": 34359738368 },
         );
       });
 
@@ -265,6 +268,7 @@ describe("listing active helm repositories in preferences", () => {
           expect(execFileMock).toHaveBeenCalledWith(
             "some-helm-binary-path",
             ["repo", "add", "bitnami", "https://charts.bitnami.com/bitnami"],
+            { "maxBuffer": 34359738368 },
           );
         });
 
@@ -400,6 +404,7 @@ describe("listing active helm repositories in preferences", () => {
             expect(execFileMock).not.toHaveBeenCalledWith(
               "some-helm-binary-path",
               ["repo", "add", "bitnami", "https://charts.bitnami.com/bitnami"],
+              { "maxBuffer": 34359738368 },
             );
           });
 

--- a/src/features/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
+++ b/src/features/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
@@ -86,6 +86,7 @@ describe("remove helm repository from list of active repositories in preferences
           expect(execFileMock).toHaveBeenCalledWith(
             "some-helm-binary-path",
             ["repo", "remove", "some-active-repository"],
+            { "maxBuffer": 34359738368 },
           );
         });
 

--- a/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -3314,7 +3314,21 @@ exports[`showing details for helm release given application is started when navi
         <div
           class="drawer-title-text flex gaps align-center"
         >
-          
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
@@ -3341,6 +3355,9926 @@ exports[`showing details for helm release given application is started when navi
           class="Spinner singleColor center"
           data-testid="helm-release-detail-content-spinner"
         />
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div
+          class="Spinner singleColor center"
+          data-testid="helm-release-detail-content-spinner"
+        />
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-configuration
+              </textarea>
+              <button
+                class="Button primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="false"
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when changing the configuration renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-new-configuration
+              </textarea>
+              <button
+                class="Button primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="false"
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when changing the configuration when saving renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-new-configuration
+              </textarea>
+              <button
+                class="Button waiting primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="true"
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when changing the configuration when saving when update resolves with failure renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  0 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="Spinner singleColor center"
+                    data-testid="helm-releases-spinner"
+                  />
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-new-configuration
+              </textarea>
+              <button
+                class="Button primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="false"
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when changing the configuration when saving when update resolves with success renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  0 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="Spinner singleColor center"
+                    data-testid="helm-releases-spinner"
+                  />
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center disabled"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  disabled=""
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-new-configuration
+              </textarea>
+              <button
+                class="Button primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="false"
+                disabled=""
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when changing the configuration when toggling to see only user defined values when configuration resolves renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <ul
+          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
+          id="menu-actions-for-release-menu-for-some-namespace/some-name"
+        >
+          <li
+            class="MenuItem"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="refresh"
+              >
+                refresh
+              </span>
+            </i>
+            <div>
+              Upgrade
+            </div>
+            <span
+              class="title"
+            >
+              Upgrade
+            </span>
+          </li>
+          <li
+            class="MenuItem"
+            data-testid="menu-action-remove"
+            tabindex="0"
+          >
+            <i
+              class="Icon material interactive focusable"
+              tabindex="0"
+            >
+              <span
+                class="icon"
+                data-icon-name="delete"
+              >
+                delete
+              </span>
+            </i>
+            <div>
+              Delete
+            </div>
+            <span
+              class="title"
+            >
+              Delete
+            </span>
+          </li>
+        </ul>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div>
+          <div
+            class="DrawerItem chart"
+          >
+            <span
+              class="name"
+            >
+              Chart
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="flex gaps align-center"
+              >
+                <span>
+                  some-chart
+                </span>
+                <button
+                  class="Button box right upgrade primary"
+                  data-testid="helm-release-upgrade-button"
+                  type="button"
+                >
+                  Upgrade
+                </button>
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Updated
+            </span>
+            <span
+              class="value"
+            >
+              NaNy
+               ago (some-updated)
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Namespace
+            </span>
+            <span
+              class="value"
+            >
+              some-namespace
+            </span>
+          </div>
+          <div
+            class="DrawerItem"
+          >
+            <span
+              class="name"
+            >
+              Version
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="version flex gaps align-center"
+              >
+                <span />
+              </div>
+            </span>
+          </div>
+          <div
+            class="DrawerItem status labelsOnly"
+          >
+            <span
+              class="name"
+            >
+              Status
+            </span>
+            <span
+              class="value"
+            >
+              <div
+                class="badge some-status"
+              >
+                Some-status
+              </div>
+            </span>
+          </div>
+          <div
+            class="values"
+          >
+            <div
+              class="DrawerTitle title"
+            >
+              Values
+            </div>
+            <div
+              class="flex column gaps"
+            >
+              <label
+                class="Checkbox flex align-center checked"
+              >
+                <input
+                  data-testid="user-supplied-values-only-checkbox"
+                  type="checkbox"
+                />
+                <i
+                  class="box flex align-center"
+                />
+                <span
+                  class="label"
+                >
+                  User-supplied values only
+                </span>
+              </label>
+              <textarea
+                data-testid="monaco-editor-for-helm-release-configuration"
+              >
+                some-other-configuration
+              </textarea>
+              <button
+                class="Button primary"
+                data-testid="helm-release-configuration-save-button"
+                data-waiting="false"
+                type="button"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Notes
+          </div>
+          <div
+            class="notes"
+          >
+            some-notes
+          </div>
+          <div
+            class="DrawerTitle title"
+          >
+            Resources
+          </div>
+          <div
+            class="resources"
+          >
+            <div
+              class="SubTitle"
+            >
+              some-kind
+               
+            </div>
+            <div
+              class="Table flex column autoSize"
+            >
+              <div
+                class="TableHead"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  Name
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                class="TableRow"
+              >
+                <div
+                  class="TableCell name"
+                >
+                  some-resource
+                </div>
+                <div
+                  class="TableCell namespace"
+                >
+                  some-namespace
+                </div>
+                <div
+                  class="TableCell age"
+                >
+                  0s
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ResizingAnchor horizontal leading"
+    />
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolve with release when configuration resolves when selecting to upgrade chart renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock isOpen"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Tab flex gaps align-center DockTab active"
+                  data-testid="dock-tab-for-some-tab-id"
+                  id="tab-some-tab-id"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable small"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="install_desktop"
+                    >
+                      install_desktop
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Helm Upgrade: some-name
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_down"
+                >
+                  keyboard_arrow_down
+                </span>
+              </i>
+              <div>
+                Minimize
+              </div>
+            </div>
+          </div>
+          <div
+            class="tab-content upgrade-chart"
+            data-testid="dock-tab-content-for-some-tab-id"
+            style="flex-basis: 300px;"
+          >
+            <div
+              class="Spinner singleColor center"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when call for release resolves with error renders 1`] = `
+<body>
+  <div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+    <div
+      class="mainLayout"
+      style="--sidebar-width: 200px;"
+    >
+      <div
+        class="sidebar"
+      >
+        <div
+          class="flex flex-col"
+          data-testid="cluster-sidebar"
+        >
+          <div
+            class="SidebarCluster"
+          >
+            <div
+              class="Avatar rounded loadingAvatar"
+              style="width: 40px; height: 40px;"
+            >
+              ??
+            </div>
+            <div
+              class="loadingClusterName"
+            />
+          </div>
+          <div
+            class="sidebarNav sidebar-active-status"
+          >
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-workloads"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-workloads"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Workloads
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-config"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-config"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="list"
+                  >
+                    list
+                  </span>
+                </i>
+                <span>
+                  Config
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-network"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-network"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="device_hub"
+                  >
+                    device_hub
+                  </span>
+                </i>
+                <span>
+                  Network
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-storage"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-storage"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="storage"
+                  >
+                    storage
+                  </span>
+                </i>
+                <span>
+                  Storage
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="true"
+              data-testid="sidebar-item-helm"
+            >
+              <a
+                aria-current="page"
+                class="navItem active"
+                data-testid="sidebar-item-link-for-helm"
+                href="/"
+              >
+                <i
+                  class="Icon svg focusable"
+                >
+                  <span
+                    class="icon"
+                  />
+                </i>
+                <span>
+                  Helm
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-user-management"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-user-management"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="security"
+                  >
+                    security
+                  </span>
+                </i>
+                <span>
+                  Access Control
+                </span>
+              </a>
+            </div>
+            <div
+              class="SidebarItem"
+              data-is-active-test="false"
+              data-testid="sidebar-item-custom-resources"
+            >
+              <a
+                class="navItem"
+                data-testid="sidebar-item-link-for-custom-resources"
+                href="/"
+              >
+                <i
+                  class="Icon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="extension"
+                  >
+                    extension
+                  </span>
+                </i>
+                <span>
+                  Custom Resources
+                </span>
+                <i
+                  class="Icon expandIcon material focusable"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="keyboard_arrow_down"
+                  >
+                    keyboard_arrow_down
+                  </span>
+                </i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ResizingAnchor horizontal trailing"
+        />
+      </div>
+      <div
+        class="contents"
+      >
+        <div
+          class="TabLayout"
+          data-testid="tab-layout"
+        >
+          <div
+            class="Tabs center scrollable"
+          >
+            <div
+              class="Tab flex gaps align-center"
+              data-is-active-test="false"
+              data-testid="tab-link-for-charts"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Charts
+              </div>
+            </div>
+            <div
+              class="Tab flex gaps align-center active"
+              data-is-active-test="true"
+              data-testid="tab-link-for-releases"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="label"
+              >
+                Releases
+              </div>
+            </div>
+          </div>
+          <main>
+            <div
+              class="ItemListLayout flex column HelmReleases"
+            >
+              <div
+                class="header flex gaps align-center"
+              >
+                <h5
+                  class="title"
+                >
+                  Releases
+                </h5>
+                <div
+                  class="info-panel box grow"
+                >
+                  2 items
+                </div>
+                <div
+                  class="NamespaceSelectFilterParent"
+                  data-testid="namespace-select-filter"
+                >
+                  <div
+                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-namespace-select-filter-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class="Select__control css-1s2u09g-control"
+                    >
+                      <div
+                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
+                      >
+                        <div
+                          class="Select__placeholder css-14el2xx-placeholder"
+                          id="react-select-namespace-select-filter-placeholder"
+                        >
+                          Namespaces: some-namespace, some-other-namespace
+                        </div>
+                        <div
+                          class="Select__input-container css-6j8wv5-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-describedby="react-select-namespace-select-filter-placeholder"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class="Select__input"
+                            id="namespace-select-filter"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Input SearchInput focused"
+                >
+                  <label
+                    class="input-area flex gaps align-center"
+                    id=""
+                  >
+                    <input
+                      class="input box grow"
+                      placeholder="Search Releases..."
+                      spellcheck="false"
+                      value=""
+                    />
+                    <i
+                      class="Icon material focusable small"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="search"
+                      >
+                        search
+                      </span>
+                    </i>
+                  </label>
+                  <div
+                    class="input-info flex gaps"
+                  />
+                </div>
+              </div>
+              <div
+                class="items box grow flex column"
+              >
+                <div
+                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
+                >
+                  <div
+                    class="TableHead sticky nowrap topLine"
+                  >
+                    <div
+                      class="TableCell checkbox"
+                    >
+                      <label
+                        class="Checkbox flex align-center"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <i
+                          class="box flex align-center"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="TableCell name nowrap sorting"
+                      id="name"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Name
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell namespace nowrap sorting"
+                      id="namespace"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Namespace
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell chart nowrap sorting"
+                      id="chart"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Chart
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell revision nowrap sorting"
+                      id="revision"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Revision
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell version nowrap"
+                      id="version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell app-version nowrap"
+                      id="app-version"
+                    >
+                      <div
+                        class="content"
+                      >
+                        App Version
+                      </div>
+                    </div>
+                    <div
+                      class="TableCell status nowrap sorting"
+                      id="status"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Status
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell updated nowrap sorting"
+                      id="update"
+                    >
+                      <div
+                        class="content"
+                      >
+                        Updated
+                      </div>
+                      <i
+                        class="Icon sortIcon material focusable"
+                      >
+                        <span
+                          class="icon"
+                          data-icon-name="arrow_drop_down"
+                        >
+                          arrow_drop_down
+                        </span>
+                      </i>
+                    </div>
+                    <div
+                      class="TableCell menu nowrap"
+                    >
+                      <div
+                        class="content"
+                      >
+                        <i
+                          class="Icon material interactive focusable"
+                          id="menu-actions-for-item-object-list-content"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="more_vert"
+                          >
+                            more_vert
+                          </span>
+                        </i>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="VirtualList HelmReleases box grow dark"
+                  >
+                    <div>
+                      <div
+                        class="list"
+                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
+                      >
+                        <div
+                          style="height: 66px; width: 100%;"
+                        >
+                          <div
+                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-namespace/some-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-app-version
+                              </div>
+                              <div
+                                class="TableCell some-status status"
+                              >
+                                Some-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
+                          >
+                            <div
+                              class="TableRow nowrap"
+                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
+                            >
+                              <div
+                                class="TableCell checkbox"
+                              >
+                                <label
+                                  class="Checkbox flex align-center"
+                                >
+                                  <input
+                                    type="checkbox"
+                                  />
+                                  <i
+                                    class="box flex align-center"
+                                  />
+                                </label>
+                              </div>
+                              <div
+                                class="TableCell name"
+                              >
+                                some-other-name
+                              </div>
+                              <div
+                                class="TableCell namespace"
+                              >
+                                some-other-namespace
+                              </div>
+                              <div
+                                class="TableCell chart"
+                              >
+                                some-other-chart
+                              </div>
+                              <div
+                                class="TableCell revision"
+                              >
+                                NaN
+                              </div>
+                              <div
+                                class="TableCell version"
+                              >
+                                
+                              </div>
+                              <div
+                                class="TableCell app-version"
+                              >
+                                some-other-app-version
+                              </div>
+                              <div
+                                class="TableCell some-other-status status"
+                              >
+                                Some-other-status
+                              </div>
+                              <div
+                                class="TableCell updated"
+                              >
+                                NaNy
+                              </div>
+                              <div
+                                class="TableCell menu"
+                              >
+                                <div>
+                                  <i
+                                    class="Icon material interactive focusable"
+                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
+                                    tabindex="0"
+                                  >
+                                    <span
+                                      class="icon"
+                                      data-icon-name="more_vert"
+                                    >
+                                      more_vert
+                                    </span>
+                                  </i>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="AddRemoveButtons flex gaps"
+                />
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <div
+          class="Dock"
+          tabindex="-1"
+        >
+          <div
+            class="ResizingAnchor vertical leading"
+          />
+          <div
+            class="tabs-container flex align-center"
+          >
+            <div
+              class="dockTabs"
+              role="tablist"
+            >
+              <div
+                class="Tabs tabs"
+              >
+                <div
+                  class="Tab flex gaps align-center DockTab TerminalTab active"
+                  data-testid="dock-tab-for-terminal"
+                  id="tab-terminal"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <i
+                    class="Icon material focusable"
+                  >
+                    <span
+                      class="icon"
+                      data-icon-name="terminal"
+                    >
+                      terminal
+                    </span>
+                  </i>
+                  <div
+                    class="label"
+                  >
+                    <div
+                      class="flex align-center"
+                    >
+                      <span
+                        class="title"
+                      >
+                        Terminal
+                      </span>
+                      <div
+                        class="close"
+                      >
+                        <i
+                          class="Icon material interactive focusable small"
+                          tabindex="0"
+                        >
+                          <span
+                            class="icon"
+                            data-icon-name="close"
+                          >
+                            close
+                          </span>
+                        </i>
+                        <div>
+                          Close ⌘+W
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="toolbar flex gaps align-center box grow"
+            >
+              <div
+                class="dock-menu box grow"
+              >
+                <i
+                  class="Icon new-dock-tab material interactive focusable"
+                  id="menu-actions-for-dock"
+                  tabindex="0"
+                >
+                  <span
+                    class="icon"
+                    data-icon-name="add"
+                  >
+                    add
+                  </span>
+                </i>
+                <div>
+                  New tab
+                </div>
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="fullscreen"
+                >
+                  fullscreen
+                </span>
+              </i>
+              <div>
+                Fit to window
+              </div>
+              <i
+                class="Icon material interactive focusable"
+                tabindex="0"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="keyboard_arrow_up"
+                >
+                  keyboard_arrow_up
+                </span>
+              </i>
+              <div>
+                Open
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="Animate slide-right Drawer ReleaseDetails dark right enter"
+    data-testid="helm-release-details-for-some-namespace/some-name"
+    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
+  >
+    <div
+      class="drawer-wrapper flex column"
+    >
+      <div
+        class="drawer-title flex align-center"
+      >
+        <div
+          class="drawer-title-text flex gaps align-center"
+        >
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
+        </div>
+        <i
+          class="Icon material interactive focusable"
+          data-testid="close-helm-release-detail"
+          tabindex="0"
+        >
+          <span
+            class="icon"
+            data-icon-name="close"
+          >
+            close
+          </span>
+        </i>
+        <div
+          data-testid="tooltip-content-for-close-helm-release-detail"
+        >
+          Close
+        </div>
+      </div>
+      <div
+        class="drawer-content flex column box grow"
+      >
+        <div
+          data-testid="helm-release-detail-error"
+        >
+          Failed to load release
+        </div>
       </div>
     </div>
     <div
@@ -5183,7 +15117,21 @@ exports[`showing details for helm release given application is started when navi
         <div
           class="drawer-title-text flex gaps align-center"
         >
-          
+          some-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="content_copy"
+            >
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
+          </div>
         </div>
         <i
           class="Icon material interactive focusable"
@@ -5215,8939 +15163,6 @@ exports[`showing details for helm release given application is started when navi
     <div
       class="ResizingAnchor horizontal leading"
     />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          
-        </div>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div
-          class="Spinner singleColor center"
-          data-testid="helm-release-detail-content-spinner"
-        />
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-configuration
-              </textarea>
-              <button
-                class="Button primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="false"
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when changing the configuration renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-new-configuration
-              </textarea>
-              <button
-                class="Button primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="false"
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when changing the configuration when saving renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-new-configuration
-              </textarea>
-              <button
-                class="Button waiting primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="true"
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when changing the configuration when saving when update resolves with failure renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  0 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="Spinner singleColor center"
-                    data-testid="helm-releases-spinner"
-                  />
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-new-configuration
-              </textarea>
-              <button
-                class="Button primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="false"
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when changing the configuration when saving when update resolves with success renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  0 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="Spinner singleColor center"
-                    data-testid="helm-releases-spinner"
-                  />
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center disabled"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  disabled=""
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-new-configuration
-              </textarea>
-              <button
-                class="Button primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="false"
-                disabled=""
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when changing the configuration when toggling to see only user defined values when configuration resolves renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          some-name
-          <i
-            class="Icon material interactive focusable"
-            tabindex="0"
-          >
-            <span
-              class="icon"
-              data-icon-name="content_copy"
-            >
-              content_copy
-            </span>
-          </i>
-          <div>
-            Copy
-          </div>
-        </div>
-        <ul
-          class="Menu MenuActions flex HelmReleaseMenu toolbar gaps right bottom"
-          id="menu-actions-for-release-menu-for-some-namespace/some-name"
-        >
-          <li
-            class="MenuItem"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="refresh"
-              >
-                refresh
-              </span>
-            </i>
-            <div>
-              Upgrade
-            </div>
-            <span
-              class="title"
-            >
-              Upgrade
-            </span>
-          </li>
-          <li
-            class="MenuItem"
-            data-testid="menu-action-remove"
-            tabindex="0"
-          >
-            <i
-              class="Icon material interactive focusable"
-              tabindex="0"
-            >
-              <span
-                class="icon"
-                data-icon-name="delete"
-              >
-                delete
-              </span>
-            </i>
-            <div>
-              Delete
-            </div>
-            <span
-              class="title"
-            >
-              Delete
-            </span>
-          </li>
-        </ul>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
-          >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div>
-          <div
-            class="DrawerItem chart"
-          >
-            <span
-              class="name"
-            >
-              Chart
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="flex gaps align-center"
-              >
-                <span>
-                  some-chart
-                </span>
-                <button
-                  class="Button box right upgrade primary"
-                  data-testid="helm-release-upgrade-button"
-                  type="button"
-                >
-                  Upgrade
-                </button>
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Updated
-            </span>
-            <span
-              class="value"
-            >
-              NaNy
-               ago (some-updated)
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Namespace
-            </span>
-            <span
-              class="value"
-            >
-              some-namespace
-            </span>
-          </div>
-          <div
-            class="DrawerItem"
-          >
-            <span
-              class="name"
-            >
-              Version
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="version flex gaps align-center"
-              >
-                <span />
-              </div>
-            </span>
-          </div>
-          <div
-            class="DrawerItem status labelsOnly"
-          >
-            <span
-              class="name"
-            >
-              Status
-            </span>
-            <span
-              class="value"
-            >
-              <div
-                class="badge some-status"
-              >
-                Some-status
-              </div>
-            </span>
-          </div>
-          <div
-            class="values"
-          >
-            <div
-              class="DrawerTitle title"
-            >
-              Values
-            </div>
-            <div
-              class="flex column gaps"
-            >
-              <label
-                class="Checkbox flex align-center checked"
-              >
-                <input
-                  data-testid="user-supplied-values-only-checkbox"
-                  type="checkbox"
-                />
-                <i
-                  class="box flex align-center"
-                />
-                <span
-                  class="label"
-                >
-                  User-supplied values only
-                </span>
-              </label>
-              <textarea
-                data-testid="monaco-editor-for-helm-release-configuration"
-              >
-                some-other-configuration
-              </textarea>
-              <button
-                class="Button primary"
-                data-testid="helm-release-configuration-save-button"
-                data-waiting="false"
-                type="button"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Notes
-          </div>
-          <div
-            class="notes"
-          >
-            some-notes
-          </div>
-          <div
-            class="DrawerTitle title"
-          >
-            Resources
-          </div>
-          <div
-            class="resources"
-          >
-            <div
-              class="SubTitle"
-            >
-              some-kind
-               
-            </div>
-            <div
-              class="Table flex column autoSize"
-            >
-              <div
-                class="TableHead"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  Name
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
-              </div>
-              <div
-                class="TableRow"
-              >
-                <div
-                  class="TableCell name"
-                >
-                  some-resource
-                </div>
-                <div
-                  class="TableCell namespace"
-                >
-                  some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when details resolve when configuration resolves when selecting to upgrade chart renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
-            >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
-          </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock isOpen"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Tab flex gaps align-center DockTab active"
-                  data-testid="dock-tab-for-some-tab-id"
-                  id="tab-some-tab-id"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable small"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="install_desktop"
-                    >
-                      install_desktop
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Helm Upgrade: some-name
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_down"
-                >
-                  keyboard_arrow_down
-                </span>
-              </i>
-              <div>
-                Minimize
-              </div>
-            </div>
-          </div>
-          <div
-            class="tab-content upgrade-chart"
-            data-testid="dock-tab-content-for-some-tab-id"
-            style="flex-basis: 300px;"
-          >
-            <div
-              class="Spinner singleColor center"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </body>
 `;
@@ -15074,965 +16089,21 @@ exports[`showing details for helm release given application is started when navi
         <div
           class="drawer-title-text flex gaps align-center"
         >
-          
-        </div>
-        <i
-          class="Icon material interactive focusable"
-          data-testid="close-helm-release-detail"
-          tabindex="0"
-        >
-          <span
-            class="icon"
-            data-icon-name="close"
+          some-other-name
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
           >
-            close
-          </span>
-        </i>
-        <div
-          data-testid="tooltip-content-for-close-helm-release-detail"
-        >
-          Close
-        </div>
-      </div>
-      <div
-        class="drawer-content flex column box grow"
-      >
-        <div
-          class="Spinner singleColor center"
-          data-testid="helm-release-detail-content-spinner"
-        />
-      </div>
-    </div>
-    <div
-      class="ResizingAnchor horizontal leading"
-    />
-  </div>
-</body>
-`;
-
-exports[`showing details for helm release given application is started when navigating to helm releases when releases resolve when selecting release to see details when release resolve with no data, renders 1`] = `
-<body>
-  <div>
-    <div
-      class="Notifications flex column align-flex-end"
-    />
-    <div
-      class="mainLayout"
-      style="--sidebar-width: 200px;"
-    >
-      <div
-        class="sidebar"
-      >
-        <div
-          class="flex flex-col"
-          data-testid="cluster-sidebar"
-        >
-          <div
-            class="SidebarCluster"
-          >
-            <div
-              class="Avatar rounded loadingAvatar"
-              style="width: 40px; height: 40px;"
+            <span
+              class="icon"
+              data-icon-name="content_copy"
             >
-              ??
-            </div>
-            <div
-              class="loadingClusterName"
-            />
+              content_copy
+            </span>
+          </i>
+          <div>
+            Copy
           </div>
-          <div
-            class="sidebarNav sidebar-active-status"
-          >
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-workloads"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-workloads"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Workloads
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-config"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-config"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="list"
-                  >
-                    list
-                  </span>
-                </i>
-                <span>
-                  Config
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-network"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-network"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="device_hub"
-                  >
-                    device_hub
-                  </span>
-                </i>
-                <span>
-                  Network
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-storage"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-storage"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="storage"
-                  >
-                    storage
-                  </span>
-                </i>
-                <span>
-                  Storage
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="true"
-              data-testid="sidebar-item-helm"
-            >
-              <a
-                aria-current="page"
-                class="navItem active"
-                data-testid="sidebar-item-link-for-helm"
-                href="/"
-              >
-                <i
-                  class="Icon svg focusable"
-                >
-                  <span
-                    class="icon"
-                  />
-                </i>
-                <span>
-                  Helm
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-user-management"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-user-management"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="security"
-                  >
-                    security
-                  </span>
-                </i>
-                <span>
-                  Access Control
-                </span>
-              </a>
-            </div>
-            <div
-              class="SidebarItem"
-              data-is-active-test="false"
-              data-testid="sidebar-item-custom-resources"
-            >
-              <a
-                class="navItem"
-                data-testid="sidebar-item-link-for-custom-resources"
-                href="/"
-              >
-                <i
-                  class="Icon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="extension"
-                  >
-                    extension
-                  </span>
-                </i>
-                <span>
-                  Custom Resources
-                </span>
-                <i
-                  class="Icon expandIcon material focusable"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="keyboard_arrow_down"
-                  >
-                    keyboard_arrow_down
-                  </span>
-                </i>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div
-          class="ResizingAnchor horizontal trailing"
-        />
-      </div>
-      <div
-        class="contents"
-      >
-        <div
-          class="TabLayout"
-          data-testid="tab-layout"
-        >
-          <div
-            class="Tabs center scrollable"
-          >
-            <div
-              class="Tab flex gaps align-center"
-              data-is-active-test="false"
-              data-testid="tab-link-for-charts"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Charts
-              </div>
-            </div>
-            <div
-              class="Tab flex gaps align-center active"
-              data-is-active-test="true"
-              data-testid="tab-link-for-releases"
-              role="tab"
-              tabindex="0"
-            >
-              <div
-                class="label"
-              >
-                Releases
-              </div>
-            </div>
-          </div>
-          <main>
-            <div
-              class="ItemListLayout flex column HelmReleases"
-            >
-              <div
-                class="header flex gaps align-center"
-              >
-                <h5
-                  class="title"
-                >
-                  Releases
-                </h5>
-                <div
-                  class="info-panel box grow"
-                >
-                  2 items
-                </div>
-                <div
-                  class="NamespaceSelectFilterParent"
-                  data-testid="namespace-select-filter"
-                >
-                  <div
-                    class="Select theme-dark NamespaceSelect NamespaceSelectFilter css-b62m3t-container"
-                  >
-                    <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-namespace-select-filter-live-region"
-                    />
-                    <span
-                      aria-atomic="false"
-                      aria-live="polite"
-                      aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
-                    />
-                    <div
-                      class="Select__control css-1s2u09g-control"
-                    >
-                      <div
-                        class="Select__value-container Select__value-container--is-multi css-319lph-ValueContainer"
-                      >
-                        <div
-                          class="Select__placeholder css-14el2xx-placeholder"
-                          id="react-select-namespace-select-filter-placeholder"
-                        >
-                          Namespaces: some-namespace, some-other-namespace
-                        </div>
-                        <div
-                          class="Select__input-container css-6j8wv5-Input"
-                          data-value=""
-                        >
-                          <input
-                            aria-autocomplete="list"
-                            aria-describedby="react-select-namespace-select-filter-placeholder"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            class="Select__input"
-                            id="namespace-select-filter"
-                            role="combobox"
-                            spellcheck="false"
-                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-                            tabindex="0"
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        class="Select__indicators css-1hb7zxy-IndicatorsContainer"
-                      >
-                        <span
-                          class="Select__indicator-separator css-1okebmr-indicatorSeparator"
-                        />
-                        <div
-                          aria-hidden="true"
-                          class="Select__indicator Select__dropdown-indicator css-tlfecz-indicatorContainer"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="css-tj5bde-Svg"
-                            focusable="false"
-                            height="20"
-                            viewBox="0 0 20 20"
-                            width="20"
-                          >
-                            <path
-                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="Input SearchInput focused"
-                >
-                  <label
-                    class="input-area flex gaps align-center"
-                    id=""
-                  >
-                    <input
-                      class="input box grow"
-                      placeholder="Search Releases..."
-                      spellcheck="false"
-                      value=""
-                    />
-                    <i
-                      class="Icon material focusable small"
-                    >
-                      <span
-                        class="icon"
-                        data-icon-name="search"
-                      >
-                        search
-                      </span>
-                    </i>
-                  </label>
-                  <div
-                    class="input-info flex gaps"
-                  />
-                </div>
-              </div>
-              <div
-                class="items box grow flex column"
-              >
-                <div
-                  class="Table flex column HelmReleases box grow dark selectable scrollable sortable autoSize virtual"
-                >
-                  <div
-                    class="TableHead sticky nowrap topLine"
-                  >
-                    <div
-                      class="TableCell checkbox"
-                    >
-                      <label
-                        class="Checkbox flex align-center"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <i
-                          class="box flex align-center"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="TableCell name nowrap sorting"
-                      id="name"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Name
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell namespace nowrap sorting"
-                      id="namespace"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Namespace
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell chart nowrap sorting"
-                      id="chart"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Chart
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell revision nowrap sorting"
-                      id="revision"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Revision
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell version nowrap"
-                      id="version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell app-version nowrap"
-                      id="app-version"
-                    >
-                      <div
-                        class="content"
-                      >
-                        App Version
-                      </div>
-                    </div>
-                    <div
-                      class="TableCell status nowrap sorting"
-                      id="status"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Status
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell updated nowrap sorting"
-                      id="update"
-                    >
-                      <div
-                        class="content"
-                      >
-                        Updated
-                      </div>
-                      <i
-                        class="Icon sortIcon material focusable"
-                      >
-                        <span
-                          class="icon"
-                          data-icon-name="arrow_drop_down"
-                        >
-                          arrow_drop_down
-                        </span>
-                      </i>
-                    </div>
-                    <div
-                      class="TableCell menu nowrap"
-                    >
-                      <div
-                        class="content"
-                      >
-                        <i
-                          class="Icon material interactive focusable"
-                          id="menu-actions-for-item-object-list-content"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="more_vert"
-                          >
-                            more_vert
-                          </span>
-                        </i>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="VirtualList HelmReleases box grow dark"
-                  >
-                    <div>
-                      <div
-                        class="list"
-                        style="position: relative; height: 420000px; width: 100%; overflow: auto; will-change: transform; direction: ltr;"
-                      >
-                        <div
-                          style="height: 66px; width: 100%;"
-                        >
-                          <div
-                            style="position: absolute; left: 0px; top: 0px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-namespace/some-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-app-version
-                              </div>
-                              <div
-                                class="TableCell some-status status"
-                              >
-                                Some-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-namespace/some-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            style="position: absolute; left: 0px; top: 33px; height: 33px; width: 100%;"
-                          >
-                            <div
-                              class="TableRow nowrap"
-                              data-testid="helm-release-row-for-some-other-namespace/some-other-name"
-                            >
-                              <div
-                                class="TableCell checkbox"
-                              >
-                                <label
-                                  class="Checkbox flex align-center"
-                                >
-                                  <input
-                                    type="checkbox"
-                                  />
-                                  <i
-                                    class="box flex align-center"
-                                  />
-                                </label>
-                              </div>
-                              <div
-                                class="TableCell name"
-                              >
-                                some-other-name
-                              </div>
-                              <div
-                                class="TableCell namespace"
-                              >
-                                some-other-namespace
-                              </div>
-                              <div
-                                class="TableCell chart"
-                              >
-                                some-other-chart
-                              </div>
-                              <div
-                                class="TableCell revision"
-                              >
-                                NaN
-                              </div>
-                              <div
-                                class="TableCell version"
-                              >
-                                
-                              </div>
-                              <div
-                                class="TableCell app-version"
-                              >
-                                some-other-app-version
-                              </div>
-                              <div
-                                class="TableCell some-other-status status"
-                              >
-                                Some-other-status
-                              </div>
-                              <div
-                                class="TableCell updated"
-                              >
-                                NaNy
-                              </div>
-                              <div
-                                class="TableCell menu"
-                              >
-                                <div>
-                                  <i
-                                    class="Icon material interactive focusable"
-                                    id="menu-actions-for-release-menu-for-some-other-namespace/some-other-name"
-                                    tabindex="0"
-                                  >
-                                    <span
-                                      class="icon"
-                                      data-icon-name="more_vert"
-                                    >
-                                      more_vert
-                                    </span>
-                                  </i>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="AddRemoveButtons flex gaps"
-                />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-      <div
-        class="footer"
-      >
-        <div
-          class="Dock"
-          tabindex="-1"
-        >
-          <div
-            class="ResizingAnchor vertical leading"
-          />
-          <div
-            class="tabs-container flex align-center"
-          >
-            <div
-              class="dockTabs"
-              role="tablist"
-            >
-              <div
-                class="Tabs tabs"
-              >
-                <div
-                  class="Tab flex gaps align-center DockTab TerminalTab active"
-                  data-testid="dock-tab-for-terminal"
-                  id="tab-terminal"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <i
-                    class="Icon material focusable"
-                  >
-                    <span
-                      class="icon"
-                      data-icon-name="terminal"
-                    >
-                      terminal
-                    </span>
-                  </i>
-                  <div
-                    class="label"
-                  >
-                    <div
-                      class="flex align-center"
-                    >
-                      <span
-                        class="title"
-                      >
-                        Terminal
-                      </span>
-                      <div
-                        class="close"
-                      >
-                        <i
-                          class="Icon material interactive focusable small"
-                          tabindex="0"
-                        >
-                          <span
-                            class="icon"
-                            data-icon-name="close"
-                          >
-                            close
-                          </span>
-                        </i>
-                        <div>
-                          Close ⌘+W
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="toolbar flex gaps align-center box grow"
-            >
-              <div
-                class="dock-menu box grow"
-              >
-                <i
-                  class="Icon new-dock-tab material interactive focusable"
-                  id="menu-actions-for-dock"
-                  tabindex="0"
-                >
-                  <span
-                    class="icon"
-                    data-icon-name="add"
-                  >
-                    add
-                  </span>
-                </i>
-                <div>
-                  New tab
-                </div>
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="fullscreen"
-                >
-                  fullscreen
-                </span>
-              </i>
-              <div>
-                Fit to window
-              </div>
-              <i
-                class="Icon material interactive focusable"
-                tabindex="0"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="keyboard_arrow_up"
-                >
-                  keyboard_arrow_up
-                </span>
-              </i>
-              <div>
-                Open
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="Animate slide-right Drawer ReleaseDetails dark right enter"
-    data-testid="helm-release-details-for-some-namespace/some-name"
-    style="--size: 725px; --enter-duration: 100ms; --leave-duration: 100ms;"
-  >
-    <div
-      class="drawer-wrapper flex column"
-    >
-      <div
-        class="drawer-title flex align-center"
-      >
-        <div
-          class="drawer-title-text flex gaps align-center"
-        >
-          
         </div>
         <i
           class="Icon material interactive focusable"

--- a/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -5388,8 +5388,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -6613,8 +6612,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -7838,8 +7836,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -8890,8 +8887,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -9942,8 +9938,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -11169,8 +11164,7 @@ exports[`showing details for helm release given application is started when navi
             <span
               class="value"
             >
-              NaNy
-               ago (some-updated)
+              NaNy ago (some-updated)
             </span>
           </div>
           <div
@@ -13273,7 +13267,9 @@ exports[`showing details for helm release given application is started when navi
         <div
           data-testid="helm-release-detail-error"
         >
-          Failed to load release
+          Failed to load release:
+           
+          some-error
         </div>
       </div>
     </div>

--- a/src/features/helm-releases/showing-details-for-helm-release.test.ts
+++ b/src/features/helm-releases/showing-details-for-helm-release.test.ts
@@ -288,15 +288,42 @@ describe("showing details for helm release", () => {
             });
           });
 
-          it("when release resolve with no data, renders", async () => {
-            await callForHelmReleaseMock.resolve(undefined);
 
-            expect(rendered.baseElement).toMatchSnapshot();
+          describe("when call for release resolves with error", () => {
+            beforeEach(async () => {
+              await callForHelmReleaseMock.resolve({
+                callWasSuccessful: false,
+                error: "some-error",
+              });
+            });
+
+            it("renders", async () => {
+              expect(rendered.baseElement).toMatchSnapshot();
+            });
+
+            it("does not show spinner anymore", () => {
+              expect(
+                rendered.queryByTestId("helm-release-detail-content-spinner"),
+              ).not.toBeInTheDocument();
+            });
+
+            it("shows error message about missing release", () => {
+              expect(
+                rendered.getByTestId("helm-release-detail-error"),
+              ).toBeInTheDocument();
+            });
+
+            it("does not call for release configuration", () => {
+              expect(callForHelmReleaseConfigurationMock).not.toHaveBeenCalled();
+            });
           });
 
-          describe("when details resolve", () => {
+          describe("when call for release resolve with release", () => {
             beforeEach(async () => {
-              await callForHelmReleaseMock.resolve(detailedReleaseFake);
+              await callForHelmReleaseMock.resolve({
+                callWasSuccessful: true,
+                response: detailedReleaseFake,
+              });
             });
 
             it("renders", () => {

--- a/src/main/getDiForUnitTesting.ts
+++ b/src/main/getDiForUnitTesting.ts
@@ -83,12 +83,10 @@ import getHelmChartValuesInjectable from "./helm/helm-service/get-helm-chart-val
 import listHelmChartsInjectable from "./helm/helm-service/list-helm-charts.injectable";
 import deleteHelmReleaseInjectable from "./helm/helm-service/delete-helm-release.injectable";
 import getHelmReleaseHistoryInjectable from "./helm/helm-service/get-helm-release-history.injectable";
-import getHelmReleaseInjectable from "./helm/helm-service/get-helm-release.injectable";
 import getHelmReleaseValuesInjectable from "./helm/helm-service/get-helm-release-values.injectable";
 import installHelmChartInjectable from "./helm/helm-service/install-helm-chart.injectable";
 import listHelmReleasesInjectable from "./helm/helm-service/list-helm-releases.injectable";
 import rollbackHelmReleaseInjectable from "./helm/helm-service/rollback-helm-release.injectable";
-import updateHelmReleaseInjectable from "./helm/helm-service/update-helm-release.injectable";
 import waitUntilBundledExtensionsAreLoadedInjectable from "./start-main-application/lens-window/application-window/wait-until-bundled-extensions-are-loaded.injectable";
 import { registerMobX } from "@ogre-tools/injectable-extension-for-mobx";
 import electronInjectable from "./utils/resolve-system-proxy/electron.injectable";
@@ -168,12 +166,10 @@ export function getDiForUnitTesting(opts: { doGeneralOverrides?: boolean } = {})
       listHelmChartsInjectable,
       deleteHelmReleaseInjectable,
       getHelmReleaseHistoryInjectable,
-      getHelmReleaseInjectable,
       getHelmReleaseValuesInjectable,
       installHelmChartInjectable,
       listHelmReleasesInjectable,
       rollbackHelmReleaseInjectable,
-      updateHelmReleaseInjectable,
       writeJsonFileInjectable,
       readJsonFileInjectable,
       readFileInjectable,

--- a/src/main/helm/exec-helm/exec-helm.injectable.ts
+++ b/src/main/helm/exec-helm/exec-helm.injectable.ts
@@ -8,14 +8,16 @@ import helmBinaryPathInjectable from "../helm-binary-path.injectable";
 import type { AsyncResult } from "../../../common/utils/async-result";
 import { getErrorMessage } from "../../../common/utils/get-error-message";
 
+export type ExecHelm = (...args: string[]) => Promise<AsyncResult<string>>;
+
 const execHelmInjectable = getInjectable({
   id: "exec-helm",
 
-  instantiate: (di) => {
+  instantiate: (di): ExecHelm => {
     const execFile = di.inject(execFileInjectable);
     const helmBinaryPath = di.inject(helmBinaryPathInjectable);
 
-    return async (...args: string[]): Promise<AsyncResult<string>> => {
+    return async (...args) => {
       try {
         const response = await execFile(helmBinaryPath, args);
 

--- a/src/main/helm/exec-helm/exec-helm.injectable.ts
+++ b/src/main/helm/exec-helm/exec-helm.injectable.ts
@@ -8,7 +8,7 @@ import helmBinaryPathInjectable from "../helm-binary-path.injectable";
 import type { AsyncResult } from "../../../common/utils/async-result";
 import { getErrorMessage } from "../../../common/utils/get-error-message";
 
-export type ExecHelm = (...args: string[]) => Promise<AsyncResult<string>>;
+export type ExecHelm = (args: string[]) => Promise<AsyncResult<string>>;
 
 const execHelmInjectable = getInjectable({
   id: "exec-helm",
@@ -17,9 +17,11 @@ const execHelmInjectable = getInjectable({
     const execFile = di.inject(execFileInjectable);
     const helmBinaryPath = di.inject(helmBinaryPathInjectable);
 
-    return async (...args) => {
+    return async (args) => {
       try {
-        const response = await execFile(helmBinaryPath, args);
+        const response = await execFile(helmBinaryPath, args, {
+          maxBuffer: 32 * 1024 * 1024 * 1024, // 32 MiB
+        });
 
         return { callWasSuccessful: true, response };
       } catch (error) {

--- a/src/main/helm/get-helm-env/get-helm-env.injectable.ts
+++ b/src/main/helm/get-helm-env/get-helm-env.injectable.ts
@@ -18,7 +18,7 @@ const getHelmEnvInjectable = getInjectable({
     const execHelm = di.inject(execHelmInjectable);
 
     return async (): Promise<AsyncResult<HelmEnv>> => {
-      const result = await execHelm("env");
+      const result = await execHelm(["env"]);
 
       if (!result.callWasSuccessful) {
         return { callWasSuccessful: false, error: result.error };

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
@@ -6,12 +6,7 @@ import { getInjectable } from "@ogre-tools/injectable";
 import type { AsyncResult } from "../../../../../common/utils/async-result";
 import execHelmInjectable from "../../../exec-helm/exec-helm.injectable";
 import yaml from "js-yaml";
-
-export interface HelmResourceManifest {
-  metadata: {
-    namespace: string;
-  };
-}
+import type { KubeJsonApiData } from "../../../../../common/k8s-api/kube-json-api";
 
 const callForHelmManifestInjectable = getInjectable({
   id: "call-for-helm-manifest",
@@ -23,7 +18,7 @@ const callForHelmManifestInjectable = getInjectable({
       name: string,
       namespace: string,
       kubeconfigPath: string,
-    ): Promise<AsyncResult<HelmResourceManifest[]>> => {
+    ): Promise<AsyncResult<KubeJsonApiData[]>> => {
       const result = await execHelm(
         "get",
         "manifest",
@@ -42,7 +37,7 @@ const callForHelmManifestInjectable = getInjectable({
         callWasSuccessful: true,
         response: yaml
           .loadAll(result.response)
-          .filter((manifest) => !!manifest) as HelmResourceManifest[],
+          .filter((manifest) => !!manifest) as KubeJsonApiData[],
       };
     };
 

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
@@ -19,7 +19,7 @@ const callForHelmManifestInjectable = getInjectable({
       namespace: string,
       kubeconfigPath: string,
     ): Promise<AsyncResult<KubeJsonApiData[]>> => {
-      const result = await execHelm(
+      const result = await execHelm([
         "get",
         "manifest",
         name,
@@ -27,7 +27,7 @@ const callForHelmManifestInjectable = getInjectable({
         namespace,
         "--kubeconfig",
         kubeconfigPath,
-      );
+      ]);
 
       if (!result.callWasSuccessful) {
         return { callWasSuccessful: false, error: result.error };

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { AsyncResult } from "../../../../../common/utils/async-result";
+import execHelmInjectable from "../../../exec-helm/exec-helm.injectable";
+import yaml from "js-yaml";
+
+export interface HelmResourceManifest {
+  metadata: {
+    namespace: string;
+  };
+}
+
+const callForHelmManifestInjectable = getInjectable({
+  id: "call-for-helm-manifest",
+
+  instantiate: (di) => {
+    const execHelm = di.inject(execHelmInjectable);
+
+    return async (
+      name: string,
+      namespace: string,
+      kubeconfigPath: string,
+    ): Promise<AsyncResult<HelmResourceManifest[]>> => {
+      const result = await execHelm(
+        "get",
+        "manifest",
+        name,
+        "--namespace",
+        namespace,
+        "--kubeconfig",
+        kubeconfigPath,
+      );
+
+      if (!result.callWasSuccessful) {
+        return { callWasSuccessful: false, error: result.error };
+      }
+
+      return {
+        callWasSuccessful: true,
+        response: yaml
+          .loadAll(result.response)
+          .filter((manifest) => !!manifest) as HelmResourceManifest[],
+      };
+    };
+
+  },
+});
+
+export default callForHelmManifestInjectable;

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { JsonObject } from "type-fest";
+import { json } from "../../../../../common/utils";
+import yaml from "js-yaml";
+import execFileWithInputInjectable from "./exec-file-with-input/exec-file-with-input.injectable";
+import { getErrorMessage } from "../../../../../common/utils/get-error-message";
+import { map } from "lodash/fp";
+import { pipeline } from "@ogre-tools/fp";
+import type { HelmResourceManifest } from "../call-for-helm-manifest/call-for-helm-manifest.injectable";
+
+export type CallForKubeResourcesByManifest = (
+  namespace: string,
+  kubeconfigPath: string,
+  kubectlPath: string,
+  resourceManifests: HelmResourceManifest[]
+) => Promise<JsonObject[]>;
+
+const callForKubeResourcesByManifestInjectable = getInjectable({
+  id: "call-for-kube-resources-by-manifest",
+
+  instantiate: (di): CallForKubeResourcesByManifest => {
+    const execFileWithInput = di.inject(execFileWithInputInjectable);
+
+    return async (
+      namespace,
+      kubeconfigPath,
+      kubectlPath,
+      resourceManifests,
+    ) => {
+      const input = pipeline(
+        resourceManifests,
+        map((manifest) => yaml.dump(manifest)),
+        wideJoin("---\n"),
+      );
+
+      const result = await execFileWithInput({
+        filePath: kubectlPath,
+        input,
+
+        commandArguments: [
+          "get",
+          "--kubeconfig",
+          kubeconfigPath,
+          "-f",
+          "-",
+          "--namespace",
+          namespace,
+          "--output",
+          "json",
+        ],
+      });
+
+      if (!result.callWasSuccessful) {
+        const errorMessage = getErrorMessage(result.error);
+
+        throw new Error(errorMessage);
+      }
+
+      const output = json.parse(result.response) as { items: JsonObject[] };
+
+      return output.items;
+    };
+  },
+});
+
+export default callForKubeResourcesByManifestInjectable;
+
+const wideJoin = (joiner: string) => (items: string[]) =>
+  `${joiner}${items.join(joiner)}${joiner}`;

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable.ts
@@ -10,13 +10,13 @@ import execFileWithInputInjectable from "./exec-file-with-input/exec-file-with-i
 import { getErrorMessage } from "../../../../../common/utils/get-error-message";
 import { map } from "lodash/fp";
 import { pipeline } from "@ogre-tools/fp";
-import type { HelmResourceManifest } from "../call-for-helm-manifest/call-for-helm-manifest.injectable";
+import type { KubeJsonApiData } from "../../../../../common/k8s-api/kube-json-api";
 
 export type CallForKubeResourcesByManifest = (
   namespace: string,
   kubeconfigPath: string,
   kubectlPath: string,
-  resourceManifests: HelmResourceManifest[]
+  resourceManifests: KubeJsonApiData[]
 ) => Promise<JsonObject[]>;
 
 const callForKubeResourcesByManifestInjectable = getInjectable({

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.global-override-for-injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.global-override-for-injectable.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getGlobalOverride } from "../../../../../../common/test-utils/get-global-override";
+import execFileWithInputInjectable from "./exec-file-with-input.injectable";
+
+export default getGlobalOverride(execFileWithInputInjectable, () => () => {
+  throw new Error(
+    "Tried to call exec file with input without explicit override",
+  );
+});

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { AsyncResult } from "../../../../../../common/utils/async-result";
+import nonPromiseExecFileInjectable from "./non-promise-exec-file.injectable";
+import { isNumber } from "../../../../../../common/utils";
+import assert from "assert";
+import type { ChildProcess } from "child_process";
+
+export type ExecFileWithInput = (options: {
+  filePath: string;
+  commandArguments: string[];
+  input: string;
+}) => Promise<AsyncResult<string, unknown>>;
+
+const execFileWithInputInjectable = getInjectable({
+  id: "exec-file-with-input",
+
+  instantiate: (di): ExecFileWithInput => {
+    const execFile = di.inject(nonPromiseExecFileInjectable);
+
+    return async ({ filePath, commandArguments, input }) =>
+      new Promise((resolve) => {
+        let execution: ChildProcess;
+
+        try {
+          execution = execFile(filePath, commandArguments);
+        } catch (e) {
+          resolve({ callWasSuccessful: false, error: e });
+
+          return;
+        }
+
+        assert(execution.stdout, "stdout is not defined");
+        assert(execution.stderr, "stderr is not defined");
+        assert(execution.stdin, "stdin is not defined");
+
+        let stdout = "";
+        let stderr = "";
+
+        execution.stdout.on("data", (data) => {
+          stdout += data;
+        });
+
+        execution.stderr.on("data", (data) => {
+          stderr += data;
+        });
+
+        execution.on("error", (error) =>
+          resolve({ callWasSuccessful: false, error }),
+        );
+
+        execution.on("exit", (code, signal) => {
+          if (!isNumber(code)) {
+            resolve({
+              callWasSuccessful: false,
+              error: "Exited without exit code",
+            });
+
+            return;
+          }
+
+          if (code !== 0) {
+            resolve({
+              callWasSuccessful: false,
+              error: stderr ? stderr : `Failed with error: ${signal}`,
+            });
+
+            return;
+          }
+
+          resolve({ callWasSuccessful: true, response: stdout });
+        });
+
+        execution.stdin.end(input);
+      });
+  },
+});
+
+export default execFileWithInputInjectable;

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
@@ -26,7 +26,9 @@ const execFileWithInputInjectable = getInjectable({
         let execution: ChildProcess;
 
         try {
-          execution = execFile(filePath, commandArguments);
+          execution = execFile(filePath, commandArguments, {
+            maxBuffer: 8 * 1024 * 1024 * 1024, // 8 MiB
+          });
         } catch (e) {
           resolve({ callWasSuccessful: false, error: e });
 
@@ -56,7 +58,7 @@ const execFileWithInputInjectable = getInjectable({
           if (!isNumber(code)) {
             resolve({
               callWasSuccessful: false,
-              error: "Exited without exit code",
+              error: `Exited via ${signal}`,
             });
 
             return;

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable.ts
@@ -56,6 +56,14 @@ const execFileWithInputInjectable = getInjectable({
 
         execution.on("exit", (code, signal) => {
           if (!isNumber(code)) {
+            /**
+             * According to https://nodejs.org/api/child_process.html#class-childprocess (section about the "exit" event)
+             * it says the following:
+             *
+             * If the process exited, code is the final exit code of the process, otherwise null.
+             * If the process terminated due to receipt of a signal, signal is the string name of the signal, otherwise null.
+             * One of the two will always be non-null.
+             */
             resolve({
               callWasSuccessful: false,
               error: `Exited via ${signal}`,

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getDiForUnitTesting } from "../../../../../getDiForUnitTesting";
+import type { ExecFileWithInput } from "./exec-file-with-input.injectable";
+import execFileWithInputInjectable from "./exec-file-with-input.injectable";
+import type { AsyncResult } from "../../../../../../common/utils/async-result";
+import nonPromiseExecFileInjectable from "./non-promise-exec-file.injectable";
+import { getPromiseStatus } from "../../../../../../common/test-utils/get-promise-status";
+import EventEmitter from "events";
+
+describe("exec-file-with-input", () => {
+  let execFileWithInput: ExecFileWithInput;
+  let execFileMock: jest.Mock;
+
+  let executionStub: EventEmitter & {
+    stdin: { end: jest.Mock };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+
+  beforeEach(() => {
+    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+
+    di.unoverride(execFileWithInputInjectable);
+
+    executionStub = new EventEmitter() as any;
+    executionStub.stdin = { end: jest.fn() };
+    executionStub.stdout = new EventEmitter();
+    executionStub.stderr = new EventEmitter();
+
+    execFileMock = jest.fn(() => executionStub);
+
+    di.override(nonPromiseExecFileInjectable, () => execFileMock as any);
+
+    execFileWithInput = di.inject(execFileWithInputInjectable);
+  });
+
+  it("given call, when throws synchronously, resolves with failure", async () => {
+    execFileMock.mockImplementation(() => {
+      throw new Error("some-error");
+    });
+
+    const actual = await execFileWithInput({
+      filePath: "./irrelevant",
+      commandArguments: ["irrelevant"],
+      input: "irrelevant",
+    });
+
+    expect(actual).toEqual({
+      callWasSuccessful: false,
+      error: expect.any(Error),
+    });
+  });
+
+  describe("when called", () => {
+    let actualPromise: Promise<AsyncResult<string, unknown>>;
+
+    beforeEach(() => {
+      actualPromise = execFileWithInput({
+        filePath: "./some-file-path",
+        commandArguments: ["some-arg", "some-other-arg"],
+        input: "some-input",
+      });
+    });
+
+    it("calls for file with arguments", () => {
+      expect(execFileMock).toHaveBeenCalledWith("./some-file-path", [
+        "some-arg",
+        "some-other-arg",
+      ]);
+    });
+
+    it("calls with input", () => {
+      expect(executionStub.stdin.end).toHaveBeenCalledWith("some-input");
+    });
+
+    it("does not resolve yet", async () => {
+      const promiseStatus = await getPromiseStatus(actualPromise);
+
+      expect(promiseStatus.fulfilled).toBe(false);
+    });
+
+    describe("when stdout receives data", () => {
+      beforeEach(() => {
+        executionStub.stdout.emit("data", "some-data");
+      });
+
+      it("does not resolve yet", async () => {
+        const promiseStatus = await getPromiseStatus(actualPromise);
+
+        expect(promiseStatus.fulfilled).toBe(false);
+      });
+
+      describe("when stdout receives more data", () => {
+        beforeEach(() => {
+          executionStub.stdout.emit("data", "some-other-data");
+        });
+
+        it("does not resolve yet", async () => {
+          const promiseStatus = await getPromiseStatus(actualPromise);
+
+          expect(promiseStatus.fulfilled).toBe(false);
+        });
+
+        it("when execution exits with success, resolves with result", async () => {
+          executionStub.emit("exit", 0);
+
+          const actual = await actualPromise;
+
+          expect(actual).toEqual({
+            callWasSuccessful: true,
+            response: "some-datasome-other-data",
+          });
+        });
+
+        it("when execution exits without exit code, resolves with failure", async () => {
+          executionStub.emit("exit");
+
+          const actual = await actualPromise;
+
+          expect(actual).toEqual({
+            callWasSuccessful: false,
+            error: "Exited without exit code",
+          });
+        });
+
+        it("when execution exits with failure, resolves with failure", async () => {
+          executionStub.emit("exit", 42, "some-signal");
+
+          const actual = await actualPromise;
+
+          expect(actual).toEqual({
+            callWasSuccessful: false,
+            error: "Failed with error: some-signal",
+          });
+        });
+
+        describe("when stderr receives data", () => {
+          beforeEach(() => {
+            executionStub.stderr.emit("data", "some-error");
+          });
+
+          it("does not resolve yet", async () => {
+            const promiseStatus = await getPromiseStatus(actualPromise);
+
+            expect(promiseStatus.fulfilled).toBe(false);
+          });
+
+          describe("when stderr receives more data", () => {
+            beforeEach(() => {
+              executionStub.stderr.emit("data", "some-other-error");
+            });
+
+            it("does not resolve yet", async () => {
+              const promiseStatus = await getPromiseStatus(actualPromise);
+
+              expect(promiseStatus.fulfilled).toBe(false);
+            });
+
+            it("when execution exits with success, resolves with result", async () => {
+              executionStub.emit("exit", 0);
+
+              const actual = await actualPromise;
+
+              expect(actual).toEqual({
+                callWasSuccessful: true,
+                response: "some-datasome-other-data",
+              });
+            });
+
+            it("when execution exits without exit code, resolves with failure", async () => {
+              executionStub.emit("exit");
+
+              const actual = await actualPromise;
+
+              expect(actual).toEqual({
+                callWasSuccessful: false,
+                error: "Exited without exit code",
+              });
+            });
+
+            it("when execution exits with failure, resolves with errors", async () => {
+              executionStub.emit("exit", 42, "irrelevant");
+
+              const actual = await actualPromise;
+
+              expect(actual).toEqual({
+                callWasSuccessful: false,
+                error: "some-errorsome-other-error",
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it("when execution receives error, resolves with error", async () => {
+      executionStub.emit("error", new Error("some-error"));
+
+      const actual = await actualPromise;
+
+      expect(actual).toEqual({
+        callWasSuccessful: false,
+        error: expect.any(Error),
+      });
+    });
+  });
+});

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/non-promise-exec-file.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/non-promise-exec-file.injectable.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import { execFile } from "child_process";
+
+const nonPromiseExecFileInjectable = getInjectable({
+  id: "non-promise-exec-file",
+  instantiate: () => execFile,
+  causesSideEffects: true,
+});
+
+export default nonPromiseExecFileInjectable;

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import callForKubeResourcesByManifestInjectable from "./call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable";
+import { groupBy, map } from "lodash/fp";
+import type { JsonObject } from "type-fest";
+import { pipeline } from "@ogre-tools/fp";
+import callForHelmManifestInjectable from "./call-for-helm-manifest/call-for-helm-manifest.injectable";
+
+export type GetHelmReleaseResources = (
+  name: string,
+  namespace: string,
+  kubeconfigPath: string,
+  kubectlPath: string
+) => Promise<JsonObject[]>;
+
+const getHelmReleaseResourcesInjectable = getInjectable({
+  id: "get-helm-release-resources",
+
+  instantiate: (di): GetHelmReleaseResources => {
+    const callForHelmManifest = di.inject(callForHelmManifestInjectable);
+    const callForKubeResourcesByManifest = di.inject(callForKubeResourcesByManifestInjectable);
+
+    return async (name, namespace, kubeconfigPath, kubectlPath) => {
+      const result = await callForHelmManifest(name, namespace, kubeconfigPath);
+
+      if (!result.callWasSuccessful) {
+        throw new Error(result.error);
+      }
+
+      const results = await pipeline(
+        result.response,
+
+        groupBy((item) => item.metadata.namespace || namespace),
+
+        (x) => Object.entries(x),
+
+        map(([namespace, manifest]) =>
+          callForKubeResourcesByManifest(namespace, kubeconfigPath, kubectlPath, manifest),
+        ),
+
+        promises => Promise.all(promises),
+      );
+
+      return results.flat(1);
+    };
+  },
+});
+
+export default getHelmReleaseResourcesInjectable;

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
@@ -48,9 +48,9 @@ describe("get helm release resources", () => {
     });
 
     it("calls for release manifest", () => {
-      expect(execHelmMock).toHaveBeenCalledWith(
+      expect(execHelmMock).toHaveBeenCalledWith([
         "get", "manifest", "some-release", "--namespace", "some-namespace", "--kubeconfig", "/some-kubeconfig-path",
-      );
+      ]);
     });
 
     it("does not call for resources yet", () => {

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { getDiForUnitTesting } from "../../../getDiForUnitTesting";
+import type { GetHelmReleaseResources } from "./get-helm-release-resources.injectable";
+import getHelmReleaseResourcesInjectable from "./get-helm-release-resources.injectable";
+import type { ExecHelm } from "../../exec-helm/exec-helm.injectable";
+import execHelmInjectable from "../../exec-helm/exec-helm.injectable";
+import type { AsyncFnMock } from "@async-fn/jest";
+import asyncFn from "@async-fn/jest";
+import type { JsonObject } from "type-fest";
+import type { ExecFileWithInput } from "./call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable";
+import execFileWithInputInjectable from "./call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable";
+
+describe("get helm release resources", () => {
+  let getHelmReleaseResources: GetHelmReleaseResources;
+  let execHelmMock: AsyncFnMock<ExecHelm>;
+  let execFileWithStreamInputMock: AsyncFnMock<ExecFileWithInput>;
+
+  beforeEach(() => {
+    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+
+    execHelmMock = asyncFn();
+    execFileWithStreamInputMock = asyncFn();
+
+    di.override(execHelmInjectable, () => execHelmMock);
+
+    di.override(
+      execFileWithInputInjectable,
+      () => execFileWithStreamInputMock,
+    );
+
+    getHelmReleaseResources = di.inject(getHelmReleaseResourcesInjectable);
+  });
+
+  describe("when called", () => {
+    let actualPromise: Promise<JsonObject[]>;
+
+    beforeEach(() => {
+      actualPromise = getHelmReleaseResources(
+        "some-release",
+        "some-namespace",
+        "/some-kubeconfig-path",
+        "/some-kubectl-path",
+      );
+    });
+
+    it("calls for release manifest", () => {
+      expect(execHelmMock).toHaveBeenCalledWith(
+        "get", "manifest", "some-release", "--namespace", "some-namespace", "--kubeconfig", "/some-kubeconfig-path",
+      );
+    });
+
+    it("does not call for resources yet", () => {
+      expect(execFileWithStreamInputMock).not.toHaveBeenCalled();
+    });
+
+    it("when call for manifest resolves without resources, resolves without resources", async () => {
+      await execHelmMock.resolve({
+        callWasSuccessful: true,
+        response: "",
+      });
+
+      const actual = await actualPromise;
+
+      expect(actual).toEqual([]);
+    });
+
+    describe("when call for manifest resolves", () => {
+      beforeEach(async () => {
+        await execHelmMock.resolve({
+          callWasSuccessful: true,
+          response: `---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-same-namespace
+  namespace: some-namespace
+---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-without-namespace
+---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-different-namespace
+  namespace: some-other-namespace
+---
+`,
+        });
+      });
+
+      it("calls for resources from each namespace separately using the manifest as input", () => {
+        expect(execFileWithStreamInputMock.mock.calls).toEqual([
+          [
+            {
+              filePath: "/some-kubectl-path",
+              commandArguments: ["get", "--kubeconfig", "/some-kubeconfig-path", "-f", "-", "--namespace", "some-namespace", "--output", "json"],
+              input: `---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-same-namespace
+  namespace: some-namespace
+---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-without-namespace
+---
+`,
+            },
+          ],
+
+          [
+            {
+              filePath: "/some-kubectl-path",
+              commandArguments: ["get", "--kubeconfig", "/some-kubeconfig-path", "-f", "-", "--namespace", "some-other-namespace", "--output", "json"],
+              input: `---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-different-namespace
+  namespace: some-other-namespace
+---
+`,
+            },
+          ],
+        ]);
+      });
+
+      it("when all calls for resources resolve, resolves with combined result", async () => {
+        await execFileWithStreamInputMock.resolveSpecific(
+          ([{ commandArguments }]) =>
+            commandArguments.includes("some-namespace"),
+          {
+            callWasSuccessful: true,
+
+            response: JSON.stringify({
+              items: [{ some: "item" }],
+
+              kind: "List",
+
+              metadata: {
+                resourceVersion: "",
+                selfLink: "",
+              },
+            }),
+          },
+        );
+
+        await execFileWithStreamInputMock.resolveSpecific(
+          ([{ commandArguments }]) =>
+            commandArguments.includes("some-other-namespace"),
+          {
+            callWasSuccessful: true,
+
+            response: JSON.stringify({
+              items: [{ some: "other-item" }],
+
+              kind: "List",
+
+              metadata: {
+                resourceVersion: "",
+                selfLink: "",
+              },
+            }),
+          },
+        );
+
+        const actual = await actualPromise;
+
+        expect(actual).toEqual([{ some: "item" }, { some: "other-item" }]);
+      });
+
+      it("given some call fails, when all calls have finished, rejects with failure", async () => {
+        await execFileWithStreamInputMock.resolveSpecific(
+          ([{ commandArguments }]) =>
+            commandArguments.includes("some-namespace"),
+
+          {
+            callWasSuccessful: true,
+
+            response: JSON.stringify({
+              items: [{ some: "item" }],
+
+              kind: "List",
+
+              metadata: {
+                resourceVersion: "",
+                selfLink: "",
+              },
+            }),
+          },
+        );
+
+        execFileWithStreamInputMock.resolveSpecific(
+          ([{ commandArguments }]) =>
+            commandArguments.includes("some-other-namespace"),
+
+          {
+            callWasSuccessful: false,
+            error: "some-error",
+          },
+        );
+
+        return expect(actualPromise).rejects.toEqual(expect.any(Error));
+      });
+    });
+  });
+});

--- a/src/main/helm/helm-service/get-helm-release.global-override-for-injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release.global-override-for-injectable.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getGlobalOverride } from "../../../common/test-utils/get-global-override";
+import getHelmReleaseInjectable from "./get-helm-release.injectable";
+
+export default getGlobalOverride(getHelmReleaseInjectable, () => () => {
+  throw new Error("Tried to get helm release without explicit override");
+});

--- a/src/main/helm/helm-service/update-helm-release.global-override-for-injectable.ts
+++ b/src/main/helm/helm-service/update-helm-release.global-override-for-injectable.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getGlobalOverride } from "../../../common/test-utils/get-global-override";
+import updateHelmReleaseInjectable from "./update-helm-release.injectable";
+
+export default getGlobalOverride(updateHelmReleaseInjectable, () => () => {
+  throw new Error("Tried to update helm release without explicit override");
+});

--- a/src/main/helm/repositories/add-helm-repository/add-helm-repository.injectable.ts
+++ b/src/main/helm/repositories/add-helm-repository/add-helm-repository.injectable.ts
@@ -54,7 +54,7 @@ const addHelmRepositoryInjectable = getInjectable({
         args.push("--cert-file", certFile);
       }
 
-      return await execHelm(...args);
+      return await execHelm(args);
     };
   },
 });

--- a/src/main/helm/repositories/get-active-helm-repositories/get-active-helm-repositories.injectable.ts
+++ b/src/main/helm/repositories/get-active-helm-repositories/get-active-helm-repositories.injectable.ts
@@ -75,7 +75,7 @@ const getActiveHelmRepositoriesInjectable = getInjectable({
         };
       }
 
-      const updateResult = await execHelm("repo", "update");
+      const updateResult = await execHelm(["repo", "update"]);
 
       if (!updateResult.callWasSuccessful) {
         if (!updateResult.error.includes(internalHelmErrorForNoRepositoriesFound)) {
@@ -84,7 +84,7 @@ const getActiveHelmRepositoriesInjectable = getInjectable({
             error: `Error updating Helm repositories: ${updateResult.error}`,
           };
         }
-        const resultOfAddingDefaultRepository = await execHelm("repo", "add", "bitnami", "https://charts.bitnami.com/bitnami");
+        const resultOfAddingDefaultRepository = await execHelm(["repo", "add", "bitnami", "https://charts.bitnami.com/bitnami"]);
 
         if (!resultOfAddingDefaultRepository.callWasSuccessful) {
           return {

--- a/src/main/helm/repositories/remove-helm-repository/remove-helm-repository.injectable.ts
+++ b/src/main/helm/repositories/remove-helm-repository/remove-helm-repository.injectable.ts
@@ -17,11 +17,11 @@ const removeHelmRepositoryInjectable = getInjectable({
     return async (repo: HelmRepo) => {
       logger.info(`[HELM]: removing repo ${repo.name} (${repo.url})`);
 
-      return execHelm(
+      return execHelm([
         "repo",
         "remove",
         repo.name,
-      );
+      ]);
     };
   },
 });

--- a/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
@@ -34,10 +34,16 @@ interface Dependencies {
 }
 
 const NonInjectedReleaseDetailsContent = observer(({ model }: Dependencies & ReleaseDetailsContentProps) => {
-  const failedToLoad = model.failedToLoad.get();
+  const loadingError = model.loadingError.get();
 
-  if (failedToLoad) {
-    return <div data-testid="helm-release-detail-error">Failed to load release</div>;
+  if (loadingError) {
+    return (
+      <div data-testid="helm-release-detail-error">
+        Failed to load release:
+        {" "}
+        {loadingError}
+      </div>
+    );
   }
 
 
@@ -58,8 +64,7 @@ const NonInjectedReleaseDetailsContent = observer(({ model }: Dependencies & Rel
       </DrawerItem>
 
       <DrawerItem name="Updated">
-        {model.release.getUpdated()}
-        {` ago (${model.release.updated})`}
+        {`${model.release.getUpdated()} ago (${model.release.updated})`}
       </DrawerItem>
 
       <DrawerItem name="Namespace">{model.release.getNs()}</DrawerItem>

--- a/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
@@ -8,8 +8,8 @@ import "./release-details.scss";
 import React from "react";
 
 import { Link } from "react-router-dom";
-import { Drawer, DrawerItem, DrawerTitle } from "../../drawer";
-import { cssNames, stopPropagation } from "../../../utils";
+import { DrawerItem, DrawerTitle } from "../../drawer";
+import { stopPropagation } from "../../../utils";
 import { observer } from "mobx-react";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import type { ConfigurationInput, MinimalResourceGroup, OnlyUserSuppliedValuesAreShownToggle, ReleaseDetailsModel } from "./release-details-model/release-details-model.injectable";
@@ -20,7 +20,6 @@ import { Badge } from "../../badge";
 import { SubTitle } from "../../layout/sub-title";
 import { Table, TableCell, TableHead, TableRow } from "../../table";
 import { ReactiveDuration } from "../../duration/reactive-duration";
-import { HelmReleaseMenu } from "../release-menu";
 import { Checkbox } from "../../checkbox";
 import { MonacoEditor } from "../../monaco-editor";
 import { Spinner } from "../../spinner";
@@ -36,96 +35,85 @@ interface Dependencies {
 
 const NonInjectedReleaseDetailsContent = observer(({ model }: Dependencies & ReleaseDetailsContentProps) => {
   const isLoading = model.isLoading.get();
+  const failedToLoad = model.failedToLoad.get();
+
+  if (failedToLoad) {
+    return <div data-testid="helm-release-detail-error">Failed to load release</div>;
+  }
+
 
   return (
-    <Drawer
-      className={cssNames("ReleaseDetails", model.activeTheme)}
-      usePortal={true}
-      open={true}
-      title={isLoading ? "" : model.release.getName()}
-      onClose={model.close}
-      testIdForClose="close-helm-release-detail"
-      toolbar={
-        !isLoading && (
-          <HelmReleaseMenu
-            release={model.release}
-            toolbar
-            hideDetails={model.close}
-          />
-        )
-      }
-      data-testid={`helm-release-details-for-${model.id}`}
-    >
-      {isLoading ? (
-        <Spinner center data-testid="helm-release-detail-content-spinner" />
-      ) : (
-        <div>
-          <DrawerItem name="Chart" className="chart">
-            <div className="flex gaps align-center">
-              <span>{model.release.chart}</span>
+    (isLoading ? (
+      <Spinner center data-testid="helm-release-detail-content-spinner" />
+    ) : (
+      <div>
+        <DrawerItem name="Chart" className="chart">
+          <div className="flex gaps align-center">
+            <span>{model.release.chart}</span>
 
-              <Button
-                primary
-                label="Upgrade"
-                className="box right upgrade"
-                onClick={model.startUpgradeProcess}
-                data-testid="helm-release-upgrade-button"
-              />
-            </div>
-          </DrawerItem>
-
-          <DrawerItem name="Updated">
-            {model.release.getUpdated()}
-            {` ago (${model.release.updated})`}
-          </DrawerItem>
-
-          <DrawerItem name="Namespace">{model.release.getNs()}</DrawerItem>
-
-          <DrawerItem name="Version" onClick={stopPropagation}>
-            <div className="version flex gaps align-center">
-              <span>{model.release.getVersion()}</span>
-            </div>
-          </DrawerItem>
-
-          <DrawerItem
-            name="Status"
-            className="status"
-            labelsOnly>
-            <Badge
-              label={model.release.getStatus()}
-              className={kebabCase(model.release.getStatus())}
+            <Button
+              primary
+              label="Upgrade"
+              className="box right upgrade"
+              onClick={model.startUpgradeProcess}
+              data-testid="helm-release-upgrade-button"
             />
-          </DrawerItem>
+          </div>
+        </DrawerItem>
 
-          <ReleaseValues
-            configuration={model.configuration}
-            onlyUserSuppliedValuesAreShown={
-              model.onlyUserSuppliedValuesAreShown
-            }
+        <DrawerItem name="Updated">
+          {model.release.getUpdated()}
+          {` ago (${model.release.updated})`}
+        </DrawerItem>
+
+        <DrawerItem name="Namespace">{model.release.getNs()}</DrawerItem>
+
+        <DrawerItem name="Version" onClick={stopPropagation}>
+          <div className="version flex gaps align-center">
+            <span>{model.release.getVersion()}</span>
+          </div>
+        </DrawerItem>
+
+        <DrawerItem
+          name="Status"
+          className="status"
+          labelsOnly>
+          <Badge
+            label={model.release.getStatus()}
+            className={kebabCase(model.release.getStatus())}
           />
+        </DrawerItem>
 
-          <DrawerTitle>Notes</DrawerTitle>
+        <ReleaseValues
+          configuration={model.configuration}
+          onlyUserSuppliedValuesAreShown={
+            model.onlyUserSuppliedValuesAreShown
+          }
+        />
 
-          {model.notes && <div className="notes">{model.notes}</div>}
+        <DrawerTitle>Notes</DrawerTitle>
 
-          <DrawerTitle>Resources</DrawerTitle>
+        {model.notes && <div className="notes">{model.notes}</div>}
 
-          {model.groupedResources.length > 0 && (
-            <div className="resources">
-              {model.groupedResources.map((group) => (
-                <ResourceGroup key={group.kind} group={group} />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </Drawer>
+        <DrawerTitle>Resources</DrawerTitle>
+
+        {model.groupedResources.length > 0 && (
+          <div className="resources">
+            {model.groupedResources.map((group) => (
+              <ResourceGroup key={group.kind} group={group} />
+            ))}
+          </div>
+        )}
+      </div>
+    ))
   );
 });
 
 export const ReleaseDetailsContent = withInjectables<Dependencies, ReleaseDetailsContentProps>(NonInjectedReleaseDetailsContent, {
-  getProps: (di, props) => ({
-    model: di.inject(releaseDetailsModelInjectable, props.targetRelease),
+  getPlaceholder: () => <Spinner center data-testid="helm-release-detail-content-spinner" />,
+
+  getProps: async (di, props) => ({
+    model: await di.inject(releaseDetailsModelInjectable, props.targetRelease),
     ...props,
   }),
 });

--- a/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
@@ -34,7 +34,6 @@ interface Dependencies {
 }
 
 const NonInjectedReleaseDetailsContent = observer(({ model }: Dependencies & ReleaseDetailsContentProps) => {
-  const isLoading = model.isLoading.get();
   const failedToLoad = model.failedToLoad.get();
 
   if (failedToLoad) {
@@ -43,69 +42,65 @@ const NonInjectedReleaseDetailsContent = observer(({ model }: Dependencies & Rel
 
 
   return (
-    (isLoading ? (
-      <Spinner center data-testid="helm-release-detail-content-spinner" />
-    ) : (
-      <div>
-        <DrawerItem name="Chart" className="chart">
-          <div className="flex gaps align-center">
-            <span>{model.release.chart}</span>
+    <div>
+      <DrawerItem name="Chart" className="chart">
+        <div className="flex gaps align-center">
+          <span>{model.release.chart}</span>
 
-            <Button
-              primary
-              label="Upgrade"
-              className="box right upgrade"
-              onClick={model.startUpgradeProcess}
-              data-testid="helm-release-upgrade-button"
-            />
-          </div>
-        </DrawerItem>
-
-        <DrawerItem name="Updated">
-          {model.release.getUpdated()}
-          {` ago (${model.release.updated})`}
-        </DrawerItem>
-
-        <DrawerItem name="Namespace">{model.release.getNs()}</DrawerItem>
-
-        <DrawerItem name="Version" onClick={stopPropagation}>
-          <div className="version flex gaps align-center">
-            <span>{model.release.getVersion()}</span>
-          </div>
-        </DrawerItem>
-
-        <DrawerItem
-          name="Status"
-          className="status"
-          labelsOnly>
-          <Badge
-            label={model.release.getStatus()}
-            className={kebabCase(model.release.getStatus())}
+          <Button
+            primary
+            label="Upgrade"
+            className="box right upgrade"
+            onClick={model.startUpgradeProcess}
+            data-testid="helm-release-upgrade-button"
           />
-        </DrawerItem>
+        </div>
+      </DrawerItem>
 
-        <ReleaseValues
-          configuration={model.configuration}
-          onlyUserSuppliedValuesAreShown={
-            model.onlyUserSuppliedValuesAreShown
-          }
+      <DrawerItem name="Updated">
+        {model.release.getUpdated()}
+        {` ago (${model.release.updated})`}
+      </DrawerItem>
+
+      <DrawerItem name="Namespace">{model.release.getNs()}</DrawerItem>
+
+      <DrawerItem name="Version" onClick={stopPropagation}>
+        <div className="version flex gaps align-center">
+          <span>{model.release.getVersion()}</span>
+        </div>
+      </DrawerItem>
+
+      <DrawerItem
+        name="Status"
+        className="status"
+        labelsOnly>
+        <Badge
+          label={model.release.getStatus()}
+          className={kebabCase(model.release.getStatus())}
         />
+      </DrawerItem>
 
-        <DrawerTitle>Notes</DrawerTitle>
+      <ReleaseValues
+        configuration={model.configuration}
+        onlyUserSuppliedValuesAreShown={
+          model.onlyUserSuppliedValuesAreShown
+        }
+      />
 
-        {model.notes && <div className="notes">{model.notes}</div>}
+      <DrawerTitle>Notes</DrawerTitle>
 
-        <DrawerTitle>Resources</DrawerTitle>
+      {model.notes && <div className="notes">{model.notes}</div>}
 
-        {model.groupedResources.length > 0 && (
-          <div className="resources">
-            {model.groupedResources.map((group) => (
-              <ResourceGroup key={group.kind} group={group} />
-            ))}
-          </div>
-        )}
-      </div>
-    ))
+      <DrawerTitle>Resources</DrawerTitle>
+
+      {model.groupedResources.length > 0 && (
+        <div className="resources">
+          {model.groupedResources.map((group) => (
+            <ResourceGroup key={group.kind} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 });
 

--- a/src/renderer/components/+helm-releases/release-details/release-details-drawer-toolbar.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-drawer-toolbar.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import "./release-details.scss";
+
+import React from "react";
+
+import { observer } from "mobx-react";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import type { TargetHelmRelease } from "./target-helm-release.injectable";
+import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
+import type { ReleaseDetailsModel } from "./release-details-model/release-details-model.injectable";
+import releaseDetailsModelInjectable from "./release-details-model/release-details-model.injectable";
+import { HelmReleaseMenu } from "../release-menu";
+
+interface ReleaseDetailsDrawerProps {
+  targetRelease: TargetHelmRelease;
+}
+
+interface Dependencies {
+  model: ReleaseDetailsModel;
+  closeDrawer: () => void;
+}
+
+const NonInjectedReleaseDetailsDrawerToolbar = observer(
+  ({ model, closeDrawer }: Dependencies & ReleaseDetailsDrawerProps) =>
+    model.failedToLoad.get() ? null : (
+      <HelmReleaseMenu
+        release={model.release}
+        toolbar
+        hideDetails={closeDrawer}
+      />
+    ),
+);
+
+export const ReleaseDetailsDrawerToolbar = withInjectables<
+  Dependencies,
+  ReleaseDetailsDrawerProps
+>(NonInjectedReleaseDetailsDrawerToolbar, {
+  getPlaceholder: () => <></>,
+
+  getProps: async (di, props) => ({
+    model: await di.inject(releaseDetailsModelInjectable, props.targetRelease),
+    closeDrawer: di.inject(navigateToHelmReleasesInjectable),
+    ...props,
+  }),
+});

--- a/src/renderer/components/+helm-releases/release-details/release-details-drawer-toolbar.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-drawer-toolbar.tsx
@@ -21,19 +21,23 @@ interface ReleaseDetailsDrawerProps {
 
 interface Dependencies {
   model: ReleaseDetailsModel;
-  closeDrawer: () => void;
+  navigateToHelmReleases: () => void;
 }
 
-const NonInjectedReleaseDetailsDrawerToolbar = observer(
-  ({ model, closeDrawer }: Dependencies & ReleaseDetailsDrawerProps) =>
-    model.failedToLoad.get() ? null : (
+const NonInjectedReleaseDetailsDrawerToolbar = observer(({
+  model,
+  navigateToHelmReleases,
+}: Dependencies & ReleaseDetailsDrawerProps) => (
+  model.loadingError.get()
+    ? null
+    : (
       <HelmReleaseMenu
         release={model.release}
         toolbar
-        hideDetails={closeDrawer}
+        hideDetails={navigateToHelmReleases}
       />
-    ),
-);
+    )
+));
 
 export const ReleaseDetailsDrawerToolbar = withInjectables<
   Dependencies,
@@ -43,7 +47,7 @@ export const ReleaseDetailsDrawerToolbar = withInjectables<
 
   getProps: async (di, props) => ({
     model: await di.inject(releaseDetailsModelInjectable, props.targetRelease),
-    closeDrawer: di.inject(navigateToHelmReleasesInjectable),
+    navigateToHelmReleases: di.inject(navigateToHelmReleasesInjectable),
     ...props,
   }),
 });

--- a/src/renderer/components/+helm-releases/release-details/release-details-drawer.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-drawer.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import "./release-details.scss";
+
+import React from "react";
+
+import { Drawer } from "../../drawer";
+import { cssNames } from "../../../utils";
+import { observer } from "mobx-react";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import type { TargetHelmRelease } from "./target-helm-release.injectable";
+import type { ActiveThemeType } from "../../../themes/active-type.injectable";
+import activeThemeTypeInjectable from "../../../themes/active-type.injectable";
+import { ReleaseDetailsContent } from "./release-details-content";
+import navigateToHelmReleasesInjectable from "../../../../common/front-end-routing/routes/cluster/helm/releases/navigate-to-helm-releases.injectable";
+import { ReleaseDetailsDrawerToolbar } from "./release-details-drawer-toolbar";
+
+interface ReleaseDetailsDrawerProps {
+  targetRelease: TargetHelmRelease;
+}
+
+interface Dependencies {
+  activeThemeType: ActiveThemeType;
+  closeDrawer: () => void;
+}
+
+const NonInjectedReleaseDetailsDrawer = observer(({
+  activeThemeType,
+  closeDrawer,
+  targetRelease,
+}: Dependencies & ReleaseDetailsDrawerProps) => (
+  <Drawer
+    className={cssNames("ReleaseDetails", activeThemeType.get())}
+    usePortal={true}
+    open={true}
+    title={targetRelease.name}
+    onClose={closeDrawer}
+    testIdForClose="close-helm-release-detail"
+    toolbar={<ReleaseDetailsDrawerToolbar targetRelease={targetRelease} />}
+    data-testid={`helm-release-details-for-${targetRelease.namespace}/${targetRelease.name}`}
+  >
+    <ReleaseDetailsContent targetRelease={targetRelease} />
+  </Drawer>
+));
+
+export const ReleaseDetailsDrawer = withInjectables<
+  Dependencies,
+  ReleaseDetailsDrawerProps
+>(NonInjectedReleaseDetailsDrawer, {
+  getProps: (di, props) => ({
+    activeThemeType: di.inject(activeThemeTypeInjectable),
+    closeDrawer: di.inject(navigateToHelmReleasesInjectable),
+    ...props,
+  }),
+});

--- a/src/renderer/components/+helm-releases/release-details/release-details-model/call-for-helm-release/call-for-helm-release.injectable.ts
+++ b/src/renderer/components/+helm-releases/release-details/release-details-model/call-for-helm-release/call-for-helm-release.injectable.ts
@@ -7,6 +7,7 @@ import type { HelmReleaseDto } from "../../../../../../common/k8s-api/endpoints/
 import callForHelmReleasesInjectable from "../../../call-for-helm-releases/call-for-helm-releases.injectable";
 import type { HelmReleaseDetails } from "./call-for-helm-release-details/call-for-helm-release-details.injectable";
 import callForHelmReleaseDetailsInjectable from "./call-for-helm-release-details/call-for-helm-release-details.injectable";
+import type { AsyncResult } from "../../../../../../common/utils/async-result";
 
 export interface DetailedHelmRelease {
   release: HelmReleaseDto;
@@ -16,7 +17,7 @@ export interface DetailedHelmRelease {
 export type CallForHelmRelease = (
   name: string,
   namespace: string
-) => Promise<DetailedHelmRelease | undefined>;
+) => Promise<AsyncResult<DetailedHelmRelease | undefined>>;
 
 const callForHelmReleaseInjectable = getInjectable({
   id: "call-for-helm-release",
@@ -36,10 +37,13 @@ const callForHelmReleaseInjectable = getInjectable({
       );
 
       if (!release) {
-        return undefined;
+        return {
+          callWasSuccessful: false,
+          error: `Release ${name} didn't exist in ${namespace} namespace.`,
+        };
       }
 
-      return { release, details };
+      return { callWasSuccessful: true, response: { release, details }};
     };
   },
 });

--- a/src/renderer/components/+helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
@@ -103,7 +103,6 @@ export class ReleaseDetailsModel {
 
   private detailedRelease = observable.box<DetailedHelmRelease | undefined>();
 
-  readonly isLoading = observable.box(false);
   readonly failedToLoad = observable.box(false);
 
   readonly configuration: ConfigurationInput = {
@@ -171,10 +170,6 @@ export class ReleaseDetailsModel {
   };
 
   load = async () => {
-    runInAction(() => {
-      this.isLoading.set(true);
-    });
-
     const { name, namespace } = this.dependencies.targetRelease;
 
     const result = await this.dependencies.callForHelmRelease(
@@ -195,10 +190,6 @@ export class ReleaseDetailsModel {
     });
 
     await this.loadConfiguration();
-
-    runInAction(() => {
-      this.isLoading.set(false);
-    });
   };
 
   private loadConfiguration = async () => {

--- a/src/renderer/components/+helm-releases/release-details/release-details.scss
+++ b/src/renderer/components/+helm-releases/release-details/release-details.scss
@@ -49,16 +49,19 @@
       .TableCell {
         text-overflow: unset;
         word-break: break-word;
-        min-width: 100px;
 
         &.name {
-          flex-basis: auto;
-          flex-grow: 0;
-          width: 230px;
+          flex-grow: 3;
         }
 
-        &.volume {
-          flex-basis: 30%;
+        &.namespace {
+          flex-grow: 1;
+        }
+
+        &.age {
+          flex-basis: 100px;
+          flex-grow: 0;
+          flex-shrink: 0;
         }
       }
     }

--- a/src/renderer/components/+helm-releases/release-details/release-details.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details.tsx
@@ -11,9 +11,9 @@ import { observer } from "mobx-react";
 import { withInjectables } from "@ogre-tools/injectable-react";
 
 import type { IComputedValue } from "mobx";
-import { ReleaseDetailsContent } from "./release-details-content";
 import type { TargetHelmRelease } from "./target-helm-release.injectable";
 import targetHelmReleaseInjectable from "./target-helm-release.injectable";
+import { ReleaseDetailsDrawer } from "./release-details-drawer";
 
 interface Dependencies {
   targetRelease: IComputedValue<
@@ -25,7 +25,7 @@ const NonInjectedReleaseDetails = observer(
   ({ targetRelease }: Dependencies) => {
     const release = targetRelease.get();
 
-    return release ? <ReleaseDetailsContent targetRelease={release} /> : null;
+    return release ? <ReleaseDetailsDrawer targetRelease={release} /> : null;
   },
 );
 

--- a/src/renderer/themes/active-type.injectable.ts
+++ b/src/renderer/themes/active-type.injectable.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { IComputedValue } from "mobx";
+import { computed } from "mobx";
+import type { LensThemeType } from "./store";
+import themeStoreInjectable from "./store.injectable";
+
+export type ActiveThemeType = IComputedValue<LensThemeType>;
+
+const activeThemeTypeInjectable = getInjectable({
+  id: "active-theme-type",
+
+  instantiate: (di) => {
+    const store = di.inject(themeStoreInjectable);
+
+    return computed(() => store.activeTheme.type);
+  },
+});
+
+export default activeThemeTypeInjectable;

--- a/src/renderer/themes/store.ts
+++ b/src/renderer/themes/store.ts
@@ -17,10 +17,10 @@ import type { ReadonlyDeep } from "type-fest/source/readonly-deep";
 import assert from "assert";
 
 export type ThemeId = string;
-
+export type LensThemeType = "dark" | "light";
 export interface LensTheme {
   name: string;
-  type: "dark" | "light";
+  type: LensThemeType;
   colors: Record<string, string>;
   description: string;
   author: string;


### PR DESCRIPTION
Fixes #6031

Review commit by commit. Please verify with multiple charts and installing them to separate namespaces etc.

Problem:

The issue comes from place where we get resources of a Helm release.

Before this PR, the process of getting resources of a Helm release works like this:
1.  Get manifest of a Helm release e.g. `$ helm get manifest chatwoot-1660899467 --namespace some-namespace --kubeconfig /var/folders/_3/some-kubeconfig`
2. With response of first command, we call `kubectl` to get kube resources. e.g. `$ kubectl get --kubeconfig /var/folders/_3/some-kubeconfig --output json -f -` (notice output of first command as input)

However, latter command doesn't work properly:

1. In case Helm Release has resources in single namespace, it doesn't matter if we specify `--namespace`
2. In case Helm Release has resources in single namespace and resources without namespace, we have to specify `--namespace` to get all resources (it will crash without it, because it cannot find the resource without namespace)
3. In case Helm Release has resources in multiple namespaces, we shouldn't specify `--namespace` (it will crash if namespace doesn't match)

This means that to get all of these combinations to work properly, we have to:
1. Helm manifest of Helm release
2. Split resources from manifest to groups with namespace and default to whatever namespace was set in the 1. command.
3. Get resources from `kubectl` for each group individually and specify the `--namespace`.


---

Also fixed the CSS for the resources tables so that everything lines up even without namespaces and that the names of the resources get the most space:


![Screen Shot 2022-09-08 at 8 24 14 AM](https://user-images.githubusercontent.com/8225332/189121288-a5a29aff-cdc2-4a97-a613-acf99290a125.png)
