### PR TITLE
Fix KubeObjectDetails light theme table view

### DIFF
--- a/src/renderer/components/+events/event-details.tsx
+++ b/src/renderer/components/+events/event-details.tsx
@@ -78,7 +78,7 @@ const NonInjectedEventDetails = observer(({
 
       <DrawerTitle>Involved object</DrawerTitle>
       <Table>
-        <TableHead>
+        <TableHead flat>
           <TableCell>Name</TableCell>
           <TableCell>Namespace</TableCell>
           <TableCell>Kind</TableCell>

--- a/src/renderer/components/+network-ingresses/ingress-details.tsx
+++ b/src/renderer/components/+network-ingresses/ingress-details.tsx
@@ -37,7 +37,7 @@ class NonInjectedIngressDetails extends React.Component<IngressDetailsProps & De
           )}
           {rule.http && (
             <Table className="paths">
-              <TableHead>
+              <TableHead flat>
                 <TableCell className="path">Path</TableCell>
                 <TableCell className="link">Link</TableCell>
                 <TableCell className="backends">Backends</TableCell>

--- a/src/renderer/components/+network-services/service-details-endpoint.tsx
+++ b/src/renderer/components/+network-services/service-details-endpoint.tsx
@@ -46,7 +46,7 @@ class NonInjectedServiceDetailsEndpoint extends React.Component<ServiceDetailsEn
           scrollable={false}
           className="box grow"
         >
-          <TableHead>
+          <TableHead flat>
             <TableCell className="name" >Name</TableCell>
             <TableCell className="endpoints">Endpoints</TableCell>
           </TableHead>

--- a/src/renderer/components/+nodes/details-resources.tsx
+++ b/src/renderer/components/+nodes/details-resources.tsx
@@ -38,7 +38,7 @@ export function NodeDetailsResources({ type, node: { status = {}}}: NodeDetailsR
         selectable
         scrollable={false}
       >
-        <TableHead sticky={false}>
+        <TableHead sticky={false} flat>
           <TableCell className="cpu">CPU</TableCell>
           <TableCell className="memory">Memory</TableCell>
           <TableCell className="ephemeral-storage">Ephemeral Storage</TableCell>

--- a/src/renderer/components/+workloads-deployments/deployment-replicasets.tsx
+++ b/src/renderer/components/+workloads-deployments/deployment-replicasets.tsx
@@ -78,7 +78,7 @@ class NonInjectedDeploymentReplicaSets extends React.Component<DeploymentReplica
           sortSyncWithUrl={false}
           className="box grow"
         >
-          <TableHead>
+          <TableHead flat>
             <TableCell className="name" sortBy={sortBy.name}>Name</TableCell>
             <TableCell className="warning"/>
             <TableCell className="namespace" sortBy={sortBy.namespace}>Namespace</TableCell>

--- a/src/renderer/components/+workloads-pods/pod-details-list.tsx
+++ b/src/renderer/components/+workloads-pods/pod-details-list.tsx
@@ -190,7 +190,7 @@ class NonInjectedPodDetailsList extends React.Component<PodDetailsListProps & De
           )}
           className="box grow"
         >
-          <TableHead>
+          <TableHead flat>
             <TableCell className="name" sortBy={sortBy.name}>Name</TableCell>
             <TableCell className="warning"/>
             <TableCell className="node" sortBy={sortBy.node}>Node</TableCell>

--- a/src/renderer/components/drawer/drawer.scss
+++ b/src/renderer/components/drawer/drawer.scss
@@ -86,9 +86,5 @@
   .drawer-content {
     overflow: auto;
     padding: var(--spacing);
-
-    .Table .TableHead {
-      border-bottom: 1px solid var(--borderFaintColor);
-    }
   }
 }

--- a/src/renderer/components/table/table-head.scss
+++ b/src/renderer/components/table/table-head.scss
@@ -36,4 +36,9 @@
       }
     }
   }
+
+  &.flat {
+    background-color: transparent;
+    font-weight: 600;
+  }
 }

--- a/src/renderer/components/table/table-head.tsx
+++ b/src/renderer/components/table/table-head.tsx
@@ -15,6 +15,7 @@ export interface TableHeadProps extends React.DOMAttributes<HTMLDivElement> {
   showTopLine?: boolean; // show border line at the top
   sticky?: boolean; // keep header on top when scrolling
   nowrap?: boolean; // white-space: nowrap, align inner <TableCell> in one line
+  flat?: boolean; // no header background
 }
 
 export class TableHead extends React.Component<TableHeadProps> {
@@ -23,10 +24,11 @@ export class TableHead extends React.Component<TableHeadProps> {
   };
 
   render() {
-    const { className, sticky, nowrap, showTopLine, children, ...headProps } = this.props;
+    const { className, sticky, nowrap, showTopLine, flat, children, ...headProps } = this.props;
     const classNames = cssNames("TableHead", className, {
       sticky, nowrap,
       topLine: showTopLine,
+      flat,
     });
 
     return (


### PR DESCRIPTION
There are too much of gray lines in details panel across different workloads. An example:

<img width="735" alt="gray lines light theme" src="https://user-images.githubusercontent.com/9607060/213403836-6f5a8135-a296-438a-8bba-de1629d657ca.png">

This PR makes details panel table view similar to dark theme without any `TableHead` background.


https://user-images.githubusercontent.com/9607060/213404131-6830ff98-72a2-4cdf-a9b3-05ca1b827268.mov


