### PR TITLE
Fix update button being visible when download for update fails

### DIFF
--- a/packages/core/src/features/application-update/__snapshots__/installing-update.test.ts.snap
+++ b/packages/core/src/features/application-update/__snapshots__/installing-update.test.ts.snap
@@ -919,6 +919,601 @@ exports[`installing update when started when user checks for updates when new up
             </i>
           </div>
           <div
+            class="separator"
+          />
+        </div>
+      </div>
+      <main>
+        <div
+          id="lens-views"
+        />
+        <div
+          class="flex justify-center Welcome align-center"
+          data-testid="welcome-page"
+        >
+          <div
+            data-testid="welcome-banner-container"
+            style="width: 320px;"
+          >
+            <i
+              class="Icon logo svg focusable"
+            >
+              <span
+                class="icon"
+              />
+            </i>
+            <div
+              class="flex justify-center"
+            >
+              <div
+                data-testid="welcome-text-container"
+                style="width: 320px;"
+              >
+                <h2>
+                  Welcome to some-product-name!
+                </h2>
+                <p>
+                  To get you started we have auto-detected your clusters in your
+                   
+                  kubeconfig file and added them to the catalog, your centralized
+                   
+                  view for managing all your cloud-native resources.
+                  <br />
+                  <br />
+                  If you have any questions or feedback, please join our 
+                  <a
+                    class="link"
+                    href="https://forums.k8slens.dev"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Lens Forums
+                  </a>
+                  .
+                </p>
+                <ul
+                  class="block"
+                  data-testid="welcome-menu-container"
+                  style="width: 320px;"
+                >
+                  <li
+                    class="flex grid-12"
+                  >
+                    <i
+                      class="Icon box col-1 material focusable"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="view_list"
+                      >
+                        view_list
+                      </span>
+                    </i>
+                    <a
+                      class="box col-10"
+                    >
+                      Browse Clusters in Catalog
+                    </a>
+                    <i
+                      class="Icon box col-1 material focusable"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="navigate_next"
+                      >
+                        navigate_next
+                      </span>
+                    </i>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <div
+        class="HotbarMenu flex column"
+      >
+        <div
+          class="HotbarItems flex column gaps"
+        >
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="0"
+          >
+            <div
+              style="z-index: 12; position: absolute;"
+            >
+              <div
+                class="HotbarIcon contextMenuAvailable"
+              >
+                <div
+                  class="Avatar rounded disabled avatar"
+                  id="hotbarIcon-hotbar-icon-catalog-entity"
+                  style="width: 40px; height: 40px; background: rgb(5, 1, 130);"
+                >
+                  Ca
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="1"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="2"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="3"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="4"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="5"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="6"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="7"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="8"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="9"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="10"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="11"
+          />
+        </div>
+        <div
+          class="HotbarSelector"
+        >
+          <i
+            class="Icon Icon previous material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="arrow_left"
+            >
+              arrow_left
+            </span>
+          </i>
+          <div
+            class="HotbarIndex"
+          >
+            <div
+              class="badge Badge small clickable"
+              id="hotbarIndex"
+            >
+              1
+            </div>
+          </div>
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="arrow_right"
+            >
+              arrow_right
+            </span>
+          </i>
+        </div>
+      </div>
+      <div
+        class="StatusBar"
+        data-testid="status-bar"
+      >
+        <div
+          class="leftSide"
+          data-testid="status-bar-left"
+        />
+        <div
+          class="rightSide"
+          data-testid="status-bar-right"
+        />
+      </div>
+    </div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+  </div>
+</body>
+`;
+
+exports[`installing update when started when user checks for updates when new update is discovered when download succeeds given checking for updates again when check resolves with different update that was previously downloaded when download resolves successfully renders 1`] = `
+<body>
+  <div>
+    <div
+      class="ClusterManager"
+    >
+      <div
+        class="topBar"
+      >
+        <div
+          class="items"
+        >
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="home-button"
+            >
+              <span
+                class="icon"
+                data-icon-name="home"
+              >
+                home
+              </span>
+            </i>
+          </div>
+          <div
+            class="size-sm"
+          />
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="history-back"
+            >
+              <span
+                class="icon"
+                data-icon-name="arrow_back"
+              >
+                arrow_back
+              </span>
+            </i>
+          </div>
+          <div
+            class="size-sm"
+          />
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="history-forward"
+            >
+              <span
+                class="icon"
+                data-icon-name="arrow_forward"
+              >
+                arrow_forward
+              </span>
+            </i>
+          </div>
+          <div
+            class="size-sm"
+          />
+          <div
+            class="preventedDragging"
+          >
+            <button
+              class="updateButton"
+              data-testid="update-button"
+              data-warning-level="light"
+              id="update-lens-button"
+            >
+              Update
+              <i
+                class="Icon icon material focusable"
+              >
+                <span
+                  class="icon"
+                  data-icon-name="arrow_drop_down"
+                >
+                  arrow_drop_down
+                </span>
+              </i>
+            </button>
+          </div>
+          <div
+            class="separator"
+          />
+        </div>
+      </div>
+      <main>
+        <div
+          id="lens-views"
+        />
+        <div
+          class="flex justify-center Welcome align-center"
+          data-testid="welcome-page"
+        >
+          <div
+            data-testid="welcome-banner-container"
+            style="width: 320px;"
+          >
+            <i
+              class="Icon logo svg focusable"
+            >
+              <span
+                class="icon"
+              />
+            </i>
+            <div
+              class="flex justify-center"
+            >
+              <div
+                data-testid="welcome-text-container"
+                style="width: 320px;"
+              >
+                <h2>
+                  Welcome to some-product-name!
+                </h2>
+                <p>
+                  To get you started we have auto-detected your clusters in your
+                   
+                  kubeconfig file and added them to the catalog, your centralized
+                   
+                  view for managing all your cloud-native resources.
+                  <br />
+                  <br />
+                  If you have any questions or feedback, please join our 
+                  <a
+                    class="link"
+                    href="https://forums.k8slens.dev"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Lens Forums
+                  </a>
+                  .
+                </p>
+                <ul
+                  class="block"
+                  data-testid="welcome-menu-container"
+                  style="width: 320px;"
+                >
+                  <li
+                    class="flex grid-12"
+                  >
+                    <i
+                      class="Icon box col-1 material focusable"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="view_list"
+                      >
+                        view_list
+                      </span>
+                    </i>
+                    <a
+                      class="box col-10"
+                    >
+                      Browse Clusters in Catalog
+                    </a>
+                    <i
+                      class="Icon box col-1 material focusable"
+                    >
+                      <span
+                        class="icon"
+                        data-icon-name="navigate_next"
+                      >
+                        navigate_next
+                      </span>
+                    </i>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <div
+        class="HotbarMenu flex column"
+      >
+        <div
+          class="HotbarItems flex column gaps"
+        >
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="0"
+          >
+            <div
+              style="z-index: 12; position: absolute;"
+            >
+              <div
+                class="HotbarIcon contextMenuAvailable"
+              >
+                <div
+                  class="Avatar rounded disabled avatar"
+                  id="hotbarIcon-hotbar-icon-catalog-entity"
+                  style="width: 40px; height: 40px; background: rgb(5, 1, 130);"
+                >
+                  Ca
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="1"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="2"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="3"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="4"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="5"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="6"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="7"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="8"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="9"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="10"
+          />
+          <div
+            class="HotbarCell isDraggingOwner animateDown"
+            index="11"
+          />
+        </div>
+        <div
+          class="HotbarSelector"
+        >
+          <i
+            class="Icon Icon previous material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="arrow_left"
+            >
+              arrow_left
+            </span>
+          </i>
+          <div
+            class="HotbarIndex"
+          >
+            <div
+              class="badge Badge small clickable"
+              id="hotbarIndex"
+            >
+              1
+            </div>
+          </div>
+          <i
+            class="Icon material interactive focusable"
+            tabindex="0"
+          >
+            <span
+              class="icon"
+              data-icon-name="arrow_right"
+            >
+              arrow_right
+            </span>
+          </i>
+        </div>
+      </div>
+      <div
+        class="StatusBar"
+        data-testid="status-bar"
+      >
+        <div
+          class="leftSide"
+          data-testid="status-bar-left"
+        />
+        <div
+          class="rightSide"
+          data-testid="status-bar-right"
+        />
+      </div>
+    </div>
+    <div
+      class="Notifications flex column align-flex-end"
+    />
+  </div>
+</body>
+`;
+
+exports[`installing update when started when user checks for updates when new update is discovered when download succeeds given checking for updates again when check resolves with same update that is already downloaded renders 1`] = `
+<body>
+  <div>
+    <div
+      class="ClusterManager"
+    >
+      <div
+        class="topBar"
+      >
+        <div
+          class="items"
+        >
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="home-button"
+            >
+              <span
+                class="icon"
+                data-icon-name="home"
+              >
+                home
+              </span>
+            </i>
+          </div>
+          <div
+            class="size-sm"
+          />
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="history-back"
+            >
+              <span
+                class="icon"
+                data-icon-name="arrow_back"
+              >
+                arrow_back
+              </span>
+            </i>
+          </div>
+          <div
+            class="size-sm"
+          />
+          <div
+            class="preventedDragging"
+          >
+            <i
+              class="Icon material interactive disabled focusable"
+              data-testid="history-forward"
+            >
+              <span
+                class="icon"
+                data-icon-name="arrow_forward"
+              >
+                arrow_forward
+              </span>
+            </i>
+          </div>
+          <div
             class="size-sm"
           />
           <div

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/__snapshots__/installing-update-using-tray.test.ts.snap
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/__snapshots__/installing-update-using-tray.test.ts.snap
@@ -919,31 +919,6 @@ exports[`installing update using tray when started when user checks for updates 
             </i>
           </div>
           <div
-            class="size-sm"
-          />
-          <div
-            class="preventedDragging"
-          >
-            <button
-              class="updateButton"
-              data-testid="update-button"
-              data-warning-level="light"
-              id="update-lens-button"
-            >
-              Update
-              <i
-                class="Icon icon material focusable"
-              >
-                <span
-                  class="icon"
-                  data-icon-name="arrow_drop_down"
-                >
-                  arrow_drop_down
-                </span>
-              </i>
-            </button>
-          </div>
-          <div
             class="separator"
           />
         </div>

--- a/packages/core/src/features/application-update/installing-update.test.ts
+++ b/packages/core/src/features/application-update/installing-update.test.ts
@@ -18,10 +18,11 @@ import setUpdateOnQuitInjectable from "../../main/electron-app/features/set-upda
 import processCheckingForUpdatesInjectable from "./main/process-checking-for-updates.injectable";
 import { testUsingFakeTime } from "../../test-utils/use-fake-time";
 import staticFilesDirectoryInjectable from "../../common/vars/static-files-directory.injectable";
+import electronQuitAndInstallUpdateInjectable from "../../main/electron-app/features/electron-quit-and-install-update.injectable";
 
 describe("installing update", () => {
   let builder: ApplicationBuilder;
-  let quitAndInstallUpdateMock: jest.Mock;
+  let electronQuitAndInstallUpdateMock: jest.Mock;
   let checkForPlatformUpdatesMock: AsyncFnMock<CheckForPlatformUpdates>;
   let downloadPlatformUpdateMock: AsyncFnMock<DownloadPlatformUpdate>;
   let setUpdateOnQuitMock: jest.Mock;
@@ -32,7 +33,7 @@ describe("installing update", () => {
     builder = getApplicationBuilder();
 
     builder.beforeApplicationStart((mainDi) => {
-      quitAndInstallUpdateMock = jest.fn();
+      electronQuitAndInstallUpdateMock = jest.fn();
       checkForPlatformUpdatesMock = asyncFn();
       downloadPlatformUpdateMock = asyncFn();
       setUpdateOnQuitMock = jest.fn();
@@ -52,8 +53,8 @@ describe("installing update", () => {
       );
 
       mainDi.override(
-        quitAndInstallUpdateInjectable,
-        () => quitAndInstallUpdateMock,
+        electronQuitAndInstallUpdateInjectable,
+        () => electronQuitAndInstallUpdateMock,
       );
 
       mainDi.override(electronUpdaterIsActiveInjectable, () => true);
@@ -64,12 +65,17 @@ describe("installing update", () => {
   describe("when started", () => {
     let rendered: RenderResult;
     let processCheckingForUpdates: (source: string) => Promise<{ updateIsReadyToBeInstalled: boolean }>;
+    let quitAndInstallUpdate: () => void;
 
     beforeEach(async () => {
       rendered = await builder.render();
 
       processCheckingForUpdates = builder.mainDi.inject(
         processCheckingForUpdatesInjectable,
+      );
+
+      quitAndInstallUpdate = builder.mainDi.inject(
+        quitAndInstallUpdateInjectable,
       );
     });
 
@@ -155,7 +161,7 @@ describe("installing update", () => {
           });
 
           it("does not quit and install update yet", () => {
-            expect(quitAndInstallUpdateMock).not.toHaveBeenCalled();
+            expect(electronQuitAndInstallUpdateMock).not.toHaveBeenCalled();
           });
 
           it("still shows normal tray icon", () => {
@@ -167,6 +173,12 @@ describe("installing update", () => {
           it("renders", () => {
             expect(rendered.baseElement).toMatchSnapshot();
           });
+
+          it("does not show the update button", () => {
+            const button = rendered.queryByTestId("update-button");
+
+            expect(button).not.toBeInTheDocument();
+          });
         });
 
         describe("when download succeeds", () => {
@@ -175,7 +187,7 @@ describe("installing update", () => {
           });
 
           it("does not quit and install update yet", () => {
-            expect(quitAndInstallUpdateMock).not.toHaveBeenCalled();
+            expect(electronQuitAndInstallUpdateMock).not.toHaveBeenCalled();
           });
 
           it("shows tray icon for update being available", () => {
@@ -218,6 +230,26 @@ describe("installing update", () => {
                   "/some-static-files-directory/build/tray/trayIconUpdateAvailableTemplate.png",
                 );
               });
+
+              it("does not quit and install update yet", () => {
+                expect(electronQuitAndInstallUpdateMock).not.toHaveBeenCalled();
+              });
+
+              it("renders", () => {
+                expect(rendered.baseElement).toMatchSnapshot();
+              });
+
+              it("shows the update button", () => {
+                const button = rendered.getByTestId("update-button");
+
+                expect(button).toBeInTheDocument();
+              });
+
+              it("when triggering the update, quits and installs the update", () => {
+                quitAndInstallUpdate();
+
+                expect(electronQuitAndInstallUpdateMock).toHaveBeenCalled();
+              });
             });
 
             describe("when check resolves with different update that was previously downloaded", () => {
@@ -236,6 +268,45 @@ describe("installing update", () => {
                 expect(builder.tray.getIconPath()).toBe(
                   "/some-static-files-directory/build/tray/trayIconCheckingForUpdatesTemplate.png",
                 );
+              });
+
+              it("still shows the update button", () => {
+                const button = rendered.getByTestId("update-button");
+
+                expect(button).toBeInTheDocument();
+              });
+
+              describe("when download resolves successfully", () => {
+                beforeEach(async () => {
+                  await downloadPlatformUpdateMock.resolve({ downloadWasSuccessful: true });
+                });
+
+                it("still shows the update button", () => {
+                  const button =
+                    rendered.getByTestId("update-button");
+
+                  expect(button).toBeInTheDocument();
+                });
+
+                it("does not quit and install update yet", () => {
+                  expect(electronQuitAndInstallUpdateMock).not.toHaveBeenCalled();
+                });
+
+                it("shows tray icon for update being available", () => {
+                  expect(builder.tray.getIconPath()).toBe(
+                    "/some-static-files-directory/build/tray/trayIconUpdateAvailableTemplate.png",
+                  );
+                });
+
+                it("renders", () => {
+                  expect(rendered.baseElement).toMatchSnapshot();
+                });
+
+                it("when triggering the update, quits and installs the update", () => {
+                  quitAndInstallUpdate();
+
+                  expect(electronQuitAndInstallUpdateMock).toHaveBeenCalled();
+                });
               });
             });
           });

--- a/packages/core/src/features/application-update/main/download-update/download-update.injectable.ts
+++ b/packages/core/src/features/application-update/main/download-update/download-update.injectable.ts
@@ -40,11 +40,11 @@ const downloadUpdateInjectable = getInjectable({
         if (!downloadWasSuccessful) {
           progressOfUpdateDownload.set({ percentage: 0, failed: "Download of update failed" });
           discoveredVersionState.set(null);
+        } else {
+          const currentDateTime = getCurrentDateTime();
+
+          updateDownloadedDate.set(currentDateTime);
         }
-
-        const currentDateTime = getCurrentDateTime();
-
-        updateDownloadedDate.set(currentDateTime);
 
         downloadingUpdateState.set(false);
       });


### PR DESCRIPTION
Download for an update fails when e.g. computer is in sleep mode without access for network. 

```
installing update
    when started
    ✓ checks for updates
    ✓ shows tray icon for checking for updates
    ✓ renders
    when no new update is discovered
      ✓ shows tray icon for normal
      ✓ does not start downloading update
      ✓ renders
    when new update is discovered
      ✓ starts downloading the update
      ✓ still shows tray icon for downloading
      ✓ renders
      when download fails
        ✓ does not quit and install update yet
        ✓ still shows normal tray icon
        ✓ renders
        ✕ does not show the update button
        
        given time passes and checking for updates again
          ✕ does not show the update button
```

Fixes #7334 