### PR TITLE
Remove need to download node_modules twice in build-impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ integration: build
 	yarn integration
 
 .PHONY: build-impl
-build-impl: binaries/client
+build-impl:
+	yarn run download:binaries
 	yarn run build:tray-icons
 	yarn run compile
 ifeq "$(DETECTED_OS)" "Windows"
@@ -59,7 +60,7 @@ endif
 	yarn run electron-builder --publish onTag $(ELECTRON_BUILDER_EXTRA_ARGS)
 
 .PHONY: build
-build: node_modules build-impl
+build: node_modules binaries/client build-impl
 
 src/extensions/npm/extensions/__mocks__:
 	cp -r __mocks__ src/extensions/npm/extensions/


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>
