### PR TITLE
Fix CronJob trigger menu missing

### DIFF
--- a/extensions/kube-object-event-status/package.json
+++ b/extensions/kube-object-event-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kube-object-event-status",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Adds kube object status from events",
   "renderer": "dist/renderer.js",
   "lens": {

--- a/extensions/kube-object-event-status/renderer.tsx
+++ b/extensions/kube-object-event-status/renderer.tsx
@@ -35,12 +35,18 @@ export default class EventResourceStatusRendererExtension extends Renderer.LensE
     },
     {
       kind: "Job",
-      apiVersions: ["batch/v1"],
+      apiVersions: [
+        "batch/v1",
+        "batch/v1beta1",
+      ],
       resolve: (job: Renderer.K8sApi.Job) => resolveStatus(job),
     },
     {
       kind: "CronJob",
-      apiVersions: ["batch/v1"],
+      apiVersions: [
+        "batch/v1",
+        "batch/v1beta1",
+      ],
       resolve: (cronJob: Renderer.K8sApi.CronJob) => resolveStatusForCronJobs(cronJob),
     },
   ];

--- a/src/renderer/components/kube-object-menu/kube-object-menu-items/cron-job-menu.injectable.ts
+++ b/src/renderer/components/kube-object-menu/kube-object-menu-items/cron-job-menu.injectable.ts
@@ -13,7 +13,10 @@ const cronJobMenuInjectable = getInjectable({
 
   instantiate: () => (  {
     kind: "CronJob",
-    apiVersions: ["batch/v1beta1"],
+    apiVersions: [
+      "batch/v1beta1",
+      "batch/v1",
+    ],
     Component: CronJobMenu as KubeObjectMenuItemComponent,
     enabled: computed(() => true),
     orderNumber: 20,


### PR DESCRIPTION
- It was only missing for users of newer versions of Kube

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes https://github.com/lensapp/lens/issues/6572