### PR TITLE
Bump Horizontal Pod Autoscaler apiBase version

### DIFF
--- a/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
+++ b/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
@@ -78,17 +78,17 @@ interface HorizontalPodAutoscalerBehavior {
 }
 
 interface HPAScalingRules {
-	stabilizationWindowSecond?: number;
-	selectPolicy?: ScalingPolicySelect;
-	policies?: HPAScalingPolicy[];
+  stabilizationWindowSecond?: number;
+  selectPolicy?: ScalingPolicySelect;
+  policies?: HPAScalingPolicy[];
 }
 
 type ScalingPolicySelect = string;
 
 interface HPAScalingPolicy {
-	type: HPAScalingPolicyType;
-	value: number;
-	periodSeconds: number;
+  type: HPAScalingPolicyType;
+  value: number;
+  periodSeconds: number;
 }
 
 type HPAScalingPolicyType = string;

--- a/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
+++ b/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
@@ -72,6 +72,27 @@ export type HorizontalPodAutoscalerMetricSpec =
   | OptionVarient<HpaMetricType.Pods, BaseHorizontalPodAutoscalerMetricSpec, "pods">
   | OptionVarient<HpaMetricType.ContainerResource, BaseHorizontalPodAutoscalerMetricSpec, "containerResource">;
 
+type HorizontalPodAutoscalerBehavior = {
+  scaleUp?: HPAScalingRules,
+  scaleDown?: HPAScalingRules,
+}
+
+type HPAScalingRules = {
+	stabilizationWindowSecond?: number,
+	selectPolicy?: ScalingPolicySelect,
+	policies?: HPAScalingPolicy[],
+}
+
+type ScalingPolicySelect = string
+
+type HPAScalingPolicy = {
+	type: HPAScalingPolicyType,
+	value: number,
+	periodSeconds: number
+}
+
+type HPAScalingPolicyType = string
+
 export interface ContainerResourceMetricStatus {
   container: string;
   currentAverageUtilization?: number;
@@ -132,6 +153,7 @@ export interface HorizontalPodAutoscalerSpec {
   minReplicas?: number;
   maxReplicas: number;
   metrics?: HorizontalPodAutoscalerMetricSpec[];
+  behavior?: HorizontalPodAutoscalerBehavior;
 }
 
 export interface HorizontalPodAutoscalerStatus {

--- a/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
+++ b/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
@@ -153,7 +153,7 @@ export class HorizontalPodAutoscaler extends KubeObject<
 > {
   static readonly kind = "HorizontalPodAutoscaler";
   static readonly namespaced = true;
-  static readonly apiBase = "/apis/autoscaling/v2beta1/horizontalpodautoscalers";
+  static readonly apiBase = "/apis/autoscaling/v2/horizontalpodautoscalers";
 
   getMaxPods() {
     return this.spec.maxReplicas ?? 0;
@@ -204,8 +204,15 @@ export class HorizontalPodAutoscaler extends KubeObject<
 export class HorizontalPodAutoscalerApi extends KubeApi<HorizontalPodAutoscaler> {
   constructor(deps: KubeApiDependencies, opts?: DerivedKubeApiOptions) {
     super(deps, {
-      objectConstructor: HorizontalPodAutoscaler,
       ...opts ?? {},
+      objectConstructor: HorizontalPodAutoscaler,
+      checkPreferredVersion: true,
+      // Kubernetes < 1.26
+      fallbackApiBases: [
+        "/apis/autoscaling/v2beta2/horizontalpodautoscalers",
+        "/apis/autoscaling/v2beta1/horizontalpodautoscalers",
+        "/apis/autoscaling/v1/horizontalpodautoscalers",
+      ],
     });
   }
 }

--- a/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
+++ b/src/common/k8s-api/endpoints/horizontal-pod-autoscaler.api.ts
@@ -72,26 +72,26 @@ export type HorizontalPodAutoscalerMetricSpec =
   | OptionVarient<HpaMetricType.Pods, BaseHorizontalPodAutoscalerMetricSpec, "pods">
   | OptionVarient<HpaMetricType.ContainerResource, BaseHorizontalPodAutoscalerMetricSpec, "containerResource">;
 
-type HorizontalPodAutoscalerBehavior = {
-  scaleUp?: HPAScalingRules,
-  scaleDown?: HPAScalingRules,
+interface HorizontalPodAutoscalerBehavior {
+  scaleUp?: HPAScalingRules;
+  scaleDown?: HPAScalingRules;
 }
 
-type HPAScalingRules = {
-	stabilizationWindowSecond?: number,
-	selectPolicy?: ScalingPolicySelect,
-	policies?: HPAScalingPolicy[],
+interface HPAScalingRules {
+	stabilizationWindowSecond?: number;
+	selectPolicy?: ScalingPolicySelect;
+	policies?: HPAScalingPolicy[];
 }
 
-type ScalingPolicySelect = string
+type ScalingPolicySelect = string;
 
-type HPAScalingPolicy = {
-	type: HPAScalingPolicyType,
-	value: number,
-	periodSeconds: number
+interface HPAScalingPolicy {
+	type: HPAScalingPolicyType;
+	value: number;
+	periodSeconds: number;
 }
 
-type HPAScalingPolicyType = string
+type HPAScalingPolicyType = string;
 
 export interface ContainerResourceMetricStatus {
   container: string;


### PR DESCRIPTION
* Switched to `v2` version (introduced in [k8s v1.23](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#-strong-api-groups-strong-))
* Added fallbackApiBases: 
```
fallbackApiBases: [
  "/apis/autoscaling/v2beta2/horizontalpodautoscalers",
  "/apis/autoscaling/v2beta1/horizontalpodautoscalers",
  "/apis/autoscaling/v1/horizontalpodautoscalers",
],
```
* Update some types

Now HPAs get loaded using version `v2` for newer k8s. And new fields such as `behavior` and `metrics` presented:

https://user-images.githubusercontent.com/9607060/211752380-6902da32-6d0d-42b5-acaa-5673a344d255.mov

![autoscaling:v2](https://user-images.githubusercontent.com/9607060/211752403-9e0124f8-81b4-4276-ba5d-9ac43b8c1494.png)

HPAs get loaded using some of the fallback api versions if running older kubernetes:

https://user-images.githubusercontent.com/9607060/211752600-adc3cf58-32a0-425c-b245-3e328a14dafe.mov


Fixes #6168
Fixes #6817 
Fixes #6827 