### PR TITLE
Update release guide and fix release script

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -11,9 +11,12 @@ All releases will be made by creating a PR which bumps the version field in the 
 
 ## Steps
 
-1. If you are making a minor or major release (or prereleases for one) make sure you are on the `master` branch.
+1. If you are making a minor or major release (or prereleases of one) make sure you are on the `master` branch.
 1. If you are making a patch release (or a prerelease for one) make sure you are on the `release/v<MAJOR>.<MINOR>` branch.
-1. Run `npm run create-release-pr <release-type>`. If you are making a subsequent prerelease release, provide the `--check-commits` flag.
-1. If you are checking the commits, type `y<ENTER>` to pick a commit, and `n<ENTER>` to skip it. You will want to skip the commits that were part of previous prerelease releases.
+1. Run `npm run create-release-pr`.
+1. Pick the PRs that you want to include in this release using the keys listed.
 1. Once the PR is created, approved, and then merged the `Release Open Lens` workflow will create a tag and release for you.
 1. If you are making a major or minor release, create a `release/v<MAJOR>.<MINOR>` branch and push it to `origin` so that future patch releases can be made from it.
+1. If you released a major or minor version, create a new patch milestone and move all bug issues to that milestone and all enhancement issues to the next minor milestone.
+1. If you released a patch version, create a new patch milestone for the next patch version and move all the issues and PRs (open or closed) that weren't included in the current release to that milestone.
+1. Close the milestone related to the release that was just made (if not a prerelease release).


### PR DESCRIPTION
- Fix for release script boils down to incrementing the patch version for the milestone that we are looking for when picking PRs to use when making a non-prerelease