### PR TITLE
Release 6.4.0-beta.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "npmClient": "yarn"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -123,7 +123,7 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.0",
     "@hapi/subtext": "^7.0.4",
-    "@k8slens/node-fetch": "^6.4.0-alpha.4",
+    "@k8slens/node-fetch": "^6.4.0-beta.0",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@ogre-tools/fp": "^12.0.1",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/src/extension-api.js",
@@ -22,7 +22,7 @@
     "prepare:dev": "yarn run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-alpha.4"
+    "@k8slens/core": "^6.4.0-beta.0"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/node-fetch",
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "description": "Node fetch for Lens",
   "license": "MIT",
   "private": false,

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -192,7 +192,7 @@
     }
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-alpha.4",
+    "@k8slens/core": "^6.4.0-beta.0",
     "@ogre-tools/fp": "^12.0.1",
     "@ogre-tools/injectable": "^12.0.1",
     "@ogre-tools/injectable-extension-for-auto-registration": "^12.0.1",
@@ -201,7 +201,7 @@
     "mobx": "^6.7.0"
   },
   "devDependencies": {
-    "@k8slens/node-fetch": "^6.4.0-alpha.4",
+    "@k8slens/node-fetch": "^6.4.0-beta.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/core": "^1.3.28",
     "@swc/jest": "^0.2.24",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.4.0-alpha.4",
+  "version": "6.4.0-beta.0",
   "description": "Release tool for lens monorepo",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/release-tool/src/index.ts
+++ b/packages/release-tool/src/index.ts
@@ -83,8 +83,7 @@ if (basename(process.cwd()) === "scripts") {
   console.error(errorMessages.wrongCwd);
 }
 
-const packageJson = await fse.readJson("./package.json");
-const currentVersion = new SemVer(packageJson.version);
+const currentVersion = new SemVer((await fse.readJson("./lerna.json")).version);
 
 console.log(`current version: ${currentVersion.format()}`);
 


### PR DESCRIPTION
## Changes since 6.4.0-alpha.4

## 🚀 Features

- Add ability for KubeApi to filter server versions (**[#6908](https://github.com/lensapp/lens/pull/6908)**) https://github.com/Nokel81

## 🐛 Bug Fixes

- Broadcast error messages within Cluster.getConnectionStatus (**[#6964](https://github.com/lensapp/lens/pull/6964)**) https://github.com/Nokel81
- Do not show Created on DetailsPane when there's no timestamp. (**[#6984](https://github.com/lensapp/lens/pull/6984)**) https://github.com/jweak
- Export type-space versions of constructors to fix extension API (**[#6990](https://github.com/lensapp/lens/pull/6990)**) https://github.com/Nokel81
- Parse HPA metrics from different versions (**[#6971](https://github.com/lensapp/lens/pull/6971)**) https://github.com/aleksfront
- Change renderer attempting to load CAs to go through main (**[#7003](https://github.com/lensapp/lens/pull/7003)**) https://github.com/Nokel81
- Bump bundled helm to v3.11.0 (**[#6988](https://github.com/lensapp/lens/pull/6988)**) https://github.com/Nokel81
- Fix getting metrics name for HPA v1 (**[#7011](https://github.com/lensapp/lens/pull/7011)**) https://github.com/aleksfront
- Fix PodDistruptionBudgets not displaying on newer Kube versions (**[#6989](https://github.com/lensapp/lens/pull/6989)**) https://github.com/Nokel81
- Add more resiliancy to listing kube API resource kinds (**[#6995](https://github.com/lensapp/lens/pull/6995)**) https://github.com/Nokel81
- Fix monaco editor scroll block in config map details (**[#7000](https://github.com/lensapp/lens/pull/7000)**) https://github.com/aleksfront

## 🧰 Maintenance

- Bump esbuild from 0.17.2 to 0.17.3 (**[#6977](https://github.com/lensapp/lens/pull/6977)**) https://github.com/app/dependabot
- Upgrade to codeql@v2 (**[#6976](https://github.com/lensapp/lens/pull/6976)**) https://github.com/Nokel81
- Improve the injectability of cluster metadata detection (**[#6910](https://github.com/lensapp/lens/pull/6910)**) https://github.com/Nokel81
- Remove last usages of request in our code (**[#6911](https://github.com/lensapp/lens/pull/6911)**) https://github.com/Nokel81
- Restructure to monorepo (**[#6907](https://github.com/lensapp/lens/pull/6907)**) https://github.com/jakolehm
- Remove deleted make target invocation (**[#7005](https://github.com/lensapp/lens/pull/7005)**) https://github.com/Nokel81
- Add --skip-nx-cache to lerna run dev command (**[#7010](https://github.com/lensapp/lens/pull/7010)**) https://github.com/aleksfront
- Fix core package name and version (**[#7007](https://github.com/lensapp/lens/pull/7007)**) https://github.com/jakolehm
- Bump @swc/core from 1.3.25 to 1.3.28 (**[#7006](https://github.com/lensapp/lens/pull/7006)**) https://github.com/app/dependabot
- Move node-fetch to separate package (**[#7009](https://github.com/lensapp/lens/pull/7009)**) https://github.com/jakolehm
- Fix building docs and verify:docs workflow (**[#7013](https://github.com/lensapp/lens/pull/7013)**) https://github.com/Nokel81
-  Bump @kubernetes/client-node from 0.18.0 to 0.18.1 (**[#6992](https://github.com/lensapp/lens/6992)**) https://github.com/app/dependabot
-  Bump @typescript-eslint/parser from 5.48.2 to 5.49.0 (**[#6998](https://github.com/lensapp/lens/6998)**) https://github.com/app/dependabot
-  Bump @typescript-eslint/eslint-plugin from 5.48.2 to 5.49.0 (**[#6999](https://github.com/lensapp/lens/6999)**) https://github.com/app/dependabot
