### PR TITLE
Fix node conditions column text-align

### DIFF
--- a/src/renderer/components/+nodes/nodes.scss
+++ b/src/renderer/components/+nodes/nodes.scss
@@ -49,7 +49,6 @@
 
     &.conditions {
       flex: 1.7;
-      text-align: right;
 
       .condition {
         display: inline-block;


### PR DESCRIPTION

![conditions on left](https://user-images.githubusercontent.com/9607060/186424706-d83034ee-ec91-40d3-8e08-683427563be0.png)

Fixes #5919 

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>