### PR TITLE
Specify artifactName to fix Windows autoupdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
       ]
     },
     "win": {
+      "artifactName": "${productName} Setup ${version}.exe",
       "target": [
         "nsis"
       ],


### PR DESCRIPTION
Currently the artifactName, e.g. filename for the Windows build is e.g. `Lens.Setup.2022.9.161904-alpha.exe` instead of the generated filename `Lens Setup 2022.9.161904-alpha.exe`, which causes autoupdate to fail.