### PR TITLE
Change typing for after/before window/application start

### DIFF
--- a/packages/core/src/common/app-paths/app-paths.test.ts
+++ b/packages/core/src/common/app-paths/app-paths.test.ts
@@ -38,7 +38,7 @@ describe("app-paths", () => {
       userData: "/some-irrelevant-user-data",
     };
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(
         getElectronAppPathInjectable,
         () =>
@@ -120,7 +120,7 @@ describe("app-paths", () => {
     let windowDi: DiContainer;
 
     beforeEach(async () => {
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(
           directoryForIntegrationTestingInjectable,
           () => "/some-integration-testing-app-data",

--- a/packages/core/src/common/utils/channel/channel.test.ts
+++ b/packages/core/src/common/utils/channel/channel.test.ts
@@ -50,7 +50,7 @@ describe("channel", () => {
         injectionToken: messageChannelListenerInjectionToken,
       });
 
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         runInAction(() => {
           windowDi.register(testChannelListenerInTestWindowInjectable);
         });
@@ -123,7 +123,7 @@ describe("channel", () => {
         injectionToken: messageChannelListenerInjectionToken,
       });
 
-      applicationBuilder.beforeApplicationStart((mainDi) => {
+      applicationBuilder.beforeApplicationStart(({ mainDi }) => {
         runInAction(() => {
           mainDi.register(testChannelListenerInMainInjectable);
         });
@@ -157,7 +157,7 @@ describe("channel", () => {
         handler: () => requestListenerInMainMock,
       });
 
-      applicationBuilder.beforeApplicationStart((mainDi) => {
+      applicationBuilder.beforeApplicationStart(({ mainDi }) => {
         runInAction(() => {
           mainDi.register(testChannelListenerInMainInjectable);
         });
@@ -224,7 +224,7 @@ describe("channel", () => {
       injectionToken: requestChannelListenerInjectionToken,
     });
 
-    applicationBuilder.beforeApplicationStart((mainDi) => {
+    applicationBuilder.beforeApplicationStart(({ mainDi }) => {
       runInAction(() => {
         mainDi.register(someChannelListenerInjectable);
         mainDi.register(someOtherChannelListenerInjectable);

--- a/packages/core/src/common/utils/sync-box/sync-box.test.ts
+++ b/packages/core/src/common/utils/sync-box/sync-box.test.ts
@@ -17,13 +17,13 @@ describe("sync-box", () => {
   beforeEach(() => {
     applicationBuilder = getApplicationBuilder();
 
-    applicationBuilder.beforeApplicationStart(mainDi => {
+    applicationBuilder.beforeApplicationStart(({ mainDi }) => {
       runInAction(() => {
         mainDi.register(someInjectable);
       });
     });
 
-    applicationBuilder.beforeWindowStart((windowDi) => {
+    applicationBuilder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(someInjectable);
       });

--- a/packages/core/src/extensions/__tests__/configurable-directories.test.ts
+++ b/packages/core/src/extensions/__tests__/configurable-directories.test.ts
@@ -15,13 +15,11 @@ describe("configurable directories for extension files", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart(
-      (mainDi) => {
-        runInAction(() => {
-          mainDi.override(getHashInjectable, () => x => x);
-        });
-      },
-    );
+    builder.beforeApplicationStart(({ mainDi }) => {
+      runInAction(() => {
+        mainDi.override(getHashInjectable, () => x => x);
+      });
+    });
 
     await builder.startHidden();
 

--- a/packages/core/src/features/application-menu/application-menu-in-legacy-extension-api.test.ts
+++ b/packages/core/src/features/application-menu/application-menu-in-legacy-extension-api.test.ts
@@ -18,20 +18,18 @@ describe("application-menu-in-legacy-extension-api", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart(
-      (mainDi) => {
-        runInAction(() => {
-          mainDi.register(
-            someTopMenuItemInjectable,
-            someNonExtensionBasedMenuItemInjectable,
-          );
-        });
+    builder.beforeApplicationStart(({ mainDi }) => {
+      runInAction(() => {
+        mainDi.register(
+          someTopMenuItemInjectable,
+          someNonExtensionBasedMenuItemInjectable,
+        );
+      });
 
-        logErrorMock = jest.fn();
+      logErrorMock = jest.fn();
 
-        mainDi.override(logErrorInjectable, () => logErrorMock);
-      },
-    );
+      mainDi.override(logErrorInjectable, () => logErrorMock);
+    });
 
     await builder.startHidden();
   });

--- a/packages/core/src/features/application-menu/application-menu.test.ts
+++ b/packages/core/src/features/application-menu/application-menu.test.ts
@@ -20,7 +20,7 @@ describe.each(allPlatforms)("application-menu, given platform is '%s'", (platfor
 
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(platformInjectable, () => platform);
 
       mainDi.override(

--- a/packages/core/src/features/application-menu/handling-of-orphan-application-menu-items.test.ts
+++ b/packages/core/src/features/application-menu/handling-of-orphan-application-menu-items.test.ts
@@ -25,7 +25,7 @@ describe("handling-of-orphan-application-menu-items, given orphan menu item", ()
 
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       const someOrphanMenuItemInjectable = getInjectable({
         id: "some-orphan-menu-item",
         instantiate: () => ({

--- a/packages/core/src/features/application-update/analytics-for-installing-update.test.ts
+++ b/packages/core/src/features/application-update/analytics-for-installing-update.test.ts
@@ -35,7 +35,7 @@ describe("analytics for installing update", () => {
 
     analyticsListenerMock = jest.fn();
 
-    builder.beforeApplicationStart(mainDi => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getBuildVersionInjectable, () => () => "42.0.0");
 
       checkForPlatformUpdatesMock = asyncFn();

--- a/packages/core/src/features/application-update/child-features/application-update-using-top-bar/installing-update-using-topbar-button.test.tsx
+++ b/packages/core/src/features/application-update/child-features/application-update-using-top-bar/installing-update-using-topbar-button.test.tsx
@@ -33,7 +33,7 @@ describe("encourage user to update when sufficient time passed since update was 
 
     applicationBuilder = getApplicationBuilder();
 
-    applicationBuilder.beforeApplicationStart((mainDi) => {
+    applicationBuilder.beforeApplicationStart(({ mainDi }) => {
       checkForPlatformUpdatesMock = asyncFn();
       downloadPlatformUpdateMock = asyncFn();
 

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
@@ -24,7 +24,7 @@ describe("installing update using tray", () => {
   beforeEach(() => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       checkForPlatformUpdatesMock = asyncFn();
       downloadPlatformUpdateMock = asyncFn();
 

--- a/packages/core/src/features/application-update/child-features/force-update/force-update.test.ts
+++ b/packages/core/src/features/application-update/child-features/force-update/force-update.test.ts
@@ -35,7 +35,7 @@ describe("force user to update when too long since update was downloaded", () =>
 
     applicationBuilder = getApplicationBuilder();
 
-    applicationBuilder.beforeApplicationStart(mainDi => {
+    applicationBuilder.beforeApplicationStart(({ mainDi }) => {
       checkForPlatformUpdatesMock = asyncFn();
 
       mainDi.override(checkForPlatformUpdatesInjectable, () => checkForPlatformUpdatesMock);
@@ -49,7 +49,7 @@ describe("force user to update when too long since update was downloaded", () =>
       mainDi.override(quitAndInstallUpdateInjectable, () => quitAndInstallUpdateMock);
     });
 
-    applicationBuilder.beforeWindowStart(windowDi => {
+    applicationBuilder.beforeWindowStart(({ windowDi }) => {
       windowDi.unoverride(forceUpdateModalRootFrameComponentInjectable);
       windowDi.permitSideEffects(forceUpdateModalRootFrameComponentInjectable);
 

--- a/packages/core/src/features/application-update/child-features/periodical-checking-of-updates/periodical-checking-of-updates.test.ts
+++ b/packages/core/src/features/application-update/child-features/periodical-checking-of-updates/periodical-checking-of-updates.test.ts
@@ -22,7 +22,7 @@ describe("periodical checking of updates", () => {
 
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.unoverride(periodicalCheckForUpdatesInjectable);
       mainDi.permitSideEffects(periodicalCheckForUpdatesInjectable);
 
@@ -39,7 +39,7 @@ describe("periodical checking of updates", () => {
     let rendered: RenderResult;
 
     beforeEach(async () => {
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(electronUpdaterIsActiveInjectable, () => true);
         mainDi.override(publishIsConfiguredInjectable, () => true);
       });
@@ -74,7 +74,7 @@ describe("periodical checking of updates", () => {
 
   describe("given updater is enabled but no configuration exist, when started", () => {
     beforeEach(async () => {
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(electronUpdaterIsActiveInjectable, () => true);
         mainDi.override(publishIsConfiguredInjectable, () => false);
       });
@@ -95,7 +95,7 @@ describe("periodical checking of updates", () => {
 
   describe("given updater is not enabled but and configuration exist, when started", () => {
     beforeEach(async () => {
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(electronUpdaterIsActiveInjectable, () => false);
         mainDi.override(publishIsConfiguredInjectable, () => true);
       });

--- a/packages/core/src/features/application-update/child-features/selection-of-update-stability/selection-of-update-stability.test.ts
+++ b/packages/core/src/features/application-update/child-features/selection-of-update-stability/selection-of-update-stability.test.ts
@@ -37,7 +37,7 @@ describe("selection of update stability", () => {
   beforeEach(() => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       quitAndInstallUpdateMock = jest.fn();
       checkForPlatformUpdatesMock = asyncFn();
       downloadPlatformUpdateMock = asyncFn();
@@ -64,7 +64,7 @@ describe("selection of update stability", () => {
       mainDi.override(publishIsConfiguredInjectable, () => true);
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       showInfoNotificationMock = jest.fn(() => () => {});
 
       windowDi.override(showInfoNotificationInjectable, () => showInfoNotificationMock);
@@ -260,7 +260,7 @@ describe("selection of update stability", () => {
   });
 
   it('given no update channel selection is stored and currently using stable release, when user checks for updates, checks for updates from "latest" update channel by default', async () => {
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getBuildVersionInjectable, () => () => "1.0.0");
     });
 
@@ -277,7 +277,7 @@ describe("selection of update stability", () => {
   });
 
   it('given no update channel selection is stored and currently using alpha release, when checking for updates, checks for updates from "alpha" channel', async () => {
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getBuildVersionInjectable, () => () => "1.0.0-alpha");
     });
 
@@ -291,7 +291,7 @@ describe("selection of update stability", () => {
   });
 
   it('given no update channel selection is stored and currently using beta release, when checking for updates, checks for updates from "beta" channel', async () => {
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getBuildVersionInjectable, () => () => "1.0.0-beta");
     });
 

--- a/packages/core/src/features/application-update/downgrading-version-update.test.ts
+++ b/packages/core/src/features/application-update/downgrading-version-update.test.ts
@@ -24,7 +24,7 @@ describe("downgrading version update", () => {
   beforeEach(() => {
     applicationBuilder = getApplicationBuilder();
 
-    applicationBuilder.beforeApplicationStart(mainDi => {
+    applicationBuilder.beforeApplicationStart(({ mainDi }) => {
       checkForPlatformUpdatesMock = asyncFn();
 
       mainDi.override(

--- a/packages/core/src/features/application-update/installing-update.test.ts
+++ b/packages/core/src/features/application-update/installing-update.test.ts
@@ -32,7 +32,7 @@ describe("installing update", () => {
 
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       electronQuitAndInstallUpdateMock = jest.fn();
       checkForPlatformUpdatesMock = asyncFn();
       downloadPlatformUpdateMock = asyncFn();

--- a/packages/core/src/features/catalog/entity-running.test.tsx
+++ b/packages/core/src/features/catalog/entity-running.test.tsx
@@ -84,7 +84,7 @@ describe("entity running technical tests", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.afterWindowStart((windowDi) => {
+    builder.afterWindowStart(({ windowDi }) => {
       onRun = jest.fn();
 
       const catalogCategoryRegistery = windowDi.inject(catalogCategoryRegistryInjectable);

--- a/packages/core/src/features/catalog/opening-entity-details.test.tsx
+++ b/packages/core/src/features/catalog/opening-entity-details.test.tsx
@@ -26,7 +26,7 @@ describe("opening catalog entity details panel", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       // TODO: remove once ClusterStore can be used without overriding it
       windowDi.override(getClusterByIdInjectable, () => (clusterId) => {
         if (clusterId === cluster?.id) {
@@ -39,7 +39,7 @@ describe("opening catalog entity details panel", () => {
 
     testUsingFakeTime();
 
-    builder.afterWindowStart((windowDi) => {
+    builder.afterWindowStart(({ windowDi }) => {
       clusterEntity = new KubernetesCluster({
         metadata: {
           labels: {},

--- a/packages/core/src/features/cluster/delete-dialog/delete-cluster-dialog.test.tsx
+++ b/packages/core/src/features/cluster/delete-dialog/delete-cluster-dialog.test.tsx
@@ -76,17 +76,17 @@ describe("Deleting a cluster", () => {
     config = new KubeConfig();
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(kubectlBinaryNameInjectable, () => "kubectl");
       mainDi.override(kubectlDownloadingNormalizedArchInjectable, () => "amd64");
       mainDi.override(normalizedPlatformInjectable, () => "darwin");
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       openDeleteClusterDialog = windowDi.inject(openDeleteClusterDialogInjectable);
     });
 
-    builder.afterWindowStart(windowDi => {
+    builder.afterWindowStart(({ windowDi }) => {
       const navigateToCatalog = windowDi.inject(navigateToCatalogInjectable);
 
       navigateToCatalog();

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
@@ -26,7 +26,7 @@ describe("disable kube object detail items when cluster is not relevant", () => 
     builder = getApplicationBuilder();
     builder.setEnvironmentToClusterFrame();
 
-    builder.afterWindowStart((windowDi) => {
+    builder.afterWindowStart(({ windowDi }) => {
       const apiManager = windowDi.inject(apiManagerInjectable);
       const api = {
         apiBase: "/apis/some-api-version/some-kind",

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
@@ -25,7 +25,7 @@ describe("reactively hide kube object detail item", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.afterWindowStart((windowDi) => {
+    builder.afterWindowStart(({ windowDi }) => {
       const apiManager = windowDi.inject(apiManagerInjectable);
       const api = {
         apiBase: "/apis/some-api-version/some-kind",

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/disable-kube-object-menu-items-when-cluster-is-not-relevant.test.tsx
@@ -29,7 +29,7 @@ describe("disable kube object menu items when cluster is not relevant", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testRouteInjectable, testRouteComponentInjectable);
       });

--- a/packages/core/src/features/cluster/kube-object-menu/extension-api/reactively-hide-kube-object-menu-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-menu/extension-api/reactively-hide-kube-object-menu-item.test.tsx
@@ -25,7 +25,7 @@ describe("reactively hide kube object menu item", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testRouteInjectable, testRouteComponentInjectable);
       });

--- a/packages/core/src/features/cluster/kube-object-status-icon/extension-api/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-status-icon/extension-api/disable-kube-object-statuses-when-cluster-is-not-relevant.test.tsx
@@ -30,7 +30,7 @@ describe("disable kube object statuses when cluster is not relevant", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testRouteInjectable, testRouteComponentInjectable);
       });

--- a/packages/core/src/features/cluster/kube-object-status-icon/extension-api/reactively-hide-kube-object-status.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-status-icon/extension-api/reactively-hide-kube-object-status.test.tsx
@@ -26,7 +26,7 @@ describe("reactively hide kube object status", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testRouteInjectable, testRouteComponentInjectable);
       });

--- a/packages/core/src/features/cluster/kube-object-status-icon/show-status-for-a-kube-object.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-status-icon/show-status-for-a-kube-object.test.tsx
@@ -93,7 +93,7 @@ describe("show status for a kube object", () => {
       }),
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(
           testRouteInjectable,

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -36,7 +36,7 @@ describe("cluster/namespaces - edit namespace from new tab", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(
         directoryForLensLocalStorageInjectable,
         () => "/some-directory-for-lens-local-storage",

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-previously-opened-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-previously-opened-tab.test.tsx
@@ -26,7 +26,7 @@ describe("cluster/namespaces - edit namespaces from previously opened tab", () =
 
     callForNamespaceMock = asyncFn();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(
         directoryForLensLocalStorageInjectable,
         () => "/some-directory-for-lens-local-storage",
@@ -47,7 +47,7 @@ describe("cluster/namespaces - edit namespaces from previously opened tab", () =
     let rendered: RenderResult;
 
     beforeEach(async () => {
-      builder.beforeWindowStart(async (windowDi) => {
+      builder.beforeWindowStart(async ({ windowDi }) => {
         const writeJsonFile = windowDi.inject(writeJsonFileInjectable);
 
         await writeJsonFile(

--- a/packages/core/src/features/cluster/order-of-sidebar-items.test.tsx
+++ b/packages/core/src/features/cluster/order-of-sidebar-items.test.tsx
@@ -21,7 +21,7 @@ describe("cluster - order of sidebar items", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testSidebarItemsInjectable);
       });

--- a/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-core.test.tsx
+++ b/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-core.test.tsx
@@ -35,14 +35,14 @@ describe("cluster - sidebar and tab navigation for core", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(storageSaveDelayInjectable, () => 250);
     });
   });
 
   describe("given core registrations", () => {
     beforeEach(() => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         runInAction(() => {
           windowDi.register(testRouteInjectable);
           windowDi.register(testRouteComponentInjectable);
@@ -86,7 +86,7 @@ describe("cluster - sidebar and tab navigation for core", () => {
 
     describe("given state for expanded sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        builder.beforeWindowStart(async (windowDi) => {
+        builder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFile = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFile(
@@ -122,7 +122,7 @@ describe("cluster - sidebar and tab navigation for core", () => {
 
     describe("given state for expanded unknown sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        builder.beforeWindowStart(async (windowDi) => {
+        builder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFileFake = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFileFake(
@@ -152,7 +152,7 @@ describe("cluster - sidebar and tab navigation for core", () => {
 
     describe("given empty state for expanded sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        builder.beforeWindowStart(async (windowDi) => {
+        builder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFileFake = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFileFake(

--- a/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
+++ b/packages/core/src/features/cluster/sidebar-and-tab-navigation-for-extensions.test.tsx
@@ -34,7 +34,7 @@ describe("cluster - sidebar and tab navigation for extensions", () => {
 
     applicationBuilder.setEnvironmentToClusterFrame();
 
-    applicationBuilder.beforeWindowStart((windowDi) => {
+    applicationBuilder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(storageSaveDelayInjectable, () => 250);
 
       windowDi.override(
@@ -171,7 +171,7 @@ describe("cluster - sidebar and tab navigation for extensions", () => {
 
     describe("given state for expanded sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        applicationBuilder.beforeWindowStart(async (windowDi) => {
+        applicationBuilder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFileFake = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFileFake(
@@ -207,7 +207,7 @@ describe("cluster - sidebar and tab navigation for extensions", () => {
 
     describe("given state for expanded unknown sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        applicationBuilder.beforeWindowStart(async (windowDi) => {
+        applicationBuilder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFileFake = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFileFake(
@@ -237,7 +237,7 @@ describe("cluster - sidebar and tab navigation for extensions", () => {
 
     describe("given empty state for expanded sidebar items already exists, when rendered", () => {
       beforeEach(async () => {
-        applicationBuilder.beforeWindowStart(async (windowDi) => {
+        applicationBuilder.beforeWindowStart(async ({ windowDi }) => {
           const writeJsonFileFake = windowDi.inject(writeJsonFileInjectable);
 
           await writeJsonFileFake(

--- a/packages/core/src/features/cluster/visibility-of-sidebar-items.test.tsx
+++ b/packages/core/src/features/cluster/visibility-of-sidebar-items.test.tsx
@@ -24,7 +24,7 @@ describe("cluster - visibility of sidebar items", () => {
 
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(testRouteInjectable);
         windowDi.register(testRouteComponentInjectable);

--- a/packages/core/src/features/cluster/workloads/overview/extension-api/order-of-workload-overview-details.test.tsx
+++ b/packages/core/src/features/cluster/workloads/overview/extension-api/order-of-workload-overview-details.test.tsx
@@ -16,7 +16,7 @@ describe("order of workload overview details", () => {
   beforeEach(async () => {
     const builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.unoverride(getRandomIdInjectable);
       windowDi.permitSideEffects(getRandomIdInjectable);
 

--- a/packages/core/src/features/command-pallet/keyboard-shortcuts.test.tsx
+++ b/packages/core/src/features/command-pallet/keyboard-shortcuts.test.tsx
@@ -18,7 +18,7 @@ describe("Command Pallet: keyboard shortcut tests", () => {
 
   describe("when on macOS", () => {
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(platformInjectable, () => "darwin");
       });
 
@@ -86,7 +86,7 @@ describe("Command Pallet: keyboard shortcut tests", () => {
 
   describe("when on linux", () => {
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(platformInjectable, () => "linux");
       });
 

--- a/packages/core/src/features/entity-settings/showing-settings-for-correct-entity.test.tsx
+++ b/packages/core/src/features/entity-settings/showing-settings-for-correct-entity.test.tsx
@@ -24,7 +24,7 @@ describe("Showing correct entity settings", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       // TODO: remove once ClusterStore can be used without overriding it
       windowDi.override(getClusterByIdInjectable, () => (clusterId) => {
         if (clusterId === cluster.id) {
@@ -35,7 +35,7 @@ describe("Showing correct entity settings", () => {
       });
     });
 
-    builder.afterWindowStart((windowDi) => {
+    builder.afterWindowStart(({ windowDi }) => {
       clusterEntity = new KubernetesCluster({
         metadata: {
           labels: {},

--- a/packages/core/src/features/extensions/navigation-using-application-menu.test.ts
+++ b/packages/core/src/features/extensions/navigation-using-application-menu.test.ts
@@ -19,7 +19,7 @@ describe("extensions - navigation using application menu", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       focusWindowMock = jest.fn();
 
       windowDi.override(focusWindowInjectable, () => focusWindowMock);

--- a/packages/core/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/add-custom-helm-repository-in-preferences.test.ts
@@ -40,13 +40,13 @@ describe("add custom helm repository in preferences", () => {
     showSuccessNotificationMock = jest.fn();
     showErrorNotificationMock = jest.fn();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getActiveHelmRepositoriesInjectable, () => getActiveHelmRepositoriesMock);
       mainDi.override(execFileInjectable, () => execFileMock);
       mainDi.override(helmBinaryPathInjectable, () => "some-helm-binary-path");
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(requestPublicHelmRepositoriesInjectable, () => async () => []);
       windowDi.override(showSuccessNotificationInjectable, () => showSuccessNotificationMock);
       windowDi.override(showErrorNotificationInjectable, () => showErrorNotificationMock);

--- a/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/add-helm-repository-from-list-in-preferences.test.ts
@@ -35,13 +35,13 @@ describe("add helm repository from list in preferences", () => {
     showSuccessNotificationMock = jest.fn();
     showErrorNotificationMock = jest.fn();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getActiveHelmRepositoriesInjectable, () => getActiveHelmRepositoriesMock);
       mainDi.override(execFileInjectable, () => execFileMock);
       mainDi.override(helmBinaryPathInjectable, () => "some-helm-binary-path");
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(showSuccessNotificationInjectable, () => showSuccessNotificationMock);
       windowDi.override(showErrorNotificationInjectable, () => showErrorNotificationMock);
       windowDi.override(requestPublicHelmRepositoriesInjectable, () => callForPublicHelmRepositoriesMock);

--- a/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-new-tab.test.ts
@@ -55,7 +55,7 @@ describe("installing helm chart from new tab", () => {
     requestCreateHelmReleaseMock = asyncFn();
     requestHelmReleasesMock = asyncFn();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(directoryForLensLocalStorageInjectable, () => "/some-directory-for-lens-local-storage");
       windowDi.override(requestDetailedHelmReleaseInjectable, () => requestDetailedHelmReleaseMock);
       windowDi.override(requestHelmChartsInjectable, () => requestHelmChartsMock);

--- a/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-previously-opened-tab.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/installing-helm-chart-from-previously-opened-tab.test.ts
@@ -34,7 +34,7 @@ describe("installing helm chart from previously opened tab", () => {
     builder.namespaces.add("default");
     builder.namespaces.add("some-other-namespace");
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(directoryForLensLocalStorageInjectable, () => "/some-directory-for-lens-local-storage");
       windowDi.override(requestHelmChartVersionsInjectable, () => requestHelmChartVersionsMock);
       windowDi.override(requestHelmChartValuesInjectable, () => requestHelmChartValuesMock);
@@ -52,7 +52,7 @@ describe("installing helm chart from previously opened tab", () => {
     let rendered: RenderResult;
 
     beforeEach(async () => {
-      builder.beforeWindowStart(async (windowDi) => {
+      builder.beforeWindowStart(async ({ windowDi }) => {
         const writeJsonFile = windowDi.inject(writeJsonFileInjectable);
 
         await writeJsonFile(

--- a/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
+++ b/packages/core/src/features/helm-charts/installing-chart/opening-dock-tab-for-installing-helm-chart.test.ts
@@ -38,7 +38,7 @@ describe("opening dock tab for installing helm chart", () => {
     requestHelmChartReadmeMock = asyncFn();
     requestHelmChartValuesMock = jest.fn();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(directoryForLensLocalStorageInjectable, () => "/some-directory-for-lens-local-storage");
       windowDi.override(hostedClusterIdInjectable, () => "some-cluster-id");
       windowDi.override(requestHelmChartsInjectable, () => requestHelmChartsMock);

--- a/packages/core/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/listing-active-helm-repositories-in-preferences.test.ts
@@ -41,14 +41,14 @@ describe("listing active helm repositories in preferences", () => {
       warn: noop,
     };
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(readYamlFileInjectable, () => readYamlFileMock);
       mainDi.override(execFileInjectable, () => execFileMock);
       mainDi.override(helmBinaryPathInjectable, () => "some-helm-binary-path");
       mainDi.override(loggerInjectable, () => loggerStub);
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(showErrorNotificationInjectable, () => showErrorNotificationMock);
       windowDi.override(requestPublicHelmRepositoriesInjectable, () => async () => []);
     });

--- a/packages/core/src/features/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
+++ b/packages/core/src/features/helm-charts/remove-helm-repository-from-list-of-active-repository-in-preferences.test.ts
@@ -28,13 +28,13 @@ describe("remove helm repository from list of active repositories in preferences
     execFileMock = asyncFn();
     getActiveHelmRepositoriesMock = asyncFn();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(getActiveHelmRepositoriesInjectable, () => getActiveHelmRepositoriesMock);
       mainDi.override(execFileInjectable, () => execFileMock);
       mainDi.override(helmBinaryPathInjectable, () => "some-helm-binary-path");
     });
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(requestPublicHelmRepositoriesInjectable, () => async () => []);
     });
 

--- a/packages/core/src/features/helm-charts/upgrade-chart/upgrade-chart-new-tab.test.ts
+++ b/packages/core/src/features/helm-charts/upgrade-chart/upgrade-chart-new-tab.test.ts
@@ -35,7 +35,7 @@ describe("New Upgrade Helm Chart Dock Tab", () => {
     builder = getApplicationBuilder();
     builder.setEnvironmentToClusterFrame();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       requestHelmReleaseConfigurationMock = asyncFn();
       windowDi.override(requestHelmReleaseConfigurationInjectable, () => requestHelmReleaseConfigurationMock);
 

--- a/packages/core/src/features/helm-releases/showing-details-for-helm-release.test.ts
+++ b/packages/core/src/features/helm-releases/showing-details-for-helm-release.test.ts
@@ -63,7 +63,7 @@ describe("showing details for helm release", () => {
     showSuccessNotificationMock = jest.fn();
     showCheckedErrorNotificationMock = jest.fn();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(getRandomUpgradeChartTabIdInjectable, () => () => "some-tab-id");
       windowDi.override(showSuccessNotificationInjectable, () => showSuccessNotificationMock);
       windowDi.override(showCheckedErrorInjectable, () => showCheckedErrorNotificationMock);

--- a/packages/core/src/features/navigating-between-routes.test.tsx
+++ b/packages/core/src/features/navigating-between-routes.test.tsx
@@ -31,7 +31,7 @@ describe("navigating between routes", () => {
     let windowDi: DiContainer;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         runInAction(() => {
           windowDi.register(testRouteWithoutPathParametersInjectable);
           windowDi.register(testRouteWithoutPathParametersComponentInjectable);
@@ -107,7 +107,7 @@ describe("navigating between routes", () => {
     let windowDi: DiContainer;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         runInAction(() => {
           windowDi.register(routeWithOptionalPathParametersInjectable);
           windowDi.register(routeWithOptionalPathParametersComponentInjectable);

--- a/packages/core/src/features/pod-logs/download-logs.test.tsx
+++ b/packages/core/src/features/pod-logs/download-logs.test.tsx
@@ -57,7 +57,7 @@ describe("download logs options in logs dock tab", () => {
     getLogsMock = jest.fn();
     getSplittedLogsMock = jest.fn();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(callForLogsInjectable, () => callForLogsMock);
 
       // Overriding internals of logsViewModelInjectable
@@ -99,7 +99,7 @@ describe("download logs options in logs dock tab", () => {
     beforeEach(async () => {
       rendered = await builder.render();
       windowDi = builder.applicationWindow.only.di;
-  
+
       const dockStore = windowDi.inject(dockStoreInjectable);
 
       dockStore.closeTab("terminal");
@@ -108,10 +108,10 @@ describe("download logs options in logs dock tab", () => {
     describe("when logs not available", () => {
       beforeEach(async () => {
         const createLogsTab = windowDi.inject(createPodLogsTabInjectable);
-    
+
         getLogsMock.mockReturnValue([]);
         getSplittedLogsMock.mockReturnValue([]);
-  
+
         createLogsTab({
           selectedPod: pod,
           selectedContainer: container,
@@ -132,10 +132,10 @@ describe("download logs options in logs dock tab", () => {
     describe("when logs available", () => {
       beforeEach(async () => {
         const createLogsTab = windowDi.inject(createPodLogsTabInjectable);
-    
+
         getLogsMock.mockReturnValue(["some-logs"]);
         getSplittedLogsMock.mockReturnValue([...logs]);
-  
+
         createLogsTab({
           selectedPod: pod,
           selectedContainer: container,
@@ -157,7 +157,7 @@ describe("download logs options in logs dock tab", () => {
       describe("when clicking on dropdown", () => {
         beforeEach(() => {
           const button = rendered.getByTestId("download-logs-dropdown");
-  
+
           act(() => button.click());
         });
 
@@ -182,7 +182,7 @@ describe("download logs options in logs dock tab", () => {
             beforeEach(async () => {
               await act(async () => {
                 const button = rendered.getByTestId("download-all-logs");
-  
+
                 button.click();
               });
             });
@@ -193,11 +193,11 @@ describe("download logs options in logs dock tab", () => {
                 { "previous": true, "timestamps": false },
               );
             });
-  
+
             it("shows save dialog with proper attributes", async () => {
               expect(openSaveFileDialogMock).toHaveBeenCalledWith("dockerExporter.log", "all-logs", "text/plain");
             });
-  
+
             it("doesn't block download dropdown for interaction after click", async () => {
               expect(rendered.getByTestId("download-logs-dropdown")).not.toHaveAttribute("disabled");
             });
@@ -206,19 +206,19 @@ describe("download logs options in logs dock tab", () => {
           describe("blocking user interaction after menu item click", () => {
             it("block download dropdown for interaction when selected 'download all logs'", async () => {
               const downloadMenuItem = rendered.getByTestId("download-all-logs");
-  
+
               act(() => downloadMenuItem.click());
-  
+
               await waitFor(() => {
                 expect(rendered.getByTestId("download-logs-dropdown")).toHaveAttribute("disabled");
               });
             });
-  
+
             it("doesn't block dropdown for interaction when selected 'download visible logs'", () => {
               const downloadMenuItem = rendered.getByTestId("download-visible-logs");
-  
+
               act(() => downloadMenuItem.click());
-  
+
               expect(rendered.getByTestId("download-logs-dropdown")).not.toHaveAttribute("disabled");
             });
           });
@@ -233,7 +233,7 @@ describe("download logs options in logs dock tab", () => {
             beforeEach(async () => {
               await act(async () => {
                 const button = rendered.getByTestId("download-all-logs");
-  
+
                 button.click();
               });
             });
@@ -241,7 +241,7 @@ describe("download logs options in logs dock tab", () => {
             it("doesn't show save dialog", () => {
               expect(openSaveFileDialogMock).not.toHaveBeenCalled();
             });
-  
+
             it("shows error notification", () => {
               expect(showErrorNotificationMock).toHaveBeenCalled();
             });
@@ -252,23 +252,23 @@ describe("download logs options in logs dock tab", () => {
           beforeEach(() => {
             callForLogsMock.mockRejectedValue("error");
           });
-  
+
           describe("when selected 'download all logs'", () => {
             beforeEach(async () => {
               await act(async () => {
                 const button = rendered.getByTestId("download-all-logs");
-  
+
                 button.click();
               });
             });
-  
+
             it("logs have been called", () => {
               expect(callForLogsMock).toHaveBeenCalledWith(
                 { name: "dockerExporter", namespace: "default" },
                 { "previous": true, "timestamps": false },
               );
             });
-  
+
             it("doesn't show save dialog", async () => {
               expect(openSaveFileDialogMock).not.toHaveBeenCalled();
             });

--- a/packages/core/src/features/preferences/closing-preferences.test.tsx
+++ b/packages/core/src/features/preferences/closing-preferences.test.tsx
@@ -26,7 +26,7 @@ describe("preferences - closing-preferences", () => {
   beforeEach(() => {
     builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       runInAction(() => {
         windowDi.register(
           testPreferenceTabInjectable,
@@ -54,7 +54,7 @@ describe("preferences - closing-preferences", () => {
     let windowDi: DiContainer;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(observableHistoryInjectable, () => {
           const historyFake = createMemoryHistory({
             initialEntries: ["/some-page"],
@@ -135,7 +135,7 @@ describe("preferences - closing-preferences", () => {
     let windowDi: DiContainer;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(observableHistoryInjectable, () => {
           const historyFake = createMemoryHistory({
             initialEntries: ["/preferences/app"],

--- a/packages/core/src/features/preferences/navigation-to-application-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-application-preferences.test.tsx
@@ -70,7 +70,7 @@ describe("preferences - navigation to application preferences", () => {
     let discover: Discover;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         const navigateToProxyPreferences = windowDi.inject(navigateToProxyPreferencesInjectable);
 
         navigateToProxyPreferences();

--- a/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-extension-specific-preferences.test.tsx
@@ -27,7 +27,7 @@ describe("preferences - navigation to extension specific preferences", () => {
     beforeEach(async () => {
       logErrorMock = jest.fn();
 
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(logErrorInjectable, () => logErrorMock);
 
         builder.preferences.navigate();

--- a/packages/core/src/features/preferences/navigation-to-kubernetes-preferences.test.ts
+++ b/packages/core/src/features/preferences/navigation-to-kubernetes-preferences.test.ts
@@ -22,14 +22,14 @@ describe("preferences - navigation to kubernetes preferences", () => {
     let discover: Discover;
 
     beforeEach(async () => {
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(
           getActiveHelmRepositoriesInjectable,
           () => async () => ({ callWasSuccessful: true, response: [] }),
         );
       });
 
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(requestPublicHelmRepositoriesInjectable, () => async () => []);
       });
 

--- a/packages/core/src/features/preferences/navigation-to-telemetry-preferences.test.tsx
+++ b/packages/core/src/features/preferences/navigation-to-telemetry-preferences.test.tsx
@@ -142,7 +142,7 @@ describe("preferences - navigation to telemetry preferences", () => {
     let discover: Discover;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(sentryDataSourceNameInjectable, () => "some-sentry-dns-url");
       });
 
@@ -177,7 +177,7 @@ describe("preferences - navigation to telemetry preferences", () => {
     let discover: Discover;
 
     beforeEach(async () => {
-      builder.beforeWindowStart((windowDi) => {
+      builder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(sentryDataSourceNameInjectable, () => null);
       });
 

--- a/packages/core/src/features/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
+++ b/packages/core/src/features/quitting-and-restarting-the-app/opening-application-window-using-tray.test.ts
@@ -32,7 +32,7 @@ describe("opening application window using tray", () => {
 
       builder = getApplicationBuilder();
 
-      builder.beforeApplicationStart((mainDi) => {
+      builder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(focusApplicationInjectable, () => focusApplicationMock);
 
         mainDi.override(

--- a/packages/core/src/features/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
+++ b/packages/core/src/features/quitting-and-restarting-the-app/quitting-the-app-using-application-menu.test.ts
@@ -22,17 +22,15 @@ describe("quitting the app using application menu", () => {
 
       builder = getApplicationBuilder();
 
-      builder.beforeApplicationStart(
-        (mainDi) => {
-          mainDi.unoverride(stopServicesAndExitAppInjectable);
+      builder.beforeApplicationStart(({ mainDi }) => {
+        mainDi.unoverride(stopServicesAndExitAppInjectable);
 
-          clusterManagerStub = { stop: jest.fn() } as unknown as ClusterManager;
-          mainDi.override(clusterManagerInjectable, () => clusterManagerStub);
+        clusterManagerStub = { stop: jest.fn() } as unknown as ClusterManager;
+        mainDi.override(clusterManagerInjectable, () => clusterManagerStub);
 
-          exitAppMock = jest.fn();
-          mainDi.override(exitAppInjectable, () => exitAppMock);
-        },
-      );
+        exitAppMock = jest.fn();
+        mainDi.override(exitAppInjectable, () => exitAppMock);
+      });
 
       await builder.render();
     });

--- a/packages/core/src/features/resolve-system-proxy/resolve-system-proxy.test.ts
+++ b/packages/core/src/features/resolve-system-proxy/resolve-system-proxy.test.ts
@@ -21,7 +21,7 @@ describe("resolve-system-proxy", () => {
 
     resolveSystemProxyFromElectronMock = asyncFn();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.override(
         resolveSystemProxyFromElectronInjectable,
         () => resolveSystemProxyFromElectronMock,

--- a/packages/core/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
+++ b/packages/core/src/features/status-bar/status-bar-items-originating-from-extensions.test.tsx
@@ -16,7 +16,7 @@ describe("status-bar-items-originating-from-extensions", () => {
   beforeEach(() => {
     applicationBuilder = getApplicationBuilder();
 
-    applicationBuilder.beforeWindowStart((windowDi) => {
+    applicationBuilder.beforeWindowStart(({ windowDi }) => {
       windowDi.unoverride(getRandomIdInjectable);
       windowDi.permitSideEffects(getRandomIdInjectable);
     });

--- a/packages/core/src/features/tray/clicking-tray-menu-item-originating-from-extension.test.ts
+++ b/packages/core/src/features/tray/clicking-tray-menu-item-originating-from-extension.test.ts
@@ -15,7 +15,7 @@ describe("clicking tray menu item originating from extension", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       logErrorMock = jest.fn();
 
       mainDi.override(logErrorInjectable, () => logErrorMock);

--- a/packages/core/src/features/tray/multiple-separators-originating-from-extension.test.ts
+++ b/packages/core/src/features/tray/multiple-separators-originating-from-extension.test.ts
@@ -12,7 +12,7 @@ describe("multiple separators originating from extension", () => {
   beforeEach(async () => {
     builder = getApplicationBuilder();
 
-    builder.beforeApplicationStart((mainDi) => {
+    builder.beforeApplicationStart(({ mainDi }) => {
       mainDi.unoverride(getRandomIdInjectable);
       mainDi.permitSideEffects(getRandomIdInjectable);
     });

--- a/packages/core/src/features/welcome/setting-welcome-page.test.tsx
+++ b/packages/core/src/features/welcome/setting-welcome-page.test.tsx
@@ -24,11 +24,11 @@ describe("setting-welcome-page", () => {
 
   describe("given configuration of welcome page route is the default", () => {
     beforeEach(async () => {
-      applicationBuilder.beforeApplicationStart((mainDi) => {
+      applicationBuilder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(welcomeRouteConfigInjectable, () => "/welcome");
       });
 
-      applicationBuilder.beforeWindowStart((windowDi) => {
+      applicationBuilder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(welcomeRouteConfigInjectable, () => "/welcome");
       });
 
@@ -54,11 +54,11 @@ describe("setting-welcome-page", () => {
 
   describe("given configuration of welcome page route is set to a custom page", () => {
     beforeEach(async () => {
-      applicationBuilder.beforeApplicationStart((mainDi) => {
+      applicationBuilder.beforeApplicationStart(({ mainDi }) => {
         mainDi.override(welcomeRouteConfigInjectable, () => "/extension/some-extension-name/some-welcome-page");
       });
 
-      applicationBuilder.beforeWindowStart((windowDi) => {
+      applicationBuilder.beforeWindowStart(({ windowDi }) => {
         windowDi.override(welcomeRouteConfigInjectable, () => "/extension/some-extension-name/some-welcome-page");
       });
 

--- a/packages/core/src/renderer/components/status-bar/status-bar.test.tsx
+++ b/packages/core/src/renderer/components/status-bar/status-bar.test.tsx
@@ -23,7 +23,7 @@ describe("<StatusBar />", () => {
 
     builder = getApplicationBuilder();
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.unoverride(getRandomIdInjectable);
       windowDi.permitSideEffects(getRandomIdInjectable);
       windowDi.override(directoryForUserDataInjectable, () => "some-directory-for-user-data");
@@ -63,7 +63,7 @@ describe("<StatusBar />", () => {
     const testId = "testId";
     const text = "heee";
 
-    builder.beforeWindowStart((windowDi) => {
+    builder.beforeWindowStart(({ windowDi }) => {
       windowDi.override(statusBarItemsInjectable, () => computed(() => ({
         right: [ { origin: testId, component: () => <span data-testid={testId} >{text}</span> }],
         left: [],

--- a/packages/technical-features/application/electron-main/src/starting-of-electron-main-application.test.ts
+++ b/packages/technical-features/application/electron-main/src/starting-of-electron-main-application.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@k8slens/application";
 import asyncFn, { AsyncFnMock } from "@async-fn/jest";
 import whenAppIsReadyInjectable from "./start-application/when-app-is-ready.injectable";
-import { beforeAnythingInjectionToken, beforeElectronIsReadyInjectionToken } from "./start-application/time-slots";
+import * as timeSlots from "./start-application/time-slots";
 
 describe("starting-of-electron-main-application", () => {
   let di: DiContainer;
@@ -30,13 +30,13 @@ describe("starting-of-electron-main-application", () => {
     const beforeAnythingIsLoadingInjectable = getInjectable({
       id: "before-anything",
       instantiate: () => ({ run: beforeAnythingMock }),
-      injectionToken: beforeAnythingInjectionToken,
+      injectionToken: timeSlots.beforeAnythingInjectionToken,
     });
 
     const beforeElectronIsReadyIsLoadingInjectable = getInjectable({
       id: "before-electron-is-ready",
       instantiate: () => ({ run: beforeElectronIsReadyMock }),
-      injectionToken: beforeElectronIsReadyInjectionToken,
+      injectionToken: timeSlots.beforeElectronIsReadyInjectionToken,
     });
 
     const beforeApplicationIsLoadingInjectable = getInjectable({


### PR DESCRIPTION
- Now the callback is provided with an object containing either `mainDi` or `windowDi` fields. This should help with confusion over which environment the `di` is for