### PR TITLE
Add --skip-nx-cache to lerna run dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:docs": "lerna run --stream build:docs",
     "clean": "lerna run clean --stream",
     "clean:node_modules": "lerna clean -y && rm -rf node_modules",
-    "dev": "lerna run dev --stream",
+    "dev": "lerna run dev --stream --skip-nx-cache",
     "lint": "lerna run lint --stream",
     "mkdocs:serve-local": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocs-serve-local:latest",
     "mkdocs:verify": "docker build -t mkdocs-serve-local:latest mkdocs/ && docker run --rm -v ${PWD}:/docs mkdocs-serve-local:latest build --strict",


### PR DESCRIPTION
To catch up changes from codebase and show current state.

https://lerna.js.org/docs/concepts/how-caching-works#skipping-cache

Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>