### PR TITLE
Fix small TabLayout jump when switching pages

### DIFF
--- a/src/renderer/components/layout/tab-layout.scss
+++ b/src/renderer/components/layout/tab-layout.scss
@@ -11,7 +11,8 @@
 
   > .Tabs {
     background: var(--layoutTabsBackground);
-    min-height: 36px;
+    flex-shrink: 0;
+    height: 34px;
   }
 
   main {


### PR DESCRIPTION
Fixing barely visible but annoying layout jump.

Before:

https://user-images.githubusercontent.com/9607060/209935347-4dd37921-e5ca-4f1b-9dd6-d4a6699bb1eb.mov

After:


https://user-images.githubusercontent.com/9607060/209935359-2e92ad8d-1e99-4b51-b8a4-21cd145bc8b1.mov




Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>