### PR TITLE
Add missing space in "Remove x items"

### DIFF
--- a/src/renderer/components/item-object-list/content.tsx
+++ b/src/renderer/components/item-object-list/content.tsx
@@ -195,7 +195,7 @@ class NonInjectedItemListLayoutContent<
       )
       : (
         <p>
-          Remove
+          {"Remove "}
           <b>{selectedCount}</b>
           {" items "}
           <b>{selectedNames}</b>


### PR DESCRIPTION
When checking multiple items in a list and clicking the remove button, the message in the dialog was missing a space between the word "Remove" and the number of items:
<img width="598" alt="image" src="https://user-images.githubusercontent.com/1380292/192297852-a5c8ef9b-6001-42e1-abff-1df275cb8d12.png">

This change adds the missing space.