### PR TITLE
Quick fix for store migration version being wrong

### DIFF
--- a/packages/core/src/common/vars/store-migration-version.injectable.ts
+++ b/packages/core/src/common/vars/store-migration-version.injectable.ts
@@ -2,12 +2,11 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import { applicationInformationToken } from "@k8slens/application";
 import { getInjectable } from "@ogre-tools/injectable";
 
 const storeMigrationVersionInjectable = getInjectable({
   id: "store-migration-version",
-  instantiate: (di) => di.inject(applicationInformationToken).version,
+  instantiate: () => "6.4.0",
 });
 
 export default storeMigrationVersionInjectable;


### PR DESCRIPTION
fixes https://github.com/lensapp/lens-ide/issues/529

Better version is in #4571, which makes the migration version specific to each store.