### PR TITLE
Clickable links in pods details for ServiceAccount, PriorityClass and RuntimeClass

### DIFF
--- a/src/common/k8s-api/endpoints/legacy-globals.ts
+++ b/src/common/k8s-api/endpoints/legacy-globals.ts
@@ -11,9 +11,12 @@ import networkPolicyApiInjectable from "./network-policy.api.injectable";
 import nodeApiInjectable from "./node.api.injectable";
 import persistentVolumeClaimApiInjectable from "./persistent-volume-claim.api.injectable";
 import podApiInjectable from "./pod.api.injectable";
+import priorityClassApiInjectable from "./priority-class.api.injectable";
 import resourceQuotaApiInjectable from "./resource-quota.api.injectable";
 import roleApiInjectable from "./role.api.injectable";
+import runtimeClassApiInjectable from "./runtime-class.api.injectable";
 import secretApiInjectable from "./secret.api.injectable";
+import serviceAccountApiInjectable from "./service-account.api.injectable";
 import serviceApiInjectable from "./service.api.injectable";
 import storageClassApiInjectable from "./storage-class.api.injectable";
 
@@ -58,14 +61,29 @@ export const nodeApi = asLegacyGlobalForExtensionApi(nodeApiInjectable);
 export const persistentVolumeClaimApi = asLegacyGlobalForExtensionApi(persistentVolumeClaimApiInjectable);
 
 /**
+ * @deprecated use `di.inject(priorityClassApiInjectable)` instead
+ */
+export const priorityClassApi = asLegacyGlobalForExtensionApi(priorityClassApiInjectable);
+
+/**
  * @deprecated use `di.inject(resourceQuotaApiInjectable)` instead
  */
 export const resourceQuotaApi = asLegacyGlobalForExtensionApi(resourceQuotaApiInjectable);
 
 /**
+ * @deprecated use `di.inject(runtimeClassApiInjectable)` instead
+ */
+export const runtimeClassApi = asLegacyGlobalForExtensionApi(runtimeClassApiInjectable);
+
+/**
  * @deprecated use `di.inject(secretApiInjectable)` instead
  */
 export const secretApi = asLegacyGlobalForExtensionApi(secretApiInjectable);
+
+/**
+ * @deprecated use `di.inject(serviceAccountApiInjectable)` instead
+ */
+export const serviceAccountApi = asLegacyGlobalForExtensionApi(serviceAccountApiInjectable);
 
 /**
  * @deprecated use `di.inject(serviceApiInjectable)` instead

--- a/src/common/k8s-api/endpoints/legacy-globals.ts
+++ b/src/common/k8s-api/endpoints/legacy-globals.ts
@@ -11,12 +11,9 @@ import networkPolicyApiInjectable from "./network-policy.api.injectable";
 import nodeApiInjectable from "./node.api.injectable";
 import persistentVolumeClaimApiInjectable from "./persistent-volume-claim.api.injectable";
 import podApiInjectable from "./pod.api.injectable";
-import priorityClassApiInjectable from "./priority-class.api.injectable";
 import resourceQuotaApiInjectable from "./resource-quota.api.injectable";
 import roleApiInjectable from "./role.api.injectable";
-import runtimeClassApiInjectable from "./runtime-class.api.injectable";
 import secretApiInjectable from "./secret.api.injectable";
-import serviceAccountApiInjectable from "./service-account.api.injectable";
 import serviceApiInjectable from "./service.api.injectable";
 import storageClassApiInjectable from "./storage-class.api.injectable";
 
@@ -61,29 +58,14 @@ export const nodeApi = asLegacyGlobalForExtensionApi(nodeApiInjectable);
 export const persistentVolumeClaimApi = asLegacyGlobalForExtensionApi(persistentVolumeClaimApiInjectable);
 
 /**
- * @deprecated use `di.inject(priorityClassApiInjectable)` instead
- */
-export const priorityClassApi = asLegacyGlobalForExtensionApi(priorityClassApiInjectable);
-
-/**
  * @deprecated use `di.inject(resourceQuotaApiInjectable)` instead
  */
 export const resourceQuotaApi = asLegacyGlobalForExtensionApi(resourceQuotaApiInjectable);
 
 /**
- * @deprecated use `di.inject(runtimeClassApiInjectable)` instead
- */
-export const runtimeClassApi = asLegacyGlobalForExtensionApi(runtimeClassApiInjectable);
-
-/**
  * @deprecated use `di.inject(secretApiInjectable)` instead
  */
 export const secretApi = asLegacyGlobalForExtensionApi(secretApiInjectable);
