### PR TITLE
Simplify test setup by removing option for global overrides

### DIFF
--- a/packages/core/src/common/__tests__/cluster-store.test.ts
+++ b/packages/core/src/common/__tests__/cluster-store.test.ts
@@ -67,7 +67,7 @@ describe("cluster-store", () => {
   let writeFileSyncAndReturnPath: (filePath: string, contents: string) => string;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(directoryForTempInjectable, () => "/some-temp-directory");

--- a/packages/core/src/common/__tests__/create-resource-stack.test.ts
+++ b/packages/core/src/common/__tests__/create-resource-stack.test.ts
@@ -17,7 +17,7 @@ describe("create resource stack tests", () => {
   let cluster: KubernetesCluster;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     cluster = {
       getId: () => "test-cluster",
     } as any;

--- a/packages/core/src/common/__tests__/hotbar-store.test.ts
+++ b/packages/core/src/common/__tests__/hotbar-store.test.ts
@@ -43,7 +43,7 @@ describe("HotbarStore", () => {
   let loggerMock: jest.Mocked<Logger>;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     testCluster = getMockCatalogEntity({
       apiVersion: "v1",

--- a/packages/core/src/common/__tests__/user-store.test.ts
+++ b/packages/core/src/common/__tests__/user-store.test.ts
@@ -21,7 +21,7 @@ describe("user store tests", () => {
   let di: DiContainer;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(writeFileInjectable, () => () => Promise.resolve());
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");

--- a/packages/core/src/common/catalog-entities/__tests__/kubernetes-cluster.test.ts
+++ b/packages/core/src/common/catalog-entities/__tests__/kubernetes-cluster.test.ts
@@ -12,7 +12,7 @@ describe("kubernetesClusterCategory", () => {
   let kubernetesClusterCategory: KubernetesClusterCategory;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     kubernetesClusterCategory = di.inject(kubernetesClusterCategoryInjectable);
   });

--- a/packages/core/src/common/cluster/request-namespace-list-permissions.test.ts
+++ b/packages/core/src/common/cluster/request-namespace-list-permissions.test.ts
@@ -20,7 +20,7 @@ describe("requestNamespaceListPermissions", () => {
   let requestNamespaceListPermissions: RequestNamespaceListPermissionsFor;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     requestNamespaceListPermissions = di.inject(requestNamespaceListPermissionsForInjectable);
   });
 

--- a/packages/core/src/common/front-end-routing/verify-that-all-routes-have-route-component.test.ts
+++ b/packages/core/src/common/front-end-routing/verify-that-all-routes-have-route-component.test.ts
@@ -12,7 +12,7 @@ import { pipeline } from "@ogre-tools/fp";
 
 describe("verify-that-all-routes-have-component", () => {
   it("verify that routes have route component", () => {
-    const rendererDi = getDiForUnitTesting({ doGeneralOverrides: true });
+    const rendererDi = getDiForUnitTesting();
 
     rendererDi.override(clusterStoreInjectable, () => ({
       getById: () => null,

--- a/packages/core/src/common/initializable-state/create.test.ts
+++ b/packages/core/src/common/initializable-state/create.test.ts
@@ -15,7 +15,7 @@ describe("InitializableState tests", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
   });
 
   describe("when created", () => {

--- a/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
@@ -37,7 +37,7 @@ describe("ApiManager", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/common/k8s-api/__tests__/deployment.api.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/deployment.api.test.ts
@@ -15,7 +15,7 @@ describe("DeploymentApi", () => {
   let kubeJsonApi: jest.Mocked<KubeJsonApi>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
     kubeJsonApi = {

--- a/packages/core/src/common/k8s-api/__tests__/kube-api-version-detection.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-api-version-detection.test.ts
@@ -30,7 +30,7 @@ describe("KubeApi", () => {
   let di: DiContainer;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     fetchMock = asyncFn();
     di.override(fetchInjectable, () => fetchMock);

--- a/packages/core/src/common/k8s-api/__tests__/kube-api.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-api.test.ts
@@ -42,7 +42,7 @@ describe("createKubeApiForRemoteCluster", () => {
   let fetchMock: AsyncFnMock<Fetch>;
 
   beforeEach(async () => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");
@@ -145,7 +145,7 @@ describe("KubeApi", () => {
   let di: DiContainer;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/common/k8s-api/__tests__/stateful-set.api.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/stateful-set.api.test.ts
@@ -15,7 +15,7 @@ describe("StatefulSetApi", () => {
   let kubeJsonApi: jest.Mocked<KubeJsonApi>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
     kubeJsonApi = {

--- a/packages/core/src/common/utils/with-error-logging/with-error-logging.test.ts
+++ b/packages/core/src/common/utils/with-error-logging/with-error-logging.test.ts
@@ -18,7 +18,7 @@ describe("with-error-logging", () => {
     let logErrorMock: jest.Mock;
 
     beforeEach(() => {
-      const di = getDiForUnitTesting({ doGeneralOverrides: true });
+      const di = getDiForUnitTesting();
 
       logErrorMock = jest.fn();
 
@@ -116,7 +116,7 @@ describe("with-error-logging", () => {
     let logErrorMock: jest.Mock;
 
     beforeEach(() => {
-      const di = getDiForUnitTesting({ doGeneralOverrides: true });
+      const di = getDiForUnitTesting();
 
       logErrorMock = jest.fn();
 

--- a/packages/core/src/common/utils/with-orphan-promise/with-orphan-promise.test.ts
+++ b/packages/core/src/common/utils/with-orphan-promise/with-orphan-promise.test.ts
@@ -14,7 +14,7 @@ describe("with orphan promise, when called", () => {
   let logErrorMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     logErrorMock = jest.fn();
 

--- a/packages/core/src/extensions/__tests__/extension-loader.test.ts
+++ b/packages/core/src/extensions/__tests__/extension-loader.test.ts
@@ -23,7 +23,7 @@ describe("ExtensionLoader", () => {
   let updateExtensionStateMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(currentlyInClusterFrameInjectable, () => false);

--- a/packages/core/src/extensions/extension-discovery/extension-discovery.test.ts
+++ b/packages/core/src/extensions/extension-discovery/extension-discovery.test.ts
@@ -32,7 +32,7 @@ describe("ExtensionDiscovery", () => {
   let homeDirectoryPath: string;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(installExtensionInjectable, () => () => Promise.resolve());

--- a/packages/core/src/extensions/extension-loader/file-system-provisioner-store/ensure-hashed-directory-for-extension.test.ts
+++ b/packages/core/src/extensions/extension-loader/file-system-provisioner-store/ensure-hashed-directory-for-extension.test.ts
@@ -18,7 +18,7 @@ describe("ensure-hashed-directory-for-extension", () => {
   let registeredExtensions: ObservableMap<string, string>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({  doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     ensureDirMock = jest.fn();
 

--- a/packages/core/src/features/application-update/main/check-for-updates/check-for-platform-updates/check-for-platform-updates.test.ts
+++ b/packages/core/src/features/application-update/main/check-for-updates/check-for-platform-updates/check-for-platform-updates.test.ts
@@ -23,7 +23,7 @@ describe("check-for-platform-updates", () => {
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
-    di.unoverride(checkForPlatformUpdatesInjectable)
+    di.unoverride(checkForPlatformUpdatesInjectable);
 
     checkForUpdatesMock = asyncFn();
 

--- a/packages/core/src/features/application-update/main/check-for-updates/check-for-platform-updates/check-for-platform-updates.test.ts
+++ b/packages/core/src/features/application-update/main/check-for-updates/check-for-platform-updates/check-for-platform-updates.test.ts
@@ -23,6 +23,8 @@ describe("check-for-platform-updates", () => {
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
+    di.unoverride(checkForPlatformUpdatesInjectable)
+
     checkForUpdatesMock = asyncFn();
 
     electronUpdaterFake = {

--- a/packages/core/src/features/application-update/main/download-update/download-platform-update/download-platform-update.test.ts
+++ b/packages/core/src/features/application-update/main/download-update/download-platform-update/download-platform-update.test.ts
@@ -26,6 +26,8 @@ describe("download-platform-update", () => {
   beforeEach(() => {
     di = getDiForUnitTesting();
 
+    di.unoverride(downloadPlatformUpdateInjectable);
+
     downloadUpdateMock = asyncFn();
     electronUpdaterOnMock = jest.fn();
     electronUpdaterOffMock = jest.fn();

--- a/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
+++ b/packages/core/src/features/shell-sync/main/compute-unix-shell-environment.test.ts
@@ -37,9 +37,7 @@ describe("computeUnixShellEnvironment technical tests", () => {
   let unixShellEnv: ReturnType<ComputeUnixShellEnvironment>;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({
-      doGeneralOverrides: true,
-    });
+    di = getDiForUnitTesting();
 
     spawnMock = jest.fn().mockImplementation((spawnfile, spawnargs) => {
       shellStdin = new MemoryStream();

--- a/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
+++ b/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
@@ -14,7 +14,7 @@ describe("emit-telemetry-from-specific-function-calls", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
   });
 
   describe("given a telemetry white-list for injectables which instantiate a function", () => {

--- a/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
+++ b/packages/core/src/features/telemetry/emit-telemetry-from-specific-function-calls.test.ts
@@ -9,12 +9,15 @@ import { getDiForUnitTesting } from "../../renderer/getDiForUnitTesting";
 import telemetryWhiteListForFunctionsInjectable from "./renderer/telemetry-white-list-for-functions.injectable";
 import emitEventInjectable from "../../common/app-event-bus/emit-event.injectable";
 import logErrorInjectable from "../../common/log-error.injectable";
+import telemetryDecoratorInjectable from "./renderer/telemetry-decorator.injectable";
 
 describe("emit-telemetry-from-specific-function-calls", () => {
   let di: DiContainer;
 
   beforeEach(() => {
     di = getDiForUnitTesting();
+
+    di.unoverride(telemetryDecoratorInjectable);
   });
 
   describe("given a telemetry white-list for injectables which instantiate a function", () => {

--- a/packages/core/src/features/telemetry/renderer/telemetry-decorator.global-override-for-injectable.ts
+++ b/packages/core/src/features/telemetry/renderer/telemetry-decorator.global-override-for-injectable.ts
@@ -1,0 +1,7 @@
+import { identity } from "lodash/fp";
+import { getGlobalOverride } from "../../../common/test-utils/get-global-override";
+import telemetryDecoratorInjectable from "./telemetry-decorator.injectable";
+
+export default getGlobalOverride(telemetryDecoratorInjectable, () => ({
+  decorate: identity,
+}));

--- a/packages/core/src/features/telemetry/renderer/telemetry-decorator.global-override-for-injectable.ts
+++ b/packages/core/src/features/telemetry/renderer/telemetry-decorator.global-override-for-injectable.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
 import { identity } from "lodash/fp";
 import { getGlobalOverride } from "../../../common/test-utils/get-global-override";
 import telemetryDecoratorInjectable from "./telemetry-decorator.injectable";

--- a/packages/core/src/main/__test__/cluster.test.ts
+++ b/packages/core/src/main/__test__/cluster.test.ts
@@ -31,7 +31,7 @@ describe("create clusters", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
     const clusterServerUrl = "https://192.168.64.3:8443";
 
     di.override(directoryForUserDataInjectable, () => "some-directory-for-user-data");

--- a/packages/core/src/main/__test__/context-handler.test.ts
+++ b/packages/core/src/main/__test__/context-handler.test.ts
@@ -53,7 +53,7 @@ describe("ContextHandler", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     di.override(createKubeAuthProxyInjectable, () => ({} as any));
 
     createContextHandler = di.inject(createContextHandlerInjectable);

--- a/packages/core/src/main/__test__/kube-auth-proxy.test.ts
+++ b/packages/core/src/main/__test__/kube-auth-proxy.test.ts
@@ -39,7 +39,7 @@ describe("kube auth proxy tests", () => {
   let getBasenameOfPath: GetBasenameOfPath;
 
   beforeEach(async () => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(directoryForTempInjectable, () => "/some-directory-for-temp");

--- a/packages/core/src/main/__test__/kubeconfig-manager.test.ts
+++ b/packages/core/src/main/__test__/kubeconfig-manager.test.ts
@@ -46,7 +46,7 @@ describe("kubeconfig manager tests", () => {
   let ensureServerMock: AsyncFnMock<() => Promise<void>>;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForTempInjectable, () => "/some-directory-for-temp");
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");

--- a/packages/core/src/main/__test__/static-file-route.test.ts
+++ b/packages/core/src/main/__test__/static-file-route.test.ts
@@ -11,7 +11,7 @@ describe("static-file-route", () => {
   let handleStaticFileRoute: Route<Buffer, "/{path*}">;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     handleStaticFileRoute = di.inject(staticFileRouteInjectable);
   });

--- a/packages/core/src/main/app-paths/get-electron-app-path/get-electron-app-path.test.ts
+++ b/packages/core/src/main/app-paths/get-electron-app-path/get-electron-app-path.test.ts
@@ -11,7 +11,7 @@ describe("get-electron-app-path", () => {
   let getElectronAppPath: (name: string) => string;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: false });
+    const di = getDiForUnitTesting();
 
     const appStub = {
       name: "some-app-name",

--- a/packages/core/src/main/app-paths/get-electron-app-path/get-electron-app-path.test.ts
+++ b/packages/core/src/main/app-paths/get-electron-app-path/get-electron-app-path.test.ts
@@ -13,6 +13,8 @@ describe("get-electron-app-path", () => {
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
+    di.unoverride(getElectronAppPathInjectable);
+
     const appStub = {
       name: "some-app-name",
 

--- a/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
+++ b/packages/core/src/main/catalog-sources/__test__/kubeconfig-sync.test.ts
@@ -43,7 +43,7 @@ describe("kubeconfig-sync.source tests", () => {
   let di: DiContainer;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(directoryForTempInjectable, () => "/some-directory-for-temp");

--- a/packages/core/src/main/catalog/__tests__/catalog-entity-registry.test.ts
+++ b/packages/core/src/main/catalog/__tests__/catalog-entity-registry.test.ts
@@ -65,7 +65,7 @@ describe("CatalogEntityRegistry", () => {
   });
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     entityRegistry = di.inject(catalogEntityRegistryInjectable);
   });

--- a/packages/core/src/main/cluster-detectors/detect-cluster-metadata.test.ts
+++ b/packages/core/src/main/cluster-detectors/detect-cluster-metadata.test.ts
@@ -24,7 +24,7 @@ describe("detect-cluster-metadata", () => {
   let cluster: Cluster;
 
   beforeEach(async () => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     const lastSeenDetectMock = jest.fn().mockReturnValue(Promise.resolve({ value: "some-time-stamp", accuracy: 100 }));
     const nodeCountDetectMock = jest.fn().mockReturnValue(Promise.resolve({ value: 42, accuracy: 100 }));

--- a/packages/core/src/main/helm/__tests__/helm-service.test.ts
+++ b/packages/core/src/main/helm/__tests__/helm-service.test.ts
@@ -16,7 +16,7 @@ describe("Helm Service tests", () => {
   let getActiveHelmRepositoriesMock: jest.Mock<Promise<AsyncResult<HelmRepo[]>>>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     getActiveHelmRepositoriesMock = jest.fn();
 

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/call-for-kube-resources-by-manifest/exec-file-with-input/exec-file-with-input.test.ts
@@ -21,7 +21,7 @@ describe("exec-file-with-input", () => {
   };
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.unoverride(execFileWithInputInjectable);
 

--- a/packages/core/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
+++ b/packages/core/src/main/helm/helm-service/get-helm-release-resources/get-helm-release-resources.test.ts
@@ -21,7 +21,7 @@ describe("get helm release resources", () => {
   let execFileWithStreamInputMock: AsyncFnMock<ExecFileWithInput>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     execHelmMock = asyncFn();
     execFileWithStreamInputMock = asyncFn();

--- a/packages/core/src/main/protocol-handler/__test__/router.test.ts
+++ b/packages/core/src/main/protocol-handler/__test__/router.test.ts
@@ -37,7 +37,7 @@ describe("protocol router tests", () => {
   let broadcastMessageMock: jest.Mock;
 
   beforeEach(async () => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(pathExistsInjectable, () => () => { throw new Error("tried call pathExists without override"); });
     di.override(pathExistsSyncInjectable, () => () => { throw new Error("tried call pathExistsSync without override"); });

--- a/packages/core/src/main/router/router.test.ts
+++ b/packages/core/src/main/router/router.test.ts
@@ -28,7 +28,7 @@ describe("router", () => {
   beforeEach(async () => {
     routeHandlerMock = asyncFn();
 
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(parseRequestInjectable, () => () => Promise.resolve({
       payload: "some-payload",

--- a/packages/core/src/main/shell-session/local-shell-session/techincal.test.ts
+++ b/packages/core/src/main/shell-session/local-shell-session/techincal.test.ts
@@ -26,9 +26,7 @@ describe("technical unit tests for local shell sessions", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({
-      doGeneralOverrides: true,
-    });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
     di.override(buildVersionInjectable, () => ({

--- a/packages/core/src/main/utils/channel/channel-listeners/enlist-message-channel-listener.test.ts
+++ b/packages/core/src/main/utils/channel/channel-listeners/enlist-message-channel-listener.test.ts
@@ -15,7 +15,7 @@ describe("enlist message channel listener in main", () => {
   let offMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     onMock = jest.fn();
     offMock = jest.fn();

--- a/packages/core/src/main/utils/channel/channel-listeners/enlist-request-channel-listener.test.ts
+++ b/packages/core/src/main/utils/channel/channel-listeners/enlist-request-channel-listener.test.ts
@@ -26,7 +26,7 @@ describe("enlist request channel listener in main", () => {
   let offMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     handleMock = jest.fn();
     offMock = jest.fn();

--- a/packages/core/src/main/utils/channel/message-to-channel.test.ts
+++ b/packages/core/src/main/utils/channel/message-to-channel.test.ts
@@ -15,7 +15,7 @@ describe("message-to-channel", () => {
   let sendToWindowMock: jest.Mock;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     sendToWindowMock = jest.fn();
 

--- a/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.test.ts
+++ b/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.test.ts
@@ -20,7 +20,7 @@ describe("technical: resolve-system-proxy-from-electron", () => {
   let actualPromise: Promise<string>;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     logErrorMock = jest.fn();
     di.override(logErrorInjectable, () => logErrorMock);

--- a/packages/core/src/renderer/api/__tests__/catalog-entity-registry.test.ts
+++ b/packages/core/src/renderer/api/__tests__/catalog-entity-registry.test.ts
@@ -80,7 +80,7 @@ describe("CatalogEntityRegistry", () => {
   let catalogCategoryRegistry: CatalogCategoryRegistry;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     entityRegistry = di.inject(catalogEntityRegistryInjectable);
     catalogCategoryRegistry = di.inject(catalogCategoryRegistryInjectable);

--- a/packages/core/src/renderer/api/__tests__/websocket-api.test.ts
+++ b/packages/core/src/renderer/api/__tests__/websocket-api.test.ts
@@ -18,7 +18,7 @@ describe("WebsocketApi tests", () => {
   let api: TestWebSocketApi;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     api = new TestWebSocketApi({
       defaultParams: di.inject(defaultWebsocketApiParamsInjectable),

--- a/packages/core/src/renderer/components/+catalog/__tests__/catalog-add-button.test.tsx
+++ b/packages/core/src/renderer/components/+catalog/__tests__/catalog-add-button.test.tsx
@@ -31,7 +31,7 @@ describe("CatalogAddButton", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/+catalog/__tests__/catalog-entity-store.test.ts
+++ b/packages/core/src/renderer/components/+catalog/__tests__/catalog-entity-store.test.ts
@@ -70,7 +70,7 @@ describe("CatalogEntityStore", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
   });
 
   describe("getTotalCount", () => {

--- a/packages/core/src/renderer/components/+catalog/__tests__/custom-columns.test.ts
+++ b/packages/core/src/renderer/components/+catalog/__tests__/custom-columns.test.ts
@@ -44,7 +44,7 @@ describe("Custom Category Columns", () => {
   let getCategoryColumns: (params: GetCategoryColumnsParams) => CategoryColumns;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(hotbarStoreInjectable, () => ({}));
     di.override(currentlyInClusterFrameInjectable, () => false);

--- a/packages/core/src/renderer/components/+catalog/__tests__/custom-views.test.ts
+++ b/packages/core/src/renderer/components/+catalog/__tests__/custom-views.test.ts
@@ -16,7 +16,7 @@ describe("Custom Category Views", () => {
   let di: DiContainer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
   });
 
   it("should order items correctly over all extensions", () => {

--- a/packages/core/src/renderer/components/+config-horizontal-pod-autoscalers/hpa-details.test.tsx
+++ b/packages/core/src/renderer/components/+config-horizontal-pod-autoscalers/hpa-details.test.tsx
@@ -39,7 +39,7 @@ describe("<HpaDetails/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/+config-secrets/__tests__/secret-details.test.tsx
+++ b/packages/core/src/renderer/components/+config-secrets/__tests__/secret-details.test.tsx
@@ -20,7 +20,7 @@ jest.mock("../../kube-object-meta/kube-object-meta", () => ({
 
 describe("SecretDetails tests", () => {
   it("should show the visibility toggle when the secret value is ''", () => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
     const render = renderFor(di);
 
     di.override(directoryForUserDataInjectable, () => "/some-user-data");

--- a/packages/core/src/renderer/components/+custom-resources/__tests__/custom-resource-details.test.tsx
+++ b/packages/core/src/renderer/components/+custom-resources/__tests__/custom-resource-details.test.tsx
@@ -15,7 +15,7 @@ describe("<CustomResourceDetails />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/+extensions/__tests__/extensions.test.tsx
+++ b/packages/core/src/renderer/components/+extensions/__tests__/extensions.test.tsx
@@ -39,7 +39,7 @@ describe("Extensions", () => {
   let downloadBinary: jest.MockedFunction<DownloadBinary>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "some-directory-for-user-data");
     di.override(directoryForDownloadsInjectable, () => "some-directory-for-downloads");

--- a/packages/core/src/renderer/components/+namespaces/namespace-select-filter.test.tsx
+++ b/packages/core/src/renderer/components/+namespaces/namespace-select-filter.test.tsx
@@ -48,7 +48,7 @@ describe("<NamespaceSelectFilter />", () => {
   let cleanup: Disposer;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     di.unoverride(subscribeStoresInjectable);
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");

--- a/packages/core/src/renderer/components/+namespaces/namespace-store.test.ts
+++ b/packages/core/src/renderer/components/+namespaces/namespace-store.test.ts
@@ -105,7 +105,7 @@ describe("NamespaceStore", () => {
   let namespaceStore: NamespaceStore;
 
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/+namespaces/namespace-tree-view.test.tsx
+++ b/packages/core/src/renderer/components/+namespaces/namespace-tree-view.test.tsx
@@ -106,7 +106,7 @@ describe("<NamespaceTreeView />", () => {
   let render: DiRender;
   
   beforeEach(async () => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(hierarchicalNamespacesInjectable, () => [
       acmeGroup,

--- a/packages/core/src/renderer/components/+network-policies/__tests__/network-policy-details.test.tsx
+++ b/packages/core/src/renderer/components/+network-policies/__tests__/network-policy-details.test.tsx
@@ -15,7 +15,7 @@ describe("NetworkPolicyDetails", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/+user-management/+cluster-role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/+user-management/+cluster-role-bindings/__tests__/dialog.test.tsx
@@ -27,7 +27,7 @@ describe("ClusterRoleBindingDialog tests", () => {
   let openClusterRoleBindingDialog: OpenClusterRoleBindingDialog;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/+user-management/+role-bindings/__tests__/dialog.test.tsx
+++ b/packages/core/src/renderer/components/+user-management/+role-bindings/__tests__/dialog.test.tsx
@@ -24,7 +24,7 @@ describe("RoleBindingDialog tests", () => {
   let openRoleBindingDialog: OpenRoleBindingDialog;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/+welcome/__test__/welcome.test.tsx
+++ b/packages/core/src/renderer/components/+welcome/__test__/welcome.test.tsx
@@ -23,7 +23,7 @@ describe("<Welcome/>", () => {
   let welcomeBannersStub: WelcomeBannerRegistration[];
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(currentlyInClusterFrameInjectable, () => false);
 

--- a/packages/core/src/renderer/components/+workloads-deployments/scale/dialog.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-deployments/scale/dialog.test.tsx
@@ -88,7 +88,7 @@ describe("<DeploymentScaleDialog />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
 

--- a/packages/core/src/renderer/components/+workloads-pods/__tests__/pod-container-env.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-pods/__tests__/pod-container-env.test.tsx
@@ -21,7 +21,7 @@ describe("<ContainerEnv />", () => {
   let configMapStore: jest.Mocked<Pick<ConfigMapStore, "load" | "getByName">>;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     secretStore = ({
       load: jest.fn().mockImplementation(async () => {

--- a/packages/core/src/renderer/components/+workloads-pods/__tests__/pod-tolerations.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-pods/__tests__/pod-tolerations.test.tsx
@@ -32,7 +32,7 @@ describe("<PodTolerations />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForLensLocalStorageInjectable, () => "some-directory-for-lens-local-storage" );
 

--- a/packages/core/src/renderer/components/+workloads-pods/details/volumes/variants/__tests__/ceph-fs.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-pods/details/volumes/variants/__tests__/ceph-fs.test.tsx
@@ -16,7 +16,7 @@ describe("<CephFs />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
 

--- a/packages/core/src/renderer/components/+workloads-replicasets/scale-dialog/dialog.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-replicasets/scale-dialog/dialog.test.tsx
@@ -81,7 +81,7 @@ describe("<ReplicaSetScaleDialog />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
 

--- a/packages/core/src/renderer/components/+workloads-statefulsets/scale/dialog.test.tsx
+++ b/packages/core/src/renderer/components/+workloads-statefulsets/scale/dialog.test.tsx
@@ -92,7 +92,7 @@ describe("<StatefulSetScaleDialog />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
 

--- a/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/cronjob.store.test.ts
@@ -121,7 +121,7 @@ describe("CronJob Store tests", () => {
   let cronJobStore: CronJobStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/daemonset.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/daemonset.store.test.ts
@@ -138,7 +138,7 @@ describe("DaemonSet Store tests", () => {
   let daemonSetStore: DaemonSetStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/deployments.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/deployments.store.test.ts
@@ -210,7 +210,7 @@ describe("Deployment Store tests", () => {
   let deploymentStore: DeploymentStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/job.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/job.store.test.ts
@@ -175,7 +175,7 @@ describe("Job Store tests", () => {
   let jobStore: JobStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/pods.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/pods.store.test.ts
@@ -121,7 +121,7 @@ describe("Pod Store tests", () => {
   let podStore: PodStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/replicaset.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/replicaset.store.test.ts
@@ -138,7 +138,7 @@ describe("ReplicaSet Store tests", () => {
   let replicaSetStore: ReplicaSetStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/__tests__/statefulset.store.test.ts
+++ b/packages/core/src/renderer/components/__tests__/statefulset.store.test.ts
@@ -138,7 +138,7 @@ describe("StatefulSet Store tests", () => {
   let statefulSetStore: StatefulSetStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/core/src/renderer/components/avatar/__tests__/avatar.test.tsx
@@ -14,7 +14,7 @@ describe("<Avatar/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/__tests__/cluster-local-terminal-settings.test.tsx
@@ -21,7 +21,7 @@ describe("ClusterLocalTerminalSettings", () => {
   let statMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     showErrorNotificationMock = jest.fn();
 

--- a/packages/core/src/renderer/components/dock/__test__/dock-store.test.ts
+++ b/packages/core/src/renderer/components/dock/__test__/dock-store.test.ts
@@ -22,7 +22,7 @@ describe("DockStore", () => {
   let dockStore: DockStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(hostedClusterIdInjectable, () => "some-cluster-id");
     di.override(directoryForUserDataInjectable, () => "some-directory-for-user-data");

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-resource-selector.test.tsx
@@ -107,7 +107,7 @@ describe("<LogResourceSelector />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     const { ensureDirSync } = di.inject(fsInjectable);
 

--- a/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/log-search.test.tsx
@@ -63,7 +63,7 @@ describe("LogSearch tests", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
+++ b/packages/core/src/renderer/components/dock/logs/__test__/to-bottom.test.tsx
@@ -15,7 +15,7 @@ describe("<ToBottom/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/drawer/drawer-param-toggler.test.tsx
+++ b/packages/core/src/renderer/components/drawer/drawer-param-toggler.test.tsx
@@ -14,7 +14,7 @@ describe("<DrawerParamToggler />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
     result = render((

--- a/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
+++ b/packages/core/src/renderer/components/hotbar/__tests__/hotbar-remove-command.test.tsx
@@ -30,7 +30,7 @@ describe("<HotbarRemoveCommand />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(storesAndApisCanBeCreatedInjectable, () => true);
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");

--- a/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-list-layout/kube-object-list-layout.test.tsx
@@ -28,7 +28,7 @@ describe("kube-object-list-layout", () => {
   let podStore: PodStore;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-user-store-path");
     di.override(directoryForKubeConfigsInjectable, () => "/some-kube-configs");

--- a/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
+++ b/packages/core/src/renderer/components/kube-object-menu/kube-object-menu.test.tsx
@@ -32,7 +32,7 @@ describe("kube-object-menu", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     runInAction(() => {
       di.register(

--- a/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
+++ b/packages/core/src/renderer/components/layout/__tests__/sidebar-cluster.test.tsx
@@ -34,7 +34,7 @@ describe("<SidebarCluster/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(hotbarStoreInjectable, () => ({
       isAddedToActive: () => {},

--- a/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
+++ b/packages/core/src/renderer/components/layout/top-bar/top-bar.test.tsx
@@ -34,7 +34,7 @@ describe("<TopBar/>", () => {
   let toggleMaximizeWindow: jest.MockedFunction<() => void>;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
 
     di.override(rendererExtensionsInjectable, () => computed(() => []));
     di.override(openAppContextMenuInjectable, () => openAppContextMenu = jest.fn());

--- a/packages/core/src/renderer/components/monaco-editor/get-editor-height-from-lines-number.test.ts
+++ b/packages/core/src/renderer/components/monaco-editor/get-editor-height-from-lines-number.test.ts
@@ -12,6 +12,8 @@ describe("get-editor-height-from-lines-number", () => {
   beforeEach(() => {
     const di = getDiForUnitTesting();
 
+    di.unoverride(getEditorHeightFromLinesCountInjectable);
+
     getEditorHeightFromLinesNumber = di.inject(getEditorHeightFromLinesCountInjectable);
   });
 

--- a/packages/core/src/renderer/components/monaco-editor/get-editor-height-from-lines-number.test.ts
+++ b/packages/core/src/renderer/components/monaco-editor/get-editor-height-from-lines-number.test.ts
@@ -10,7 +10,7 @@ describe("get-editor-height-from-lines-number", () => {
   let getEditorHeightFromLinesNumber: (linesCount: number) => number;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: false });
+    const di = getDiForUnitTesting();
 
     getEditorHeightFromLinesNumber = di.inject(getEditorHeightFromLinesCountInjectable);
   });

--- a/packages/core/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
+++ b/packages/core/src/renderer/components/render-delay/__tests__/render-delay.test.tsx
@@ -17,7 +17,7 @@ describe("<RenderDelay/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
 

--- a/packages/core/src/renderer/components/scroll-spy/__tests__/scroll-spy.test.tsx
+++ b/packages/core/src/renderer/components/scroll-spy/__tests__/scroll-spy.test.tsx
@@ -25,7 +25,7 @@ describe("<ScrollSpy/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });
@@ -107,7 +107,7 @@ describe("<TreeView/> dataTree inside <ScrollSpy/>", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     render = renderFor(di);
   });

--- a/packages/core/src/renderer/components/select/select.test.tsx
+++ b/packages/core/src/renderer/components/select/select.test.tsx
@@ -20,7 +20,7 @@ describe("<Select />", () => {
   let render: DiRender;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     render = renderFor(di);
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");

--- a/packages/core/src/renderer/components/test-utils/get-application-builder.tsx
+++ b/packages/core/src/renderer/components/test-utils/get-application-builder.tsx
@@ -168,9 +168,7 @@ interface Environment {
 }
 
 export const getApplicationBuilder = () => {
-  const mainDi = getMainDi({
-    doGeneralOverrides: true,
-  });
+  const mainDi = getMainDi();
 
   runInAction(() => {
     registerFeature(
@@ -236,7 +234,7 @@ export const getApplicationBuilder = () => {
   const createElectronWindowFake: CreateElectronWindow = (configuration) => {
     const windowId = configuration.id;
 
-    const windowDi = getRendererDi({ doGeneralOverrides: true });
+    const windowDi = getRendererDi();
 
     overrideForWindow(windowDi, windowId);
     overrideFsWithFakes(windowDi);

--- a/packages/core/src/renderer/frames/cluster-frame/cluster-frame.test.tsx
+++ b/packages/core/src/renderer/frames/cluster-frame/cluster-frame.test.tsx
@@ -32,7 +32,7 @@ describe("<ClusterFrame />", () => {
   let cluster: Cluster;
 
   beforeEach(() => {
-    di = getDiForUnitTesting({ doGeneralOverrides: true });
+    di = getDiForUnitTesting();
     render = () => testingLibraryRender((
       <DiContextProvider value={{ di }}>
         <Router history={di.inject(historyInjectable)}>

--- a/packages/core/src/renderer/getDiForUnitTesting.tsx
+++ b/packages/core/src/renderer/getDiForUnitTesting.tsx
@@ -24,11 +24,7 @@ import {
 } from "@ogre-tools/injectable-extension-for-mobx";
 import { registerInjectableReact } from "@ogre-tools/injectable-react";
 
-export const getDiForUnitTesting = (
-  opts: { doGeneralOverrides?: boolean } = {},
-) => {
-  const { doGeneralOverrides = false } = opts;
-
+export const getDiForUnitTesting = () => {
   const environment = "renderer";
   const di = createContainer(environment);
 
@@ -49,34 +45,32 @@ export const getDiForUnitTesting = (
     }
   });
 
-  if (doGeneralOverrides) {
-    for (const globalOverridePath of global.injectablePaths.renderer.globalOverridePaths) {
-      const globalOverride = require(globalOverridePath).default as GlobalOverride;
+  for (const globalOverridePath of global.injectablePaths.renderer.globalOverridePaths) {
+    const globalOverride = require(globalOverridePath).default as GlobalOverride;
 
-      di.override(globalOverride.injectable, globalOverride.overridingInstantiate);
-    }
-
-    [
-      startTopbarStateSyncInjectable,
-    ].forEach((injectable) => {
-      di.override(injectable, () => ({
-        id: injectable.id,
-        run: () => {},
-      }));
-    });
-
-    di.override(terminalSpawningPoolInjectable, () => document.createElement("div"));
-    di.override(hostedClusterIdInjectable, () => undefined);
-
-    di.override(legacyOnChannelListenInjectable, () => () => noop);
-
-    di.override(requestAnimationFrameInjectable, () => (callback) => callback());
-    di.override(watchHistoryStateInjectable, () => () => () => {});
-
-    di.override(requestFromChannelInjectable, () => () => Promise.resolve(undefined as never));
-
-    getOverrideFsWithFakes()(di);
+    di.override(globalOverride.injectable, globalOverride.overridingInstantiate);
   }
+
+  [
+    startTopbarStateSyncInjectable,
+  ].forEach((injectable) => {
+    di.override(injectable, () => ({
+      id: injectable.id,
+      run: () => {},
+    }));
+  });
+
+  di.override(terminalSpawningPoolInjectable, () => document.createElement("div"));
+  di.override(hostedClusterIdInjectable, () => undefined);
+
+  di.override(legacyOnChannelListenInjectable, () => () => noop);
+
+  di.override(requestAnimationFrameInjectable, () => (callback) => callback());
+  di.override(watchHistoryStateInjectable, () => () => () => {});
+
+  di.override(requestFromChannelInjectable, () => () => Promise.resolve(undefined as never));
+
+  getOverrideFsWithFakes()(di);
 
   return di;
 };

--- a/packages/core/src/renderer/search-store/search-store.test.ts
+++ b/packages/core/src/renderer/search-store/search-store.test.ts
@@ -18,7 +18,7 @@ describe("search store tests", () => {
   let searchStore: SearchStore;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     di.override(directoryForUserDataInjectable, () => "/some-directory-for-user-data");
 

--- a/packages/core/src/renderer/utils/__tests__/storage-helper.test.ts
+++ b/packages/core/src/renderer/utils/__tests__/storage-helper.test.ts
@@ -20,7 +20,7 @@ describe("renderer/utils/StorageHelper", () => {
   let createStorageHelper: CreateStorageHelper;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     createStorageHelper = di.inject(createStorageHelperInjectable);
   });

--- a/packages/core/src/renderer/utils/channel/channel-listeners/enlist-message-channel-listener.test.ts
+++ b/packages/core/src/renderer/utils/channel/channel-listeners/enlist-message-channel-listener.test.ts
@@ -15,7 +15,7 @@ describe("enlist message channel listener in renderer", () => {
   let offMock: jest.Mock;
 
   beforeEach(() => {
-    const di = getDiForUnitTesting({ doGeneralOverrides: true });
+    const di = getDiForUnitTesting();
 
     onMock = jest.fn();
     offMock = jest.fn();


### PR DESCRIPTION
Motivation is to negate overly complex part of test setup, remove duplication and optimize test performance.