### PR TITLE
Adding spacing between Metrics Settings sections

### DIFF
--- a/extensions/metrics-cluster-feature/src/metrics-settings.tsx
+++ b/extensions/metrics-cluster-feature/src/metrics-settings.tsx
@@ -190,7 +190,7 @@ export class MetricsSettings extends React.Component<MetricsSettingsProps> {
 
   render() {
     return (
-      <>
+      <section style={{ display: "flex", flexDirection: "column", rowGap: "1.5rem" }}>
         { this.props.cluster.status.phase !== "connected" && (
           <section>
             <p style={ { color: "var(--colorError)" } }>
@@ -270,7 +270,7 @@ export class MetricsSettings extends React.Component<MetricsSettingsProps> {
             )}
           </div>
         </section>
-      </>
+      </section>
     );
   }
 }


### PR DESCRIPTION
After https://github.com/lensapp/lens/pull/6437 all `<section>` tags dropped generic styles for margin.

This PR fixes spacing in bundled metrics settings extension.

Before:
![metrics spacing bug](https://user-images.githubusercontent.com/9607060/203512303-76918a5b-e683-4c88-b2b5-85528749c81f.png)

After:
![metrics spacing fix](https://user-images.githubusercontent.com/9607060/203512315-0793d906-c740-4bbd-9511-44f14fa8bca9.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>