### PR TITLE
Configure dependabot to update all packages in monorepo

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
Currently it checks only root directory to dependencies. This PR configures to respect other packages as well.

As described in https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027