### PR TITLE
Fix resize anchor z-index

### DIFF
--- a/src/renderer/components/resizing-anchor/resizing-anchor.scss
+++ b/src/renderer/components/resizing-anchor/resizing-anchor.scss
@@ -13,7 +13,7 @@ body.resizing {
   $dimension: 12px;
 
   position: absolute;
-  z-index: var(--z-index-base);
+  z-index: var(--z-index-above);
 
   &::after {
     content: " ";


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/9607060/208435242-0420776e-dd93-4e6c-9f0c-21d74e4d1cc3.mov



After:


https://user-images.githubusercontent.com/9607060/208435263-bc49aef6-66e3-4361-bb62-b31c04e33dca.mov


Fix after https://github.com/lensapp/lens/pull/6733.

Marking as `6.3.0` milestone because 6733 marked also as `6.3.0`.

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>