### PR TITLE
Simplify Error.cause logging

### DIFF
--- a/src/main/logger/console-format.ts
+++ b/src/main/logger/console-format.ts
@@ -7,6 +7,7 @@ import { LEVEL, MESSAGE, SPLAT } from "triple-beam";
 import chalk from "chalk";
 import type { InspectOptions } from "util";
 import { inspect } from "util";
+import { omit } from "lodash";
 
 // The following license was copied from https://github.com/duccio/winston-console-format/blob/master/LICENSE
 // This was modified to support formatting causes
@@ -112,8 +113,8 @@ export class ConsoleFormat {
     const messages: string[] = [];
 
     if (source instanceof Error && source.cause) {
-      messages.push(`Cause: ${source.cause}`);
-      messages.push(...this.getLines(source.cause).map(l => `    ${l}`));
+      messages.push("Cause:");
+      messages.push(...this.getLines(omit(source.cause, "response")).map(l => `    ${l}`));
       messages.push(...this._cause(source.cause));
     }
 


### PR DESCRIPTION
- Errors from "request" package (and thus the "@kubernetes/client-node" package too) contain a "response" field which is very large and has redundent information on it

Signed-off-by: Sebastian Malton <sebastian@malton.name>