### PR TITLE
Release 6.5.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34384,7 +34384,7 @@
     },
     "packages/core": {
       "name": "@k8slens/core",
-      "version": "6.5.0-alpha.2",
+      "version": "6.5.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@astronautlabs/jsonpath": "^1.1.0",
@@ -34661,10 +34661,10 @@
     },
     "packages/extension-api": {
       "name": "@k8slens/extensions",
-      "version": "6.5.0-alpha.2",
+      "version": "6.5.0-alpha.3",
       "license": "MIT",
       "dependencies": {
-        "@k8slens/core": "^6.5.0-alpha.2"
+        "@k8slens/core": "^6.5.0-alpha.3"
       },
       "devDependencies": {
         "@types/node": "^16.18.6",
@@ -36377,10 +36377,10 @@
     },
     "packages/legacy-extension-example": {
       "name": "@k8slens/legacy-extension-example",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
-        "@k8slens/extensions": "^6.5.0-alpha.2",
+        "@k8slens/extensions": "^6.5.0-alpha.3",
         "@types/node": "^16.18.16",
         "typescript": "^4.9.5",
         "webpack": "^5.76.1",
@@ -36652,18 +36652,18 @@
       }
     },
     "packages/open-lens": {
-      "version": "6.5.0-alpha.2",
+      "version": "6.5.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@k8slens/application": "^6.5.0-alpha.1",
+        "@k8slens/application": "^6.5.0-alpha.2",
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.1",
-        "@k8slens/core": "^6.5.0-alpha.2",
+        "@k8slens/core": "^6.5.0-alpha.3",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.1",
         "@k8slens/feature-core": "^6.5.0-alpha.1",
         "@k8slens/generate-tray-icons": "^6.5.0-alpha.1",
-        "@k8slens/legacy-extension-example": "^1.0.0-alpha.0",
-        "@k8slens/legacy-extensions": "^1.0.0-alpha.0",
+        "@k8slens/legacy-extension-example": "^1.0.0-alpha.1",
+        "@k8slens/legacy-extensions": "^1.0.0-alpha.1",
         "@k8slens/run-many": "^1.0.0-alpha.1",
         "@k8slens/test-utils": "^1.0.0-alpha.1",
         "@k8slens/utilities": "^1.0.0-alpha.1",
@@ -37175,7 +37175,7 @@
     },
     "packages/technical-features/application/agnostic": {
       "name": "@k8slens/application",
-      "version": "6.5.0-alpha.1",
+      "version": "6.5.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@async-fn/jest": "^1.6.4",
@@ -37208,7 +37208,7 @@
     },
     "packages/technical-features/application/legacy-extensions": {
       "name": "@k8slens/legacy-extensions",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@k8slens/eslint-config": "6.5.0-alpha.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.2",
+  "version": "6.5.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.5.0-alpha.2",
+  "version": "6.5.0-alpha.3",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "npm run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.5.0-alpha.2"
+    "@k8slens/core": "^6.5.0-alpha.3"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/legacy-extension-example/package.json
+++ b/packages/legacy-extension-example/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/legacy-extension-example",
   "private": false,
   "description": "An example bundled Lens extensions using the v1 API",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "type": "commonjs",
   "files": [
     "dist"
@@ -38,7 +38,7 @@
     "lint:fix": "lens-lint --fix"
   },
   "devDependencies": {
-    "@k8slens/extensions": "^6.5.0-alpha.2",
+    "@k8slens/extensions": "^6.5.0-alpha.3",
     "@types/node": "^16.18.16",
     "typescript": "^4.9.5",
     "webpack": "^5.76.1",

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.2",
+  "version": "6.5.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -195,14 +195,14 @@
     }
   },
   "dependencies": {
-    "@k8slens/application": "^6.5.0-alpha.1",
+    "@k8slens/application": "^6.5.0-alpha.2",
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.1",
-    "@k8slens/core": "^6.5.0-alpha.2",
+    "@k8slens/core": "^6.5.0-alpha.3",
     "@k8slens/ensure-binaries": "^6.5.0-alpha.1",
     "@k8slens/feature-core": "^6.5.0-alpha.1",
     "@k8slens/generate-tray-icons": "^6.5.0-alpha.1",
-    "@k8slens/legacy-extension-example": "^1.0.0-alpha.0",
-    "@k8slens/legacy-extensions": "^1.0.0-alpha.0",
+    "@k8slens/legacy-extension-example": "^1.0.0-alpha.1",
+    "@k8slens/legacy-extensions": "^1.0.0-alpha.1",
     "@k8slens/run-many": "^1.0.0-alpha.1",
     "@k8slens/test-utils": "^1.0.0-alpha.1",
     "@k8slens/utilities": "^1.0.0-alpha.1",

--- a/packages/technical-features/application/agnostic/package.json
+++ b/packages/technical-features/application/agnostic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/application",
   "private": false,
-  "version": "6.5.0-alpha.1",
+  "version": "6.5.0-alpha.2",
   "description": "Package for creating Lens applications",
   "type": "commonjs",
   "files": [

--- a/packages/technical-features/application/legacy-extensions/package.json
+++ b/packages/technical-features/application/legacy-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/legacy-extensions",
   "private": false,
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Package for Lens extensions using the v1 API",
   "type": "commonjs",
   "files": [


### PR DESCRIPTION
## Changes since 6.5.0-alpha.2

## 🚀 Features

- Adding cluster settings icon menu items using injection token (**[#7341](https://github.com/lensapp/lens/pull/7341)**) https://github.com/aleksfront

## 🐛 Bug Fixes

- Fix bundled extensions not being loaded (**[#7359](https://github.com/lensapp/lens/pull/7359)**) https://github.com/Nokel81

## 🧰 Maintenance

- Move activating cluster into injectable IPC (**[#7355](https://github.com/lensapp/lens/pull/7355)**) https://github.com/Nokel81
- Move deactivating a cluster into injectable IPC (**[#7356](https://github.com/lensapp/lens/pull/7356)**) https://github.com/Nokel81
