### PR TITLE
Update repository in statefulset template from k8s.gcr.io to registry.k8s

### DIFF
--- a/packages/open-lens/templates/create-resource/StatefulSet.yaml
+++ b/packages/open-lens/templates/create-resource/StatefulSet.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
According to official [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) the k8s.gcr.io repository will be deprecated soon and be replaced by registry.k8s.

So, for mantain the best practices in the template, i updated the template of `StatefulSet` with the new repository `registry.k8s` (i check the checksum's too and its the same).