### PR TITLE
Remove error overlay in dev mode

### DIFF
--- a/webpack/renderer.ts
+++ b/webpack/renderer.ts
@@ -128,7 +128,7 @@ export function webpackLensRenderer({ showVars = true } = {}): webpack.Configura
 
       ...(
         isDevelopment
-          ? [new ReactRefreshWebpackPlugin()]
+          ? [new ReactRefreshWebpackPlugin({ overlay: false })]
           : []
       ),
     ],


### PR DESCRIPTION
Removing `ReactRefreshWebpackPlugin` error overlay such as:

![error overlay](https://user-images.githubusercontent.com/9607060/209544678-313d92ad-74a4-4986-a124-ea1d15184582.png)


Reasoning:
1. Workaround for https://github.com/lensapp/lens/issues/6599 until we jump on electron 20.
2. We do not need error overlay in dev mode. Messages in devtools is enough.
Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>