### PR TITLE
Fix manually set prometheus service address to work after re-connect

### DIFF
--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -53,6 +53,7 @@ export class ContextHandler implements ClusterContextHandler {
 
   constructor(private dependencies: Dependencies, protected cluster: Cluster) {
     this.clusterUrl = url.parse(cluster.apiUrl);
+    this.setupPrometheus(cluster.preferences);
   }
 
   public setupPrometheus(preferences: ClusterPrometheusPreferences = {}) {

--- a/src/main/context-handler/context-handler.ts
+++ b/src/main/context-handler/context-handler.ts
@@ -53,7 +53,6 @@ export class ContextHandler implements ClusterContextHandler {
 
   constructor(private dependencies: Dependencies, protected cluster: Cluster) {
     this.clusterUrl = url.parse(cluster.apiUrl);
-    this.setupPrometheus(cluster.preferences);
   }
 
   public setupPrometheus(preferences: ClusterPrometheusPreferences = {}) {
@@ -94,6 +93,8 @@ export class ContextHandler implements ClusterContextHandler {
   }
 
   protected async getPrometheusService(): Promise<PrometheusService> {
+    this.setupPrometheus(this.cluster.preferences);
+
     if (this.prometheus && this.prometheusProvider) {
       return {
         id: this.prometheusProvider,


### PR DESCRIPTION
When disconnecting the cluster, prometheus configuration is reset on context handler. However, that is never setup again and when reconnecting the cluster manually set prometheus service address is ignored and auto-detected is used instead. This PR will read prometheus preferences every time prometheus service is resolved. 