### PR TITLE
Add a bit of spacing before Installed extensions title

### DIFF
--- a/packages/core/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
+++ b/packages/core/src/features/extensions/__snapshots__/navigation-using-application-menu.test.ts.snap
@@ -423,6 +423,9 @@ exports[`extensions - navigation using application menu when navigating to exten
                   : you can drag and drop a tarball file to this area
                 </small>
               </section>
+              <div
+                class="size-md"
+              />
               <div>
                 <div
                   class="Spinner singleColor center"

--- a/packages/core/src/renderer/components/+extensions/extensions.tsx
+++ b/packages/core/src/renderer/components/+extensions/extensions.tsx
@@ -37,6 +37,7 @@ import installOnDropInjectable from "./install-on-drop.injectable";
 import { supportedExtensionFormats } from "./supported-extension-formats";
 import extensionInstallationStateStoreInjectable from "../../../extensions/extension-installation-state-store/extension-installation-state-store.injectable";
 import type { ExtensionInstallationStateStore } from "../../../extensions/extension-installation-state-store/extension-installation-state-store";
+import Gutter from "../gutter/gutter";
 
 interface Dependencies {
   userExtensions: IComputedValue<InstalledExtension[]>;
@@ -112,6 +113,8 @@ class NonInjectedExtensions extends React.Component<Dependencies> {
               installFromSelectFileDialog={this.props.installFromSelectFileDialog}
               installPath={this.installPath}
             />
+
+            <Gutter size="md" />
 
             <InstalledExtensions
               extensions={userExtensions}


### PR DESCRIPTION
Before:

![missed padding](https://user-images.githubusercontent.com/9607060/218734350-ab65f83f-7892-41b1-b96b-3fcbdc3ad561.png)


After:

![installed extension padding](https://user-images.githubusercontent.com/9607060/218734388-08c94d2a-d7d7-4224-8930-54800ec6a687.png)


Signed-off-by: Alex Andreev <alex.andreev.email@gmail.com>