### PR TITLE
Renderer file logging transport

### DIFF
--- a/packages/core/src/common/logger.injectable.ts
+++ b/packages/core/src/common/logger.injectable.ts
@@ -3,20 +3,13 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import { createLogger, format } from "winston";
 import type { Logger } from "./logger";
-import { loggerTransportInjectionToken } from "./logger/transports";
+import winstonLoggerInjectable from "./winston-logger.injectable";
 
 const loggerInjectable = getInjectable({
   id: "logger",
   instantiate: (di): Logger => {
-    const baseLogger = createLogger({
-      format: format.combine(
-        format.splat(),
-        format.simple(),
-      ),
-      transports: di.injectMany(loggerTransportInjectionToken),
-    });
+    const baseLogger = di.inject(winstonLoggerInjectable);
 
     return {
       debug: (message, ...data) => baseLogger.debug(message, ...data),

--- a/packages/core/src/common/winston-logger.injectable.ts
+++ b/packages/core/src/common/winston-logger.injectable.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import { createLogger, format } from "winston";
+import { loggerTransportInjectionToken } from "./logger/transports";
+
+const winstonLoggerInjectable = getInjectable({
+  id: "winston-logger",
+  instantiate: (di) => createLogger({
+    format: format.combine(
+      format.splat(),
+      format.simple(),
+    ),
+    transports: di.injectMany(loggerTransportInjectionToken),
+  }),
+});
+
+export default winstonLoggerInjectable;

--- a/packages/core/src/renderer/bootstrap.tsx
+++ b/packages/core/src/renderer/bootstrap.tsx
@@ -19,7 +19,6 @@ import { Router } from "react-router";
 import historyInjectable from "./navigation/history.injectable";
 import assert from "assert";
 import startFrameInjectable from "./start-frame/start-frame.injectable";
-import closeRendererLogFileInjectable from "./logger/close-renderer-log-file.injectable";
 
 export async function bootstrap(di: DiContainer) {
   const startFrame = di.inject(startFrameInjectable);
@@ -55,15 +54,9 @@ export async function bootstrap(di: DiContainer) {
   }
 
   try {
-    const unmount = () => {
-      const closeLogFile = di.inject(closeRendererLogFileInjectable);
-
-      closeLogFile();
-
+    await initializeApp(() => {
       unmountComponentAtNode(rootElem);
-    };
-
-    await initializeApp(unmount);
+    });
   } catch (error) {
     console.error(`[BOOTSTRAP]: view initialization error: ${error}`, {
       origin: location.href,

--- a/packages/core/src/renderer/bootstrap.tsx
+++ b/packages/core/src/renderer/bootstrap.tsx
@@ -19,6 +19,7 @@ import { Router } from "react-router";
 import historyInjectable from "./navigation/history.injectable";
 import assert from "assert";
 import startFrameInjectable from "./start-frame/start-frame.injectable";
+import closeRendererLogFileInjectable from "./logger/close-renderer-log-file.injectable";
 
 export async function bootstrap(di: DiContainer) {
   const startFrame = di.inject(startFrameInjectable);
@@ -54,7 +55,15 @@ export async function bootstrap(di: DiContainer) {
   }
 
   try {
-    await initializeApp(() => unmountComponentAtNode(rootElem));
+    const unmount = () => {
+      const closeLogFile = di.inject(closeRendererLogFileInjectable);
+
+      closeLogFile();
+
+      unmountComponentAtNode(rootElem);
+    };
+
+    await initializeApp(unmount);
   } catch (error) {
     console.error(`[BOOTSTRAP]: view initialization error: ${error}`, {
       origin: location.href,

--- a/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
+++ b/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.injectable.ts
@@ -12,6 +12,7 @@ import emitAppEventInjectable from "../../../../common/app-event-bus/emit-event.
 import loadExtensionsInjectable from "../../load-extensions.injectable";
 import loggerInjectable from "../../../../common/logger.injectable";
 import showErrorNotificationInjectable from "../../../components/notifications/show-error-notification.injectable";
+import closeRendererLogFileInjectable from "../../../logger/close-renderer-log-file.injectable";
 
 const initClusterFrameInjectable = getInjectable({
   id: "init-cluster-frame",
@@ -29,6 +30,7 @@ const initClusterFrameInjectable = getInjectable({
       emitAppEvent: di.inject(emitAppEventInjectable),
       logger: di.inject(loggerInjectable),
       showErrorNotification: di.inject(showErrorNotificationInjectable),
+      closeFileLogging: di.inject(closeRendererLogFileInjectable),
     });
   },
 });

--- a/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -73,7 +73,7 @@ export const initClusterFrame = ({
       });
     });
 
-    window.onbeforeunload = () => {
+    window.onpagehide = () => {
       logger.info(
         `${logPrefix} Unload dashboard, clusterId=${(hostedCluster.id)}, frameId=${frameRoutingId}`,
       );

--- a/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
+++ b/packages/core/src/renderer/frames/cluster-frame/init-cluster-frame/init-cluster-frame.ts
@@ -84,6 +84,6 @@ export const initClusterFrame = ({
       unmountRoot();
     });
 
-    window.addEventListener("beforeunload", onCloseFrame, { capture: true });
-    window.addEventListener("pagehide", onCloseFrame, { capture: true });
+    window.addEventListener("beforeunload", onCloseFrame);
+    window.addEventListener("pagehide", onCloseFrame);
   };

--- a/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
+++ b/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
@@ -57,7 +57,7 @@ const initRootFrameInjectable = getInjectable({
 
       registerIpcListeners();
 
-      window.addEventListener("beforeunload", () => {
+      window.addEventListener("pagehide", () => {
         logger.info("[ROOT-FRAME]: Unload app");
 
         unmountRoot();

--- a/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
+++ b/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
@@ -13,6 +13,7 @@ import loggerInjectable from "../../../common/logger.injectable";
 import { delay } from "../../../common/utils";
 import { broadcastMessage } from "../../../common/ipc";
 import { bundledExtensionsLoaded } from "../../../common/ipc/extension-handling";
+import closeRendererLogFileInjectable from "../../logger/close-renderer-log-file.injectable";
 
 const initRootFrameInjectable = getInjectable({
   id: "init-root-frame",
@@ -24,6 +25,7 @@ const initRootFrameInjectable = getInjectable({
     const lensProtocolRouterRenderer = di.inject(lensProtocolRouterRendererInjectable);
     const catalogEntityRegistry = di.inject(catalogEntityRegistryInjectable);
     const logger = di.inject(loggerInjectable);
+    const closeRendererLogFile = di.inject(closeRendererLogFileInjectable);
 
     return async (unmountRoot: () => void) => {
       catalogEntityRegistry.init();
@@ -59,7 +61,7 @@ const initRootFrameInjectable = getInjectable({
 
       window.addEventListener("pagehide", () => {
         logger.info("[ROOT-FRAME]: Unload app");
-
+        closeRendererLogFile();
         unmountRoot();
       });
     };

--- a/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
+++ b/packages/core/src/renderer/frames/root-frame/init-root-frame.injectable.ts
@@ -59,7 +59,7 @@ const initRootFrameInjectable = getInjectable({
 
       registerIpcListeners();
 
-      window.addEventListener("pagehide", () => {
+      window.addEventListener("beforeunload", () => {
         logger.info("[ROOT-FRAME]: Unload app");
         closeRendererLogFile();
         unmountRoot();

--- a/packages/core/src/renderer/logger/close-renderer-log-file.injectable.ts
+++ b/packages/core/src/renderer/logger/close-renderer-log-file.injectable.ts
@@ -3,15 +3,18 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
+import winstonLoggerInjectable from "../../common/winston-logger.injectable";
 import rendererFileLoggerTransportInjectable from "./file-transport.injectable";
 
 const closeRendererLogFileInjectable = getInjectable({
   id: "close-renderer-log-file",
   instantiate: (di) => {
+    const winstonLogger = di.inject(winstonLoggerInjectable);
     const fileLoggingTransport = di.inject(rendererFileLoggerTransportInjectable);
 
     return () => {
       fileLoggingTransport.close?.();
+      winstonLogger.remove(fileLoggingTransport);
     };
   },
 });

--- a/packages/core/src/renderer/logger/close-renderer-log-file.injectable.ts
+++ b/packages/core/src/renderer/logger/close-renderer-log-file.injectable.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import rendererFileLoggerTransportInjectable from "./file-transport.injectable";
+
+const closeRendererLogFileInjectable = getInjectable({
+  id: "close-renderer-log-file",
+  instantiate: (di) => {
+    const fileLoggingTransport = di.inject(rendererFileLoggerTransportInjectable);
+
+    return () => {
+      fileLoggingTransport.close?.();
+    };
+  },
+});
+
+export default closeRendererLogFileInjectable;

--- a/packages/core/src/renderer/logger/file-transport.injectable.ts
+++ b/packages/core/src/renderer/logger/file-transport.injectable.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import { transports } from "winston";
+import directoryForLogsInjectable from "../../common/app-paths/directory-for-logs.injectable";
+import { loggerTransportInjectionToken } from "../../common/logger/transports";
+import windowLocationInjectable from "../../common/k8s-api/window-location.injectable";
+import currentlyInClusterFrameInjectable from "../routes/currently-in-cluster-frame.injectable";
+import { getClusterIdFromHost } from "../utils";
+
+const rendererFileLoggerTransportInjectable = getInjectable({
+  id: "renderer-file-logger-transport",
+  instantiate: (di) => {
+    let frameId: string;
+
+    const currentlyInClusterFrame = di.inject(
+      currentlyInClusterFrameInjectable,
+    );
+
+    if (currentlyInClusterFrame) {
+      const { host } = di.inject(windowLocationInjectable);
+      const clusterId = getClusterIdFromHost(host);
+
+      frameId = clusterId ? `cluster-${clusterId}` : "cluster";
+    } else {
+      frameId = "main";
+    }
+
+    return new transports.File({
+      handleExceptions: false,
+      level: "debug",
+      filename: `lens-renderer-${frameId}.log`,
+      dirname: di.inject(directoryForLogsInjectable),
+      maxsize: 1024 * 1024,
+      maxFiles: 0,
+      tailable: true,
+    });
+  },
+  injectionToken: loggerTransportInjectionToken,
+});
+
+export default rendererFileLoggerTransportInjectable;

--- a/packages/core/src/renderer/logger/file-transport.injectable.ts
+++ b/packages/core/src/renderer/logger/file-transport.injectable.ts
@@ -30,7 +30,7 @@ const rendererFileLoggerTransportInjectable = getInjectable({
 
     return new transports.File({
       handleExceptions: false,
-      level: "debug",
+      level: "info",
       filename: `lens-renderer-${frameId}.log`,
       dirname: di.inject(directoryForLogsInjectable),
       maxsize: 1024 * 1024,

--- a/packages/core/src/renderer/logger/file-transport.injectable.ts
+++ b/packages/core/src/renderer/logger/file-transport.injectable.ts
@@ -34,7 +34,7 @@ const rendererFileLoggerTransportInjectable = getInjectable({
       filename: `lens-renderer-${frameId}.log`,
       dirname: di.inject(directoryForLogsInjectable),
       maxsize: 1024 * 1024,
-      maxFiles: 0,
+      maxFiles: 2,
       tailable: true,
     });
   },


### PR DESCRIPTION
Add file logging to renderer, writing separate log files for renderer main frame and each cluster frame.

Closes file handles (otherwise left open by Winston) on main and cluster frame refresh and when cluster frame is closed through cluster disconnect.

Related to lensapp/support-lens-extension#118