### PR TITLE
Fix: adjust padding after cluster settings avatar

### DIFF
--- a/src/renderer/components/+entity-settings/entity-settings.module.scss
+++ b/src/renderer/components/+entity-settings/entity-settings.module.scss
@@ -16,3 +16,9 @@
 .settingsAvatar {
   margin: 0 10px;
 }
+
+.avatarAndName {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--margin);
+}

--- a/src/renderer/components/+entity-settings/entity-settings.tsx
+++ b/src/renderer/components/+entity-settings/entity-settings.tsx
@@ -86,7 +86,7 @@ class NonInjectedEntitySettings extends React.Component<Dependencies> {
 
     return (
       <>
-        <div className="flex items-center pb-8">
+        <div className={styles.avatarAndName}>
           <Avatar
             title={entity.getName()}
             colorHash={`${entity.getName()}-${entity.metadata.source}`}


### PR DESCRIPTION
Before:
![avatar big padding](https://user-images.githubusercontent.com/9607060/203515919-f973c234-af1d-442a-8cdd-75ce0e49c594.png)

After:
![avatar normal padding](https://user-images.githubusercontent.com/9607060/203515941-5d850e5d-8961-4169-a7b0-0cdc8a504e36.png)
![long cluster name](https://user-images.githubusercontent.com/9607060/203515956-c113157e-b7e7-4f29-9b7c-3c5e9ca7eda6.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>