### PR TITLE
Fix loading helm release details

### DIFF
--- a/src/common/utils/objects.ts
+++ b/src/common/utils/objects.ts
@@ -17,6 +17,7 @@ export function keys<K extends keyof any>(obj: Record<K, any>): K[] {
   return Object.keys(obj) as K[];
 }
 
+export function entries<K extends string, V>(obj: Partial<Record<K, V>> | null | undefined): [K, V][];
 export function entries<K extends string | number | symbol, V>(obj: Partial<Record<K, V>> | null | undefined): [K, V][];
 export function entries<K extends string | number | symbol, V>(obj: Record<K, V> | null | undefined): [K, V][];
 

--- a/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -5552,11 +5552,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -5570,11 +5565,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>
@@ -6784,11 +6774,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -6802,11 +6787,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>
@@ -8016,11 +7996,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -8034,11 +8009,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>
@@ -9073,11 +9043,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -9091,11 +9056,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>
@@ -10132,11 +10092,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -10150,11 +10105,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>
@@ -11364,11 +11314,6 @@ exports[`showing details for helm release given application is started when navi
                 >
                   Namespace
                 </div>
-                <div
-                  class="TableCell age"
-                >
-                  Age
-                </div>
               </div>
               <div
                 class="TableRow"
@@ -11382,11 +11327,6 @@ exports[`showing details for helm release given application is started when navi
                   class="TableCell namespace"
                 >
                   some-namespace
-                </div>
-                <div
-                  class="TableCell age"
-                >
-                  0s
                 </div>
               </div>
             </div>

--- a/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/call-for-helm-manifest/call-for-helm-manifest.injectable.ts
@@ -6,7 +6,7 @@ import { getInjectable } from "@ogre-tools/injectable";
 import type { AsyncResult } from "../../../../../common/utils/async-result";
 import execHelmInjectable from "../../../exec-helm/exec-helm.injectable";
 import yaml from "js-yaml";
-import type { KubeJsonApiData } from "../../../../../common/k8s-api/kube-json-api";
+import type { KubeJsonApiData, KubeJsonApiDataList } from "../../../../../common/k8s-api/kube-json-api";
 
 const callForHelmManifestInjectable = getInjectable({
   id: "call-for-helm-manifest",
@@ -18,7 +18,7 @@ const callForHelmManifestInjectable = getInjectable({
       name: string,
       namespace: string,
       kubeconfigPath: string,
-    ): Promise<AsyncResult<KubeJsonApiData[]>> => {
+    ): Promise<AsyncResult<(KubeJsonApiData | KubeJsonApiDataList)[]>> => {
       const result = await execHelm([
         "get",
         "manifest",

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
@@ -3,48 +3,38 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import callForKubeResourcesByManifestInjectable from "./call-for-kube-resources-by-manifest/call-for-kube-resources-by-manifest.injectable";
-import { groupBy, map } from "lodash/fp";
-import type { JsonObject } from "type-fest";
-import { pipeline } from "@ogre-tools/fp";
 import callForHelmManifestInjectable from "./call-for-helm-manifest/call-for-helm-manifest.injectable";
+import type { KubeJsonApiData, KubeJsonApiDataList } from "../../../../common/k8s-api/kube-json-api";
+import type { AsyncResult } from "../../../../common/utils/async-result";
 
 export type GetHelmReleaseResources = (
   name: string,
   namespace: string,
   kubeconfigPath: string,
   kubectlPath: string
-) => Promise<JsonObject[]>;
+) => Promise<AsyncResult<KubeJsonApiData[], string>>;
 
 const getHelmReleaseResourcesInjectable = getInjectable({
   id: "get-helm-release-resources",
 
   instantiate: (di): GetHelmReleaseResources => {
     const callForHelmManifest = di.inject(callForHelmManifestInjectable);
-    const callForKubeResourcesByManifest = di.inject(callForKubeResourcesByManifestInjectable);
 
-    return async (name, namespace, kubeconfigPath, kubectlPath) => {
+    return async (name, namespace, kubeconfigPath) => {
       const result = await callForHelmManifest(name, namespace, kubeconfigPath);
 
       if (!result.callWasSuccessful) {
-        throw new Error(result.error);
+        return result;
       }
 
-      const results = await pipeline(
-        result.response,
-
-        groupBy((item) => item.metadata.namespace || namespace),
-
-        (x) => Object.entries(x),
-
-        map(([namespace, manifest]) =>
-          callForKubeResourcesByManifest(namespace, kubeconfigPath, kubectlPath, manifest),
-        ),
-
-        promises => Promise.all(promises),
-      );
-
-      return results.flat(1);
+      return {
+        callWasSuccessful: true,
+        response: result.response.flatMap(item => (
+          Array.isArray(item.items)
+            ? (item as KubeJsonApiDataList).items
+            : item as KubeJsonApiData
+        )),
+      };
     };
   },
 });

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.injectable.ts
@@ -11,7 +11,6 @@ export type GetHelmReleaseResources = (
   name: string,
   namespace: string,
   kubeconfigPath: string,
-  kubectlPath: string
 ) => Promise<AsyncResult<KubeJsonApiData[], string>>;
 
 const getHelmReleaseResourcesInjectable = getInjectable({

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
@@ -10,9 +10,10 @@ import type { ExecHelm } from "../../exec-helm/exec-helm.injectable";
 import execHelmInjectable from "../../exec-helm/exec-helm.injectable";
 import type { AsyncFnMock } from "@async-fn/jest";
 import asyncFn from "@async-fn/jest";
-import type { JsonObject } from "type-fest";
 import type { ExecFileWithInput } from "./call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable";
 import execFileWithInputInjectable from "./call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.injectable";
+import type { AsyncResult } from "../../../../common/utils/async-result";
+import type { KubeJsonApiData } from "../../../../common/k8s-api/kube-json-api";
 
 describe("get helm release resources", () => {
   let getHelmReleaseResources: GetHelmReleaseResources;
@@ -36,7 +37,7 @@ describe("get helm release resources", () => {
   });
 
   describe("when called", () => {
-    let actualPromise: Promise<JsonObject[]>;
+    let actualPromise: Promise<AsyncResult<KubeJsonApiData[], string>>;
 
     beforeEach(() => {
       actualPromise = getHelmReleaseResources(

--- a/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
+++ b/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
@@ -70,5 +70,76 @@ describe("get helm release resources", () => {
         response: [],
       });
     });
+
+    it("when call to manifest resolves with resources, resolves with resources", async () => {
+      await execHelmMock.resolve({
+        callWasSuccessful: true,
+        response: `---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-same-namespace
+  namespace: some-namespace
+---
+apiVersion: v1
+kind: SomeOtherKind
+metadata:
+  name: some-resource-without-namespace
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: collection-sumologic-fluentd-logs
+      namespace: some-namespace
+---
+apiVersion: v1
+kind: SomeKind
+metadata:
+  name: some-resource-with-different-namespace
+  namespace: some-other-namespace
+---
+`,
+      });
+
+      expect(await actualPromise).toEqual({
+        callWasSuccessful: true,
+        response: [
+          {
+            apiVersion: "v1",
+            kind: "SomeKind",
+            metadata: {
+              name: "some-resource-with-same-namespace",
+              namespace: "some-namespace",
+            },
+          },
+          {
+            apiVersion: "v1",
+            kind: "SomeOtherKind",
+            metadata: {
+              name: "some-resource-without-namespace",
+            },
+          },
+          {
+            apiVersion: "monitoring.coreos.com/v1",
+            kind: "ServiceMonitor",
+            metadata: {
+              name: "collection-sumologic-fluentd-logs",
+              namespace: "some-namespace",
+            },
+          },
+          {
+            apiVersion: "v1",
+            kind: "SomeKind",
+            metadata: {
+              name: "some-resource-with-different-namespace",
+              namespace: "some-other-namespace",
+            },
+          },
+        ],
+      });
+    });
   });
 });

--- a/src/main/helm/helm-service/get-helm-release.injectable.ts
+++ b/src/main/helm/helm-service/get-helm-release.injectable.ts
@@ -19,8 +19,6 @@ const getHelmReleaseInjectable = getInjectable({
 
     return async (cluster: Cluster, releaseName: string, namespace: string) => {
       const kubeconfigPath = await cluster.getProxyKubeconfigPath();
-      const kubectl = await cluster.ensureKubectl();
-      const kubectlPath = await kubectl.getPath();
 
       logger.debug("Fetch release");
 
@@ -51,7 +49,6 @@ const getHelmReleaseInjectable = getInjectable({
         releaseName,
         namespace,
         kubeconfigPath,
-        kubectlPath,
       );
 
       if (!resourcesResult.callWasSuccessful) {

--- a/src/main/router/create-handler-for-route.injectable.ts
+++ b/src/main/router/create-handler-for-route.injectable.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { ServerResponse } from "http";
+import loggerInjectable from "../../common/logger.injectable";
+import { object } from "../../common/utils";
+import type { LensApiRequest, Route } from "./route";
+import { contentTypes } from "./router-content-types";
+
+export type RouteHandler = (request: LensApiRequest<string>, response: ServerResponse) => Promise<void>;
+export type CreateHandlerForRoute = (route: Route<unknown, string>) => RouteHandler;
+
+interface LensServerResponse {
+  statusCode: number;
+  content: any;
+  headers: {
+    [name: string]: string;
+  };
+}
+
+const writeServerResponseFor = (serverResponse: ServerResponse) => ({
+  statusCode,
+  content,
+  headers,
+}: LensServerResponse) => {
+  serverResponse.statusCode = statusCode;
+
+  for (const [name, value] of object.entries(headers)) {
+    serverResponse.setHeader(name, value);
+  }
+
+  if (content instanceof Buffer) {
+    serverResponse.write(content);
+    serverResponse.end();
+  } else if (content) {
+    serverResponse.end(content);
+  } else {
+    serverResponse.end();
+  }
+};
+
+const createHandlerForRouteInjectable = getInjectable({
+  id: "create-handler-for-route",
+  instantiate: (di): CreateHandlerForRoute => {
+    const logger = di.inject(loggerInjectable);
+
+    return (route) => async (request, response) => {
+      const writeServerResponse = writeServerResponseFor(response);
+
+      try {
+        const result = await route.handler(request);
+
+        if (!result) {
+          const mappedResult = contentTypes.txt.resultMapper({
+            statusCode: 204,
+            response: undefined,
+          });
+
+          writeServerResponse(mappedResult);
+        } else if (!result.proxy) {
+          const contentType = result.contentType || contentTypes.json;
+
+          writeServerResponse(contentType.resultMapper(result));
+        }
+      } catch(error) {
+        const mappedResult = contentTypes.txt.resultMapper({
+          statusCode: 500,
+          error: error ? String(error) : "unknown error",
+        });
+
+        logger.error(`[ROUTER]: route ${route.path}, called with ${request.path}, threw an error`, error);
+        writeServerResponse(mappedResult);
+      }
+    };
+  },
+});
+
+export default createHandlerForRouteInjectable;

--- a/src/main/router/router.injectable.ts
+++ b/src/main/router/router.injectable.ts
@@ -7,6 +7,7 @@ import { getInjectable, getInjectionToken } from "@ogre-tools/injectable";
 import { Router } from "./router";
 import parseRequestInjectable from "./parse-request.injectable";
 import type { Route } from "./route";
+import createHandlerForRouteInjectable from "./create-handler-for-route.injectable";
 
 export const routeInjectionToken = getInjectionToken<Route<unknown, string>>({
   id: "route-injection-token",
@@ -24,13 +25,11 @@ export function getRouteInjectable<T, Path extends string>(
 const routerInjectable = getInjectable({
   id: "router",
 
-  instantiate: (di) => {
-    const routes = di.injectMany(routeInjectionToken);
-
-    return new Router(routes, {
-      parseRequest: di.inject(parseRequestInjectable),
-    });
-  },
+  instantiate: (di) => new Router({
+    parseRequest: di.inject(parseRequestInjectable),
+    routes: di.injectMany(routeInjectionToken),
+    createHandlerForRoute: di.inject(createHandlerForRouteInjectable),
+  }),
 });
 
 export default routerInjectable;

--- a/src/main/router/router.ts
+++ b/src/main/router/router.ts
@@ -5,12 +5,11 @@
 
 import Call from "@hapi/call";
 import type http from "http";
-import { toPairs } from "lodash/fp";
 import type { Cluster } from "../../common/cluster/cluster";
-import { contentTypes } from "./router-content-types";
-import type { LensApiRequest, LensApiResult, Route } from "./route";
+import type { LensApiRequest, Route } from "./route";
 import type { ServerIncomingMessage } from "../lens-proxy/lens-proxy";
 import type { ParseRequest } from "./parse-request.injectable";
+import type { CreateHandlerForRoute, RouteHandler } from "./create-handler-for-route.injectable";
 
 export interface RouterRequestOpts {
   req: http.IncomingMessage;
@@ -22,15 +21,17 @@ export interface RouterRequestOpts {
 
 interface Dependencies {
   parseRequest: ParseRequest;
+  createHandlerForRoute: CreateHandlerForRoute;
+  readonly routes: Route<unknown, string>[];
 }
 
 export class Router {
-  protected router = new Call.Router<ReturnType<typeof handleRoute>>();
+  private readonly router = new Call.Router<RouteHandler>();
 
-  constructor(routes: Route<unknown, string>[], private dependencies: Dependencies) {
-    routes.forEach(route => {
-      this.router.add({ method: route.method, path: route.path }, handleRoute(route));
-    });
+  constructor(private readonly dependencies: Dependencies) {
+    for (const route of this.dependencies.routes) {
+      this.router.add({ method: route.method, path: route.path }, this.dependencies.createHandlerForRoute(route));
+    }
   }
 
   public async route(cluster: Cluster | undefined, req: ServerIncomingMessage, res: http.ServerResponse): Promise<boolean> {
@@ -52,7 +53,6 @@ export class Router {
 
   protected async getRequest(opts: RouterRequestOpts): Promise<LensApiRequest<string>> {
     const { req, res, url, cluster, params } = opts;
-
     const { payload } = await this.dependencies.parseRequest(req, null, {
       parse: true,
       output: "data",
@@ -70,77 +70,3 @@ export class Router {
     };
   }
 }
-
-const handleRoute = (route: Route<unknown, string>) => async (request: LensApiRequest<string>, response: http.ServerResponse) => {
-  let result: LensApiResult<any> | void;
-
-  const writeServerResponse = writeServerResponseFor(response);
-
-  try {
-    result = await route.handler(request);
-  } catch(error) {
-    const mappedResult = contentTypes.txt.resultMapper({
-      statusCode: 500,
-      error: error ? String(error) : "unknown error",
-    });
-
-    writeServerResponse(mappedResult);
-
-    return;
-  }
-
-  if (!result) {
-    const mappedResult = contentTypes.txt.resultMapper({
-      statusCode: 204,
-      response: undefined,
-    });
-
-    writeServerResponse(mappedResult);
-
-    return;
-  }
-
-  if (result.proxy) {
-    return;
-  }
-
-  const contentType = result.contentType || contentTypes.json;
-
-  const mappedResult = contentType.resultMapper(result);
-
-  writeServerResponse(mappedResult);
-};
-
-const writeServerResponseFor =
-  (serverResponse: http.ServerResponse) =>
-    ({
-      statusCode,
-      content,
-      headers,
-    }: {
-    statusCode: number;
-    content: any;
-    headers: { [name: string]: string };
-  }) => {
-      serverResponse.statusCode = statusCode;
-
-      const headerPairs = toPairs<string>(headers);
-
-      headerPairs.forEach(([name, value]) => {
-        serverResponse.setHeader(name, value);
-      });
-
-      if (content instanceof Buffer) {
-        serverResponse.write(content);
-
-        serverResponse.end();
-
-        return;
-      }
-
-      if (content) {
-        serverResponse.end(content);
-      } else {
-        serverResponse.end();
-      }
-    };

--- a/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-content.tsx
@@ -19,7 +19,6 @@ import { kebabCase } from "lodash/fp";
 import { Badge } from "../../badge";
 import { SubTitle } from "../../layout/sub-title";
 import { Table, TableCell, TableHead, TableRow } from "../../table";
-import { ReactiveDuration } from "../../duration/reactive-duration";
 import { Checkbox } from "../../checkbox";
 import { MonacoEditor } from "../../monaco-editor";
 import { Spinner } from "../../spinner";
@@ -131,12 +130,10 @@ const ResourceGroup = ({
         <TableCell className="name">Name</TableCell>
 
         {isNamespaced && <TableCell className="namespace">Namespace</TableCell>}
-
-        <TableCell className="age">Age</TableCell>
       </TableHead>
 
       {resources.map(
-        ({ creationTimestamp, detailsUrl, name, namespace, uid }) => (
+        ({ detailsUrl, name, namespace, uid }) => (
           <TableRow key={uid}>
             <TableCell className="name">
               {detailsUrl ? <Link to={detailsUrl}>{name}</Link> : name}
@@ -145,10 +142,6 @@ const ResourceGroup = ({
             {isNamespaced && (
               <TableCell className="namespace">{namespace}</TableCell>
             )}
-
-            <TableCell className="age">
-              <ReactiveDuration timestamp={creationTimestamp} />
-            </TableCell>
           </TableRow>
         ),
       )}

--- a/src/renderer/components/+helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
+++ b/src/renderer/components/+helm-releases/release-details/release-details-model/release-details-model.injectable.tsx
@@ -222,12 +222,12 @@ export class ReleaseDetailsModel {
   }
 
   @computed get notes() {
-    return this.details.info.notes;
+    return this.details?.info.notes ?? "";
   }
 
   @computed get groupedResources(): MinimalResourceGroup[] {
     return pipeline(
-      this.details.resources,
+      this.details?.resources ?? [],
       groupBy((resource) => resource.kind),
       (grouped) => Object.entries(grouped),
 
@@ -271,20 +271,17 @@ export interface MinimalResource {
   name: string;
   namespace: string | undefined;
   detailsUrl: string | undefined;
-  creationTimestamp: string | undefined;
 }
 
 const toMinimalResourceFor =
   (getResourceDetailsUrl: GetResourceDetailsUrl, kind: string) =>
     (resource: KubeJsonApiData): MinimalResource => {
-      const { creationTimestamp, name, namespace, uid } = resource.metadata;
+      const { name, namespace, uid } = resource.metadata;
 
       return {
         uid,
         name,
         namespace,
-        creationTimestamp,
-
         detailsUrl: getResourceDetailsUrl(
           kind,
           resource.apiVersion,

--- a/src/renderer/components/+helm-releases/release-details/release-details-model/request-detailed-helm-release.injectable.ts
+++ b/src/renderer/components/+helm-releases/release-details/release-details-model/request-detailed-helm-release.injectable.ts
@@ -11,7 +11,7 @@ import type { AsyncResult } from "../../../../../common/utils/async-result";
 
 export interface DetailedHelmRelease {
   release: HelmReleaseDto;
-  details: HelmReleaseDetails;
+  details?: HelmReleaseDetails;
 }
 
 export type RequestDetailedHelmRelease = (


### PR DESCRIPTION
- The helm manifest can sometimes contain KubeJsonApiDataLists
  instead of just KubeJsonApiData entries

- Add additional logging to main for when a route handler throws so that
  we can gain more context in the future

Signed-off-by: Sebastian Malton <sebastian@malton.name>