### PR TITLE
Fix extension installation

### DIFF
--- a/packages/core/src/extensions/extension-discovery/extension-discovery.ts
+++ b/packages/core/src/extensions/extension-discovery/extension-discovery.ts
@@ -216,9 +216,6 @@ export class ExtensionDiscovery {
         const extension = await this.loadExtensionFromFolder(absPath);
 
         if (extension) {
-          // Remove a broken symlink left by a previous installation if it exists.
-          await this.dependencies.removePath(extension.manifestPath);
-
           // Install dependencies for the new extension
           await this.dependencies.installExtension(extension.absolutePath);
 


### PR DESCRIPTION
There's code that removes the `package.json` file from extension even though it's not supposed to do so. This code was added in #1718. 

Fixes #7141 

By looking at the code, I can see many major problems with it, but here's the minimal fix. Decided that I'm not going to do any major rework for the extension discovery / -loading since it will be rebuilt to support new type of extensions (Features) soon.

Examples:
1. `renderer` accesses file system directly
2. `renderer` downloads the extension
3. No clear code path to follow. (installing, file system watches etc.)