### PR TITLE
Add Restart Button to StatefulSet Menu

### DIFF
--- a/src/common/k8s-api/endpoints/stateful-set.api.ts
+++ b/src/common/k8s-api/endpoints/stateful-set.api.ts
@@ -3,6 +3,8 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
+import moment from "moment";
+
 import type { DerivedKubeApiOptions, IgnoredKubeApiOptions } from "../kube-api";
 import { KubeApi } from "../kube-api";
 import type { LabelSelector, NamespaceScopedMetadata } from "../kube-object";
@@ -39,6 +41,25 @@ export class StatefulSetApi extends KubeApi<StatefulSet> {
     {
       headers: {
         "content-type": "application/merge-patch+json",
+      },
+    });
+  }
+
+  restart(params: { namespace: string; name: string }) {
+    return this.request.patch(this.getUrl(params), {
+      data: {
+        spec: {
+          template: {
+            metadata: {
+              annotations: { "kubectl.kubernetes.io/restartedAt" : moment.utc().format() },
+            },
+          },
+        },
+      },
+    },
+    {
+      headers: {
+        "content-type": "application/strategic-merge-patch+json",
       },
     });
   }

--- a/src/renderer/components/+workloads-statefulsets/statefulset-menu.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-menu.tsx
@@ -7,23 +7,26 @@ import type { KubeObjectMenuProps } from "../kube-object-menu";
 import type { StatefulSet, StatefulSetApi } from "../../../common/k8s-api/endpoints";
 import { MenuItem } from "../menu";
 import { Icon } from "../icon";
-import { Notifications } from "../notifications";
 import { withInjectables } from "@ogre-tools/injectable-react";
 import statefulSetApiInjectable from "../../../common/k8s-api/endpoints/stateful-set.api.injectable";
 import type { OpenConfirmDialog } from "../confirm-dialog/open.injectable";
 import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
+import type { ShowCheckedErrorNotification } from "../notifications/show-checked-error.injectable";
+import showCheckedErrorNotificationInjectable from "../notifications/show-checked-error.injectable";
 
 export interface StatefulSetMenuProps extends KubeObjectMenuProps<StatefulSet> {}
 
 interface Dependencies {
   statefulsetApi: StatefulSetApi;
   openConfirmDialog: OpenConfirmDialog;
+  showCheckedErrorNotification: ShowCheckedErrorNotification;
 }
 
 const NonInjectedStatefulSetMenu = ({
   statefulsetApi,
   object,
   toolbar,
+  showCheckedErrorNotification,
   openConfirmDialog,
 }: Dependencies & StatefulSetMenuProps) => (
   <>
@@ -37,7 +40,7 @@ const NonInjectedStatefulSetMenu = ({
               name: object.getName(),
             });
           } catch (err) {
-            Notifications.checkedError(err, "Unknown error occured while restarting statefulset");
+            showCheckedErrorNotification(err, "Unknown error occured while restarting statefulset");
           }
         },
         labelOk: "Restart",
@@ -63,6 +66,7 @@ const NonInjectedStatefulSetMenu = ({
 export const StatefulSetMenu = withInjectables<Dependencies, StatefulSetMenuProps>(NonInjectedStatefulSetMenu, {
   getProps: (di, props) => ({
     ...props,
+    showCheckedErrorNotification: di.inject(showCheckedErrorNotificationInjectable),
     statefulsetApi: di.inject(statefulSetApiInjectable),
     openConfirmDialog: di.inject(openConfirmDialogInjectable),
   }),

--- a/src/renderer/components/+workloads-statefulsets/statefulset-menu.tsx
+++ b/src/renderer/components/+workloads-statefulsets/statefulset-menu.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import React from "react";
+import type { KubeObjectMenuProps } from "../kube-object-menu";
+import type { StatefulSet, StatefulSetApi } from "../../../common/k8s-api/endpoints";
+import { MenuItem } from "../menu";
+import { Icon } from "../icon";
+import { Notifications } from "../notifications";
+import { withInjectables } from "@ogre-tools/injectable-react";
+import statefulSetApiInjectable from "../../../common/k8s-api/endpoints/stateful-set.api.injectable";
+import type { OpenConfirmDialog } from "../confirm-dialog/open.injectable";
+import openConfirmDialogInjectable from "../confirm-dialog/open.injectable";
+
+export interface StatefulSetMenuProps extends KubeObjectMenuProps<StatefulSet> {}
+
+interface Dependencies {
+  statefulsetApi: StatefulSetApi;
+  openConfirmDialog: OpenConfirmDialog;
+}
+
+const NonInjectedStatefulSetMenu = ({
+  statefulsetApi,
+  object,
+  toolbar,
+  openConfirmDialog,
+}: Dependencies & StatefulSetMenuProps) => (
+  <>
+    <MenuItem
+      onClick={() => openConfirmDialog({
+        ok: async () =>
+        {
+          try {
+            await statefulsetApi.restart({
+              namespace: object.getNs(),
+              name: object.getName(),
+            });
+          } catch (err) {
+            Notifications.checkedError(err, "Unknown error occured while restarting statefulset");
+          }
+        },
+        labelOk: "Restart",
+        message: (
+          <p>
+            {"Are you sure you want to restart statefulset "}
+            <b>{object.getName()}</b>
+            ?
+          </p>
+        ),
+      })}
+    >
+      <Icon
+        material="autorenew"
+        tooltip="Restart"
+        interactive={toolbar}
+      />
+      <span className="title">Restart</span>
+    </MenuItem>
+  </>
+);
+
+export const StatefulSetMenu = withInjectables<Dependencies, StatefulSetMenuProps>(NonInjectedStatefulSetMenu, {
+  getProps: (di, props) => ({
+    ...props,
+    statefulsetApi: di.inject(statefulSetApiInjectable),
+    openConfirmDialog: di.inject(openConfirmDialogInjectable),
+  }),
+});

--- a/src/renderer/components/kube-object-menu/kube-object-menu-items/statefulset-menu.injectable.ts
+++ b/src/renderer/components/kube-object-menu/kube-object-menu-items/statefulset-menu.injectable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import type { KubeObjectMenuItemComponent } from "../kube-object-menu-item-injection-token";
+import { kubeObjectMenuItemInjectionToken } from "../kube-object-menu-item-injection-token";
+import { computed } from "mobx";
+import { StatefulSetMenu } from "../../+workloads-statefulsets/statefulset-menu";
+
+const statefulsetMenuInjectable = getInjectable({
+  id: "statefulset-menu-kube-object-menu",
+
+  instantiate: () => ({
+    kind: "StatefulSet",
+    apiVersions: ["apps/v1"],
+    Component: StatefulSetMenu as KubeObjectMenuItemComponent,
+    enabled: computed(() => true),
+    orderNumber: 30,
+  }),
+
+  injectionToken: kubeObjectMenuItemInjectionToken,
+});
+
+export default statefulsetMenuInjectable;


### PR DESCRIPTION
This code adds a restart button to the menu for StatefulSets. The method used is the same as for DaemonSets, it just adds an annotation. I have confirmed this is working in Lens with a working Kubernetes cluster.

Signed-off-by: Dan Bryant <daniel.bryant@linux.com>