### PR TITLE
HMR/live-reload fixes (webpack-dev-server)

### DIFF
--- a/packages/open-lens/webpack/dev-server.ts
+++ b/packages/open-lens/webpack/dev-server.ts
@@ -23,20 +23,25 @@ const server = new WebpackDevServer({
   allowedHosts: ".lens.app",
   host: "localhost",
   port: webpackDevServerPort,
-  static: buildDir, // aka `devServer.contentBase` in webpack@4
-  hot: "only", // use HMR only without errors
+  static: {
+    directory: buildDir,
+    serveIndex: true,
+  },
+  hot: true,
   liveReload: false,
+  // historyApiFallback: true,
   devMiddleware: {
     writeToDisk: true,
     index: "index.html",
     publicPath: "/build",
   },
-  proxy: {
-    "^/$": "/build/",
-  },
+  // proxy: {
+  //   "^/$": "/build/",
+  // },
   client: {
     overlay: false, // don't show warnings and errors on top of rendered app view
-    logging: "error",
+    logging: "info",
+    reconnect: true,
   },
 }, compiler);
 


### PR DESCRIPTION
As part of #6948 since incorrectly rebased from first `monorepo` times.

**Current master:** _only manual page refresh, e.g`Cmd+R` (example of editing `welcome.tsx`)_

https://user-images.githubusercontent.com/6377066/216606292-41b1a294-bd73-462d-b1b0-29dce42532f0.mov

**PR changes:**

Does some auto page-reloading, but doesn't respect cluster frame location, therefore leads to updating page to global catalog page which is not desired, but better then nothing. _(needs to be improved in follow up PRs)_


https://user-images.githubusercontent.com/6377066/216606864-607a2ffd-a088-4329-8350-8be5a1712863.mov


**Current error leading to full page reload instead of HMR** _(caught from video above):_

<img width="659" alt="Screenshot 2023-02-03 at 14 41 29" src="https://user-images.githubusercontent.com/6377066/216607450-ba9483c2-edeb-4303-8749-8e2e49e4d2a8.png">


