### PR TITLE
Update Button, keep left

### DIFF
--- a/src/features/application-update/__snapshots__/installing-update.test.ts.snap
+++ b/src/features/application-update/__snapshots__/installing-update.test.ts.snap
@@ -724,7 +724,7 @@ exports[`installing update when started when user checks for updates when new up
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -748,6 +748,9 @@ exports[`installing update when started when user checks for updates when new up
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>
@@ -966,7 +969,7 @@ exports[`installing update when started when user checks for updates when new up
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -990,6 +993,9 @@ exports[`installing update when started when user checks for updates when new up
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>

--- a/src/features/application-update/child-features/application-update-using-top-bar/__snapshots__/installing-update-using-topbar-button.test.tsx.snap
+++ b/src/features/application-update/child-features/application-update-using-top-bar/__snapshots__/installing-update-using-topbar-button.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`encourage user to update when sufficient time passed since update was d
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -88,6 +88,9 @@ exports[`encourage user to update when sufficient time passed since update was d
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>

--- a/src/features/application-update/child-features/application-update-using-top-bar/renderer/update-application-top-bar-item/update-application-top-bar-item.injectable.ts
+++ b/src/features/application-update/child-features/application-update-using-top-bar/renderer/update-application-top-bar-item/update-application-top-bar-item.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { computed } from "mobx";
-import { topBarItemOnRightSideInjectionToken } from "../../../../../../renderer/components/layout/top-bar/top-bar-items/top-bar-item-injection-token";
+import { topBarItemOnLeftSideInjectionToken } from "../../../../../../renderer/components/layout/top-bar/top-bar-items/top-bar-item-injection-token";
 import { UpdateButton } from "./update-button";
 import updateWarningLevelInjectable from "./update-warning-level.injectable";
 
@@ -22,7 +22,7 @@ const updateApplicationTopBarItemInjectable = getInjectable({
     };
   },
 
-  injectionToken: topBarItemOnRightSideInjectionToken,
+  injectionToken: topBarItemOnLeftSideInjectionToken,
 });
 
 export default updateApplicationTopBarItemInjectable;

--- a/src/features/application-update/child-features/application-update-using-tray/__snapshots__/installing-update-using-tray.test.ts.snap
+++ b/src/features/application-update/child-features/application-update-using-tray/__snapshots__/installing-update-using-tray.test.ts.snap
@@ -724,7 +724,7 @@ exports[`installing update using tray when started when user checks for updates 
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -748,6 +748,9 @@ exports[`installing update using tray when started when user checks for updates 
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>
@@ -966,7 +969,7 @@ exports[`installing update using tray when started when user checks for updates 
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -990,6 +993,9 @@ exports[`installing update using tray when started when user checks for updates 
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>

--- a/src/features/application-update/child-features/force-user-to-update-when-too-long-time-since-update-was-downloaded/__snapshots__/force-user-to-update-when-too-long-time-since-update-was-downloaded.test.ts.snap
+++ b/src/features/application-update/child-features/force-user-to-update-when-too-long-time-since-update-was-downloaded/__snapshots__/force-user-to-update-when-too-long-time-since-update-was-downloaded.test.ts.snap
@@ -64,7 +64,7 @@ exports[`force user to update when too long since update was downloaded when app
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -88,6 +88,9 @@ exports[`force user to update when too long since update was downloaded when app
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>
@@ -306,7 +309,7 @@ exports[`force user to update when too long since update was downloaded when app
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -330,6 +333,9 @@ exports[`force user to update when too long since update was downloaded when app
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>
@@ -595,7 +601,7 @@ exports[`force user to update when too long since update was downloaded when app
             </i>
           </div>
           <div
-            class="separator"
+            class="size-sm"
           />
           <div
             class="preventedDragging"
@@ -619,6 +625,9 @@ exports[`force user to update when too long since update was downloaded when app
               </i>
             </button>
           </div>
+          <div
+            class="separator"
+          />
         </div>
       </div>
       <main>


### PR DESCRIPTION
This was happening:

![Screen Shot 2022-11-18 at 9 43 13 AM](https://user-images.githubusercontent.com/40840436/202758649-aa6b03ad-253d-4f53-b097-615a8a9fc005.png)

This PR anchors the button on the left:

![Screen Shot 2022-11-18 at 11 57 49 AM](https://user-images.githubusercontent.com/40840436/202759883-a8b8dc50-92e2-4238-90a2-e9d17d841a3b.png)
