### PR TITLE
Improvements and more stability in support HMR/live-reload

### DIFF
--- a/webpack/dev-server.ts
+++ b/webpack/dev-server.ts
@@ -25,19 +25,19 @@ const server = new WebpackDevServer({
   host: "localhost",
   port: webpackDevServerPort,
   static: buildDir, // aka `devServer.contentBase` in webpack@4
-  hot: "only", // use HMR only without errors
+  hot: true,
   liveReload: false,
+  historyApiFallback: true,
+  compress: true, // enable gzip for everything served
   devMiddleware: {
     writeToDisk: false,
     index: "OpenLensDev.html",
     publicPath: "/build",
   },
-  proxy: {
-    "^/$": "/build/",
-  },
   client: {
+    reconnect: true,
     overlay: false, // don't show warnings and errors on top of rendered app view
-    logging: "error",
+    logging: "info",
   },
 }, compiler);
 


### PR DESCRIPTION
For currently used `webpack-dev-server@4.x`:

**Before:** _in some cases HMR/page-reload didn't happen, e.g. editing `welcome.tsx` with follow up manual page reload:_


https://user-images.githubusercontent.com/6377066/212703918-23afbc2d-0158-4ad4-bfcb-9e723641c07f.mov

**After:** _(no need to do `Cmd+R` when HMR cannot be applied in some cases, see screenshot with error below)_
On first editing `welcome.tsx` a whole app _might_ be restarted, but just once. Next edits of `welcome.tsx` behaves like auto `Cmd+R`.


https://user-images.githubusercontent.com/6377066/212704371-a3c83431-2123-4cdf-a934-64b737203d1e.mov


**Caught error from video why page-reload happens instead of HMR:**

<img width="670" alt="Screenshot 2023-01-16 at 16 26 59" src="https://user-images.githubusercontent.com/6377066/212704168-5b9b2c29-f56a-46d3-9616-32180fa62dc7.png">


