### PR TITLE
Fix: remove excessive scrollbars from the TabLayout view

### DIFF
--- a/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
@@ -272,7 +272,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"

--- a/src/features/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
@@ -327,7 +327,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -942,7 +944,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"

--- a/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
@@ -300,7 +300,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -836,7 +838,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -1392,7 +1396,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -2799,7 +2805,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -3335,7 +3343,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"

--- a/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
@@ -300,7 +300,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -836,7 +838,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -1408,7 +1412,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -1994,7 +2000,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class=""
+        >
           <div
             data-testid="some-child-page"
           >
@@ -2485,7 +2493,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class=""
+        >
           <div
             data-testid="some-other-child-page"
           >
@@ -2939,7 +2949,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class=""
+        >
           <div
             data-testid="some-child-page"
           >
@@ -3416,7 +3428,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -3952,7 +3966,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"

--- a/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
@@ -272,7 +272,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"
@@ -820,7 +822,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"

--- a/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
+++ b/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
@@ -286,7 +286,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
@@ -663,7 +663,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -1173,7 +1175,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -291,7 +291,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -801,7 +803,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -1311,7 +1315,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -281,7 +281,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -919,7 +921,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -1562,7 +1566,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -2274,7 +2280,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -2964,7 +2972,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -3726,7 +3736,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -4490,7 +4502,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -5216,7 +5230,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -5937,7 +5953,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -6649,7 +6667,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -7361,7 +7381,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -8073,7 +8095,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -8620,7 +8644,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -9341,7 +9367,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -9888,7 +9916,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >
@@ -10435,7 +10465,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
           class="TabLayout"
           data-testid="tab-layout"
         >
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column KubeObjectListLayout Namespaces"
             >

--- a/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
+++ b/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
@@ -298,7 +298,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -843,7 +845,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
@@ -273,7 +273,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -788,7 +790,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -1298,7 +1302,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -273,7 +273,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -715,7 +717,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -1628,7 +1632,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -2386,7 +2392,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -3388,7 +3396,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -4364,7 +4374,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -5335,7 +5347,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -6306,7 +6320,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -7299,7 +7315,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -8301,7 +8319,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -9272,7 +9292,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -10298,7 +10320,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -11136,7 +11160,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -11909,7 +11935,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -12760,7 +12788,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -13977,7 +14007,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -14787,7 +14819,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -15812,7 +15846,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -16835,7 +16871,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -17806,7 +17844,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -18777,7 +18817,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"

--- a/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
+++ b/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
@@ -273,7 +273,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -793,7 +795,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
+++ b/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
@@ -286,7 +286,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -783,7 +785,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -1450,7 +1454,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -2174,7 +2180,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -3081,7 +3089,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -3998,7 +4008,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -4905,7 +4917,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"
@@ -5822,7 +5836,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               data-testid="page-for-helm-charts"
               style="display: none;"

--- a/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
+++ b/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
@@ -286,7 +286,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -946,7 +948,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -1699,7 +1703,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -2506,7 +2512,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -3349,7 +3357,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -4332,7 +4342,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -5317,7 +5329,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >

