### PR TITLE
Release 6.4.0-beta.7

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "npmClient": "yarn"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -127,7 +127,7 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.0",
     "@hapi/subtext": "^7.0.4",
-    "@k8slens/node-fetch": "^6.4.0-beta.6",
+    "@k8slens/node-fetch": "^6.4.0-beta.7",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@ogre-tools/fp": "^12.0.1",

--- a/packages/download-binaries/package.json
+++ b/packages/download-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/download-binaries",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/src/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "yarn run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.6"
+    "@k8slens/core": "^6.4.0-beta.7"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/node-fetch",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "description": "Node fetch for Lens",
   "license": "MIT",
   "private": false,

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -192,8 +192,8 @@
     }
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.6",
-    "@k8slens/download-binaries": "^6.4.0-beta.6",
+    "@k8slens/core": "^6.4.0-beta.7",
+    "@k8slens/download-binaries": "^6.4.0-beta.7",
     "@ogre-tools/fp": "^12.0.1",
     "@ogre-tools/injectable": "^12.0.1",
     "@ogre-tools/injectable-extension-for-auto-registration": "^12.0.1",
@@ -202,7 +202,7 @@
     "mobx": "^6.7.0"
   },
   "devDependencies": {
-    "@k8slens/node-fetch": "^6.4.0-beta.6",
+    "@k8slens/node-fetch": "^6.4.0-beta.7",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/core": "^1.3.28",
     "@swc/jest": "^0.2.24",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "description": "Release tool for lens monorepo",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/semver",
-  "version": "6.4.0-beta.6",
+  "version": "6.4.0-beta.7",
   "description": "CLI over semver package for picking parts of a version",
   "main": "dist/index.mjs",
   "license": "MIT",


### PR DESCRIPTION
## Changes since 6.4.0-beta.6

## 🧰 Maintenance

- Bump playwright from 1.29.2 to 1.30.0 (**[#7035](https://github.com/lensapp/lens/pull/7035)**) https://github.com/app/dependabot
- Move downloading binaries to new package (**[#7033](https://github.com/lensapp/lens/pull/7033)**) https://github.com/Nokel81
- Fix missing core styles in dev mode (**[#7037](https://github.com/lensapp/lens/pull/7037)**) https://github.com/jakolehm
- Bump @side/jest-runtime from 1.0.1 to 1.1.0 (**[#7036](https://github.com/lensapp/lens/pull/7036)**) https://github.com/app/dependabot
- Bump fork-ts-checker-webpack-plugin from 7.2.14 to 7.3.0 (**[#7032](https://github.com/lensapp/lens/pull/7032)**) https://github.com/app/dependabot
