### PR TITLE
White-listing of telemetry params

### DIFF
--- a/packages/core/src/common/log-error.injectable.ts
+++ b/packages/core/src/common/log-error.injectable.ts
@@ -8,6 +8,7 @@ import loggerInjectable from "./logger.injectable";
 const logErrorInjectable = getInjectable({
   id: "log-error",
   instantiate: (di) => di.inject(loggerInjectable).error,
+  decorable: false,
 });
 
 export default logErrorInjectable;

--- a/packages/core/src/common/logger.injectable.ts
+++ b/packages/core/src/common/logger.injectable.ts
@@ -26,6 +26,8 @@ const loggerInjectable = getInjectable({
       silly: (message, ...data) => baseLogger.silly(message, ...data),
     };
   },
+
+  decorable: false,
 });
 
 export default loggerInjectable;

--- a/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
+++ b/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
@@ -63,14 +63,14 @@ describe("emit-telemetry-from-specific-function-calls", () => {
           di.register(
             whiteListedInjectable,
             whiteListedInjectableWithArgument,
-            nonWhiteListedInjectable
+            nonWhiteListedInjectable,
           );
         });
 
         injectedWhiteListedFunction = di.inject(whiteListedInjectable);
 
         injectedWhiteListedFunctionWithArgument = di.inject(
-          whiteListedInjectableWithArgument
+          whiteListedInjectableWithArgument,
         );
 
         injectedNonWhiteListedFunction = di.inject(nonWhiteListedInjectable);
@@ -135,7 +135,7 @@ describe("emit-telemetry-from-specific-function-calls", () => {
 
           injectedWhiteListedFunctionWithArgument(
             "irrelevant-argument",
-            someObservable
+            someObservable,
           );
         });
 

--- a/packages/core/src/features/telemetry/renderer/emit-telemetry.injectable.ts
+++ b/packages/core/src/features/telemetry/renderer/emit-telemetry.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import emitEventInjectable from "../../../common/app-event-bus/emit-event.injectable";
-import { toJS, observable } from "mobx";
+import { observable, toJS } from "mobx";
 
 const emitTelemetryInjectable = getInjectable({
   id: "emit-telemetry",
@@ -12,12 +12,12 @@ const emitTelemetryInjectable = getInjectable({
   instantiate: (di) => {
     const emitEvent = di.inject(emitEventInjectable);
 
-    return ({ action, args }: { action: string; args: any[] }) => {
+    return ({ action, params }: { action: string; params?: object }) => {
       emitEvent({
         destination: "auto-capture",
         action: "telemetry-from-business-action",
         name: action,
-        params: { args: toJS(observable(args)) },
+        ...(params ? { params: toJS(observable(params)) } : {}),
       });
     };
   },

--- a/packages/core/src/features/telemetry/renderer/telemetry-decorator.injectable.ts
+++ b/packages/core/src/features/telemetry/renderer/telemetry-decorator.injectable.ts
@@ -63,7 +63,6 @@ const telemetryDecoratorInjectable = getInjectable({
 
 const shouldEmitTelemetryFor =
   (whiteList: string[]) => (injectable: Injectable<any, any, any>) =>
-    injectable.tags?.includes("emit-telemetry") ||
     whiteList.includes(injectable.id);
 
 export default telemetryDecoratorInjectable;

--- a/packages/core/src/features/telemetry/renderer/telemetry-white-list-for-functions.injectable.ts
+++ b/packages/core/src/features/telemetry/renderer/telemetry-white-list-for-functions.injectable.ts
@@ -3,6 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
+import type { AppEvent } from "../../../common/app-event-bus/event-bus";
 
 const navigateTo = [
   "navigate-to-preference-tab-id",
@@ -88,21 +89,19 @@ const extensions = [
   "uninstall-extension",
 ];
 
-const externalActions = [
-  "open-link-in-browser",
-];
+const externalActions = ["open-link-in-browser"];
 
-const uiInteraction = [
-  "show-details",
-];
+const uiInteraction = ["show-details"];
 
-const terminal = [
-  "create-terminal-tab",
-];
+const terminal = ["create-terminal-tab"];
+
+export type WhiteListItem =
+  | string
+  | { id: string; getParams: (...args: unknown[]) => AppEvent["params"] };
 
 const telemetryWhiteListForFunctionsInjectable = getInjectable({
   id: "telemetry-white-list-for-functions",
-  instantiate: () => [
+  instantiate: (): WhiteListItem[] => [
     ...navigateTo,
     ...helmInjectableIds,
     ...kubeConfigActions,

--- a/packages/core/src/main/logger/console-transport.injectable.ts
+++ b/packages/core/src/main/logger/console-transport.injectable.ts
@@ -30,6 +30,7 @@ const consoleLoggerTransportInjectable = getInjectable({
     ),
   }),
   injectionToken: loggerTransportInjectionToken,
+  decorable: false,
 });
 
 export default consoleLoggerTransportInjectable;

--- a/packages/core/src/main/logger/file-transport.injectable.ts
+++ b/packages/core/src/main/logger/file-transport.injectable.ts
@@ -23,6 +23,7 @@ const fileLoggerTranportInjectable = getInjectable({
     tailable: true,
   }),
   injectionToken: loggerTransportInjectionToken,
+  decorable: false,
 });
 
 export default fileLoggerTranportInjectable;

--- a/packages/core/src/renderer/logger/browser-transport.injectable.ts
+++ b/packages/core/src/renderer/logger/browser-transport.injectable.ts
@@ -10,6 +10,7 @@ const browserLoggerTransportInjectable = getInjectable({
   id: "browser-logger-transport",
   instantiate: () => new BrowserConsole(),
   injectionToken: loggerTransportInjectionToken,
+  decorable: false,
 });
 
 export default browserLoggerTransportInjectable;


### PR DESCRIPTION
Motivation: make unexpected large params not eat resources.

With this, we can have white-list such as:
```typescript
const whiteList = [
  ...
  // old types of white-list items, but now not resulting in any args as params of telemetry
  "navigate-to-extensions",
  "navigate-to-cluster-view",
  "navigate-to-entity-settings",

  // new type of white-list item, now with selectable args as params of telemetry
  {
    id: "navigate-to-route",
    getParams: (route: Route<unknown>) => ({ param: route.path }),
  },
];  
```

Note: also telemetry by tagging is dropped for not being used.