### PR TITLE
Fix Promethes operator metrics provider detection

### DIFF
--- a/src/main/prometheus/operator.ts
+++ b/src/main/prometheus/operator.ts
@@ -15,7 +15,7 @@ export class PrometheusOperator extends PrometheusProvider {
   readonly isConfigurable: boolean = true;
 
   public async getPrometheusService(client: CoreV1Api): Promise<PrometheusService> {
-    return this.getFirstNamespacedService(client, "operated-prometheus=true", "self-monitor=true");
+    return this.getFirstNamespacedService(client, "operated-prometheus=true");
   }
 
   public getQuery(opts: Record<string, string>, queryName: string): string {


### PR DESCRIPTION
`prometheus-community/kube-prometheus-stack` helm chart does not set `self-monitor=true` label to prometheus service anymore. That's why Lens fails to auto-detect prometheus operator metrics. This PR removes that label from labelSelector.

Signed-off-by: Lauri Nevala <lauri.nevala@gmail.com>