### PR TITLE
Adding asc provider

### DIFF
--- a/build/notarize.js
+++ b/build/notarize.js
@@ -22,5 +22,6 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,
+    ascProvider:process.env.ASCPROVIDER,
   });
 };


### PR DESCRIPTION
If your AppleID belongs to multiple teams, notarize will ask for the "asc provider" aka team short name. [see docs](https://github.com/electron/electron-notarize#api)

Signed-off-by: Billy Tobon <billy.tobon@gmail.com>