### PR TITLE
Fix issues when using newer @types/semver

### DIFF
--- a/src/common/utils/sort-compare.ts
+++ b/src/common/utils/sort-compare.ts
@@ -81,7 +81,7 @@ export function sortCharts(charts: RawHelmChart[]) {
     iter.map(
       charts,
       chart => {
-        const __version = coerce(chart.version, { includePrerelease: true, loose: true });
+        const __version = coerce(chart.version, { loose: true });
 
         if (!__version) {
           logger.warn(`[HELM-SERVICE]: Version from helm chart is not loosely coercable to semver.`, { name: chart.name, version: chart.version, repo: chart.repo });

--- a/src/extensions/extension-discovery/is-compatible-extension/is-compatible-extension.ts
+++ b/src/extensions/extension-discovery/is-compatible-extension/is-compatible-extension.ts
@@ -27,7 +27,6 @@ export const isCompatibleExtension = ({ appSemVer }: Dependencies): ((manifest: 
 
     const { major: extMajor, minor: extMinor } = semver.coerce(manifestLensEngine, {
       loose: true,
-      includePrerelease: false,
     }) as semver.SemVer;
     const supportedVersionsByExtension = semver.validRange(`^${extMajor}.${extMinor}`) as string;
 

--- a/src/main/kubectl/kubectl.ts
+++ b/src/main/kubectl/kubectl.ts
@@ -67,7 +67,7 @@ export class Kubectl {
     let version: SemVer;
 
     try {
-      version = new SemVer(clusterVersion, { includePrerelease: false });
+      version = new SemVer(clusterVersion);
     } catch {
       version = new SemVer(Kubectl.bundledKubectlVersion);
     }

--- a/src/renderer/components/+extensions/attempt-install-by-info.injectable.tsx
+++ b/src/renderer/components/+extensions/attempt-install-by-info.injectable.tsx
@@ -91,7 +91,7 @@ const attemptInstallByInfo = ({
       }
     } else {
       const versions = Object.keys(json.versions)
-        .map(version => new SemVer(version, { loose: true, includePrerelease: true }))
+        .map(version => new SemVer(version, { loose: true }))
         // ignore pre-releases for auto picking the version
         .filter(version => version.prerelease.length === 0);
 

--- a/src/renderer/components/+helm-charts/helm-chart.store.ts
+++ b/src/renderer/components/+helm-charts/helm-chart.store.ts
@@ -55,7 +55,7 @@ export class HelmChartStore extends ItemStore<HelmChart> {
 
   protected sortVersions = (versions: ChartVersion[]) => {
     return versions
-      .map(chartVersion => ({ ...chartVersion, __version: semver.coerce(chartVersion.version, { includePrerelease: true, loose: true }) }))
+      .map(chartVersion => ({ ...chartVersion, __version: semver.coerce(chartVersion.version, { loose: true }) }))
       .sort(sortCompareChartVersions)
       .map(({ __version, ...chartVersion }) => chartVersion);
   };


### PR DESCRIPTION
- All the removed uses of `includePrerelease` that are removed were not
  actually used within the semver package

Signed-off-by: Sebastian Malton <sebastian@malton.name>