### PR TITLE
Remove blue borders in light themed tables

### DIFF
--- a/src/renderer/components/table/table-head.scss
+++ b/src/renderer/components/table/table-head.scss
@@ -4,18 +4,14 @@
  */
 
 .TableHead {
-  $border: 1px solid var(--tableHeaderBorderColor);
-
   background-color: var(--tableHeaderBackground);
-  border-bottom-width: var(--tableHeaderBorderWidth);
-  border-bottom-style: solid;
-  border-bottom-color: var(--tableHeaderBorderColor);
+  border-bottom: 1px solid var(--borderFaintColor);
   color: var(--tableHeaderColor);
   display: flex;
   flex-shrink: 0;
 
   &.topLine {
-    border-top: $border;
+    border-top: 1px solid var(--borderFaintColor);
   }
 
   &.sticky {

--- a/src/renderer/themes/lens-dark.ts
+++ b/src/renderer/themes/lens-dark.ts
@@ -45,8 +45,6 @@ const lensDarkTheme: LensTheme = {
     "tableBgcStripe": "#2a2d33",
     "tableBgcSelected": "#383c42",
     "tableHeaderBackground": "#262b2f",
-    "tableHeaderBorderWidth": "1px",
-    "tableHeaderBorderColor": "#36393e",
     "tableHeaderColor": "#ffffff",
     "tableSelectedRowColor": "#ffffff",
     "helmLogoBackground": "#ffffff",

--- a/src/renderer/themes/lens-light.ts
+++ b/src/renderer/themes/lens-light.ts
@@ -44,8 +44,6 @@ const lensLightTheme: LensTheme = {
     "tableBgcStripe": "#f8f8f8",
     "tableBgcSelected": "#f4f5f5",
     "tableHeaderBackground": "#f1f1f1",
-    "tableHeaderBorderWidth": "2px",
-    "tableHeaderBorderColor": "#3d90ce",
     "tableHeaderColor": "#555555",
     "tableSelectedRowColor": "#222222",
     "helmLogoBackground": "#ffffff",

--- a/src/renderer/themes/theme-vars.css
+++ b/src/renderer/themes/theme-vars.css
@@ -1,5 +1,5 @@
 
-/* 
+/*
     Generated Lens theme CSS-variables, don't edit manually.
     To refresh file run $: yarn run ts-node build/build_theme_vars.ts
 */
@@ -38,8 +38,6 @@
 --tableBgcStripe: #2a2d33;
 --tableBgcSelected: #383c42;
 --tableHeaderBackground: #262b2f;
---tableHeaderBorderWidth: 1px;
---tableHeaderBorderColor: #36393e;
 --tableHeaderColor: #ffffff;
 --tableSelectedRowColor: #ffffff;
 --helmLogoBackground: #ffffff;


### PR DESCRIPTION
Resolves #6711

Making `TableHead` light and dark coloring more consistent.

![table dark](https://user-images.githubusercontent.com/9607060/207048349-182a4f5d-cd2c-4b0c-ae16-41ab8649b4ef.png)
![table light](https://user-images.githubusercontent.com/9607060/207048354-5277face-ed3a-4b00-9cd2-7a71d2c4ad0a.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>