### PR TITLE
Fix AppImage windows not showing the application icon

### DIFF
--- a/src/common/vars/application-information.global-override-for-injectable.ts
+++ b/src/common/vars/application-information.global-override-for-injectable.ts
@@ -7,6 +7,7 @@ import { getGlobalOverride } from "../test-utils/get-global-override";
 import applicationInformationInjectable from "./application-information.injectable";
 
 export default getGlobalOverride(applicationInformationInjectable, () => ({
+  name: "some-product-name",
   productName: "some-product-name",
   version: "6.0.0",
   build: {},

--- a/src/common/vars/application-information.injectable.ts
+++ b/src/common/vars/application-information.injectable.ts
@@ -5,16 +5,16 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import packageJson from "../../../package.json";
 
-export type ApplicationInformation = Pick<typeof packageJson, "version" | "config" | "productName" | "copyright" | "description"> & {
+export type ApplicationInformation = Pick<typeof packageJson, "version" | "config" | "productName" | "copyright" | "description" | "name"> & {
   build: Partial<typeof packageJson["build"]> & { publish?: unknown[] };
 };
 
 const applicationInformationInjectable = getInjectable({
   id: "application-information",
   instantiate: (): ApplicationInformation => {
-    const { version, config, productName, build, copyright, description } = packageJson;
+    const { version, config, productName, build, copyright, description, name } = packageJson;
 
-    return { version, config, productName, build, copyright, description };
+    return { version, config, productName, build, copyright, description, name };
   },
   causesSideEffects: true,
 });


### PR DESCRIPTION
Fixes #6443, missing task bar icon on some environments (e.g. U22.04 / XFCE)

Might be interesting to use a better quality icon than the tray's one but it's beyond my knowledge

![image](https://user-images.githubusercontent.com/117580/197067971-b0e8dc82-2a6e-4c09-aced-00584afc6ce1.png) => ![image](https://user-images.githubusercontent.com/117580/197068009-55d5cb78-aafa-4063-a06c-2700cba627cb.png)
