### PR TITLE
Add missing gutter between sections in cluster settings

### DIFF
--- a/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-local-terminal-settings.tsx
@@ -18,6 +18,7 @@ import type { ValidateDirectory } from "../../../../common/fs/validate-directory
 import validateDirectoryInjectable from "../../../../common/fs/validate-directory.injectable";
 import type { ResolveTilde } from "../../../../common/path/resolve-tilde.injectable";
 import resolveTildeInjectable from "../../../../common/path/resolve-tilde.injectable";
+import Gutter from "../../gutter/gutter";
 
 export interface ClusterLocalTerminalSettingProps {
   cluster: Cluster;
@@ -139,6 +140,7 @@ const NonInjectedClusterLocalTerminalSetting = observer(({
           this is used as the current working directory (cwd) for the shell process.
         </small>
       </section>
+      <Gutter />
       <section className="default-namespace">
         <SubTitle title="Default Namespace"/>
         <Input

--- a/src/renderer/components/cluster-settings/components/cluster-node-shell-setting.tsx
+++ b/src/renderer/components/cluster-settings/components/cluster-node-shell-setting.tsx
@@ -11,6 +11,7 @@ import { Input } from "../../input/input";
 import { observer } from "mobx-react";
 import { Icon } from "../../icon/icon";
 import { initialNodeShellImage } from "../../../../common/cluster-types";
+import Gutter from "../../gutter/gutter";
 
 export interface ClusterNodeShellSettingProps {
   cluster: Cluster;
@@ -59,6 +60,7 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
             Node shell image. Used for creating node shell pod.
           </small>
         </section>
+        <Gutter />
         <section>
           <SubTitle title="Image pull secret" id="image-pull-secret"/>
           <Input


### PR DESCRIPTION
Very generic `.settingsLayout section {` css-style was removed in earlier PR's and replaced with explicit `<Gutter />` for more hands-on control over gutters. 

Change here means that use places (e.g. extensions) shouldn't rely on `section` to make assumptions over margins.
