### PR TITLE
Set cwd when spawning kube auth proxy

### DIFF
--- a/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
+++ b/packages/core/src/main/kube-auth-proxy/create-kube-auth-proxy.injectable.ts
@@ -12,6 +12,7 @@ import loggerInjectable from "../../common/logger.injectable";
 import waitUntilPortIsUsedInjectable from "./wait-until-port-is-used/wait-until-port-is-used.injectable";
 import lensK8sProxyPathInjectable from "./lens-k8s-proxy-path.injectable";
 import getPortFromStreamInjectable from "../utils/get-port-from-stream.injectable";
+import getDirnameOfPathInjectable from "../../common/path/get-dirname.injectable";
 
 export type CreateKubeAuthProxy = (cluster: Cluster, environmentVariables: NodeJS.ProcessEnv) => KubeAuthProxy;
 
@@ -25,6 +26,7 @@ const createKubeAuthProxyInjectable = getInjectable({
       logger: di.inject(loggerInjectable),
       waitUntilPortIsUsed: di.inject(waitUntilPortIsUsedInjectable),
       getPortFromStream: di.inject(getPortFromStreamInjectable),
+      dirname: di.inject(getDirnameOfPathInjectable),
     };
 
     return (cluster: Cluster, environmentVariables: NodeJS.ProcessEnv) => {

--- a/packages/core/src/main/kube-auth-proxy/kube-auth-proxy.ts
+++ b/packages/core/src/main/kube-auth-proxy/kube-auth-proxy.ts
@@ -14,6 +14,7 @@ import { TypedRegEx } from "typed-regex";
 import type { Spawn } from "../child-process/spawn.injectable";
 import type { Logger } from "../../common/logger";
 import type { WaitUntilPortIsUsed } from "./wait-until-port-is-used/wait-until-port-is-used.injectable";
+import type { GetDirnameOfPath } from "../../common/path/get-dirname.injectable";
 
 const startingServeMatcher = "starting to serve on (?<address>.+)";
 const startingServeRegex = Object.assign(TypedRegEx(startingServeMatcher, "i"), {
@@ -27,6 +28,7 @@ export interface KubeAuthProxyDependencies {
   spawn: Spawn;
   waitUntilPortIsUsed: WaitUntilPortIsUsed;
   getPortFromStream: GetPortFromStream;
+  dirname: GetDirnameOfPath;
 }
 
 export class KubeAuthProxy {
@@ -69,6 +71,7 @@ export class KubeAuthProxy {
         PROXY_KEY: cert.private,
         PROXY_CERT: cert.cert,
       },
+      cwd: this.dependencies.dirname(this.cluster.kubeConfigPath),
     });
     this.proxyProcess.on("error", (error) => {
       this.cluster.broadcastConnectUpdate(error.message, "error");


### PR DESCRIPTION
This allows to use relative paths within kubeconfig files.