### PR TITLE
Allow computed tray menu for extensions

### DIFF
--- a/src/extensions/extension-loader/extension-registrator-injection-token.ts
+++ b/src/extensions/extension-loader/extension-registrator-injection-token.ts
@@ -4,9 +4,11 @@
  */
 import type { Injectable } from "@ogre-tools/injectable";
 import { getInjectionToken } from "@ogre-tools/injectable";
+import type { IComputedValue } from "mobx";
 import type { LensExtension } from "../lens-extension";
 
-export type ExtensionRegistrator = (extension: LensExtension) => Injectable<any, any, any>[];
+export type ExtensionRegistrator = (extension: LensExtension) =>
+  Injectable<any, any, any>[] | IComputedValue<Injectable<any, any, any>[]>;
 
 export const extensionRegistratorInjectionToken = getInjectionToken<ExtensionRegistrator>({
   id: "extension-registrator-token",

--- a/src/extensions/lens-main-extension.ts
+++ b/src/extensions/lens-main-extension.ts
@@ -5,7 +5,7 @@
 
 import { LensExtension, lensExtensionDependencies } from "./lens-extension";
 import type { CatalogEntity } from "../common/catalog";
-import type { IObservableArray } from "mobx";
+import type { IComputedValue, IObservableArray } from "mobx";
 import type { MenuRegistration } from "../features/application-menu/main/menu-registration";
 import type { TrayMenuRegistration } from "../main/tray/tray-menu-registration";
 import type { ShellEnvModifier } from "../main/shell-session/shell-env-modifier/shell-env-modifier-registration";
@@ -13,7 +13,7 @@ import type { LensMainExtensionDependencies } from "./lens-extension-set-depende
 
 export class LensMainExtension extends LensExtension<LensMainExtensionDependencies> {
   appMenus: MenuRegistration[] = [];
-  trayMenus: TrayMenuRegistration[] = [];
+  trayMenus: TrayMenuRegistration[] | IComputedValue<TrayMenuRegistration[]> = [];
 
   /**
    * implement this to modify the shell environment that Lens terminals are opened with. The ShellEnvModifier type has the signature

--- a/src/features/tray/extension-adding-tray-items.test.tsx
+++ b/src/features/tray/extension-adding-tray-items.test.tsx
@@ -258,5 +258,21 @@ describe("preferences: extension adding tray items", () => {
         ),
       ).toBeNull();
     });
+
+    it("given items are removed and one added, it's shown", async () => {
+      menuItems.replace([]);
+      menuItems.push({
+        id: "some-added",
+        label: "some-added",
+        click: () => {},
+        visible: computed(() => true),
+      });
+
+      expect(
+        builder.tray.get(
+          "some-added-tray-menu-item-for-extension-some-extension",
+        ),
+      ).not.toBeNull();
+    });
   });
 });

--- a/src/features/tray/extension-adding-tray-items.test.tsx
+++ b/src/features/tray/extension-adding-tray-items.test.tsx
@@ -2,13 +2,14 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import type { IObservableValue } from "mobx";
+import type { IObservableArray, IObservableValue } from "mobx";
 import { computed, runInAction, observable } from "mobx";
+import type { TrayMenuRegistration } from "../../main/tray/tray-menu-registration";
 import type { ApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 import { getApplicationBuilder } from "../../renderer/components/test-utils/get-application-builder";
 
 describe("preferences: extension adding tray items", () => {
-  describe("when extension with tray items is enabled", () => {
+  describe("when extension with tray items are statically defined", () => {
     let builder: ApplicationBuilder;
     let someObservableForVisibility: IObservableValue<boolean>;
     let someObservableForEnabled: IObservableValue<boolean>;
@@ -188,6 +189,74 @@ describe("preferences: extension adding tray items", () => {
       );
 
       expect(item?.enabled).toBe(false);
+    });
+  });
+
+  describe("when extension with tray items are dynamically defined", () => {
+    let builder: ApplicationBuilder;
+    let menuItems: IObservableArray<TrayMenuRegistration>;
+
+    beforeEach(async () => {
+      builder = getApplicationBuilder();
+
+      await builder.render();
+
+      builder.preferences.navigate();
+
+      menuItems = observable.array([
+        {
+          id: "some-visible",
+          label: "some-visible",
+          click: () => {},
+          visible: computed(() => true),
+        },
+      ]);
+
+      const computedTrayMenu = computed(() => menuItems);
+
+      const testExtension = {
+        id: "some-extension-id",
+        name: "some-extension",
+
+        mainOptions: {
+          trayMenus: computedTrayMenu,
+        },
+      };
+
+      builder.extensions.enable(testExtension);
+    });
+
+    it("given item exists, it's shown", () => {
+      expect(
+        builder.tray.get(
+          "some-visible-tray-menu-item-for-extension-some-extension",
+        ),
+      ).not.toBeNull();
+    });
+
+    it("given item is added, it's shown", async () => {
+      menuItems.push({
+        id: "some-added",
+        label: "some-added",
+        click: () => {},
+        visible: computed(() => true),
+      });
+
+      expect(
+        builder.tray.get(
+          "some-added-tray-menu-item-for-extension-some-extension",
+        ),
+      ).not.toBeNull();
+    });
+
+    it("given item is removed, it's not shown", async () => {
+      menuItems.replace([]);
+
+      expect(
+        builder.tray.get(
+          "some-visible-tray-menu-item-for-extension-some-extension",
+        ),
+      ).toBeNull();
     });
   });
 });

--- a/src/main/tray/reactive-tray-menu-items/start-reactive-tray-menu-items.injectable.ts
+++ b/src/main/tray/reactive-tray-menu-items/start-reactive-tray-menu-items.injectable.ts
@@ -15,8 +15,8 @@ const startReactiveTrayMenuItemsInjectable = getInjectable({
 
     return {
       id: "start-reactive-tray-menu-items",
-      run: async () => {
-        await reactiveTrayMenuItems.start();
+      run: () => {
+        reactiveTrayMenuItems.start();
       },
 
       runAfter: di.inject(startTrayInjectable),

--- a/src/main/tray/tray-menu-item/tray-menu-item-registrator.injectable.ts
+++ b/src/main/tray/tray-menu-item/tray-menu-item-registrator.injectable.ts
@@ -25,9 +25,13 @@ const trayMenuItemRegistratorInjectable = getInjectable({
     const withErrorLoggingFor = di.inject(withErrorLoggingInjectable);
     const getRandomId = di.inject(getRandomIdInjectable);
 
-    return mainExtension.trayMenus.flatMap(
-      toItemInjectablesFor(mainExtension, withErrorLoggingFor, getRandomId),
-    );
+    return computed(() => {
+      const trayMenus = Array.isArray(mainExtension.trayMenus) ? mainExtension.trayMenus : mainExtension.trayMenus.get();
+
+      return trayMenus.flatMap(
+        toItemInjectablesFor(mainExtension, withErrorLoggingFor, getRandomId),
+      );
+    });
   },
 
   injectionToken: extensionRegistratorInjectionToken,
@@ -117,5 +121,3 @@ const toItemInjectablesFor = (extension: LensMainExtension, withErrorLoggingFor:
 
   return _toItemInjectables(null);
 };
-
-


### PR DESCRIPTION
* Make `trayMenus` optionally `IComputedValue` for extensions to allow extensions to dynamically change e.g. submenus
* Implementation background:
  * Makes `ExtensionRegistrator` optionally `IComputedValue` so that `trayMenuItemRegistratorInjectable` can return a `computed` that reacts to computed extension trayMenus. I originally changed the `trayMenuItemInjectionToken` to be optionally computed, but @Nokel81 suggested to change `ExtensionRegistrator` instead