### PR TITLE
Fix Singleton type in exports

### DIFF
--- a/src/extensions/common-api/utils.ts
+++ b/src/extensions/common-api/utils.ts
@@ -13,7 +13,7 @@ import type { IClassName } from "../../renderer/utils/cssNames";
 import { cssNames } from "../../renderer/utils/cssNames";
 
 export interface UtilsExtensionItems {
-  Singleton: Singleton;
+  Singleton: typeof Singleton;
   prevDefault: <E extends React.SyntheticEvent | Event, R>(callback: (evt: E) => R) => (evt: E) => R;
   stopPropagation: (evt: Event | React.SyntheticEvent) => void;
   cssNames: (...classNames: IClassName[]) => string;


### PR DESCRIPTION
It seems that https://github.com/lensapp/lens/pull/6196 had a regression in the exported Singleton type in `@k8slens/extensions` version 6.1.1 (6.0.0 worked correctly). This causes a breaking API change with error `Type 'Singleton' is not a constructor function type` for code `export class FooBar extends Common.Util.Singleton`