### PR TITLE
reinstate integration tests on windows

### DIFF
--- a/integration/__tests__/app-preferences.tests.ts
+++ b/integration/__tests__/app-preferences.tests.ts
@@ -11,7 +11,6 @@
 */
 import type { ElectronApplication, Page } from "playwright";
 import * as utils from "../helpers/utils";
-import { isWindows } from "../../src/common/vars";
 
 describe("preferences page tests", () => {
   let window: Page, cleanup: () => Promise<void>;
@@ -34,8 +33,7 @@ describe("preferences page tests", () => {
     await cleanup();
   }, 10*60*1000);
 
-  // skip on windows due to suspected playwright issue with Electron 14
-  utils.itIf(!isWindows)('shows "preferences" and can navigate through the tabs', async () => {
+  it('shows "preferences" and can navigate through the tabs', async () => {
     const pages = [
       {
         id: "application",

--- a/integration/__tests__/command-palette.tests.ts
+++ b/integration/__tests__/command-palette.tests.ts
@@ -5,7 +5,6 @@
 
 import type { ElectronApplication, Page } from "playwright";
 import * as utils from "../helpers/utils";
-import { isWindows } from "../../src/common/vars";
 
 describe("Lens command palette", () => {
   let window: Page, cleanup: () => Promise<void>, app: ElectronApplication;
@@ -20,8 +19,7 @@ describe("Lens command palette", () => {
   }, 10*60*1000);
 
   describe("menu", () => {
-    // skip on windows due to suspected playwright issue with Electron 14
-    utils.itIf(!isWindows)("opens command dialog from menu", async () => {
+    it("opens command dialog from menu", async () => {
       await app.evaluate(async ({ app }) => {
         await app.applicationMenu
           ?.getMenuItemById("view")


### PR DESCRIPTION
the playwright/Electron 14 issue seems to be solved with current playwright/Electron 19, at least locally. This PR is to confirm on CI