### PR TITLE
Download arm64 linux binaries

### DIFF
--- a/build/download_binaries.ts
+++ b/build/download_binaries.ts
@@ -194,7 +194,7 @@ async function main() {
     }, multiBar),
   ];
 
-  if (normalizedPlatform === "darwin") {
+  if (normalizedPlatform !== "windows") {
     downloaders.push(
       new LensK8sProxyDownloader({
         version: packageInfo.config.k8sProxyVersion,


### PR DESCRIPTION
Running make build on a linux arm64 machine results into error like

```
  • file source doesn't exist  from=.../lens/binaries/client/linux/arm64/kubectl
  • file source doesn't exist  from=.../lens/binaries/client/linux/arm64/lens-k8s-proxy
  • file source doesn't exist  from=.../lens/binaries/client/linux/arm64/helm
```