### PR TITLE
Navigation logging injectable

### DIFF
--- a/src/renderer/navigation/observable-history.injectable.ts
+++ b/src/renderer/navigation/observable-history.injectable.ts
@@ -4,7 +4,6 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import { createObservableHistory } from "mobx-observable-history";
-import loggerInjectable from "../../common/logger.injectable";
 import { searchParamsOptions } from "./search-params";
 import historyInjectable from "./history.injectable";
 
@@ -13,16 +12,8 @@ const observableHistoryInjectable = getInjectable({
 
   instantiate: (di) => {
     const history = di.inject(historyInjectable);
-    const logger = di.inject(loggerInjectable);
     const navigation =  createObservableHistory(history, {
       searchParams: searchParamsOptions,
-    });
-
-    navigation.listen((location, action) => {
-      const isClusterView = !process.isMainFrame;
-      const domain = global.location.href;
-
-      logger.debug(`[NAVIGATION]: ${action}-ing. Current is now:`, { isClusterView, domain, location });
     });
 
     return navigation;

--- a/src/renderer/navigation/setup-logging-for-navigation.injectable.ts
+++ b/src/renderer/navigation/setup-logging-for-navigation.injectable.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import loggerInjectable from "../../common/logger.injectable";
+import { beforeFrameStartsInjectionToken } from "../before-frame-starts/tokens";
+import observableHistoryInjectable from "./observable-history.injectable";
+
+const setupLoggingForNavigationInjectable = getInjectable({
+  id: "setup-logging-for-navigation",
+  instantiate: (di) => ({
+    id: "setup-logging-for-navigation",
+    run: () => {
+      const logger = di.inject(loggerInjectable);
+      const observableHistory = di.inject(observableHistoryInjectable);
+
+      observableHistory.listen((location, action) => {
+        const isClusterView = !process.isMainFrame;
+        const domain = global.location.href;
+
+        logger.debug(`[NAVIGATION]: ${action}-ing. Current is now:`, {
+          isClusterView,
+          domain,
+          location,
+        });
+      });
+    },
+  }),
+  injectionToken: beforeFrameStartsInjectionToken,
+});
+
+export default setupLoggingForNavigationInjectable;


### PR DESCRIPTION
Move navigation logging to `setupLoggingForNavigationInjectable` to prevent cycle of injectables from occurring. Wasn't eventually needed for #6795 but still an improvement.

Credit for the implementation goes to @Nokel81 , thanks!