### PR TITLE
Delete old extensions when app is updated on Windows

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,10 +1,6 @@
 !macro customInit
   ; Make sure all old extensions are removed
   RMDir /r "$INSTDIR\resources\extensions"
-  ; Workaround for old node_modules having already duplicate extensions
-  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-license"
-  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-survey"
-  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-telemetry"
 
   ; Workaround for installer handing when the app directory is removed manually
   ${ifNot} ${FileExists} "$INSTDIR"

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,4 +1,11 @@
 !macro customInit
+  ; Make sure all old extensions are removed
+  RMDir /r "$INSTDIR\resources\extensions"
+  ; Workaround for old node_modules having already duplicate extensions
+  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-license"
+  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-survey"
+  RMDir /r "$APPDATA\${APP_FILENAME}\node_modules\lens-telemetry"
+
   ; Workaround for installer handing when the app directory is removed manually
   ${ifNot} ${FileExists} "$INSTDIR"
     DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\{${UNINSTALL_APP_KEY}}"


### PR DESCRIPTION
NSIS installer just overwrites the app on update which leaves old files there when they are deleted in the newer version. This adds a custom installer macro to delete the extension always on install / update so the old ones shouldn't be there after install. 

Fixes #6297
