### PR TITLE
Add Restart Button to DaemonSet Menu

### DIFF
--- a/src/common/k8s-api/endpoints/daemon-set.api.ts
+++ b/src/common/k8s-api/endpoints/daemon-set.api.ts
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import moment from "moment";
+
 import type { DerivedKubeApiOptions, IgnoredKubeApiOptions } from "../kube-api";
 import { KubeApi } from "../kube-api";
 import type { KubeObjectStatus, LabelSelector, NamespaceScopedMetadata } from "../kube-object";
@@ -85,6 +87,25 @@ export class DaemonSetApi extends KubeApi<DaemonSet> {
     super({
       ...opts,
       objectConstructor: DaemonSet,
+    });
+  }
+
+  restart(params: { namespace: string; name: string }) {
+    return this.request.patch(this.getUrl(params), {
+      data: {
+        spec: {
+          template: {
+            metadata: {
+              annotations: { "kubectl.kubernetes.io/restartedAt" : moment.utc().format() },
+            },
+          },
+        },
+      },
+    },
+    {
+      headers: {
+        "content-type": "application/strategic-merge-patch+json",
+      },
     });
   }
 }

--- a/src/renderer/components/+workloads-daemonsets/daemonset-menu.tsx
+++ b/src/renderer/components/+workloads-daemonsets/daemonset-menu.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import React from "react";
+import type { KubeObjectMenuProps } from "../kube-object-menu";
+import type { DaemonSet, DaemonSetApi } from "../../../common/k8s-api/endpoints";
+import { MenuItem } from "../menu";
+import { Icon } from "../icon";
+import { Notifications } from "../notifications";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import daemonSetApiInjectable from "../../../common/k8s-api/endpoints/daemon-set.api.injectable";
+import type { OpenConfirmDialog } from "../confirm-dialog/open.injectable";
+import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
+
+export interface DaemonSetMenuProps extends KubeObjectMenuProps<DaemonSet> {}
+
+interface Dependencies {
+  daemonsetApi: DaemonSetApi;
+  openConfirmDialog: OpenConfirmDialog;
+}
+
+const NonInjectedDaemonSetMenu = ({
+  daemonsetApi,
+  object,
+  toolbar,
+  openConfirmDialog,
+}: Dependencies & DaemonSetMenuProps) => (
+  <>
+    <MenuItem
+      onClick={() => openConfirmDialog({
+        ok: async () =>
+        {
+          try {
+            await daemonsetApi.restart({
+              namespace: object.getNs(),
+              name: object.getName(),
+            });
+          } catch (err) {
+            Notifications.checkedError(err, "Unknown error occured while restarting daemonset");
+          }
+        },
+        labelOk: "Restart",
+        message: (
+          <p>
+            {"Are you sure you want to restart daemonset "}
+            <b>{object.getName()}</b>
+            ?
+          </p>
+        ),
+      })}
+    >
+      <Icon
+        material="autorenew"
+        tooltip="Restart"
+        interactive={toolbar}
+      />
+      <span className="title">Restart</span>
+    </MenuItem>
+  </>
+);
+
+export const DaemonSetMenu = withInjectables<Dependencies, DaemonSetMenuProps>(NonInjectedDaemonSetMenu, {
+  getProps: (di, props) => ({
+    ...props,
+    daemonsetApi: di.inject(daemonSetApiInjectable),
+    openConfirmDialog: di.inject(openConfirmDialogInjectable),
+  }),
+});

--- a/src/renderer/components/kube-object-menu/kube-object-menu-items/daemonset-menu.injectable.ts
+++ b/src/renderer/components/kube-object-menu/kube-object-menu-items/daemonset-menu.injectable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { KubeObjectMenuItemComponent } from "../kube-object-menu-item-injection-token";
+import { kubeObjectMenuItemInjectionToken } from "../kube-object-menu-item-injection-token";
+import { computed } from "mobx";
+import { DaemonSetMenu } from "../../+workloads-daemonsets/daemonset-menu";
+
+const daemonsetMenuInjectable = getInjectable({
+  id: "daemonset-menu-kube-object-menu",
+
+  instantiate: () => ({
+    kind: "DaemonSet",
+    apiVersions: ["apps/v1"],
+    Component: DaemonSetMenu as KubeObjectMenuItemComponent,
+    enabled: computed(() => true),
+    orderNumber: 30,
+  }),
+
+  injectionToken: kubeObjectMenuItemInjectionToken,
+});
+
+export default daemonsetMenuInjectable;


### PR DESCRIPTION
This code adds a restart button to the menu for DaemonSets. The method used is the same as for Deployments, it just adds an annotation. I have confirmed this is working in Lens with a working Kubernetes cluster.