### PR TITLE
Release 6.4.0-beta.11

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "npmClient": "yarn",
   "npmClientArgs": [
     "--network-timeout=100000"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -127,7 +127,7 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.0",
     "@hapi/subtext": "^7.0.4",
-    "@k8slens/node-fetch": "^6.4.0-beta.10",
+    "@k8slens/node-fetch": "^6.4.0-beta.11",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@ogre-tools/fp": "^12.0.1",

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/ensure-binaries",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "yarn run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.10"
+    "@k8slens/core": "^6.4.0-beta.11"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/generate-tray-icons",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "description": "CLI generating tray icons for building a lens-like application",
   "license": "MIT",
   "scripts": {

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/node-fetch",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "description": "Node fetch for Lens",
   "license": "MIT",
   "private": false,

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -192,9 +192,9 @@
     }
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.10",
-    "@k8slens/ensure-binaries": "^6.4.0-beta.10",
-    "@k8slens/generate-tray-icons": "^6.4.0-beta.10",
+    "@k8slens/core": "^6.4.0-beta.11",
+    "@k8slens/ensure-binaries": "^6.4.0-beta.11",
+    "@k8slens/generate-tray-icons": "^6.4.0-beta.11",
     "@ogre-tools/fp": "^12.0.1",
     "@ogre-tools/injectable": "^12.0.1",
     "@ogre-tools/injectable-extension-for-auto-registration": "^12.0.1",
@@ -204,7 +204,7 @@
     "rimraf": "^4.1.2"
   },
   "devDependencies": {
-    "@k8slens/node-fetch": "^6.4.0-beta.10",
+    "@k8slens/node-fetch": "^6.4.0-beta.11",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/cli": "^0.1.59",
     "@swc/core": "^1.3.31",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "description": "Release tool for lens monorepo",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/semver",
-  "version": "6.4.0-beta.10",
+  "version": "6.4.0-beta.11",
   "description": "CLI over semver package for picking parts of a version",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Changes since 6.4.0-beta.10

## 🚀 Features

- introducing vpa resources (**[#7004](https://github.com/lensapp/lens/pull/7004)**) https://github.com/jim-docker
- Allow computed catalog source from extension (**[#7053](https://github.com/lensapp/lens/pull/7053)**) https://github.com/jakolehm
- Set cwd when spawning kube auth proxy (**[#7069](https://github.com/lensapp/lens/pull/7069)**) https://github.com/jakolehm

## 🐛 Bug Fixes

- Fix @k8slens/extensions being broken after monorepo (**[#7058](https://github.com/lensapp/lens/pull/7058)**) https://github.com/Nokel81
- Fix ensure-binaries bin (**[#7078](https://github.com/lensapp/lens/pull/7078)**) https://github.com/jakolehm

## 🧰 Maintenance

- Bump @swc/core from 1.3.29 to 1.3.30 (**[#7047](https://github.com/lensapp/lens/pull/7047)**) https://github.com/app/dependabot
- Bump eslint-plugin-react from 7.32.1 to 7.32.2 (**[#7050](https://github.com/lensapp/lens/pull/7050)**) https://github.com/app/dependabot
- Bump eslint from 8.32.0 to 8.33.0 (**[#7049](https://github.com/lensapp/lens/pull/7049)**) https://github.com/app/dependabot
- Bump immer from 9.0.18 to 9.0.19 (**[#7048](https://github.com/lensapp/lens/pull/7048)**) https://github.com/app/dependabot
- Fix dev not working due to ensure-binaries (**[#7054](https://github.com/lensapp/lens/pull/7054)**) https://github.com/Nokel81
- Bump typescript from 4.9.4 to 4.9.5 (**[#7059](https://github.com/lensapp/lens/pull/7059)**) https://github.com/app/dependabot
- Rename extension api parts as 'extensionApi' (**[#7066](https://github.com/lensapp/lens/pull/7066)**) https://github.com/Nokel81
- Bump typedoc from 0.23.23 to 0.23.24 (**[#7062](https://github.com/lensapp/lens/pull/7062)**) https://github.com/app/dependabot
- Bump @swc/core from 1.3.30 to 1.3.31 (**[#7060](https://github.com/lensapp/lens/pull/7060)**) https://github.com/app/dependabot
- Bump esbuild from 0.17.4 to 0.17.5 (**[#7061](https://github.com/lensapp/lens/pull/7061)**) https://github.com/app/dependabot
- Allow to develop & build on Windows powershell (**[#7081](https://github.com/lensapp/lens/pull/7081)**) https://github.com/jakolehm
- Use rimraf for node_modules remove (**[#7083](https://github.com/lensapp/lens/pull/7083)**) https://github.com/jakolehm
- Move @k8slens/generate-tray-icons to seperate package (**[#7057](https://github.com/lensapp/lens/pull/7057)**) https://github.com/Nokel81
