### PR TITLE
Fix common extension api bundling

### DIFF
--- a/packages/core/src/common/library.ts
+++ b/packages/core/src/common/library.ts
@@ -7,5 +7,3 @@
 export { applicationInformationToken } from "./vars/application-information-token";
 export type { ApplicationInformation } from "./vars/application-information-token";
 export { bundledExtensionInjectionToken } from "../extensions/extension-discovery/bundled-extension-token";
-
-export * as extensionApi from "../extensions/common-api";

--- a/packages/core/src/main/library.ts
+++ b/packages/core/src/main/library.ts
@@ -10,5 +10,6 @@ export { beforeElectronIsReadyInjectionToken } from "./start-main-application/ru
 export { onLoadOfApplicationInjectionToken } from "./start-main-application/runnable-tokens/on-load-of-application-injection-token";
 export { createApp } from "./create-app";
 export * as Mobx from "mobx";
-export * as extensionApi from "../extensions/main-api";
+export * as mainExtensionApi from "../extensions/main-api";
+export * as commonExtensionApi from "../extensions/common-api";
 export * as Pty from "node-pty";

--- a/packages/core/src/renderer/library.ts
+++ b/packages/core/src/renderer/library.ts
@@ -12,5 +12,6 @@ export * as Mobx from "mobx";
 export * as MobxReact from "mobx-react";
 export * as ReactRouter from "react-router";
 export * as ReactRouterDom from "react-router-dom";
-export * as extensionApi from "../extensions/renderer-api";
+export * as rendererExtensionApi from "../extensions/renderer-api";
+export * as commonExtensionApi from "../extensions/common-api";
 export { createApp } from "./create-app";

--- a/packages/extension-api/src/extension-api.ts
+++ b/packages/extension-api/src/extension-api.ts
@@ -3,6 +3,5 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 
-export { extensionApi as Main } from "@k8slens/core/main";
-export { extensionApi as Renderer } from "@k8slens/core/renderer";
-export { extensionApi as Common } from "@k8slens/core/common";
+export { mainExtensionApi as Main, commonExtensionApi as Common } from "@k8slens/core/main";
+export { rendererExtensionApi as Renderer } from "@k8slens/core/renderer";

--- a/packages/open-lens/src/main/index.ts
+++ b/packages/open-lens/src/main/index.ts
@@ -1,8 +1,7 @@
 import { createContainer } from "@ogre-tools/injectable";
 import { autoRegister } from "@ogre-tools/injectable-extension-for-auto-registration";
 import { runInAction } from "mobx";
-import { createApp, extensionApi as Main } from "@k8slens/core/main";
-import { extensionApi as Common } from "@k8slens/core/common";
+import { createApp, mainExtensionApi as Main, commonExtensionApi as Common } from "@k8slens/core/main";
 
 const di = createContainer("main");
 const app = createApp({

--- a/packages/open-lens/src/renderer/index.ts
+++ b/packages/open-lens/src/renderer/index.ts
@@ -1,8 +1,7 @@
 import "@k8slens/core/styles";
 import { createContainer } from "@ogre-tools/injectable";
 import { runInAction } from "mobx";
-import { createApp, extensionApi as Renderer } from "@k8slens/core/renderer";
-import { extensionApi as Common } from "@k8slens/core/common";
+import { createApp, rendererExtensionApi as Renderer, commonExtensionApi as Common } from "@k8slens/core/renderer";
 import { autoRegister } from "@ogre-tools/injectable-extension-for-auto-registration";
 
 const di = createContainer("renderer");


### PR DESCRIPTION
We cannot export common extension api through `@k8slens/core/common` because it shares state with main & renderer.

Fixes regression from #7058 .