### PR TITLE
Remove named exports from CSS module typings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,10 @@
     },
     "plugins": [
       {
-        "name": "typescript-plugin-css-modules"
+        "name": "typescript-plugin-css-modules",
+        "options": {
+          "namedExports": false
+        }
       }
     ]
   },


### PR DESCRIPTION
- They didn't exist anyway so this now causes compile time errors instead of runtime ones

Signed-off-by: Sebastian Malton <sebastian@malton.name>