### PR TITLE
Allow extensions to control status bar item visibility

### DIFF
--- a/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
+++ b/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
@@ -8,6 +8,7 @@ import type { ApplicationBuilder } from "../../renderer/components/test-utils/ge
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import getRandomIdInjectable from "../../common/utils/get-random-id.injectable";
 import type { FakeExtensionOptions } from "../../renderer/components/test-utils/get-extension-fake";
+import { computed } from "mobx";
 
 describe("status-bar-items-originating-from-extensions", () => {
   let applicationBuilder: ApplicationBuilder;
@@ -65,7 +66,7 @@ describe("status-bar-items-originating-from-extensions", () => {
 
       const rightSide = rendered.getByTestId("status-bar-right");
 
-      const actual = getTestStatusBarTexts(rightSide, [
+      const actual = getExpectedTestStatusBarTexts(rightSide, [
         "extension1",
         "extension2",
       ]);
@@ -97,6 +98,13 @@ describe("status-bar-items-originating-from-extensions", () => {
               },
               {
                 components: {
+                  Item: () => <div data-testid="some-testId">right4</div>,
+                  position: "right" as const,
+                  visible: computed(() => false),
+                },
+              },
+              {
+                components: {
                   Item: () => <div data-testid="some-testId">left1</div>,
                   position: "left" as const,
                 },
@@ -121,7 +129,7 @@ describe("status-bar-items-originating-from-extensions", () => {
       it("shows right side status bar items in the correct order", () => {
         const rightSide = rendered.getByTestId("status-bar-right");
 
-        const actual = getTestStatusBarTexts(rightSide, [
+        const actual = getExpectedTestStatusBarTexts(rightSide, [
           "right1",
           "right2",
           "right3",
@@ -130,10 +138,16 @@ describe("status-bar-items-originating-from-extensions", () => {
         expect(actual).toEqual(["right3", "right2", "right1"]);
       });
 
+      it("doesn't show invisible status bar item", () => {
+        const rightSide = rendered.getByTestId("status-bar-right");
+
+        expect(getTestStatusBarTexts(rightSide)).not.toContain("right4");
+      });
+
       it("shows left side status bar items in the correct order", () => {
         const leftSide = rendered.getByTestId("status-bar-left");
 
-        const actual = getTestStatusBarTexts(leftSide, ["left2", "left1"]);
+        const actual = getExpectedTestStatusBarTexts(leftSide, ["left2", "left1"]);
 
         expect(actual).toEqual(["left1", "left2"]);
       });
@@ -149,7 +163,9 @@ describe("status-bar-items-originating-from-extensions", () => {
   });
 });
 
-const getTestStatusBarTexts = (actual: HTMLElement, expectedTexts: string[]) =>
+const getTestStatusBarTexts = (actual: HTMLElement) =>
   Array.from(actual.children)
-    .map((elem) => elem.textContent)
-    .filter((elem) => elem && expectedTexts.includes(elem));
+    .map((elem) => String(elem.textContent));
+
+const getExpectedTestStatusBarTexts = (actual: HTMLElement, expectedTexts: string[]) =>
+  getTestStatusBarTexts(actual).filter((textContent) => textContent && expectedTexts.includes(textContent));

--- a/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
+++ b/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
@@ -100,8 +100,8 @@ describe("status-bar-items-originating-from-extensions", () => {
                 components: {
                   Item: () => <div data-testid="some-testId">right4</div>,
                   position: "right" as const,
-                  visible: computed(() => false),
                 },
+                visible: computed(() => false),
               },
               {
                 components: {

--- a/src/renderer/components/status-bar/status-bar-item-registrator.injectable.tsx
+++ b/src/renderer/components/status-bar/status-bar-item-registrator.injectable.tsx
@@ -39,7 +39,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
     const id = `${getRandomId()}-status-bar-item-for-extension-${extension.sanitizedExtensionId}`;
     let component: React.ComponentType;
     let position: "left" | "right";
-    let visible: IComputedValue<boolean> | undefined;
+    const visible: IComputedValue<boolean> | undefined = registration?.visible;
 
     if (registration?.item) {
       const { item } = registration;
@@ -56,7 +56,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
           </>
         );
     } else if (registration?.components) {
-      const { position: pos = "right", Item, visible: componentVisible } = registration.components;
+      const { position: pos = "right", Item } = registration.components;
 
       if (pos !== "left" && pos !== "right") {
         throw new TypeError("StatusBarRegistration.components.position must be either 'right' or 'left'");
@@ -64,7 +64,6 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
 
       position = pos;
       component = Item;
-      visible = componentVisible;
     } else {
       logger.warn("StatusBarRegistration must have valid item or components field");
 

--- a/src/renderer/components/status-bar/status-bar-item-registrator.injectable.tsx
+++ b/src/renderer/components/status-bar/status-bar-item-registrator.injectable.tsx
@@ -4,6 +4,7 @@
  */
 import type { Injectable } from "@ogre-tools/injectable";
 import { getInjectable } from "@ogre-tools/injectable";
+import type { IComputedValue } from "mobx";
 import { computed } from "mobx";
 import { extensionRegistratorInjectionToken } from "../../../extensions/extension-loader/extension-registrator-injection-token";
 import type { LensRendererExtension } from "../../../extensions/lens-renderer-extension";
@@ -38,6 +39,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
     const id = `${getRandomId()}-status-bar-item-for-extension-${extension.sanitizedExtensionId}`;
     let component: React.ComponentType;
     let position: "left" | "right";
+    let visible: IComputedValue<boolean> | undefined;
 
     if (registration?.item) {
       const { item } = registration;
@@ -54,7 +56,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
           </>
         );
     } else if (registration?.components) {
-      const { position: pos = "right", Item } = registration.components;
+      const { position: pos = "right", Item, visible: componentVisible } = registration.components;
 
       if (pos !== "left" && pos !== "right") {
         throw new TypeError("StatusBarRegistration.components.position must be either 'right' or 'left'");
@@ -62,6 +64,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
 
       position = pos;
       component = Item;
+      visible = componentVisible;
     } else {
       logger.warn("StatusBarRegistration must have valid item or components field");
 
@@ -74,7 +77,7 @@ const toItemInjectableFor = (extension: LensRendererExtension, getRandomId: () =
       instantiate: () => ({
         component,
         position,
-        visible: computed(() => true),
+        visible: visible ?? computed(() => true),
       }),
 
       injectionToken: statusBarItemInjectionToken,

--- a/src/renderer/components/status-bar/status-bar-registration.ts
+++ b/src/renderer/components/status-bar/status-bar-registration.ts
@@ -25,11 +25,6 @@ export interface StatusBarComponents {
    * @default "right"
    */
   position?: "left" | "right";
-
-  /**
-   * If specified, controls item visibility
-   */
-  visible?: IComputedValue<boolean>;
 }
 
 /**
@@ -45,4 +40,9 @@ export interface StatusBarRegistration {
    * The newer API, allows for registering a component instead of a ReactNode
    */
   components?: StatusBarComponents;
+
+  /**
+   * If specified, controls item visibility
+   */
+  visible?: IComputedValue<boolean>;
 }

--- a/src/renderer/components/status-bar/status-bar-registration.ts
+++ b/src/renderer/components/status-bar/status-bar-registration.ts
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import type { IComputedValue } from "mobx";
+
 /**
  * The props for StatusBar item component
  */
@@ -23,6 +25,11 @@ export interface StatusBarComponents {
    * @default "right"
    */
   position?: "left" | "right";
+
+  /**
+   * If specified, controls item visibility
+   */
+  visible?: IComputedValue<boolean>;
 }
 
 /**


### PR DESCRIPTION
* Status bar items already had `visible` property, which defaults to true. This exposes the property for extensions.
* Set for 6.1.0 as an enhancement