### PR TITLE
Fix cluster view broken scrolling

### DIFF
--- a/packages/core/src/renderer/components/cluster-manager/cluster-manager.scss
+++ b/packages/core/src/renderer/components/cluster-manager/cluster-manager.scss
@@ -53,6 +53,7 @@
       &.hidden {
         opacity: 0;
         pointer-events: none;
+        visibility: hidden;
       }
     }
   }


### PR DESCRIPTION
If one iframe is on top of other scrolling being blocked for some reason for one of them.

Adding `visibility:hidden` solves the problem.


https://user-images.githubusercontent.com/9607060/224922401-05efd86b-855a-41fe-a4fc-69f099034ab3.mov

Fixes #7322 