--- a/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -286,7 +286,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -1027,7 +1029,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -1773,7 +1777,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -2689,7 +2695,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -3666,7 +3674,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -4643,7 +4653,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -5865,7 +5877,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -7087,7 +7101,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -8309,7 +8325,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -9356,7 +9374,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -10405,7 +10425,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -11627,7 +11649,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -12604,7 +12628,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -13584,7 +13610,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -14500,7 +14528,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >
@@ -15477,7 +15507,9 @@ exports[`showing details for helm release given application is started when navi
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class=""
+          >
             <div
               class="ItemListLayout flex column HelmReleases"
             >

--- a/src/features/pod-logs/__snapshots__/download-logs.test.tsx.snap
+++ b/src/features/pod-logs/__snapshots__/download-logs.test.tsx.snap
@@ -273,7 +273,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"
@@ -1126,7 +1128,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </div>
             </div>
           </div>
-          <main>
+          <main
+            class="scrollable"
+          >
             <div
               class="WorkloadsOverview flex column gaps"
               data-testid="page-for-workloads-overview"

--- a/src/renderer/components/+cluster/cluster-overview.tsx
+++ b/src/renderer/components/+cluster/cluster-overview.tsx
@@ -102,7 +102,7 @@ class NonInjectedClusterOverview extends React.Component<Dependencies> {
     const isMetricHidden = hostedCluster.isMetricHidden(ClusterMetricsResourceType.Cluster);
 
     return (
-      <TabLayout>
+      <TabLayout scrollable>
         <div className={styles.ClusterOverview} data-testid="cluster-overview-page">
           {this.renderClusterOverview(isLoaded, isMetricHidden)}
         </div>

--- a/src/renderer/components/+workloads-overview/overview.tsx
+++ b/src/renderer/components/+workloads-overview/overview.tsx
@@ -103,7 +103,7 @@ class NonInjectedWorkloadsOverview extends React.Component<Dependencies> {
 
   render() {
     return (
-      <SiblingsInTabLayout>
+      <SiblingsInTabLayout scrollable>
         <div className="WorkloadsOverview flex column gaps" data-testid="page-for-workloads-overview">
           <div className="header flex gaps align-center">
             <h5 className="box grow">Overview</h5>

--- a/src/renderer/components/item-object-list/item-list-layout.scss
+++ b/src/renderer/components/item-object-list/item-list-layout.scss
@@ -31,7 +31,7 @@
 
   > .items {
     position: relative;
-    min-height: 200px;
+    min-height: 130px;
   }
 }
 

--- a/src/renderer/components/layout/main-layout.module.scss
+++ b/src/renderer/components/layout/main-layout.module.scss
@@ -23,9 +23,7 @@
 }
 
 .contents {
-  grid-area: contents;
-  overflow: auto;
-  height: calc(100vh - var(--status-bar-height) - var(--main-layout-header));
+  overflow: hidden;
 }
 
 .footer {

--- a/src/renderer/components/layout/siblings-in-tab-layout.tsx
+++ b/src/renderer/components/layout/siblings-in-tab-layout.tsx
@@ -12,6 +12,7 @@ import type { HierarchicalSidebarItem } from "./sidebar-items.injectable";
 
 interface SiblingTabLayoutProps {
   children: React.ReactNode;
+  scrollable?: boolean;
 }
 
 interface Dependencies {
@@ -19,13 +20,14 @@ interface Dependencies {
 }
 
 const NonInjectedSiblingsInTabLayout = observer(
-  ({ tabs, children }: Dependencies & SiblingTabLayoutProps) => {
+  ({ tabs, children, ...other }: Dependencies & SiblingTabLayoutProps) => {
     const dereferencedTabs = tabs.get();
 
     if (dereferencedTabs.length) {
       return (
         <TabLayout
           tabs={dereferencedTabs}
+          {...other}
         >
           {children}
         </TabLayout>

--- a/src/renderer/components/layout/tab-layout-2.tsx
+++ b/src/renderer/components/layout/tab-layout-2.tsx
@@ -15,11 +15,13 @@ import type { HierarchicalSidebarItem } from "./sidebar-items.injectable";
 export interface TabLayoutProps {
   tabs?: HierarchicalSidebarItem[];
   children?: React.ReactNode;
+  scrollable?: boolean;
 }
 
 export const TabLayout = observer(
   ({
     tabs = [],
+    scrollable,
     children,
   }: TabLayoutProps) => {
     const hasTabs = tabs.length > 0;
@@ -50,7 +52,7 @@ export const TabLayout = observer(
           </Tabs>
         )}
 
-        <main>
+        <main className={cssNames({ scrollable })}>
           <ErrorBoundary>
             {children}
           </ErrorBoundary>

--- a/src/renderer/components/layout/tab-layout.scss
+++ b/src/renderer/components/layout/tab-layout.scss
@@ -11,16 +11,20 @@
 
   > .Tabs {
     background: var(--layoutTabsBackground);
-    min-height: 32px;
+    min-height: 36px;
   }
 
   main {
     $spacing: $margin * 2;
 
     flex-grow: 1;
-    overflow-y: scroll; // always reserve space for scrollbar (17px)
+    overflow-y: hidden;
     overflow-x: auto;
     margin: $spacing;
-    margin-right: 0;
+
+    &.scrollable {
+      overflow-y: scroll;
+      margin-right: 0;
+    }
   }
 }

--- a/src/renderer/components/layout/tab-layout.tsx
+++ b/src/renderer/components/layout/tab-layout.tsx
@@ -20,6 +20,7 @@ export interface TabLayoutProps {
   contentClass?: IClassName;
   tabs?: TabLayoutRoute[];
   children?: ReactNode;
+  scrollable?: boolean;
 }
 
 export interface TabLayoutRoute {
@@ -31,7 +32,7 @@ export interface TabLayoutRoute {
   default?: boolean; // initial tab to open with provided `url, by default tabs[0] is used
 }
 
-export const TabLayout = observer(({ className, contentClass, tabs = [], children }: TabLayoutProps) => {
+export const TabLayout = observer(({ className, contentClass, tabs = [], scrollable, children }: TabLayoutProps) => {
   const currentLocation = navigation.location.pathname;
   const hasTabs = tabs.length > 0;
   const startTabUrl = hasTabs ? (tabs.find(tab => tab.default) || tabs[0])?.url : null;
@@ -50,7 +51,7 @@ export const TabLayout = observer(({ className, contentClass, tabs = [], childre
           ))}
         </Tabs>
       )}
-      <main className={cssNames(contentClass)}>
+      <main className={cssNames(contentClass, { scrollable })}>
         <ErrorBoundary>
           {hasTabs && (
             <Switch>

--- a/src/renderer/components/table/table.scss
+++ b/src/renderer/components/table/table.scss
@@ -14,6 +14,10 @@
     overflow: auto;
   }
 
+  &.scrollable.virtual {
+    overflow: unset;
+  }
+
   &.selectable {
     .TableHead, .TableRow {
       padding: 0 $padding;

--- a/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
+++ b/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
@@ -786,7 +786,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
         class="TabLayout"
       >
         <main
-          class=""
+          class="scrollable"
         >
           <div
             class="ClusterOverview"
@@ -1228,7 +1228,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </div>
           </div>
         </div>
-        <main>
+        <main
+          class="scrollable"
+        >
           <div
             class="WorkloadsOverview flex column gaps"
             data-testid="page-for-workloads-overview"


### PR DESCRIPTION
When content view becomes smaller than some height, 2 scrollbars appear. Targeted layout changes fixe this issue.

Fixes #6316 


https://user-images.githubusercontent.com/9607060/205053480-1c64662d-0052-4c26-8c82-9f92e002dc72.mov



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>