### PR TITLE
Exporting ResourceMetrics and PodCharts to extension API

### DIFF
--- a/packages/core/src/extensions/renderer-api/components.ts
+++ b/packages/core/src/extensions/renderer-api/components.ts
@@ -106,6 +106,8 @@ export {
   type MonacoEditorProps, type MonacoEditorId,
   type MonacoTheme, type MonacoCustomTheme,
 } from "../../renderer/components/monaco-editor";
+export * from "../../renderer/components/resource-metrics/resource-metrics";
+export * from "../../renderer/components/+workloads-pods/pod-charts";
 
 /**
  * @deprecated Use `Renderer.Navigation.getDetailsUrl`


### PR DESCRIPTION
Resolves #7305 

<img width="892" alt="using resouce metrics" src="https://user-images.githubusercontent.com/9607060/224034984-a252d7c4-492d-4489-9973-ebf7d328da8b.png">

`<ResourceMetrics>` now can be used in extensions like so:

```
const pod = new Renderer.K8sApi.Pod({
  apiVersion: "v1",
  kind: "Pod",
  metadata: {
    uid: "1",
    name: "test",
    resourceVersion: "v1",
    namespace: "default",
    selfLink: "/api/v1/pods/default/test",
  },
  spec: {
    containers: [],
    initContainers: [],
    serviceAccount: "dummy",
    serviceAccountName: "dummy",
  },
  status: {
    phase: "Running",
    conditions: [],
    hostIP: "10.0.0.1",
    podIP: "10.0.0.1",
    startTime: "now",
    containerStatuses: [],
    initContainerStatuses: [],
  },
});

const metrics = {
  cpuUsage: {
    status: "ok",
    data: {
      resultType: "unknown",
      result: [{
        metric: {
          instance: "worker",
          node: "worker",
          pod: "test",
          kubernetes: "k8s",
          kubernetes_node: "worker",
          kubernetes_namespace: "default",
        },
        values: [
          [1678367099, "0"],
          [1678367159, "10"],
          [1678367219, "20"],
          [1678367279, "30"],
          [1678367339, "40"]
        ] as [number, string][],
      }]
    },
  },
  memoryUsage: {
    ...
  }
  ...
}

<Renderer.Component.ResourceMetrics
  tabs={[
    "CPU",
    "Memory",
    "Network",
    "Filesystem",
  ]}
  object={pod}
  metrics={metrics}
>
  <Renderer.Component.PodCharts/>
</Renderer.Component.ResourceMetrics>
```

**Note**. If used with `<PodCharts/>` it is required to provide whole pod metrics since `PodCharts` uses such form to retrieve them:

```
const {
  cpuUsage,
  memoryUsage,
  fsUsage,
  fsWrites,
  fsReads,
  networkReceive,
  networkTransmit,
} = mapValues(metrics, metric => normalizeMetrics(metric).data.result[0].values);
```

If there is a need to show different kind of metrics, similar to `PodCharts` component should be created. Please look at following links as a reference:

* PodCharts https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/%2Bworkloads-pods/pod-charts.tsx
* IngressCharts https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/%2Bnetwork-ingresses/ingress-charts.tsx
* https://github.com/lensapp/lens/blob/master/packages/core/src/renderer/components/%2Bnodes/node-charts.tsx