### PR TITLE
Fix minor typo/grammar in extension install message

### DIFF
--- a/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -420,7 +420,7 @@ exports[`extensions - navigation using application menu when navigating to exten
                   <b>
                     Pro-Tip
                   </b>
-                  : you can drag-n-drop tarball-file to this area
+                  : you can drag and drop a tarball file to this area
                 </small>
               </section>
               <div>

--- a/src/renderer/components/+extensions/install.tsx
+++ b/src/renderer/components/+extensions/install.tsx
@@ -89,7 +89,7 @@ const NonInjectedInstall: React.FC<Dependencies & InstallProps> = ({
     </div>
     <small className={styles.proTip}>
       <b>Pro-Tip</b>
-      : you can drag-n-drop tarball-file to this area
+      : you can drag and drop a tarball file to this area
     </small>
   </section>
 );

--- a/src/renderer/components/+extensions/installed-extensions.tsx
+++ b/src/renderer/components/+extensions/installed-extensions.tsx
@@ -152,7 +152,7 @@ const NonInjectedInstalledExtensions = observer(({ extensionDiscovery, extension
         <h3 className="font-medium text-3xl mt-5 mb-2">
           There are no extensions installed.
         </h3>
-        <p>Please use the form above to install or drag tarbar-file here.</p>
+        <p>Please use the form above to install or drag a tarball file here.</p>
       </div>
     );
   }


### PR DESCRIPTION
This PR fixes a typo and adjusts some grammar for the messaging about dragging and dropping extension packages into the application window.