### PR TITLE
Add KubeEventDetails empty placeholder

### DIFF
--- a/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -104,11 +104,16 @@ exports[`disable kube object detail items when cluster is not relevant given ext
           </div>
           <div>
             <div
-              class="DrawerTitle flex gaps align-center title"
+              class="DrawerTitle title"
             >
               <span>
                 Events
               </span>
+            </div>
+            <div
+              class="empty"
+            >
+              No events found
             </div>
           </div>
         </div>
@@ -725,11 +730,16 @@ exports[`disable kube object detail items when cluster is not relevant given ext
           </div>
           <div>
             <div
-              class="DrawerTitle flex gaps align-center title"
+              class="DrawerTitle title"
             >
               <span>
                 Events
               </span>
+            </div>
+            <div
+              class="empty"
+            >
+              No events found
             </div>
           </div>
         </div>
@@ -1346,11 +1356,16 @@ exports[`disable kube object detail items when cluster is not relevant given not
           </div>
           <div>
             <div
-              class="DrawerTitle flex gaps align-center title"
+              class="DrawerTitle title"
             >
               <span>
                 Events
               </span>
+            </div>
+            <div
+              class="empty"
+            >
+              No events found
             </div>
           </div>
         </div>

--- a/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
+++ b/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
@@ -99,11 +99,16 @@ exports[`reactively hide kube object detail item renders 1`] = `
           </div>
           <div>
             <div
-              class="DrawerTitle flex gaps align-center title"
+              class="DrawerTitle title"
             >
               <span>
                 Events
               </span>
+            </div>
+            <div
+              class="empty"
+            >
+              No events found
             </div>
           </div>
         </div>
@@ -725,11 +730,16 @@ exports[`reactively hide kube object detail item when the item is shown renders 
           </div>
           <div>
             <div
-              class="DrawerTitle flex gaps align-center title"
+              class="DrawerTitle title"
             >
               <span>
                 Events
               </span>
+            </div>
+            <div
+              class="empty"
+            >
+              No events found
             </div>
           </div>
         </div>

--- a/src/renderer/components/+events/kube-event-details.module.scss
+++ b/src/renderer/components/+events/kube-event-details.module.scss
@@ -22,8 +22,8 @@
       }
     }
   }
+}
 
-  .no-items {
-    text-align: center;
-  }
+.empty {
+  opacity: 0.6;
 }

--- a/src/renderer/components/+events/kube-event-details.tsx
+++ b/src/renderer/components/+events/kube-event-details.tsx
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-import "./kube-event-details.scss";
+import styles from "./kube-event-details.module.scss";
 
 import React from "react";
 import { disposeOnUnmount, observer } from "mobx-react";
@@ -57,14 +57,14 @@ class NonInjectedKubeEventDetails extends React.Component<KubeEventDetailsProps 
 
     return (
       <div>
-        <DrawerTitle className="flex gaps align-center">
+        <DrawerTitle>
           <span>Events</span>
         </DrawerTitle>
         {events.length > 0 && (
-          <div className="KubeEventDetails">
+          <div className={styles.KubeEventDetails}>
             {events.map(event => (
-              <div className="event" key={event.getId()}>
-                <div className={cssNames("title", { warning: event.isWarning() })}>
+              <div className={styles.event} key={event.getId()}>
+                <div className={cssNames(styles.title, { [styles.warning]: event.isWarning() })}>
                   {event.message}
                 </div>
                 <DrawerItem name="Source">
@@ -83,6 +83,11 @@ class NonInjectedKubeEventDetails extends React.Component<KubeEventDetailsProps 
                 )}
               </div>
             ))}
+          </div>
+        )}
+        {events.length === 0 && (
+          <div className={styles.empty}>
+            No events found
           </div>
         )}
       </div>


### PR DESCRIPTION
Adding "No events found" placeholder to `KubeEventDetails`.
<img width="785" alt="some events" src="https://user-images.githubusercontent.com/9607060/213386453-5d925ee4-932d-487f-a8ee-be8e6f6e5f62.png">
<img width="795" alt="no events found" src="https://user-images.githubusercontent.com/9607060/213386463-d1b974cc-da9a-4df3-8951-2456c2c7091a.png">



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>