### PR TITLE
Fix top-bar .separator width

### DIFF
--- a/src/renderer/components/layout/top-bar/top-bar.module.scss
+++ b/src/renderer/components/layout/top-bar/top-bar.module.scss
@@ -28,7 +28,7 @@
 }
 
 .separator {
-  flex-basis: 100%;
+  flex-grow: 1;
 }
 
 :global(.is-mac) .topBar {


### PR DESCRIPTION
Allowing `.separator` to grow in width but "respect" widths of sibling items.

Fixes #6658 

![mcc topbar item](https://user-images.githubusercontent.com/9607060/205877199-e88bde05-f543-4c6e-89db-c8275cbe1ba2.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>