-
-/**
- * @deprecated use `di.inject(serviceAccountApiInjectable)` instead
- */
-export const serviceAccountApi = asLegacyGlobalForExtensionApi(serviceAccountApiInjectable);
 
 /**
  * @deprecated use `di.inject(serviceApiInjectable)` instead

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -100,6 +100,7 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const initContainers = pod.getInitContainers();
     const containers = pod.getContainers();
 
+    const namespace = pod.getNs();
     const priorityClassName = pod.getPriorityClassName();
     const runtimeClassName = pod.getRuntimeClassName();
     const serviceAccountName = pod.getServiceAccountName();
@@ -112,6 +113,7 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     }));
     const serviceAccountDetailsUrl = getDetailsUrl(this.props.serviceAccountApi.getUrl({
       name: serviceAccountName,
+      namespace,
     }));
 
     return (

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -10,7 +10,7 @@ import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Link } from "react-router-dom";
 import { observable, reaction, makeObservable } from "mobx";
-import { Pod, priorityClassApi, runtimeClassApi, serviceAccountApi } from "../../../common/k8s-api/endpoints";
+import { Pod, PriorityClassApi, RuntimeClassApi, ServiceAccountApi } from "../../../common/k8s-api/endpoints";
 import type { NodeApi } from "../../../common/k8s-api/endpoints";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
@@ -35,6 +35,9 @@ import type { GetDetailsUrl } from "../kube-detail-params/get-details-url.inject
 import getActiveClusterEntityInjectable from "../../api/catalog/entity/get-active-cluster-entity.injectable";
 import getDetailsUrlInjectable from "../kube-detail-params/get-details-url.injectable";
 import nodeApiInjectable from "../../../common/k8s-api/endpoints/node.api.injectable";
+import runtimeClassApiInjectable from "../../../common/k8s-api/endpoints/runtime-class.api.injectable";
+import serviceAccountApiInjectable from "../../../common/k8s-api/endpoints/service-account.api.injectable";
+import priorityClassApiInjectable from "../../../common/k8s-api/endpoints/priority-class.api.injectable";
 
 export interface PodDetailsProps extends KubeObjectDetailsProps<Pod> {
 }
@@ -44,6 +47,9 @@ interface Dependencies {
   getActiveClusterEntity: GetActiveClusterEntity;
   getDetailsUrl: GetDetailsUrl;
   nodeApi: NodeApi;
+  priorityClassApi: PriorityClassApi;
+  runtimeClassApi: RuntimeClassApi;
+  serviceAccountApi: ServiceAccountApi
 }
 
 @observer
@@ -98,13 +104,13 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const runtimeClassName = pod.getRuntimeClassName();
     const serviceAccountName = pod.getServiceAccountName();
 
-    const priorityClassDetailsUrl = getDetailsUrl(priorityClassApi.getUrl({
+    const priorityClassDetailsUrl = getDetailsUrl(this.props.priorityClassApi.getUrl({
       name: priorityClassName,
     }));
-    const runtimeClassDetailsUrl = getDetailsUrl(runtimeClassApi.getUrl({
+    const runtimeClassDetailsUrl = getDetailsUrl(this.props.runtimeClassApi.getUrl({
       name: runtimeClassName,
     }));
-    const serviceAccountDetailsUrl = getDetailsUrl(serviceAccountApi.getUrl({
+    const serviceAccountDetailsUrl = getDetailsUrl(this.props.serviceAccountApi.getUrl({
       name: serviceAccountName,
     }));
 
@@ -239,5 +245,8 @@ export const PodDetails = withInjectables<Dependencies, PodDetailsProps>(NonInje
     getActiveClusterEntity: di.inject(getActiveClusterEntityInjectable),
     getDetailsUrl: di.inject(getDetailsUrlInjectable),
     nodeApi: di.inject(nodeApiInjectable),
+    priorityClassApi: di.inject(priorityClassApiInjectable),
+    runtimeClassApi: di.inject(runtimeClassApiInjectable),
+    serviceAccountApi: di.inject(serviceAccountApiInjectable),
   }),
 });

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -10,8 +10,8 @@ import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Link } from "react-router-dom";
 import { observable, reaction, makeObservable } from "mobx";
-import { Pod, PriorityClassApi, RuntimeClassApi, ServiceAccountApi } from "../../../common/k8s-api/endpoints";
-import type { NodeApi } from "../../../common/k8s-api/endpoints";
+import { Pod } from "../../../common/k8s-api/endpoints";
+import type { NodeApi, PriorityClassApi, RuntimeClassApi, ServiceAccountApi } from "../../../common/k8s-api/endpoints";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
 import { cssNames, stopPropagation, toJS } from "../../utils";
@@ -49,7 +49,7 @@ interface Dependencies {
   nodeApi: NodeApi;
   priorityClassApi: PriorityClassApi;
   runtimeClassApi: RuntimeClassApi;
-  serviceAccountApi: ServiceAccountApi
+  serviceAccountApi: ServiceAccountApi;
 }
 
 @observer

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -10,11 +10,11 @@ import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Link } from "react-router-dom";
 import { observable, reaction, makeObservable } from "mobx";
-import type { NodeApi } from "../../../common/k8s-api/endpoints";
+import { NodeApi, priorityClassApi, runtimeClassApi, serviceAccountApi } from "../../../common/k8s-api/endpoints";
 import { Pod } from "../../../common/k8s-api/endpoints";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
-import { cssNames, toJS } from "../../utils";
+import { cssNames, stopPropagation, toJS } from "../../utils";
 import { PodDetailsContainer } from "./pod-details-container";
 import { PodDetailsAffinities } from "./pod-details-affinities";
 import { PodDetailsTolerations } from "./pod-details-tolerations";
@@ -94,6 +94,20 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
     const initContainers = pod.getInitContainers();
     const containers = pod.getContainers();
 
+    const priorityClassName = pod.getPriorityClassName();
+    const runtimeClassName = pod.getRuntimeClassName();
+    const serviceAccountName = pod.getServiceAccountName();
+
+    const priorityClassDetailsUrl = getDetailsUrl(priorityClassApi.getUrl({
+      name: priorityClassName,
+    }));
+    const runtimeClassDetailsUrl = getDetailsUrl(runtimeClassApi.getUrl({
+      name: runtimeClassName,
+    }));
+    const serviceAccountDetailsUrl = getDetailsUrl(serviceAccountApi.getUrl({
+      name: serviceAccountName,
+    }));
+
     return (
       <div className="PodDetails">
         {!isMetricHidden && (
@@ -130,16 +144,22 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
           {podIPs.map(label => <Badge key={label} label={label} />)}
         </DrawerItem>
         <DrawerItem name="Service Account">
-          {pod.getServiceAccountName()}
+          <Link key="link" to={serviceAccountDetailsUrl} onClick={stopPropagation}>
+            {serviceAccountName}
+          </Link>
         </DrawerItem>
-        <DrawerItem name="Priority Class" hidden={pod.getPriorityClassName() === ""}>
-          {pod.getPriorityClassName()}
+        <DrawerItem name="Priority Class" hidden={priorityClassName === ""}>
+          <Link key="link" to={priorityClassDetailsUrl} onClick={stopPropagation}>
+            {priorityClassName}
+          </Link>
         </DrawerItem>
         <DrawerItem name="QoS Class">
           {pod.getQosClass()}
         </DrawerItem>
-        <DrawerItem name="Runtime Class" hidden={pod.getRuntimeClassName() === ""}>
-          {pod.getRuntimeClassName()}
+        <DrawerItem name="Runtime Class" hidden={runtimeClassName === ""}>
+          <Link key="link" to={runtimeClassDetailsUrl} onClick={stopPropagation}>
+            {runtimeClassName}
+          </Link>
         </DrawerItem>
 
         <DrawerItem

--- a/src/renderer/components/+workloads-pods/pod-details.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details.tsx
@@ -10,8 +10,8 @@ import kebabCase from "lodash/kebabCase";
 import { disposeOnUnmount, observer } from "mobx-react";
 import { Link } from "react-router-dom";
 import { observable, reaction, makeObservable } from "mobx";
-import { NodeApi, priorityClassApi, runtimeClassApi, serviceAccountApi } from "../../../common/k8s-api/endpoints";
-import { Pod } from "../../../common/k8s-api/endpoints";
+import { Pod, priorityClassApi, runtimeClassApi, serviceAccountApi } from "../../../common/k8s-api/endpoints";
+import type { NodeApi } from "../../../common/k8s-api/endpoints";
 import { DrawerItem, DrawerTitle } from "../drawer";
 import { Badge } from "../badge";
 import { cssNames, stopPropagation, toJS } from "../../utils";
@@ -144,12 +144,20 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
           {podIPs.map(label => <Badge key={label} label={label} />)}
         </DrawerItem>
         <DrawerItem name="Service Account">
-          <Link key="link" to={serviceAccountDetailsUrl} onClick={stopPropagation}>
+          <Link
+            key="link"
+            to={serviceAccountDetailsUrl}
+            onClick={stopPropagation}
+          >
             {serviceAccountName}
           </Link>
         </DrawerItem>
         <DrawerItem name="Priority Class" hidden={priorityClassName === ""}>
-          <Link key="link" to={priorityClassDetailsUrl} onClick={stopPropagation}>
+          <Link
+            key="link"
+            to={priorityClassDetailsUrl}
+            onClick={stopPropagation}
+          >
             {priorityClassName}
           </Link>
         </DrawerItem>
@@ -157,7 +165,11 @@ class NonInjectedPodDetails extends React.Component<PodDetailsProps & Dependenci
           {pod.getQosClass()}
         </DrawerItem>
         <DrawerItem name="Runtime Class" hidden={runtimeClassName === ""}>
-          <Link key="link" to={runtimeClassDetailsUrl} onClick={stopPropagation}>
+          <Link
+            key="link"
+            to={runtimeClassDetailsUrl}
+            onClick={stopPropagation}
+          >
             {runtimeClassName}
           </Link>
         </DrawerItem>


### PR DESCRIPTION
This is a small improvement for pod details:

![image](https://user-images.githubusercontent.com/174367/194535069-55eae4d7-6a88-4b2a-a5fe-9f3fbdc7b641.png)

Links to ServiceAccount, PriorityClass and RuntimeClass are clickable and move to the details of the chosen resource.
