### PR TITLE
Fix back navigation in entity settings

### DIFF
--- a/src/renderer/components/+entity-settings/active-tabs.injectable.ts
+++ b/src/renderer/components/+entity-settings/active-tabs.injectable.ts
@@ -67,7 +67,7 @@ const activeEntitySettingsTabInjectable = getInjectable({
         return { tabId, setting, groups };
       },
       set: action((tabId) => {
-        observableHistory.location.hash = tabId;
+        observableHistory.merge({ hash: tabId }, true);
       }),
     };
   },


### PR DESCRIPTION
- The bug was that the user would cycle through all the settings viewed

Signed-off-by: Sebastian Malton <sebastian@malton.name>