### PR TITLE
Fix log tab double scrollbars bug

### DIFF
--- a/packages/core/src/renderer/components/dock/logs/list.scss
+++ b/packages/core/src/renderer/components/dock/logs/list.scss
@@ -7,10 +7,6 @@
   --overlay-bg: #8cc474b8;
   --overlay-active-bg: orange;
 
-  // fix for `this.logsElement.scrollTop = this.logsElement.scrollHeight`
-  // `overflow: overlay` don't allow scroll to the last line
-  overflow: auto;
-
   position: relative;
   color: var(--logsForeground);
   background: var(--logsBackground);
@@ -21,6 +17,7 @@
 
     .list {
       overflow-x: scroll!important;
+      overflow-y: auto!important;
 
       .LogRow {
         padding: 2px 16px;


### PR DESCRIPTION
Before:


https://user-images.githubusercontent.com/9607060/219365456-58fdc868-d1e6-454b-9985-7c9dabd79b72.mov


After:


https://user-images.githubusercontent.com/9607060/219365467-72e052b1-0ce9-4603-bc57-8c8693386052.mov

