### PR TITLE
Use extension version as projectVersion for exported ExtensionStore

### DIFF
--- a/src/common/base-store.ts
+++ b/src/common/base-store.ts
@@ -59,10 +59,10 @@ export abstract class BaseStore<T extends object> extends Singleton {
     const getConfigurationFileModel = di.inject(getConfigurationFileModelInjectable);
 
     this.storeConfig = getConfigurationFileModel({
-      ...this.params,
       projectName: "lens",
       projectVersion: di.inject(appVersionInjectable),
       cwd: this.cwd(),
+      ...this.params,
     });
 
     const res: any = this.fromStore(this.storeConfig.store);

--- a/src/extensions/extension-store.ts
+++ b/src/extensions/extension-store.ts
@@ -15,6 +15,8 @@ export abstract class ExtensionStore<T extends object> extends BaseStore<T> {
   loadExtension(extension: LensExtension) {
     this.extension = extension;
 
+    this.params.projectVersion ??= this.extension.version;
+
     return super.load();
   }
 


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

This is technically a breaking change but the current behaviour makes no sense so I think we should change it.

The current behaviour means that migrations only happen when the version of Lens itself changes and not when an extension version changes.