### PR TITLE
Fix Notifications extension API

### DIFF
--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -72,16 +72,7 @@ export * from "../../renderer/components/drawer";
 export * from "../../renderer/components/dialog";
 export * from "../../renderer/components/line-progress";
 export * from "../../renderer/components/menu";
-
-export type {
-  CreateNotificationOptions,
-  Notification,
-  NotificationId,
-  NotificationMessage,
-  NotificationStatus,
-  ShowNotification,
-  NotificationsStore,
-} from "../../renderer/components/notifications";
+export * from "../../renderer/components/notifications";
 
 export const Notifications = {
   ok: asLegacyGlobalFunctionForExtensionApi(showSuccessNotificationInjectable),

--- a/src/extensions/renderer-api/components.ts
+++ b/src/extensions/renderer-api/components.ts
@@ -72,7 +72,16 @@ export * from "../../renderer/components/drawer";
 export * from "../../renderer/components/dialog";
 export * from "../../renderer/components/line-progress";
 export * from "../../renderer/components/menu";
-export * from "../../renderer/components/notifications";
+
+export {
+  NotificationStatus,
+  type CreateNotificationOptions,
+  type Notification,
+  type NotificationId,
+  type NotificationMessage,
+  type ShowNotification,
+  type NotificationsStore,
+} from "../../renderer/components/notifications";
 
 export const Notifications = {
   ok: asLegacyGlobalFunctionForExtensionApi(showSuccessNotificationInjectable),


### PR DESCRIPTION
* Fix regression from https://github.com/lensapp/lens/pull/6825/files which causes a breaking change in the Extension API, which causes compilation errors such as `Property 'NotificationStatus' does not exist on type 'typeof import(".../node_modules/@k8slens/extensions/dist/src/extensions/renderer-api/components")'.`
* Extensions might use `NotificationStatus` as value. If we only export as type we can't do that correctly.