### PR TITLE
Mark subnamespaces in namespace list

### DIFF
--- a/packages/core/src/renderer/components/+namespaces/namespaces.scss
+++ b/packages/core/src/renderer/components/+namespaces/namespaces.scss
@@ -22,4 +22,8 @@
       @include namespaceStatus;
     }
   }
+
+  .subnamespaceBadge {
+    margin-inline-start: var(--margin);
+  }
 }

--- a/packages/core/src/renderer/components/+namespaces/route.tsx
+++ b/packages/core/src/renderer/components/+namespaces/route.tsx
@@ -16,6 +16,7 @@ import { withInjectables } from "@ogre-tools/injectable-react";
 import namespaceStoreInjectable from "./store.injectable";
 import { KubeObjectAge } from "../kube-object/age";
 import openAddNamepaceDialogInjectable from "./add-dialog/open.injectable";
+import { SubnamespaceBadge } from "./subnamespace-badge";
 
 enum columnId {
   name = "name",
@@ -55,7 +56,12 @@ const NonInjectedNamespacesRoute = ({ namespaceStore, openAddNamespaceDialog }: 
         { title: "Status", className: "status", sortBy: columnId.status, id: columnId.status },
       ]}
       renderTableContents={namespace => [
-        namespace.getName(),
+        <>
+          {namespace.getName()}
+          {namespace.isSubnamespace() && (
+            <SubnamespaceBadge className="subnamespaceBadge" id={`namespace-list-badge-for-${namespace.getId()}`} />
+          )}
+        </>,
         <KubeObjectStatusIcon key="icon" object={namespace} />,
         namespace.getLabels().map(label => (
           <Badge

--- a/packages/core/src/renderer/components/+namespaces/subnamespace-badge.tsx
+++ b/packages/core/src/renderer/components/+namespaces/subnamespace-badge.tsx
@@ -6,16 +6,17 @@ import styles from "./subnamespace-badge.module.scss";
 
 import React from "react";
 import { Tooltip } from "../tooltip";
+import { cssNames } from "../../utils";
 
 interface SubnamespaceBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   id: string;
 }
 
-export function SubnamespaceBadge({ id, ...other }: SubnamespaceBadgeProps) {
+export function SubnamespaceBadge({ id, className, ...other }: SubnamespaceBadgeProps) {
   return (
     <>
       <span
-        className={styles.subnamespaceBadge}
+        className={cssNames(styles.subnamespaceBadge, className)}
         data-testid={id}
         id={id}
         {...other}


### PR DESCRIPTION

<img width="780" alt="subnamespace badge dark" src="https://user-images.githubusercontent.com/9607060/217758109-8ad5a413-5b23-4cd9-89de-2476fbcdf8c2.png">

<img width="786" alt="subnamespace badge light" src="https://user-images.githubusercontent.com/9607060/217758124-b2ac665a-c47e-48e8-a7f9-cdc0a66c41a0.png">

Example from kubectl (`kubectl hns tree acme-org`):

<img width="337" alt="kubectl tree view" src="https://user-images.githubusercontent.com/9607060/217758421-3f44bfc9-a1e3-444e-806d-c844dcc2ac20.png">

Resolves #7131 



Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>