### PR TITLE
Sidebar layout fixes and improved CRD readability

### DIFF
--- a/packages/core/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/legacy-extension-adding-cluster-frame-components.test.tsx.snap
@@ -71,7 +71,9 @@ exports[`legacy extension adding cluster frame components given custom component
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -92,7 +94,7 @@ exports[`legacy extension adding cluster frame components given custom component
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -104,7 +106,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -129,7 +133,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -152,7 +158,7 @@ exports[`legacy extension adding cluster frame components given custom component
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -164,7 +170,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -189,7 +197,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -209,7 +219,7 @@ exports[`legacy extension adding cluster frame components given custom component
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -221,7 +231,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -246,7 +258,9 @@ exports[`legacy extension adding cluster frame components given custom component
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -269,7 +283,7 @@ exports[`legacy extension adding cluster frame components given custom component
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"

--- a/packages/core/src/features/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/order-of-sidebar-items.test.tsx.snap
@@ -71,7 +71,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -92,7 +94,7 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -104,7 +106,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -129,7 +133,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -142,7 +148,7 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -154,7 +160,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -177,7 +185,7 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -189,7 +197,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -214,7 +224,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-some-another-parent-id"
           >
@@ -229,7 +241,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -249,7 +263,7 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -261,7 +275,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -286,7 +302,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -309,7 +327,7 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -321,7 +339,9 @@ exports[`cluster - order of sidebar items when rendered renders 1`] = `
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-some-other-parent-id"
           >
@@ -674,7 +694,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -695,7 +717,7 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -707,7 +729,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -732,7 +756,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -745,7 +771,7 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -759,7 +785,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
               class="subMenu"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-child-id"
@@ -775,7 +803,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-another-child-id"
@@ -791,7 +821,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-other-child-id"
@@ -809,7 +841,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </ul>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -832,7 +866,7 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -844,7 +878,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -869,7 +905,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-some-another-parent-id"
           >
@@ -884,7 +922,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -904,7 +944,7 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -916,7 +956,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -941,7 +983,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -964,7 +1008,7 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -976,7 +1020,9 @@ exports[`cluster - order of sidebar items when rendered when parent is expanded 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-some-other-parent-id"
           >

--- a/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-core.test.tsx.snap
@@ -71,7 +71,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -92,7 +94,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -104,7 +106,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -129,7 +133,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -145,7 +151,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -157,7 +163,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -180,7 +188,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -192,7 +200,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -217,7 +227,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -237,7 +249,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -249,7 +261,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -274,7 +288,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -297,7 +313,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -647,7 +663,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -668,7 +686,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -680,7 +698,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -705,7 +725,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -721,7 +743,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -733,7 +755,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -756,7 +780,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -768,7 +792,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -793,7 +819,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -813,7 +841,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -825,7 +853,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -850,7 +880,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -873,7 +905,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1223,7 +1255,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -1244,7 +1278,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1256,7 +1290,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -1281,7 +1317,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -1297,7 +1335,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1311,7 +1349,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               class="subMenu"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-child-id"
@@ -1329,7 +1369,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </ul>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -1352,7 +1394,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1364,7 +1406,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -1389,7 +1433,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -1409,7 +1455,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1421,7 +1467,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -1446,7 +1494,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -1469,7 +1519,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1819,7 +1869,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -1839,7 +1891,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1851,7 +1903,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -1876,7 +1930,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -1893,7 +1949,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1907,7 +1963,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               class="subMenu active"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="true"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-child-id"
@@ -1926,7 +1984,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </ul>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -1949,7 +2009,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1961,7 +2021,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -1986,7 +2048,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -2006,7 +2070,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2018,7 +2082,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -2043,7 +2109,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -2066,7 +2134,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2293,7 +2361,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -2313,7 +2383,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2325,7 +2395,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -2350,7 +2422,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -2367,7 +2441,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2379,7 +2453,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -2402,7 +2478,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2414,7 +2490,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -2439,7 +2517,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -2459,7 +2539,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2471,7 +2551,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -2496,7 +2578,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -2519,7 +2603,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2746,7 +2830,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -2767,7 +2853,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2779,7 +2865,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -2804,7 +2892,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -2820,7 +2910,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2834,7 +2924,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
               class="subMenu"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-parent-id"
                 data-testid="sidebar-item-some-child-id"
@@ -2852,7 +2944,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </ul>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -2875,7 +2969,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2887,7 +2981,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -2912,7 +3008,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -2932,7 +3030,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2944,7 +3042,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -2969,7 +3069,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -2992,7 +3094,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3342,7 +3444,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -3363,7 +3467,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3375,7 +3479,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -3400,7 +3506,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-parent-id"
           >
@@ -3416,7 +3524,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Some parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3428,7 +3536,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -3451,7 +3561,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3463,7 +3573,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -3488,7 +3600,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -3508,7 +3622,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3520,7 +3634,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -3545,7 +3661,9 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -3568,7 +3686,7 @@ exports[`cluster - sidebar and tab navigation for core given core registrations 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"

--- a/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/sidebar-and-tab-navigation-for-extensions.test.tsx.snap
@@ -71,7 +71,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -92,7 +94,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -104,7 +106,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -129,7 +133,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -152,7 +158,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -164,7 +170,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -189,7 +197,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -209,7 +219,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -221,7 +231,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -246,7 +258,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -269,7 +283,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -281,7 +295,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -297,7 +313,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -647,7 +663,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -668,7 +686,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -680,7 +698,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -705,7 +725,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -728,7 +750,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -740,7 +762,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -765,7 +789,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -785,7 +811,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -797,7 +823,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -822,7 +850,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -845,7 +875,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -857,7 +887,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -873,7 +905,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1223,7 +1255,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -1244,7 +1278,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1256,7 +1290,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -1281,7 +1317,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -1304,7 +1342,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1316,7 +1354,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -1341,7 +1381,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -1361,7 +1403,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1373,7 +1415,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -1398,7 +1442,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -1421,7 +1467,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1433,7 +1479,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -1449,7 +1497,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1463,7 +1511,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
               class="subMenu"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-child-id"
@@ -1479,7 +1529,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-other-child-id"
@@ -1835,7 +1887,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -1855,7 +1909,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1867,7 +1921,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -1892,7 +1948,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -1915,7 +1973,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1927,7 +1985,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -1952,7 +2012,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -1972,7 +2034,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1984,7 +2046,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -2009,7 +2073,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -2032,7 +2098,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2044,7 +2110,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -2061,7 +2129,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2075,7 +2143,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
               class="subMenu active"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="true"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-child-id"
@@ -2092,7 +2162,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-other-child-id"
@@ -2366,7 +2438,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -2386,7 +2460,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2398,7 +2472,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -2423,7 +2499,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -2446,7 +2524,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2458,7 +2536,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -2483,7 +2563,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -2503,7 +2585,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2515,7 +2597,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -2540,7 +2624,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -2563,7 +2649,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2575,7 +2661,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -2592,7 +2680,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2606,7 +2694,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
               class="subMenu active"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-child-id"
@@ -2622,7 +2712,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="true"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-other-child-id"
@@ -2897,7 +2989,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -2917,7 +3011,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2929,7 +3023,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -2954,7 +3050,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -2977,7 +3075,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -2989,7 +3087,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -3014,7 +3114,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -3034,7 +3136,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3046,7 +3148,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -3071,7 +3175,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -3094,7 +3200,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3106,7 +3212,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -3123,7 +3231,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3391,7 +3499,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -3412,7 +3522,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3424,7 +3534,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -3449,7 +3561,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -3472,7 +3586,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3484,7 +3598,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -3509,7 +3625,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -3529,7 +3647,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3541,7 +3659,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -3566,7 +3686,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -3589,7 +3711,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3601,7 +3723,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="true"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -3617,7 +3741,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -3631,7 +3755,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
               class="subMenu"
             >
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-child-id"
@@ -3647,7 +3773,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 </a>
               </div>
               <div
+                aria-expanded="false"
                 class="SidebarItem"
+                data-expandable="false"
                 data-is-active-test="false"
                 data-parent-id-test="some-extension-name-some-parent-id"
                 data-testid="sidebar-item-some-extension-name-some-other-child-id"
@@ -4003,7 +4131,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -4024,7 +4154,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -4036,7 +4166,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -4061,7 +4193,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -4084,7 +4218,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -4096,7 +4230,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -4121,7 +4257,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -4141,7 +4279,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -4153,7 +4291,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -4178,7 +4318,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -4201,7 +4343,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -4213,7 +4355,9 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-some-extension-name-some-parent-id"
           >
@@ -4229,7 +4373,7 @@ exports[`cluster - sidebar and tab navigation for extensions given extension wit
                 Parent
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"

--- a/packages/core/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/visibility-of-sidebar-items.test.tsx.snap
@@ -71,7 +71,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -92,7 +94,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -104,7 +106,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -129,7 +133,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -152,7 +158,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -164,7 +170,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -189,7 +197,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -209,7 +219,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -221,7 +231,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -246,7 +258,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -269,7 +283,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -619,7 +633,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -640,7 +656,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -652,7 +668,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -677,7 +695,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-some-item-id"
           >
@@ -692,7 +712,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -715,7 +737,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -727,7 +749,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -752,7 +776,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-namespaces"
           >
@@ -777,7 +803,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -797,7 +825,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -809,7 +837,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -834,7 +864,9 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -857,7 +889,7 @@ exports[`cluster - visibility of sidebar items given kube resource for route is 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"

--- a/packages/core/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
+++ b/packages/core/src/features/cluster/__snapshots__/workload-overview.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`workload overview when navigating to workload overview renders 1`] = `
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/extension-api/__snapshots__/disable-cluster-pages-when-cluster-is-not-relevant.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -209,7 +219,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -221,7 +231,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -246,7 +258,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -269,7 +283,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -500,7 +514,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -521,7 +537,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -533,7 +549,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -558,7 +576,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -581,7 +601,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -593,7 +613,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -618,7 +640,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -638,7 +662,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -650,7 +674,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -675,7 +701,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -698,7 +726,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given extension shou
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1050,7 +1078,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -1071,7 +1101,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1083,7 +1113,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1108,7 +1140,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1131,7 +1165,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1143,7 +1177,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1168,7 +1204,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1188,7 +1226,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1200,7 +1238,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1225,7 +1265,9 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1248,7 +1290,7 @@ exports[`disable-cluster-pages-when-cluster-is-not-relevant given not yet known 
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/extension-api/__snapshots__/disable-sidebar-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -282,7 +296,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-test-extension-some-sidebar-item"
             >
@@ -640,7 +656,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -661,7 +679,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -673,7 +691,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -698,7 +718,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -721,7 +743,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -733,7 +755,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -758,7 +782,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -778,7 +804,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -790,7 +816,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -815,7 +843,9 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -838,7 +868,7 @@ exports[`disable sidebar items when cluster is not relevant given extension shou
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1190,7 +1220,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -1211,7 +1243,7 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1223,7 +1255,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1248,7 +1282,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1271,7 +1307,7 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1283,7 +1319,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1308,7 +1346,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1328,7 +1368,7 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1340,7 +1380,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1365,7 +1407,9 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1388,7 +1432,7 @@ exports[`disable sidebar items when cluster is not relevant given not yet known 
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -138,7 +138,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -159,7 +161,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -171,7 +173,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -196,7 +200,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -219,7 +225,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -231,7 +237,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -256,7 +264,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -276,7 +286,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -288,7 +298,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -313,7 +325,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -336,7 +350,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -749,7 +763,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -770,7 +786,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -782,7 +798,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -807,7 +825,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -830,7 +850,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -842,7 +862,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -867,7 +889,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -887,7 +911,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -899,7 +923,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -924,7 +950,9 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -947,7 +975,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1360,7 +1388,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -1381,7 +1411,7 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1393,7 +1423,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1418,7 +1450,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1441,7 +1475,7 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1453,7 +1487,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1478,7 +1514,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1498,7 +1536,7 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1510,7 +1548,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1535,7 +1575,9 @@ exports[`disable kube object detail items when cluster is not relevant given not
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1558,7 +1600,7 @@ exports[`disable kube object detail items when cluster is not relevant given not
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
@@ -133,7 +133,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -154,7 +156,7 @@ exports[`reactively hide kube object detail item renders 1`] = `
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -166,7 +168,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -191,7 +195,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -214,7 +220,7 @@ exports[`reactively hide kube object detail item renders 1`] = `
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -226,7 +232,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -251,7 +259,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -271,7 +281,7 @@ exports[`reactively hide kube object detail item renders 1`] = `
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -283,7 +293,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -308,7 +320,9 @@ exports[`reactively hide kube object detail item renders 1`] = `
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -331,7 +345,7 @@ exports[`reactively hide kube object detail item renders 1`] = `
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -749,7 +763,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -770,7 +786,7 @@ exports[`reactively hide kube object detail item when the item is shown renders 
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -782,7 +798,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -807,7 +825,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -830,7 +850,7 @@ exports[`reactively hide kube object detail item when the item is shown renders 
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -842,7 +862,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -867,7 +889,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -887,7 +911,7 @@ exports[`reactively hide kube object detail item when the item is shown renders 
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -899,7 +923,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -924,7 +950,9 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -947,7 +975,7 @@ exports[`reactively hide kube object detail item when the item is shown renders 
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/__snapshots__/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -209,7 +219,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -221,7 +231,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -246,7 +258,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -269,7 +283,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -505,7 +519,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -525,7 +541,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -537,7 +553,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -562,7 +580,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -585,7 +605,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -597,7 +617,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -622,7 +644,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -642,7 +666,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -654,7 +678,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -679,7 +705,9 @@ exports[`disable kube object menu items when cluster is not relevant given exten
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -702,7 +730,7 @@ exports[`disable kube object menu items when cluster is not relevant given exten
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -932,7 +960,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -952,7 +982,7 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -964,7 +994,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -989,7 +1021,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1012,7 +1046,7 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1024,7 +1058,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1049,7 +1085,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1069,7 +1107,7 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1081,7 +1119,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1106,7 +1146,9 @@ exports[`disable kube object menu items when cluster is not relevant given not y
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1129,7 +1171,7 @@ exports[`disable kube object menu items when cluster is not relevant given not y
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/kube-object-status-icon/__snapshots__/show-status-for-a-kube-object.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-status-icon/__snapshots__/show-status-for-a-kube-object.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -209,7 +219,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -221,7 +231,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -246,7 +258,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -269,7 +283,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -494,7 +508,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -514,7 +530,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -526,7 +542,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -551,7 +569,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -574,7 +594,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -586,7 +606,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -611,7 +633,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -631,7 +655,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -643,7 +667,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -668,7 +694,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -691,7 +719,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -956,7 +984,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -976,7 +1006,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -988,7 +1018,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1013,7 +1045,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1036,7 +1070,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1048,7 +1082,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1073,7 +1109,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1093,7 +1131,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1105,7 +1143,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1130,7 +1170,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1153,7 +1195,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1418,7 +1460,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1438,7 +1482,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1450,7 +1494,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1475,7 +1521,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1498,7 +1546,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1510,7 +1558,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1535,7 +1585,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1555,7 +1607,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1567,7 +1619,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1592,7 +1646,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1615,7 +1671,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1840,7 +1896,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1860,7 +1918,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1872,7 +1930,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1897,7 +1957,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1920,7 +1982,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1932,7 +1994,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1957,7 +2021,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1977,7 +2043,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1989,7 +2055,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2014,7 +2082,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2037,7 +2107,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2262,7 +2332,9 @@ exports[`show status for a kube object given application starts and in test page
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2282,7 +2354,7 @@ exports[`show status for a kube object given application starts and in test page
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2294,7 +2366,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2319,7 +2393,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2342,7 +2418,7 @@ exports[`show status for a kube object given application starts and in test page
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2354,7 +2430,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2379,7 +2457,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -2399,7 +2479,7 @@ exports[`show status for a kube object given application starts and in test page
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2411,7 +2491,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2436,7 +2518,9 @@ exports[`show status for a kube object given application starts and in test page
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2459,7 +2543,7 @@ exports[`show status for a kube object given application starts and in test page
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/kube-object-status-icon/extension-api/__snapshots__/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-status-icon/extension-api/__snapshots__/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -209,7 +219,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -221,7 +231,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -246,7 +258,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -269,7 +283,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -534,7 +548,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -554,7 +570,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -566,7 +582,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -591,7 +609,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -614,7 +634,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -626,7 +646,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -651,7 +673,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -671,7 +695,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -683,7 +707,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -708,7 +734,9 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -731,7 +759,7 @@ exports[`disable kube object statuses when cluster is not relevant given extensi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -956,7 +984,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -976,7 +1006,7 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -988,7 +1018,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1013,7 +1045,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1036,7 +1070,7 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1048,7 +1082,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1073,7 +1109,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1093,7 +1131,7 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1105,7 +1143,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1130,7 +1170,9 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1153,7 +1195,7 @@ exports[`disable kube object statuses when cluster is not relevant given not yet
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -215,7 +225,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -235,7 +247,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -247,7 +259,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -272,7 +286,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -295,7 +311,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -750,7 +766,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -770,7 +788,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -782,7 +800,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -807,7 +827,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -830,7 +852,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -842,7 +864,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -867,7 +891,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -893,7 +919,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -913,7 +941,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -925,7 +953,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -950,7 +980,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -973,7 +1005,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1433,7 +1465,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1453,7 +1487,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1465,7 +1499,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1490,7 +1526,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1513,7 +1551,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1525,7 +1563,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1550,7 +1590,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -1576,7 +1618,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1596,7 +1640,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1608,7 +1652,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1633,7 +1679,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1656,7 +1704,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2185,7 +2233,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2205,7 +2255,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2217,7 +2267,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2242,7 +2294,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2265,7 +2319,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2277,7 +2331,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2302,7 +2358,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -2328,7 +2386,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -2348,7 +2408,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2360,7 +2420,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2385,7 +2447,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2408,7 +2472,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2915,7 +2979,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2935,7 +3001,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2947,7 +3013,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2972,7 +3040,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2995,7 +3065,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3007,7 +3077,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3032,7 +3104,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -3058,7 +3132,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -3078,7 +3154,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3090,7 +3166,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3115,7 +3193,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3138,7 +3218,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3717,7 +3797,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -3737,7 +3819,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3749,7 +3831,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -3774,7 +3858,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -3797,7 +3883,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3809,7 +3895,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3834,7 +3922,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -3860,7 +3950,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -3880,7 +3972,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3892,7 +3984,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3917,7 +4011,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3940,7 +4036,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4521,7 +4617,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4541,7 +4639,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4553,7 +4651,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4578,7 +4678,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -4601,7 +4703,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4613,7 +4715,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -4638,7 +4742,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -4664,7 +4770,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -4684,7 +4792,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4696,7 +4804,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -4721,7 +4831,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -4744,7 +4856,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5287,7 +5399,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -5307,7 +5421,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5319,7 +5433,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -5344,7 +5460,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -5367,7 +5485,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5379,7 +5497,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -5404,7 +5524,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -5430,7 +5552,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -5450,7 +5574,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5462,7 +5586,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -5487,7 +5613,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -5510,7 +5638,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6048,7 +6176,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -6068,7 +6198,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6080,7 +6210,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -6105,7 +6237,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -6128,7 +6262,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6140,7 +6274,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -6165,7 +6301,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -6191,7 +6329,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -6211,7 +6351,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6223,7 +6363,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -6248,7 +6390,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -6271,7 +6415,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6800,7 +6944,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -6820,7 +6966,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6832,7 +6978,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -6857,7 +7005,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -6880,7 +7030,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6892,7 +7042,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -6917,7 +7069,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -6943,7 +7097,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -6963,7 +7119,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6975,7 +7131,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -7000,7 +7158,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -7023,7 +7183,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7552,7 +7712,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -7572,7 +7734,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7584,7 +7746,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -7609,7 +7773,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -7632,7 +7798,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7644,7 +7810,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -7669,7 +7837,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -7695,7 +7865,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -7715,7 +7887,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7727,7 +7899,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -7752,7 +7926,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -7775,7 +7951,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8304,7 +8480,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -8324,7 +8502,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8336,7 +8514,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -8361,7 +8541,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -8384,7 +8566,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8396,7 +8578,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -8421,7 +8605,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -8447,7 +8633,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -8467,7 +8655,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8479,7 +8667,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -8504,7 +8694,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -8527,7 +8719,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8891,7 +9083,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -8911,7 +9105,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8923,7 +9117,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -8948,7 +9144,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -8971,7 +9169,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8983,7 +9181,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -9008,7 +9208,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -9034,7 +9236,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -9054,7 +9258,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9066,7 +9270,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -9091,7 +9297,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -9114,7 +9322,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9652,7 +9860,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -9672,7 +9882,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9684,7 +9894,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -9709,7 +9921,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -9732,7 +9946,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9744,7 +9958,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -9769,7 +9985,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -9795,7 +10013,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -9815,7 +10035,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9827,7 +10047,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -9852,7 +10074,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -9875,7 +10099,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10239,7 +10463,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -10259,7 +10485,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10271,7 +10497,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -10296,7 +10524,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -10319,7 +10549,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10331,7 +10561,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -10356,7 +10588,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -10382,7 +10616,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -10402,7 +10638,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10414,7 +10650,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -10439,7 +10677,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -10462,7 +10702,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10826,7 +11066,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -10846,7 +11088,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10858,7 +11100,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -10883,7 +11127,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -10906,7 +11152,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10918,7 +11164,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -10943,7 +11191,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="true"
               data-testid="sidebar-item-namespaces"
             >
@@ -10969,7 +11219,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -10989,7 +11241,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11001,7 +11253,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -11026,7 +11280,9 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -11049,7 +11305,7 @@ exports[`cluster/namespaces - edit namespace from new tab when navigating to nam
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-previously-opened-tab.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-namespaces"
             >
@@ -215,7 +225,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -235,7 +247,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -247,7 +259,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -272,7 +286,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -295,7 +311,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -657,7 +673,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -678,7 +696,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -690,7 +708,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -715,7 +735,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -738,7 +760,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -750,7 +772,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -775,7 +799,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-namespaces"
             >
@@ -800,7 +826,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -820,7 +848,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -832,7 +860,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -857,7 +887,9 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -880,7 +912,7 @@ exports[`cluster/namespaces - edit namespaces from previously opened tab given t
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/__snapshots__/disable-workloads-overview-details-when-cluster-is-not-relevant.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -627,7 +641,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -648,7 +664,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -660,7 +676,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -685,7 +703,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -708,7 +728,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -720,7 +740,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -745,7 +767,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -765,7 +789,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -777,7 +801,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -802,7 +828,9 @@ exports[`disable workloads overview details when cluster is not relevant given e
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -825,7 +853,7 @@ exports[`disable workloads overview details when cluster is not relevant given e
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1177,7 +1205,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -1198,7 +1228,7 @@ exports[`disable workloads overview details when cluster is not relevant given n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1210,7 +1240,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1235,7 +1267,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1258,7 +1292,7 @@ exports[`disable workloads overview details when cluster is not relevant given n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1270,7 +1304,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1295,7 +1331,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1315,7 +1353,7 @@ exports[`disable workloads overview details when cluster is not relevant given n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1327,7 +1365,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1352,7 +1392,9 @@ exports[`disable workloads overview details when cluster is not relevant given n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1375,7 +1417,7 @@ exports[`disable workloads overview details when cluster is not relevant given n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-new-tab.test.ts.snap
@@ -72,7 +72,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -541,7 +555,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -561,7 +577,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -573,7 +589,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -598,7 +616,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -621,7 +641,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -633,7 +653,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -658,7 +680,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -679,7 +703,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -691,7 +715,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -716,7 +742,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -739,7 +767,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1494,7 +1522,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1514,7 +1544,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1526,7 +1556,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1551,7 +1583,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1574,7 +1608,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1586,7 +1620,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1611,7 +1647,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -1632,7 +1670,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1644,7 +1682,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1669,7 +1709,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1692,7 +1734,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2292,7 +2334,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2312,7 +2356,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2324,7 +2368,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2349,7 +2395,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2372,7 +2420,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2384,7 +2432,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2409,7 +2459,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -2430,7 +2482,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2442,7 +2494,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2467,7 +2521,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2490,7 +2546,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3334,7 +3390,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -3354,7 +3412,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3366,7 +3424,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -3391,7 +3451,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -3414,7 +3476,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3426,7 +3488,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3451,7 +3515,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -3472,7 +3538,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3484,7 +3550,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3509,7 +3577,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3532,7 +3602,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4350,7 +4420,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4370,7 +4442,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4382,7 +4454,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4407,7 +4481,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -4430,7 +4506,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4442,7 +4518,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -4467,7 +4545,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -4488,7 +4568,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4500,7 +4580,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -4525,7 +4607,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -4548,7 +4632,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5361,7 +5445,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -5381,7 +5467,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5393,7 +5479,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -5418,7 +5506,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -5441,7 +5531,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5453,7 +5543,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -5478,7 +5570,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -5499,7 +5593,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5511,7 +5605,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -5536,7 +5632,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -5559,7 +5657,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6372,7 +6470,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -6392,7 +6492,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6404,7 +6504,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -6429,7 +6531,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -6452,7 +6556,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6464,7 +6568,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -6489,7 +6595,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -6510,7 +6618,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6522,7 +6630,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -6547,7 +6657,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -6570,7 +6682,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7405,7 +7517,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -7425,7 +7539,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7437,7 +7551,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -7462,7 +7578,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -7485,7 +7603,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7497,7 +7615,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -7522,7 +7642,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -7543,7 +7665,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7555,7 +7677,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -7580,7 +7704,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -7603,7 +7729,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8447,7 +8573,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -8467,7 +8595,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8479,7 +8607,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -8504,7 +8634,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -8527,7 +8659,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8539,7 +8671,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -8564,7 +8698,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -8585,7 +8721,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8597,7 +8733,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -8622,7 +8760,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -8645,7 +8785,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9458,7 +9598,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -9478,7 +9620,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9490,7 +9632,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -9515,7 +9659,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -9538,7 +9684,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9550,7 +9696,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -9575,7 +9723,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -9596,7 +9746,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9608,7 +9758,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -9633,7 +9785,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -9656,7 +9810,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10477,7 +10631,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -10497,7 +10653,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10509,7 +10665,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -10534,7 +10692,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -10557,7 +10717,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10569,7 +10729,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -10594,7 +10756,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -10615,7 +10779,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10627,7 +10791,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -10652,7 +10818,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -10675,7 +10843,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11355,7 +11523,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -11375,7 +11545,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11387,7 +11557,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -11412,7 +11584,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -11435,7 +11609,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11447,7 +11621,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -11472,7 +11648,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -11493,7 +11671,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11505,7 +11683,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -11530,7 +11710,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -11553,7 +11735,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12168,7 +12350,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -12188,7 +12372,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12200,7 +12384,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -12225,7 +12411,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -12248,7 +12436,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12260,7 +12448,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -12285,7 +12475,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -12306,7 +12498,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12318,7 +12510,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -12343,7 +12537,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -12366,7 +12562,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13059,7 +13255,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -13079,7 +13277,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13091,7 +13289,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -13116,7 +13316,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -13139,7 +13341,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13151,7 +13353,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -13176,7 +13380,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -13197,7 +13403,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13209,7 +13415,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -13234,7 +13442,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -13257,7 +13467,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14316,7 +14526,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -14336,7 +14548,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14348,7 +14560,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -14373,7 +14587,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -14396,7 +14612,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14408,7 +14624,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -14433,7 +14651,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -14454,7 +14674,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14466,7 +14686,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -14491,7 +14713,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -14514,7 +14738,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15166,7 +15390,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -15186,7 +15412,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15198,7 +15424,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -15223,7 +15451,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -15246,7 +15476,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15258,7 +15488,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -15283,7 +15515,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -15304,7 +15538,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15316,7 +15550,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -15341,7 +15577,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -15364,7 +15602,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16231,7 +16469,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -16251,7 +16491,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16263,7 +16503,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -16288,7 +16530,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -16311,7 +16555,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16323,7 +16567,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -16348,7 +16594,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -16369,7 +16617,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16381,7 +16629,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -16406,7 +16656,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -16429,7 +16681,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -17294,7 +17546,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -17314,7 +17568,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -17326,7 +17580,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -17351,7 +17607,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -17374,7 +17632,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -17386,7 +17644,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -17411,7 +17671,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -17432,7 +17694,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -17444,7 +17706,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -17469,7 +17733,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -17492,7 +17758,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -18305,7 +18571,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -18325,7 +18593,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -18337,7 +18605,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -18362,7 +18632,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -18385,7 +18657,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -18397,7 +18669,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -18422,7 +18696,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -18443,7 +18719,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -18455,7 +18731,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -18480,7 +18758,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -18503,7 +18783,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -19316,7 +19596,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -19336,7 +19618,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -19348,7 +19630,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -19373,7 +19657,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -19396,7 +19682,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -19408,7 +19694,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -19433,7 +19721,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -19454,7 +19744,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -19466,7 +19756,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -19491,7 +19783,9 @@ exports[`installing helm chart from new tab given tab for installing chart was n
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -19514,7 +19808,7 @@ exports[`installing helm chart from new tab given tab for installing chart was n
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/installing-helm-chart-from-previously-opened-tab.test.ts.snap
@@ -72,7 +72,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -632,7 +646,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -653,7 +669,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -665,7 +681,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -690,7 +708,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -713,7 +733,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -725,7 +745,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -750,7 +772,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -770,7 +794,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -782,7 +806,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -807,7 +833,9 @@ exports[`installing helm chart from previously opened tab given tab for installi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -830,7 +858,7 @@ exports[`installing helm chart from previously opened tab given tab for installi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
+++ b/packages/core/src/features/helm-charts/installing-chart/__snapshots__/opening-dock-tab-for-installing-helm-chart.test.ts.snap
@@ -72,7 +72,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -609,7 +623,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -629,7 +645,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -641,7 +657,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -666,7 +684,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -689,7 +709,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -701,7 +721,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -726,7 +748,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -747,7 +771,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -759,7 +783,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -784,7 +810,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -807,7 +835,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1316,7 +1344,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1336,7 +1366,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1348,7 +1378,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1373,7 +1405,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1396,7 +1430,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1408,7 +1442,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1433,7 +1469,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -1454,7 +1492,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1466,7 +1504,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1491,7 +1531,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1514,7 +1556,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2080,7 +2122,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2100,7 +2144,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2112,7 +2156,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2137,7 +2183,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2160,7 +2208,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2172,7 +2220,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2197,7 +2247,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -2218,7 +2270,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2230,7 +2282,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2255,7 +2309,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2278,7 +2334,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3027,7 +3083,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -3047,7 +3105,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3059,7 +3117,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -3084,7 +3144,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -3107,7 +3169,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3119,7 +3181,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3144,7 +3208,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -3165,7 +3231,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3177,7 +3243,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3202,7 +3270,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3225,7 +3295,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3984,7 +4054,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4004,7 +4076,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4016,7 +4088,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4041,7 +4115,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -4064,7 +4140,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4076,7 +4152,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -4101,7 +4179,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -4122,7 +4202,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4134,7 +4214,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -4159,7 +4241,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -4182,7 +4266,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4931,7 +5015,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4951,7 +5037,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4963,7 +5049,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4988,7 +5076,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -5011,7 +5101,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5023,7 +5113,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -5048,7 +5140,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -5069,7 +5163,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5081,7 +5175,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -5106,7 +5202,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -5129,7 +5227,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5882,7 +5980,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -5902,7 +6002,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5914,7 +6014,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -5939,7 +6041,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -5962,7 +6066,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5974,7 +6078,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -5999,7 +6105,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -6020,7 +6128,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6032,7 +6140,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -6057,7 +6167,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -6080,7 +6192,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6839,7 +6951,9 @@ exports[`opening dock tab for installing helm chart given application is started
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -6859,7 +6973,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6871,7 +6985,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -6896,7 +7012,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -6919,7 +7037,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6931,7 +7049,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -6956,7 +7076,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -6977,7 +7099,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6989,7 +7111,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -7014,7 +7138,9 @@ exports[`opening dock tab for installing helm chart given application is started
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -7037,7 +7163,7 @@ exports[`opening dock tab for installing helm chart given application is started
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
+++ b/packages/core/src/features/helm-charts/upgrade-chart/__snapshots__/upgrade-chart-new-tab.test.ts.snap
@@ -72,7 +72,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -772,7 +786,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -792,7 +808,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -804,7 +820,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -829,7 +847,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -852,7 +872,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -864,7 +884,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -889,7 +911,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -910,7 +934,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -922,7 +946,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -947,7 +973,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -970,7 +998,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1575,7 +1603,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1595,7 +1625,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1607,7 +1637,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1632,7 +1664,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1655,7 +1689,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1667,7 +1701,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1692,7 +1728,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -1713,7 +1751,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1725,7 +1763,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1750,7 +1790,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1773,7 +1815,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2394,7 +2436,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2414,7 +2458,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2426,7 +2470,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2451,7 +2497,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2474,7 +2522,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2486,7 +2534,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2511,7 +2561,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -2532,7 +2584,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2544,7 +2596,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2569,7 +2623,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2592,7 +2648,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3249,7 +3305,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -3269,7 +3327,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3281,7 +3339,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -3306,7 +3366,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -3329,7 +3391,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3341,7 +3403,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3366,7 +3430,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -3387,7 +3453,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3399,7 +3465,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3424,7 +3492,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3447,7 +3517,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4244,7 +4314,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4264,7 +4336,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4276,7 +4348,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4301,7 +4375,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -4324,7 +4400,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4336,7 +4412,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -4361,7 +4439,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -4382,7 +4462,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4394,7 +4474,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -4419,7 +4501,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -4442,7 +4526,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5241,7 +5325,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -5261,7 +5347,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5273,7 +5359,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -5298,7 +5386,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -5321,7 +5411,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5333,7 +5423,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -5358,7 +5450,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -5379,7 +5473,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5391,7 +5485,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -5416,7 +5512,9 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -5439,7 +5537,7 @@ exports[`New Upgrade Helm Chart Dock Tab given a namespace is selected when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
+++ b/packages/core/src/features/helm-releases/__snapshots__/showing-details-for-helm-release.test.ts.snap
@@ -72,7 +72,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -92,7 +94,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -104,7 +106,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -129,7 +133,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -152,7 +158,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -164,7 +170,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -189,7 +197,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -853,7 +867,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -873,7 +889,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -885,7 +901,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -910,7 +928,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -933,7 +953,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -945,7 +965,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -970,7 +992,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -991,7 +1015,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1003,7 +1027,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1028,7 +1054,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1051,7 +1079,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1639,7 +1667,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -1659,7 +1689,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1671,7 +1701,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1696,7 +1728,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1719,7 +1753,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1731,7 +1765,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1756,7 +1792,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -1777,7 +1815,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1789,7 +1827,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1814,7 +1854,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1837,7 +1879,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2615,7 +2657,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -2635,7 +2679,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2647,7 +2691,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -2672,7 +2718,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -2695,7 +2743,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2707,7 +2755,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -2732,7 +2782,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -2753,7 +2805,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -2765,7 +2817,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -2790,7 +2844,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -2813,7 +2869,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3652,7 +3708,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -3672,7 +3730,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3684,7 +3742,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -3709,7 +3769,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -3732,7 +3794,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3744,7 +3806,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -3769,7 +3833,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -3790,7 +3856,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -3802,7 +3868,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -3827,7 +3895,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -3850,7 +3920,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4689,7 +4759,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -4709,7 +4781,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4721,7 +4793,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -4746,7 +4820,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -4769,7 +4845,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4781,7 +4857,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -4806,7 +4884,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -4827,7 +4907,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -4839,7 +4919,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -4864,7 +4946,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -4887,7 +4971,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -5971,7 +6055,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -5991,7 +6077,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6003,7 +6089,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -6028,7 +6116,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -6051,7 +6141,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6063,7 +6153,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -6088,7 +6180,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -6109,7 +6203,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -6121,7 +6215,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -6146,7 +6242,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -6169,7 +6267,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7253,7 +7351,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -7273,7 +7373,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7285,7 +7385,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -7310,7 +7412,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -7333,7 +7437,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7345,7 +7449,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -7370,7 +7476,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -7391,7 +7499,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -7403,7 +7511,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -7428,7 +7538,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -7451,7 +7563,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8535,7 +8647,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -8555,7 +8669,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8567,7 +8681,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -8592,7 +8708,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -8615,7 +8733,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8627,7 +8745,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -8652,7 +8772,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -8673,7 +8795,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -8685,7 +8807,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -8710,7 +8834,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -8733,7 +8859,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9622,7 +9748,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -9642,7 +9770,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9654,7 +9782,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -9679,7 +9809,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -9702,7 +9834,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9714,7 +9846,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -9739,7 +9873,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -9760,7 +9896,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -9772,7 +9908,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -9797,7 +9935,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -9820,7 +9960,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10711,7 +10851,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -10731,7 +10873,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10743,7 +10885,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -10768,7 +10912,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -10791,7 +10937,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10803,7 +10949,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -10828,7 +10976,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -10849,7 +10999,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -10861,7 +11011,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -10886,7 +11038,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -10909,7 +11063,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -11993,7 +12147,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -12013,7 +12169,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12025,7 +12181,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -12050,7 +12208,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -12073,7 +12233,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12085,7 +12245,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -12110,7 +12272,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -12131,7 +12295,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -12143,7 +12307,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -12168,7 +12334,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -12191,7 +12359,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13030,7 +13198,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -13050,7 +13220,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13062,7 +13232,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -13087,7 +13259,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -13110,7 +13284,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13122,7 +13296,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -13147,7 +13323,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -13168,7 +13346,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -13180,7 +13358,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -13205,7 +13385,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -13228,7 +13410,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14070,7 +14252,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -14090,7 +14274,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14102,7 +14286,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -14127,7 +14313,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -14150,7 +14338,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14162,7 +14350,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -14187,7 +14377,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -14208,7 +14400,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -14220,7 +14412,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -14245,7 +14439,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -14268,7 +14464,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15046,7 +15242,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -15066,7 +15264,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15078,7 +15276,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -15103,7 +15303,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -15126,7 +15328,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15138,7 +15340,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -15163,7 +15367,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -15184,7 +15390,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -15196,7 +15402,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -15221,7 +15429,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -15244,7 +15454,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16083,7 +16293,9 @@ exports[`showing details for helm release given application is started when navi
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-workloads"
             >
@@ -16103,7 +16315,7 @@ exports[`showing details for helm release given application is started when navi
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16115,7 +16327,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -16140,7 +16354,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -16163,7 +16379,7 @@ exports[`showing details for helm release given application is started when navi
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16175,7 +16391,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -16200,7 +16418,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-helm"
             >
@@ -16221,7 +16441,7 @@ exports[`showing details for helm release given application is started when navi
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -16233,7 +16453,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -16258,7 +16480,9 @@ exports[`showing details for helm release given application is started when navi
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -16281,7 +16505,7 @@ exports[`showing details for helm release given application is started when navi
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/features/pod-logs/__snapshots__/download-logs.test.tsx.snap
+++ b/packages/core/src/features/pod-logs/__snapshots__/download-logs.test.tsx.snap
@@ -72,7 +72,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -93,7 +95,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -105,7 +107,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -130,7 +134,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -153,7 +159,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -165,7 +171,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -190,7 +198,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -210,7 +220,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -222,7 +232,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -247,7 +259,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -270,7 +284,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs avail
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -965,7 +979,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
             class="sidebarNav sidebar-active-status"
           >
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="true"
               data-testid="sidebar-item-workloads"
             >
@@ -986,7 +1002,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
                   Workloads
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -998,7 +1014,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-config"
             >
@@ -1023,7 +1041,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-network"
             >
@@ -1046,7 +1066,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
                   Network
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1058,7 +1078,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-storage"
             >
@@ -1083,7 +1105,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-helm"
             >
@@ -1103,7 +1127,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
                   Helm
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"
@@ -1115,7 +1139,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="false"
               data-is-active-test="false"
               data-testid="sidebar-item-user-management"
             >
@@ -1140,7 +1166,9 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
               </a>
             </div>
             <div
+              aria-expanded="false"
               class="SidebarItem"
+              data-expandable="true"
               data-is-active-test="false"
               data-testid="sidebar-item-custom-resources"
             >
@@ -1163,7 +1191,7 @@ exports[`download logs options in logs dock tab opening pod logs when logs not a
                   Custom Resources
                 </span>
                 <i
-                  class="Icon expandIcon material focusable"
+                  class="Icon expandIcon material focusable small"
                 >
                   <span
                     class="icon"

--- a/packages/core/src/renderer/components/layout/sidebar-item.tsx
+++ b/packages/core/src/renderer/components/layout/sidebar-item.tsx
@@ -105,6 +105,7 @@ class NonInjectedSidebarItem extends React.Component<
           {this.isExpandable && (
             <Icon
               className={styles.expandIcon}
+              small
               material={
                 this.expanded ? "keyboard_arrow_up" : "keyboard_arrow_down"
               }

--- a/packages/core/src/renderer/components/layout/sidebar-item.tsx
+++ b/packages/core/src/renderer/components/layout/sidebar-item.tsx
@@ -84,6 +84,7 @@ class NonInjectedSidebarItem extends React.Component<
         data-is-active-test={this.isActive}
         data-parent-id-test={this.registration.parentId}
         data-expandable={this.isExpandable}
+        aria-expanded={this.expanded}
       >
         <NavLink
           to={""}

--- a/packages/core/src/renderer/components/layout/sidebar-item.tsx
+++ b/packages/core/src/renderer/components/layout/sidebar-item.tsx
@@ -83,6 +83,7 @@ class NonInjectedSidebarItem extends React.Component<
         data-testid={`sidebar-item-${this.id}`}
         data-is-active-test={this.isActive}
         data-parent-id-test={this.registration.parentId}
+        data-expandable={this.isExpandable}
       >
         <NavLink
           to={""}

--- a/packages/core/src/renderer/components/layout/sidebar-items.injectable.ts
+++ b/packages/core/src/renderer/components/layout/sidebar-items.injectable.ts
@@ -17,8 +17,6 @@ import {
   orderBy,
   some,
 } from "lodash/fp";
-import sidebarStorageInjectable, { SidebarStorageState } from "./sidebar-storage/sidebar-storage.injectable";
-import type { StorageLayer } from "../../utils";
 
 export interface SidebarItemRegistration {
   id: string;
@@ -46,7 +44,6 @@ const sidebarItemsInjectable = getInjectable({
 
   instantiate: (di) => {
     const computedInjectMany = di.inject(computedInjectManyInjectable);
-    const sidebarStorage: StorageLayer<SidebarStorageState> = di.inject(sidebarStorageInjectable)
     const sidebarItemRegistrations = computedInjectMany(sidebarItemsInjectionToken);
 
     return computed((): HierarchicalSidebarItem[] => {
@@ -65,8 +62,6 @@ const sidebarItemsInjectable = getInjectable({
             map((registration) => {
               const children = _getSidebarItemsHierarchy(registration.id);
 
-              const parentExpanded = () => Boolean(sidebarStorage.get().expanded[registration.id])
-
               return {
                 registration,
                 children,
@@ -80,7 +75,6 @@ const sidebarItemsInjectable = getInjectable({
                     children,
                     invokeMap("isActive.get"),
                     some(identity),
-                    (identityFound) => identityFound && !parentExpanded(),
                   );
                 }),
               };

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -22,7 +22,8 @@
     }
 
     span {
-      word-break: break-word;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
@@ -35,6 +36,8 @@
       &[data-expandable="true"] {
         > .navItem > span {
           font-weight: bolder;
+          color: var(--textColorAccent);
+          opacity: 0.6;
         }
       }
 

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -29,7 +29,7 @@
   .subMenu {
     .SidebarItem {
       &[data-expandable="true"] {
-        > .navItem {
+        > .navItem > span {
           font-weight: bolder;
         }
       }

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -7,9 +7,9 @@
 
   > .navItem {
     display: flex;
-    gap: 6px;
+    gap: 8px;
     text-decoration: none;
-    padding: 6px 8px 6px 8px;
+    padding: 4px 8px 4px 8px;
     cursor: pointer;
 
     &:global(.active), &:hover {

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -27,24 +27,9 @@
   }
 
   .subMenu {
-    border-left: 4px solid transparent;
-
-    &.active {
-      border-color: var(--blue);
-    }
-  
     .SidebarItem {
-      color: var(--textColorPrimary);
-      padding-left: 25px;
-  
       .navItem {
-        padding-top: 4px;
-        padding-bottom: 4px;
-
-        &:global(.active), &:hover {
-          color: var(--sidebarSubmenuActiveColor);
-          background: none;
-        }
+        padding-left: 34px
       }
     }
   }

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -12,7 +12,11 @@
     padding: 4px 8px 4px 8px;
     cursor: pointer;
 
-    &:global(.active), &:hover {
+    &:hover {
+      background: var(--sidebarLogoBackground);
+    }
+
+    &:global(.active) {
       background: var(--blue);
       color: var(--sidebarActiveColor);
     }

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -7,9 +7,9 @@
 
   > .navItem {
     display: flex;
-    gap: 8px;
+    gap: 6px;
     text-decoration: none;
-    padding: 6px 8px 6px 10px;
+    padding: 6px 8px 6px 8px;
     cursor: pointer;
 
     &:global(.active), &:hover {

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -5,6 +5,18 @@
   width: 100%;
   user-select: none;
 
+  // Do not highlight active state when item expanded
+  &[aria-expanded='true'] {
+    > .navItem:global(.active) {
+      background-color: transparent;
+      color: var(--textColorPrimary);
+    }
+
+    >.navItem:hover {
+      background: var(--sidebarLogoBackground);
+    }
+  }
+
   > .navItem {
     display: flex;
     gap: 8px;
@@ -34,11 +46,13 @@
   .subMenu {
     .SidebarItem {
       &[data-expandable="true"] {
-        > .navItem > span {
-          font-weight: bolder;
-          color: var(--textColorAccent);
-          opacity: 0.6;
-        }
+        > .navItem {
+          > span {
+            font-weight: bolder;
+            color: var(--textColorAccent);
+            opacity: 0.7;
+          }
+        } 
       }
 
       .navItem {

--- a/packages/core/src/renderer/components/layout/sidebar-items.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar-items.module.scss
@@ -28,6 +28,12 @@
 
   .subMenu {
     .SidebarItem {
+      &[data-expandable="true"] {
+        > .navItem {
+          font-weight: bolder;
+        }
+      }
+
       .navItem {
         padding-left: 34px
       }
@@ -38,10 +44,6 @@
   .subMenu .subMenu {
     &.active {
       border-color: transparent;
-    }
-
-    .SidebarItem {
-      padding-left: calc(var(--padding) / 2);
     }
   }
 }

--- a/packages/core/src/renderer/components/layout/sidebar.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar.module.scss
@@ -4,7 +4,9 @@
  */
 
 .sidebarNav {
-  @apply flex overflow-auto flex-col;
+  display: flex;
+  flex-direction: column;
+  overflow: overlay;
   width: var(--sidebar-width);
   padding-bottom: calc(var(--padding) * 3);
 
@@ -17,6 +19,16 @@
   background-repeat: no-repeat;
   background-size: 100% 40px, 100% 40px, 100% 12px, 100% 12px;
   background-attachment: local, local, scroll, scroll;
+
+  &::-webkit-scrollbar-thumb {
+    background-color: transparent;
+  }
+
+  &:hover {
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--sidebarScrollbarBackground);
+    }
+  }
 }
 
 .sidebarNav :global(.Icon) {

--- a/packages/core/src/renderer/components/layout/sidebar.module.scss
+++ b/packages/core/src/renderer/components/layout/sidebar.module.scss
@@ -32,6 +32,7 @@
 }
 
 .sidebarNav :global(.Icon) {
+  --size: 18px;
   box-sizing: content-box;
   border-radius: 50%;
 }

--- a/packages/core/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
+++ b/packages/core/src/renderer/frames/cluster-frame/__snapshots__/cluster-frame.test.tsx.snap
@@ -75,7 +75,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="true"
             data-testid="sidebar-item-cluster-overview"
           >
@@ -98,7 +100,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-nodes"
           >
@@ -120,7 +124,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -140,7 +146,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -152,7 +158,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -177,7 +185,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -200,7 +210,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -212,7 +222,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -237,7 +249,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-namespaces"
           >
@@ -262,7 +276,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -282,7 +298,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -294,7 +310,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -319,7 +337,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -342,7 +362,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -579,7 +599,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="true"
             data-testid="sidebar-item-cluster-overview"
           >
@@ -602,7 +624,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-nodes"
           >
@@ -624,7 +648,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-workloads"
           >
@@ -644,7 +670,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -656,7 +682,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -681,7 +709,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -704,7 +734,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -716,7 +746,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -741,7 +773,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-namespaces"
           >
@@ -766,7 +800,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -786,7 +822,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -798,7 +834,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -823,7 +861,9 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -846,7 +886,7 @@ exports[`<ClusterFrame /> given cluster with list nodes and namespaces permissio
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1090,7 +1130,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
           class="sidebarNav sidebar-active-status"
         >
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="true"
             data-testid="sidebar-item-workloads"
           >
@@ -1111,7 +1153,7 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                 Workloads
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1123,7 +1165,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-config"
           >
@@ -1148,7 +1192,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-network"
           >
@@ -1171,7 +1217,7 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                 Network
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1183,7 +1229,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-storage"
           >
@@ -1208,7 +1256,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-namespaces"
           >
@@ -1233,7 +1283,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-helm"
           >
@@ -1253,7 +1305,7 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                 Helm
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"
@@ -1265,7 +1317,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="false"
             data-is-active-test="false"
             data-testid="sidebar-item-user-management"
           >
@@ -1290,7 +1344,9 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
             </a>
           </div>
           <div
+            aria-expanded="false"
             class="SidebarItem"
+            data-expandable="true"
             data-is-active-test="false"
             data-testid="sidebar-item-custom-resources"
           >
@@ -1313,7 +1369,7 @@ exports[`<ClusterFrame /> given cluster without list nodes, but with namespaces 
                 Custom Resources
               </span>
               <i
-                class="Icon expandIcon material focusable"
+                class="Icon expandIcon material focusable small"
               >
                 <span
                   class="icon"

--- a/packages/core/src/renderer/themes/lens-dark.injectable.ts
+++ b/packages/core/src/renderer/themes/lens-dark.injectable.ts
@@ -38,6 +38,7 @@ const lensDarkThemeInjectable = getInjectable({
       sidebarActiveColor: "#ffffff",
       sidebarSubmenuActiveColor: "#ffffff",
       sidebarItemHoverBackground: "#3a3e44",
+      sidebarScrollbarBackground: "#9da7b033",
       badgeBackgroundColor: "#ffba44",
       buttonPrimaryBackground: "#3d90ce",
       buttonDefaultBackground: "#414448",

--- a/packages/core/src/renderer/themes/lens-light.injectable.ts
+++ b/packages/core/src/renderer/themes/lens-light.injectable.ts
@@ -38,6 +38,7 @@ const lensLightThemeInjectable = getInjectable({
       sidebarSubmenuActiveColor: "#3d90ce",
       sidebarBackground: "#e8e8e8",
       sidebarItemHoverBackground: "#f0f2f5",
+      sidebarScrollbarBackground: "#666f7940",
       badgeBackgroundColor: "#ffba44",
       buttonPrimaryBackground: "#3d90ce",
       buttonDefaultBackground: "#414448",


### PR DESCRIPTION
* More room for item`s name by adjusting paddings, smaller icons and on-hover scrollbar
* Better readability for third level menus (CRDs)
* Consistent hover effects across menus and their submenus

Before:


https://user-images.githubusercontent.com/9607060/216939120-0e2e395d-37ca-4103-8d6a-105387473616.mov


After:


https://user-images.githubusercontent.com/9607060/216939143-265184f6-a492-4d6b-ac8a-17e02a5dce57.mov

