### PR TITLE
Allow main send messages to cluster frames

### DIFF
--- a/src/main/utils/channel/message-to-channel.injectable.ts
+++ b/src/main/utils/channel/message-to-channel.injectable.ts
@@ -6,16 +6,22 @@ import { getInjectable } from "@ogre-tools/injectable";
 import type { SendMessageToChannel } from "../../../common/utils/channel/message-to-channel-injection-token";
 import { sendMessageToChannelInjectionToken } from "../../../common/utils/channel/message-to-channel-injection-token";
 import getVisibleWindowsInjectable from "../../start-main-application/lens-window/get-visible-windows.injectable";
+import clusterFramesInjectable from "../../../common/cluster-frames.injectable";
 
 const messageToChannelInjectable = getInjectable({
   id: "message-to-channel",
 
   instantiate: (di) => {
     const getVisibleWindows = di.inject(getVisibleWindowsInjectable);
+    const clusterFrames = di.inject(clusterFramesInjectable);
 
     return ((channel, data) => {
       for (const window of getVisibleWindows()) {
         window.send({ channel: channel.id, data });
+
+        clusterFrames.forEach(frameInfo => {
+          window.send({ channel: channel.id, data, frameInfo });
+        });
       }
     }) as SendMessageToChannel;
   },

--- a/src/main/utils/channel/message-to-channel.test.ts
+++ b/src/main/utils/channel/message-to-channel.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getDiForUnitTesting } from "../../getDiForUnitTesting";
+import getVisibleWindowsInjectable from "../../start-main-application/lens-window/get-visible-windows.injectable";
+import clusterFramesInjectable from "../../../common/cluster-frames.injectable";
+import type { MessageChannel } from "../../../common/utils/channel/message-channel-listener-injection-token";
+import { sendMessageToChannelInjectionToken } from "../../../common/utils/channel/message-to-channel-injection-token";
+import type { DiContainer } from "@ogre-tools/injectable";
+import type { ClusterFrameInfo } from "../../../common/cluster-frames";
+
+describe("message-to-channel", () => {
+  let di: DiContainer;
+  let sendToWindowMock: jest.Mock;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting({ doGeneralOverrides: true });
+
+    sendToWindowMock = jest.fn();
+
+    di.override(getVisibleWindowsInjectable, () => () => [
+      {
+        id: "some-window",
+        send: sendToWindowMock,
+        show: () => {},
+        reload: () => {},
+        isStarting: false,
+        start: async () => {},
+        close: () => {},
+        isVisible: true,
+      },
+
+      {
+        id: "some-other-window",
+        send: sendToWindowMock,
+        show: () => {},
+        reload: () => {},
+        isStarting: false,
+        start: async () => {},
+        close: () => {},
+        isVisible: true,
+      },
+    ]);
+
+    di.override(
+      clusterFramesInjectable,
+      () =>
+        new Map<string, ClusterFrameInfo>([
+          [
+            "some-cluster-id",
+            { frameId: 42, processId: 84 },
+          ],
+          [
+            "some-other-cluster-id",
+            { frameId: 126, processId: 168 },
+          ],
+        ]),
+    );
+  });
+
+  describe("when sending message", () => {
+    beforeEach(() => {
+      const sendMessageToChannel = di.inject(
+        sendMessageToChannelInjectionToken,
+      );
+
+      sendMessageToChannel(someChannel, 42);
+    });
+
+    it("sends to each window and cluster frames", () => {
+      expect(sendToWindowMock.mock.calls).toEqual([
+        [{ channel: "some-channel-id", data: 42 }],
+
+        [
+          {
+            channel: "some-channel-id",
+            data: 42,
+            frameInfo: { frameId: 42, processId: 84 },
+          },
+        ],
+
+        [
+          {
+            channel: "some-channel-id",
+            data: 42,
+            frameInfo: { frameId: 126, processId: 168 },
+          },
+        ],
+
+        [{ channel: "some-channel-id", data: 42 }],
+
+        [
+          {
+            channel: "some-channel-id",
+            data: 42,
+            frameInfo: { frameId: 42, processId: 84 },
+          },
+        ],
+
+        [
+          {
+            channel: "some-channel-id",
+            data: 42,
+            frameInfo: { frameId: 126, processId: 168 },
+          },
+        ],
+      ]);
+    });
+  });
+});
+
+const someChannel: MessageChannel<number> = {
+  id: "some-channel-id",
+};


### PR DESCRIPTION
Before this PR channel abstraction was not ready to be used for communicating from `main` to `cluster-frame`. 

This was postponed since initial idea was to get rid of `cluster-frame` before we start using channel abstraction more. 

However #6690 switched the base store to use Channel abstraction for syncing stores between processes. That broke all syncing from `main` to `cluster-frame`, meaning that we had to implement it in channel abstraction.

Fixes #6829 