### PR TITLE
React on any KubeObjectStore eventsBuffer change, not just length

### DIFF
--- a/src/common/k8s-api/kube-object.store.ts
+++ b/src/common/k8s-api/kube-object.store.ts
@@ -432,7 +432,7 @@ export abstract class KubeObjectStore<
   protected eventsBuffer = observable.array<IKubeWatchEvent<D>>([], { deep: false });
 
   protected bindWatchEventsUpdater(delay = 1000) {
-    reaction(() => this.eventsBuffer.length, this.updateFromEventsBuffer, {
+    reaction(() => [...this.eventsBuffer], this.updateFromEventsBuffer, {
       delay,
     });
   }


### PR DESCRIPTION
It seems that in some (rare) cases reaction is not triggered if length stays the same -> buffer might have events but reaction only kicks in if new events are pushed to the buffer.