### PR TITLE
Navigate to catalog explicitly on cluster disconnect

### DIFF
--- a/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
@@ -127,7 +127,13 @@ export class KubernetesCluster<
         context.menuItems.push({
           title: "Disconnect",
           icon: "link_off",
-          onClick: () => requestClusterDisconnection(this.getId()),
+          onClick: () => {
+            requestClusterDisconnection(this.getId());
+            broadcastMessage(
+              IpcRendererNavigationEvents.NAVIGATE_IN_APP,
+              "/catalog",
+            )
+          },
         });
         break;
       case LensKubernetesClusterStatus.DISCONNECTED:

--- a/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
+++ b/packages/core/src/common/catalog-entities/kubernetes-cluster.ts
@@ -132,7 +132,7 @@ export class KubernetesCluster<
             broadcastMessage(
               IpcRendererNavigationEvents.NAVIGATE_IN_APP,
               "/catalog",
-            )
+            );
           },
         });
         break;

--- a/packages/core/src/renderer/components/cluster-manager/cluster-view.tsx
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-view.tsx
@@ -69,7 +69,11 @@ class NonInjectedClusterView extends React.Component<Dependencies> {
     disposeOnUnmount(this, [
       reaction(() => this.clusterId, async (clusterId) => {
         // TODO: replace with better handling
-        if (clusterId && !this.props.entityRegistry.getById(clusterId)) {
+        if (!this.clusterId) {
+          return;
+        }
+
+        if (!this.props.entityRegistry.getById(clusterId)) {
           return this.props.navigateToCatalog(); // redirect to catalog when the clusterId does not correspond to an entity
         }
 
@@ -79,12 +83,6 @@ class NonInjectedClusterView extends React.Component<Dependencies> {
         this.props.entityRegistry.activeEntity = clusterId;
       }, {
         fireImmediately: true,
-      }),
-
-      reaction(() => [this.cluster?.ready, this.cluster?.disconnected], ([, disconnected]) => {
-        if (this.isViewLoaded.get() && disconnected) {
-          this.props.navigateToCatalog(); // redirect to catalog when active cluster get disconnected/not available
-        }
       }),
     ]);
   }


### PR DESCRIPTION
Fixes #6800 

There is a race condition which prevents navigating to catalog after cluster disconnect.

### The race condition
For some reason `when` autorun in `cluster-frame-handler.ts` triggers before `reaction` in `cluster-view.tsx` **if user goes to `Settings` page before cluster disconnect**.

Cluster frame handler https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/cluster-manager/cluster-frame-handler.ts#L78
Cluster view https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/cluster-manager/cluster-view.tsx#L84

### Solution
Navigating to catalog explicitly from kubernetes cluster menu.


https://user-images.githubusercontent.com/9607060/223437969-78306eea-95b9-44a2-9679-9454875cfa1a.mov


