### PR TITLE
Fix catalog avatar font size

### DIFF
--- a/packages/core/src/renderer/components/+catalog/catalog.module.scss
+++ b/packages/core/src/renderer/components/+catalog/catalog.module.scss
@@ -127,7 +127,7 @@
 }
 
 .catalogAvatar {
-  font-size: 1.2ch;
+  font-size: 1.2ch !important;
 }
 
 .views {


### PR DESCRIPTION
Fixes #7223 

Now the font size matches the Lens 6.2.6

<img width="342" alt="image" src="https://user-images.githubusercontent.com/774344/220911615-9eea722d-7ee0-45c8-a700-bbbe38de1320.png">


I believe this is caused by some build change and the order of the classes have changed in the CSS which made the class have no effect.