### PR TITLE
UI should show resource if cluster is missing allowedResources data

### DIFF
--- a/packages/core/src/common/cluster/cluster.ts
+++ b/packages/core/src/common/cluster/cluster.ts
@@ -699,6 +699,11 @@ export class Cluster implements ClusterModel {
   }
 
   shouldShowResource(resource: KubeApiResourceDescriptor): boolean {
+    if (this.allowedResources.size === 0) {
+      // better to show than hide everything
+      return true;
+    }
+
     return this.allowedResources.has(formatKubeApiResource(resource));
   }
 


### PR DESCRIPTION
It seems the cluster allowedResources ends up being empty (because of an unknown error?) which will cause UX issue for users because they cannot see for example all Workloads menus. This PR changes the behaviour so that we always show a resource if we didn't get the allowedResources data properly.