### PR TITLE
Revert remove GITHUB_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: butlerlogic/action-autotag@stable
         id: tagger
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: v
           root: /packages/core
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>