### PR TITLE
Fix for Menu component memory leak

### DIFF
--- a/src/renderer/components/menu/menu.tsx
+++ b/src/renderer/components/menu/menu.tsx
@@ -136,6 +136,8 @@ class NonInjectedMenu extends React.Component<MenuProps & Dependencies, State> {
     window.removeEventListener("resize", this.onWindowResize);
     window.removeEventListener("click", this.onClickOutside, true);
     window.removeEventListener("scroll", this.onScrollOutside, true);
+    window.removeEventListener("blur", this.onBlur, true);
+    window.removeEventListener("contextmenu", this.onContextMenu, true);
   }
 
   componentDidUpdate(prevProps: MenuProps) {


### PR DESCRIPTION
Fixing growing memory consumption by adding missing `removeEventListener` lines for the Menu instances.

Fixes https://github.com/lensapp/lens/issues/6518

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>