### PR TITLE
Release 6.4.0-beta.14

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "npmClient": "yarn",
   "npmClientArgs": [
     "--network-timeout=100000"

--- a/packages/bump-version-for-cron/package.json
+++ b/packages/bump-version-for-cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/bump-version-for-cron",
-  "version": "6.4.0-cron.4db172da60",
+  "version": "6.4.0-beta.14",
   "description": "CLI to bump the version to during a cron daily alpha release",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -127,7 +127,7 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.1",
     "@hapi/subtext": "^7.0.4",
-    "@k8slens/node-fetch": "^6.4.0-beta.13",
+    "@k8slens/node-fetch": "^6.4.0-beta.14",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@ogre-tools/fp": "^12.0.1",

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/ensure-binaries",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "yarn run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.13"
+    "@k8slens/core": "^6.4.0-beta.14"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/generate-tray-icons",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "description": "CLI generating tray icons for building a lens-like application",
   "license": "MIT",
   "scripts": {

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/node-fetch",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "description": "Node fetch for Lens",
   "license": "MIT",
   "private": false,

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -192,9 +192,9 @@
     }
   },
   "dependencies": {
-    "@k8slens/core": "^6.4.0-beta.13",
-    "@k8slens/ensure-binaries": "^6.4.0-beta.13",
-    "@k8slens/generate-tray-icons": "^6.4.0-beta.13",
+    "@k8slens/core": "^6.4.0-beta.14",
+    "@k8slens/ensure-binaries": "^6.4.0-beta.14",
+    "@k8slens/generate-tray-icons": "^6.4.0-beta.14",
     "@ogre-tools/fp": "^12.0.1",
     "@ogre-tools/injectable": "^12.0.1",
     "@ogre-tools/injectable-extension-for-auto-registration": "^12.0.1",
@@ -204,7 +204,7 @@
     "rimraf": "^4.1.2"
   },
   "devDependencies": {
-    "@k8slens/node-fetch": "^6.4.0-beta.13",
+    "@k8slens/node-fetch": "^6.4.0-beta.14",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/cli": "^0.1.61",
     "@swc/core": "^1.3.35",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "description": "Release tool for lens monorepo",
   "main": "dist/index.mjs",
   "license": "MIT",

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/semver",
-  "version": "6.4.0-beta.13",
+  "version": "6.4.0-beta.14",
   "description": "CLI over semver package for picking parts of a version",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Changes since 6.4.0-beta.13

## 🚀 Features

- Renderer file logging transport (**[#6795](https://github.com/lensapp/lens/pull/6795)**) https://github.com/samitiilikainen
- Namespace details tree view (**[#7080](https://github.com/lensapp/lens/pull/7080)**) https://github.com/aleksfront
- Enable extension to specify storeName for persisting data (**[#7107](https://github.com/lensapp/lens/pull/7107)**) https://github.com/panuhorsmalahti
- Add bundled extension versions to 'About Lens' (**[#7163](https://github.com/lensapp/lens/pull/7163)**) https://github.com/Nokel81
- Replication Controllers (new resource view) (**[#7154](https://github.com/lensapp/lens/pull/7154)**) https://github.com/ixrock
- Add support for specifying orderNumber for ClusterPageMenus (**[#7166](https://github.com/lensapp/lens/pull/7166)**) https://github.com/Nokel81
- Export requestMetrics to extension api (**[#7167](https://github.com/lensapp/lens/pull/7167)**) https://github.com/Nokel81

## 🐛 Bug Fixes

- Use setCertificateVerifyProc to verify lens proxy certificate (**[#7118](https://github.com/lensapp/lens/pull/7118)**) https://github.com/jakolehm
- Fix typing issue with userStorePreferenceDescriptorsInjectable (**[#7144](https://github.com/lensapp/lens/pull/7144)**) https://github.com/Nokel81
- Fix node shell not loading due to Host/certificate mismatch (**[#7147](https://github.com/lensapp/lens/pull/7147)**) https://github.com/Nokel81
- Add a bit of spacing before Installed extensions title (**[#7152](https://github.com/lensapp/lens/pull/7152)**) https://github.com/aleksfront
- Fix extension installation (**[#7161](https://github.com/lensapp/lens/pull/7161)**) https://github.com/jansav
- Fix configuration shown release details being stale (**[#7174](https://github.com/lensapp/lens/pull/7174)**) https://github.com/jansav
- Fix chromium net error codes (**[#7180](https://github.com/lensapp/lens/pull/7180)**) https://github.com/jakolehm
- Fix external extensions not loading initially (**[#7189](https://github.com/lensapp/lens/pull/7189)**) https://github.com/Nokel81
- Fix empty pod logs tab content (**[#7177](https://github.com/lensapp/lens/pull/7177)**) https://github.com/aleksfront
- Fix: removed duplicated labels & annotations for Node-details view (**[#7202](https://github.com/lensapp/lens/pull/7202)**) https://github.com/ixrock
- Fix ensure hashed directory for extension (**[#7188](https://github.com/lensapp/lens/pull/7188)**) https://github.com/jweak
- Fix dropdown items readability in Dock (**[#7209](https://github.com/lensapp/lens/pull/7209)**) https://github.com/aleksfront
- Fix command line argument not being passed to lerna (**[#7210](https://github.com/lensapp/lens/pull/7210)**) https://github.com/jansav
- Fix PodList TableHead overflow (**[#7212](https://github.com/lensapp/lens/pull/7212)**) https://github.com/aleksfront

## 🧰 Maintenance

- Bump @swc/core from 1.3.31 to 1.3.32 (**[#7090](https://github.com/lensapp/lens/pull/7090)**) https://github.com/app/dependabot
- Bump @swc/cli from 0.1.59 to 0.1.61 (**[#7096](https://github.com/lensapp/lens/pull/7096)**) https://github.com/app/dependabot
- Bump http-cache-semantics from 4.1.0 to 4.1.1 (**[#7108](https://github.com/lensapp/lens/pull/7108)**) https://github.com/app/dependabot
- Add daily-alpha release for open-lens (**[#7127](https://github.com/lensapp/lens/pull/7127)**) https://github.com/Nokel81
- Remove self-referencial from root package.json (**[#7130](https://github.com/lensapp/lens/pull/7130)**) https://github.com/Nokel81
- Bump esbuild from 0.17.5 to 0.17.7 (**[#7135](https://github.com/lensapp/lens/pull/7135)**) https://github.com/app/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.50.0 to 5.51.0 (**[#7119](https://github.com/lensapp/lens/pull/7119)**) https://github.com/app/dependabot
- Bump @typescript-eslint/parser from 5.50.0 to 5.51.0 (**[#7121](https://github.com/lensapp/lens/pull/7121)**) https://github.com/app/dependabot
- Fix daily-cron failing to bump version  (**[#7129](https://github.com/lensapp/lens/pull/7129)**) https://github.com/Nokel81
- Bump @typescript-eslint/parser from 5.51.0 to 5.52.0 (**[#7148](https://github.com/lensapp/lens/pull/7148)**) https://github.com/app/dependabot
- Bump @hapi/call from 9.0.0 to 9.0.1 (**[#7151](https://github.com/lensapp/lens/pull/7151)**) https://github.com/app/dependabot
- Bump lerna from 6.4.1 to 6.5.0 (**[#7150](https://github.com/lensapp/lens/pull/7150)**) https://github.com/app/dependabot
- Bump @typescript-eslint/eslint-plugin from 5.51.0 to 5.52.0 (**[#7149](https://github.com/lensapp/lens/pull/7149)**) https://github.com/app/dependabot
- Bump @swc/core from 1.3.32 to 1.3.35 (**[#7157](https://github.com/lensapp/lens/pull/7157)**) https://github.com/app/dependabot
- Bump dompurify from 2.4.3 to 2.4.4 (**[#7160](https://github.com/lensapp/lens/pull/7160)**) https://github.com/app/dependabot
- Bump sass from 1.58.0 to 1.58.1 (**[#7158](https://github.com/lensapp/lens/pull/7158)**) https://github.com/app/dependabot
- Bump esbuild from 0.17.7 to 0.17.8 (**[#7159](https://github.com/lensapp/lens/pull/7159)**) https://github.com/app/dependabot
- Change extension ipc registration log level from info to debug (**[#7175](https://github.com/lensapp/lens/pull/7175)**) https://github.com/jakolehm
- Bump joi from 17.7.0 to 17.7.1 (**[#7172](https://github.com/lensapp/lens/pull/7172)**) https://github.com/app/dependabot
- Bump zod from 3.20.2 to 3.20.6 (**[#7169](https://github.com/lensapp/lens/pull/7169)**) https://github.com/app/dependabot
- Bump mobx from 6.7.0 to 6.8.0 (**[#7170](https://github.com/lensapp/lens/pull/7170)**) https://github.com/app/dependabot
- Bump lerna from 6.5.0 to 6.5.1 (**[#7171](https://github.com/lensapp/lens/pull/7171)**) https://github.com/app/dependabot
- Bump sass from 1.58.1 to 1.58.2 (**[#7184](https://github.com/lensapp/lens/pull/7184)**) https://github.com/app/dependabot
- Bump @types/tar from 6.1.3 to 6.1.4 (**[#7183](https://github.com/lensapp/lens/pull/7183)**) https://github.com/app/dependabot
- Bump ws from 8.12.0 to 8.12.1 (**[#7182](https://github.com/lensapp/lens/pull/7182)**) https://github.com/app/dependabot
- Bump typedoc from 0.23.24 to 0.23.25 (**[#7181](https://github.com/lensapp/lens/pull/7181)**) https://github.com/app/dependabot
- Bump @hapi/subtext from 7.0.4 to 7.1.0 (**[#7194](https://github.com/lensapp/lens/pull/7194)**) https://github.com/app/dependabot
