### PR TITLE
fix: getAllowedResources for all namespaces using SelfSubjectRulesReview

### DIFF
--- a/integration/__tests__/cluster-pages.tests.ts
+++ b/integration/__tests__/cluster-pages.tests.ts
@@ -393,19 +393,13 @@ const scenarios = [
   {
     expectedSelector: "h5.title",
     parentSidebarItemTestId: "sidebar-item-link-for-user-management",
-    sidebarItemTestId: "sidebar-item-link-for-roles",
-  },
-
-  {
-    expectedSelector: "h5.title",
-    parentSidebarItemTestId: "sidebar-item-link-for-user-management",
     sidebarItemTestId: "sidebar-item-link-for-cluster-roles",
   },
 
   {
     expectedSelector: "h5.title",
     parentSidebarItemTestId: "sidebar-item-link-for-user-management",
-    sidebarItemTestId: "sidebar-item-link-for-role-bindings",
+    sidebarItemTestId: "sidebar-item-link-for-roles",
   },
 
   {
@@ -417,7 +411,7 @@ const scenarios = [
   {
     expectedSelector: "h5.title",
     parentSidebarItemTestId: "sidebar-item-link-for-user-management",
-    sidebarItemTestId: "sidebar-item-link-for-pod-security-policies",
+    sidebarItemTestId: "sidebar-item-link-for-role-bindings",
   },
 
   {

--- a/src/common/cluster-types.ts
+++ b/src/common/cluster-types.ts
@@ -196,13 +196,6 @@ export enum ClusterMetricsResourceType {
 export const initialNodeShellImage = "docker.io/alpine:3.13";
 
 /**
- * The arguments for requesting to refresh a cluster's metadata
- */
-export interface ClusterRefreshOptions {
-  refreshMetadata?: boolean;
-}
-
-/**
  * The data representing a cluster's state, for passing between main and renderer
  */
 export interface ClusterState {

--- a/src/common/cluster/authorization-namespace-review.injectable.ts
+++ b/src/common/cluster/authorization-namespace-review.injectable.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type { KubeConfig } from "@kubernetes/client-node";
+import { AuthorizationV1Api } from "@kubernetes/client-node";
+import { getInjectable } from "@ogre-tools/injectable";
+import type { Logger } from "../logger";
+import loggerInjectable from "../logger.injectable";
+
+export type RequestNamespaceResources = (namespace: string) => Promise<string[]>; 
+
+/**
+ * @param proxyConfig This config's `currentContext` field must be set, and will be used as the target cluster
+ */
+export type AuthorizationNamespaceReview = (proxyConfig: KubeConfig) => RequestNamespaceResources; 
+
+interface Dependencies { 
+  logger: Logger;
+}
+
+const authorizationNamespaceReview = ({ logger }: Dependencies): AuthorizationNamespaceReview => {
+  return (proxyConfig) => {
+
+    const api = proxyConfig.makeApiClient(AuthorizationV1Api);
+
+    /**
+     * Requests the permissions for actions on the kube cluster
+     * @param namespace The namespace of the resources
+     * @returns list of allowed resources
+     */
+    return async (namespace: string): Promise<string[]> => {
+      try {
+        const { body } = await api.createSelfSubjectRulesReview({
+          apiVersion: "authorization.k8s.io/v1",
+          kind: "SelfSubjectRulesReview",
+          spec: { namespace },
+        });
+
+        const resources = new Set<string>();
+
+        body.status?.resourceRules.forEach(resourceRule => {
+          if (resourceRule.verbs.some(verb => ["*", "list"].includes(verb))) {
+            resourceRule.resources?.forEach(resource => resources.add(resource));
+          }
+        });
+
+        resources.delete("*");
+
+        return [...resources];
+      } catch (error) {
+        logger.error(`[AUTHORIZATION-NAMESPACE-REVIEW]: failed to create subject rules review: ${error}`, { namespace });
+
+        return [];
+      }
+    };
+  };
+};
+
+const authorizationNamespaceReviewInjectable = getInjectable({
+  id: "authorization-namespace-review",
+  instantiate: (di) => {
+    const logger = di.inject(loggerInjectable);
+
+    return authorizationNamespaceReview({ logger });
+  },
+});
+
+export default authorizationNamespaceReviewInjectable;

--- a/src/common/cluster/authorization-namespace-review.injectable.ts
+++ b/src/common/cluster/authorization-namespace-review.injectable.ts
@@ -8,8 +8,15 @@ import { AuthorizationV1Api } from "@kubernetes/client-node";
 import { getInjectable } from "@ogre-tools/injectable";
 import type { Logger } from "../logger";
 import loggerInjectable from "../logger.injectable";
+import type { KubeApiResource } from "../rbac";
 
-export type RequestNamespaceResources = (namespace: string) => Promise<string[]>; 
+/**
+ * Requests the permissions for actions on the kube cluster
+ * @param namespace The namespace of the resources
+ * @param availableResources List of available resources in the cluster to resolve glob values fir api groups
+ * @returns list of allowed resources names
+ */
+export type RequestNamespaceResources = (namespace: string, availableResources: KubeApiResource[]) => Promise<string[]>; 
 
 /**
  * @param proxyConfig This config's `currentContext` field must be set, and will be used as the target cluster
@@ -25,12 +32,7 @@ const authorizationNamespaceReview = ({ logger }: Dependencies): AuthorizationNa
 
     const api = proxyConfig.makeApiClient(AuthorizationV1Api);
 
-    /**
-     * Requests the permissions for actions on the kube cluster
-     * @param namespace The namespace of the resources
-     * @returns list of allowed resources
-     */
-    return async (namespace: string): Promise<string[]> => {
+    return async (namespace, availableResources) => {
       try {
         const { body } = await api.createSelfSubjectRulesReview({
           apiVersion: "authorization.k8s.io/v1",
@@ -41,12 +43,27 @@ const authorizationNamespaceReview = ({ logger }: Dependencies): AuthorizationNa
         const resources = new Set<string>();
 
         body.status?.resourceRules.forEach(resourceRule => {
-          if (resourceRule.verbs.some(verb => ["*", "list"].includes(verb))) {
-            resourceRule.resources?.forEach(resource => resources.add(resource));
+          if (!resourceRule.verbs.some(verb => ["*", "list"].includes(verb)) || !resourceRule.resources) {
+            return;
           }
-        });
 
-        resources.delete("*");
+          const apiGroups = resourceRule.apiGroups;
+
+          if (resourceRule.resources.length === 1 && resourceRule.resources[0] === "*" && apiGroups) {
+            if (apiGroups[0] === "*") {
+              availableResources.forEach(resource => resources.add(resource.apiName));
+            } else {
+              availableResources.forEach((apiResource)=> {
+                if (apiGroups.includes(apiResource.group || "")) {
+                  resources.add(apiResource.apiName);
+                }
+              });
+            }
+          } else {
+            resourceRule.resources.forEach(resource => resources.add(resource));
+          }
+          
+        });
 
         return [...resources];
       } catch (error) {

--- a/src/common/cluster/authorization-review.injectable.ts
+++ b/src/common/cluster/authorization-review.injectable.ts
@@ -5,42 +5,55 @@
 
 import type { KubeConfig, V1ResourceAttributes } from "@kubernetes/client-node";
 import { AuthorizationV1Api } from "@kubernetes/client-node";
-import logger from "../logger";
 import { getInjectable } from "@ogre-tools/injectable";
+import type { Logger } from "../logger";
+import loggerInjectable from "../logger.injectable";
 
+/**
+ * Requests the permissions for actions on the kube cluster
+ * @param resourceAttributes The descriptor of the action that is desired to be known if it is allowed
+ * @returns `true` if the actions described are allowed
+ */
 export type CanI = (resourceAttributes: V1ResourceAttributes) => Promise<boolean>;
 
 /**
  * @param proxyConfig This config's `currentContext` field must be set, and will be used as the target cluster
-   */
-export function authorizationReview(proxyConfig: KubeConfig): CanI {
-  const api = proxyConfig.makeApiClient(AuthorizationV1Api);
+ */
+export type AuthorizationReview = (proxyConfig: KubeConfig) => CanI; 
 
-  /**
-   * Requests the permissions for actions on the kube cluster
-   * @param resourceAttributes The descriptor of the action that is desired to be known if it is allowed
-   * @returns `true` if the actions described are allowed
-   */
-  return async (resourceAttributes: V1ResourceAttributes): Promise<boolean> => {
-    try {
-      const { body } = await api.createSelfSubjectAccessReview({
-        apiVersion: "authorization.k8s.io/v1",
-        kind: "SelfSubjectAccessReview",
-        spec: { resourceAttributes },
-      });
-
-      return body.status?.allowed ?? false;
-    } catch (error) {
-      logger.error(`[AUTHORIZATION-REVIEW]: failed to create access review: ${error}`, { resourceAttributes });
-
-      return false;
-    }
-  };
+interface Dependencies { 
+  logger: Logger;
 }
+
+const authorizationReview = ({ logger }: Dependencies): AuthorizationReview => {
+  return (proxyConfig) => {
+    const api = proxyConfig.makeApiClient(AuthorizationV1Api);
+
+    return async (resourceAttributes: V1ResourceAttributes): Promise<boolean> => {
+      try {
+        const { body } = await api.createSelfSubjectAccessReview({
+          apiVersion: "authorization.k8s.io/v1",
+          kind: "SelfSubjectAccessReview",
+          spec: { resourceAttributes },
+        });
+
+        return body.status?.allowed ?? false;
+      } catch (error) {
+        logger.error(`[AUTHORIZATION-REVIEW]: failed to create access review: ${error}`, { resourceAttributes });
+
+        return false;
+      }
+    };
+  };
+};
 
 const authorizationReviewInjectable = getInjectable({
   id: "authorization-review",
-  instantiate: () => authorizationReview,
+  instantiate: (di) => {
+    const logger = di.inject(loggerInjectable);
+
+    return authorizationReview({ logger });
+  },
 });
 
 export default authorizationReviewInjectable;

--- a/src/common/cluster/list-api-resources.injectable.ts
+++ b/src/common/cluster/list-api-resources.injectable.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import type {
+  V1APIGroupList,
+  V1APIResourceList,
+  V1APIVersions,
+} from "@kubernetes/client-node";
+import { getInjectable } from "@ogre-tools/injectable";
+import type { K8sRequest } from "../../main/k8s-request.injectable";
+import k8SRequestInjectable from "../../main/k8s-request.injectable";
+import type { Logger } from "../logger";
+import loggerInjectable from "../logger.injectable";
+import type { KubeApiResource, KubeResource } from "../rbac";
+import type { Cluster } from "./cluster";
+import plimit from "p-limit";
+
+export type RequestListApiResources = () => Promise<KubeApiResource[]>;
+
+/**
+ * @param proxyConfig This config's `currentContext` field must be set, and will be used as the target cluster
+ */
+export type ListApiResources = (cluster: Cluster) => RequestListApiResources;
+
+interface Dependencies {
+  logger: Logger;
+  k8sRequest: K8sRequest;
+}
+
+const listApiResources = ({ k8sRequest, logger }: Dependencies): ListApiResources => {
+  return (cluster) => {
+    const clusterRequest = (path: string) => k8sRequest(cluster, path);
+    const apiLimit = plimit(5);
+
+    return async () => {
+      const resources: KubeApiResource[] = [];
+
+      try {
+        const resourceListGroups:{ group:string;path:string }[] = [];
+
+        await Promise.all(
+          [
+            clusterRequest("/api").then((response:V1APIVersions)=>response.versions.forEach(version => resourceListGroups.push({ group:version, path:`/api/${version}` }))),
+            clusterRequest("/apis").then((response:V1APIGroupList) => response.groups.forEach(group => {
+              const preferredVersion = group.preferredVersion?.groupVersion;
+
+              if (preferredVersion) {
+                resourceListGroups.push({ group:group.name, path:`/apis/${preferredVersion}` });
+              }
+            })),
+          ],
+        );
+
+        await Promise.all(
+          resourceListGroups.map(({ group, path }) => apiLimit(async () => {
+            const apiResources:V1APIResourceList = await clusterRequest(path);
+
+            if (apiResources.resources) {
+              resources.push(
+                ...apiResources.resources.filter(resource => resource.verbs.includes("list")).map((resource) => ({
+                  apiName: resource.name as KubeResource,
+                  kind: resource.kind,
+                  group,
+                })),
+              );
+            }
+          }),
+          ),
+        );
+      } catch (error) {
+        logger.error(`[LIST-API-RESOURCES]: failed to list api resources: ${error}`);
+      }
+
+      return resources;
+    };
+  };
+};
+
+const listApiResourcesInjectable = getInjectable({
+  id: "list-api-resources",
+  instantiate: (di) => {
+    const k8sRequest = di.inject(k8SRequestInjectable);
+    const logger = di.inject(loggerInjectable);
+
+    return listApiResources({ k8sRequest, logger });
+  },
+});
+
+export default listApiResourcesInjectable;

--- a/src/common/ipc/cluster.ts
+++ b/src/common/ipc/cluster.ts
@@ -5,7 +5,7 @@
 
 export const clusterActivateHandler = "cluster:activate";
 export const clusterSetFrameIdHandler = "cluster:set-frame-id";
-export const clusterRefreshHandler = "cluster:refresh";
+export const clusterVisibilityHandler = "cluster:visibility";
 export const clusterDisconnectHandler = "cluster:disconnect";
 export const clusterKubectlApplyAllHandler = "cluster:kubectl-apply-all";
 export const clusterKubectlDeleteAllHandler = "cluster:kubectl-delete-all";

--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -10,6 +10,7 @@ import { getDiForUnitTesting } from "../getDiForUnitTesting";
 import type { CreateCluster } from "../../common/cluster/create-cluster-injection-token";
 import { createClusterInjectionToken } from "../../common/cluster/create-cluster-injection-token";
 import authorizationReviewInjectable from "../../common/cluster/authorization-review.injectable";
+import authorizationNamespaceReviewInjectable from "../../common/cluster/authorization-namespace-review.injectable";
 import listNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
 import createContextHandlerInjectable from "../context-handler/create-context-handler.injectable";
 import type { ClusterContextHandler } from "../context-handler/context-handler";
@@ -19,6 +20,7 @@ import directoryForTempInjectable from "../../common/app-paths/directory-for-tem
 import normalizedPlatformInjectable from "../../common/vars/normalized-platform.injectable";
 import kubectlBinaryNameInjectable from "../kubectl/binary-name.injectable";
 import kubectlDownloadingNormalizedArchInjectable from "../kubectl/normalized-arch.injectable";
+import { apiResourceRecord } from "../../common/rbac";
 
 console = new Console(process.stdout, process.stderr); // fix mockFS
 
@@ -39,6 +41,7 @@ describe("create clusters", () => {
     di.override(normalizedPlatformInjectable, () => "darwin");
     di.override(broadcastMessageInjectable, () => async () => {});
     di.override(authorizationReviewInjectable, () => () => () => Promise.resolve(true));
+    di.override(authorizationNamespaceReviewInjectable, () => () => () => Promise.resolve(Object.keys(apiResourceRecord)));
     di.override(listNamespacesInjectable, () => () => () => Promise.resolve([ "default" ]));
     di.override(createContextHandlerInjectable, () => (cluster) => ({
       restartServer: jest.fn(),

--- a/src/main/__test__/cluster.test.ts
+++ b/src/main/__test__/cluster.test.ts
@@ -20,7 +20,8 @@ import directoryForTempInjectable from "../../common/app-paths/directory-for-tem
 import normalizedPlatformInjectable from "../../common/vars/normalized-platform.injectable";
 import kubectlBinaryNameInjectable from "../kubectl/binary-name.injectable";
 import kubectlDownloadingNormalizedArchInjectable from "../kubectl/normalized-arch.injectable";
-import { apiResourceRecord } from "../../common/rbac";
+import { apiResourceRecord, apiResources } from "../../common/rbac";
+import listApiResourcesInjectable from "../../common/cluster/list-api-resources.injectable";
 
 console = new Console(process.stdout, process.stderr); // fix mockFS
 
@@ -42,6 +43,7 @@ describe("create clusters", () => {
     di.override(broadcastMessageInjectable, () => async () => {});
     di.override(authorizationReviewInjectable, () => () => () => Promise.resolve(true));
     di.override(authorizationNamespaceReviewInjectable, () => () => () => Promise.resolve(Object.keys(apiResourceRecord)));
+    di.override(listApiResourcesInjectable, () => () => () => Promise.resolve(apiResources));
     di.override(listNamespacesInjectable, () => () => () => Promise.resolve([ "default" ]));
     di.override(createContextHandlerInjectable, () => (cluster) => ({
       restartServer: jest.fn(),

--- a/src/main/create-cluster/create-cluster.injectable.ts
+++ b/src/main/create-cluster/create-cluster.injectable.ts
@@ -11,6 +11,7 @@ import createKubectlInjectable from "../kubectl/create-kubectl.injectable";
 import createContextHandlerInjectable from "../context-handler/create-context-handler.injectable";
 import { createClusterInjectionToken } from "../../common/cluster/create-cluster-injection-token";
 import authorizationReviewInjectable from "../../common/cluster/authorization-review.injectable";
+import createAuthorizationNamespaceReview from "../../common/cluster/authorization-namespace-review.injectable";
 import listNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
 import loggerInjectable from "../../common/logger.injectable";
 import detectorRegistryInjectable from "../cluster-detectors/detector-registry.injectable";
@@ -28,6 +29,7 @@ const createClusterInjectable = getInjectable({
       createKubectl: di.inject(createKubectlInjectable),
       createContextHandler: di.inject(createContextHandlerInjectable),
       createAuthorizationReview: di.inject(authorizationReviewInjectable),
+      createAuthorizationNamespaceReview: di.inject(createAuthorizationNamespaceReview),
       createListNamespaces: di.inject(listNamespacesInjectable),
       logger: di.inject(loggerInjectable),
       detectorRegistry: di.inject(detectorRegistryInjectable),

--- a/src/main/create-cluster/create-cluster.injectable.ts
+++ b/src/main/create-cluster/create-cluster.injectable.ts
@@ -13,6 +13,7 @@ import { createClusterInjectionToken } from "../../common/cluster/create-cluster
 import authorizationReviewInjectable from "../../common/cluster/authorization-review.injectable";
 import createAuthorizationNamespaceReview from "../../common/cluster/authorization-namespace-review.injectable";
 import listNamespacesInjectable from "../../common/cluster/list-namespaces.injectable";
+import createListApiResourcesInjectable from "../../common/cluster/list-api-resources.injectable";
 import loggerInjectable from "../../common/logger.injectable";
 import detectorRegistryInjectable from "../cluster-detectors/detector-registry.injectable";
 import createVersionDetectorInjectable from "../cluster-detectors/create-version-detector.injectable";
@@ -30,6 +31,7 @@ const createClusterInjectable = getInjectable({
       createContextHandler: di.inject(createContextHandlerInjectable),
       createAuthorizationReview: di.inject(authorizationReviewInjectable),
       createAuthorizationNamespaceReview: di.inject(createAuthorizationNamespaceReview),
+      createListApiResources: di.inject(createListApiResourcesInjectable),
       createListNamespaces: di.inject(listNamespacesInjectable),
       logger: di.inject(loggerInjectable),
       detectorRegistry: di.inject(detectorRegistryInjectable),

--- a/src/main/electron-app/runnables/setup-ipc-main-handlers/setup-ipc-main-handlers.ts
+++ b/src/main/electron-app/runnables/setup-ipc-main-handlers/setup-ipc-main-handlers.ts
@@ -5,7 +5,7 @@
 import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, Menu } from "electron";
 import { clusterFrameMap } from "../../../../common/cluster-frames";
-import { clusterActivateHandler, clusterSetFrameIdHandler, clusterRefreshHandler, clusterDisconnectHandler, clusterKubectlApplyAllHandler, clusterKubectlDeleteAllHandler } from "../../../../common/ipc/cluster";
+import { clusterActivateHandler, clusterSetFrameIdHandler, clusterDisconnectHandler, clusterKubectlApplyAllHandler, clusterKubectlDeleteAllHandler } from "../../../../common/ipc/cluster";
 import type { ClusterId } from "../../../../common/cluster-types";
 import { ClusterStore } from "../../../../common/cluster-store/cluster-store";
 import { broadcastMainChannel, broadcastMessage, ipcMainHandle, ipcMainOn } from "../../../../common/ipc";
@@ -59,12 +59,6 @@ export const setupIpcMainHandlers = ({
 
       pushCatalogToRenderer(catalogEntityRegistry);
     }
-  });
-
-  ipcMainHandle(clusterRefreshHandler, (event, clusterId: ClusterId) => {
-    return ClusterStore.getInstance()
-      .getById(clusterId)
-      ?.refresh({ refreshMetadata: true });
   });
 
   ipcMainHandle(clusterDisconnectHandler, (event, clusterId: ClusterId) => {

--- a/src/renderer/create-cluster/create-cluster.injectable.ts
+++ b/src/renderer/create-cluster/create-cluster.injectable.ts
@@ -29,6 +29,7 @@ const createClusterInjectable = getInjectable({
       createAuthorizationReview: () => { throw new Error("Tried to access back-end feature in front-end."); },
       createAuthorizationNamespaceReview: () => { throw new Error("Tried to access back-end feature in front-end."); },
       createListNamespaces: () => { throw new Error("Tried to access back-end feature in front-end."); },
+      createListApiResources: ()=> { throw new Error("Tried to access back-end feature in front-end."); },
       detectorRegistry: undefined as never,
       createVersionDetector: () => { throw new Error("Tried to access back-end feature in front-end."); },
     };

--- a/src/renderer/create-cluster/create-cluster.injectable.ts
+++ b/src/renderer/create-cluster/create-cluster.injectable.ts
@@ -27,6 +27,7 @@ const createClusterInjectable = getInjectable({
       createKubectl: () => { throw new Error("Tried to access back-end feature in front-end.");},
       createContextHandler: () => undefined as never,
       createAuthorizationReview: () => { throw new Error("Tried to access back-end feature in front-end."); },
+      createAuthorizationNamespaceReview: () => { throw new Error("Tried to access back-end feature in front-end."); },
       createListNamespaces: () => { throw new Error("Tried to access back-end feature in front-end."); },
       detectorRegistry: undefined as never,
       createVersionDetector: () => { throw new Error("Tried to access back-end feature in front-end."); },


### PR DESCRIPTION
fixes #6613 

the SelfSubjectRulesReview lists all resources for a namespaces. This reduces the api calls from `resource_count * namespace_count` to `namespace_count`