### PR TITLE
Release 6.4.0-beta.13

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "npmClient": "yarn",
   "npmClientArgs": [
     "--network-timeout=100000"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -127,7 +127,7 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.0",
     "@hapi/subtext": "^7.0.4",
-    "@k8slens/node-fetch": "^6.4.0-beta.12",
+    "@k8slens/node-fetch": "^6.4.0-beta.13",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@ogre-tools/fp": "^12.0.1",

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/ensure-binaries",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "yarn run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.12"
+    "@k8slens/core": "^6.4.0-beta.13"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/generate-tray-icons",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "description": "CLI generating tray icons for building a lens-like application",
   "license": "MIT",
   "scripts": {

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/node-fetch",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "description": "Node fetch for Lens",
   "license": "MIT",
   "private": false,

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -192,9 +192,9 @@
     }
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.12",
-    "@k8slens/ensure-binaries": "^6.4.0-beta.12",
-    "@k8slens/generate-tray-icons": "^6.4.0-beta.12",
+    "@k8slens/core": "^6.4.0-beta.13",
+    "@k8slens/ensure-binaries": "^6.4.0-beta.13",
+    "@k8slens/generate-tray-icons": "^6.4.0-beta.13",
     "@ogre-tools/fp": "^12.0.1",
     "@ogre-tools/injectable": "^12.0.1",
     "@ogre-tools/injectable-extension-for-auto-registration": "^12.0.1",
@@ -204,7 +204,7 @@
     "rimraf": "^4.1.2"
   },
   "devDependencies": {
-    "@k8slens/node-fetch": "^6.4.0-beta.12",
+    "@k8slens/node-fetch": "^6.4.0-beta.13",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/cli": "^0.1.59",
     "@swc/core": "^1.3.31",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "description": "Release tool for lens monorepo",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/semver",
-  "version": "6.4.0-beta.12",
+  "version": "6.4.0-beta.13",
   "description": "CLI over semver package for picking parts of a version",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Changes since 6.4.0-beta.12

## 🐛 Bug Fixes

- Export more things for the extension API (**[#7088](https://github.com/lensapp/lens/pull/7088)**) https://github.com/Nokel81
- Set core webpack dependencies as externals (**[#7094](https://github.com/lensapp/lens/pull/7094)**) https://github.com/jakolehm
- Fix invalid bin links causing errors on windows (**[#7101](https://github.com/lensapp/lens/pull/7101)**) https://github.com/jakolehm
- Fix open-lens package missing fonts (**[#7100](https://github.com/lensapp/lens/pull/7100)**) https://github.com/jakolehm
- Fix common extension api bundling (**[#7099](https://github.com/lensapp/lens/pull/7099)**) https://github.com/jakolehm
