### PR TITLE
Fix Check for updates menu item title capitalisation

### DIFF
--- a/packages/core/src/features/application-update/child-features/application-update-using-application-menu/main/check-for-updates-menu-item.injectable.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-application-menu/main/check-for-updates-menu-item.injectable.ts
@@ -28,7 +28,7 @@ const checkForUpdatesMenuItemInjectable = getInjectable({
       id: "check-for-updates",
       parentId: isMac ? "mac" : "help",
       orderNumber: isMac ? 20 : 50,
-      label: "Check for Updates",
+      label: "Check for Updates...",
       isShown: updatingIsEnabled,
 
       onClick: () => {

--- a/packages/core/src/features/application-update/child-features/application-update-using-application-menu/main/check-for-updates-menu-item.injectable.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-application-menu/main/check-for-updates-menu-item.injectable.ts
@@ -28,7 +28,7 @@ const checkForUpdatesMenuItemInjectable = getInjectable({
       id: "check-for-updates",
       parentId: isMac ? "mac" : "help",
       orderNumber: isMac ? 20 : 50,
-      label: "Check for updates",
+      label: "Check for Updates",
       isShown: updatingIsEnabled,
 
       onClick: () => {

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
@@ -146,7 +146,7 @@ describe("installing update using tray", () => {
       it("name of tray item for checking updates indicates that checking is happening", () => {
         expect(
           builder.tray.get("check-for-updates")?.label,
-        ).toBe("Checking for updates...");
+        ).toBe("Checking for Updates...");
       });
 
       it("user cannot install update yet", () => {
@@ -177,7 +177,7 @@ describe("installing update using tray", () => {
         it("name of tray item for checking updates no longer indicates that checking is happening", () => {
           expect(
             builder.tray.get("check-for-updates")?.label,
-          ).toBe("Check for updates");
+          ).toBe("Check for Updates");
         });
 
         it("renders", () => {
@@ -241,7 +241,7 @@ describe("installing update using tray", () => {
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
               builder.tray.get("check-for-updates")?.label,
-            ).toBe("Check for updates");
+            ).toBe("Check for Updates");
           });
 
           it("renders", () => {
@@ -269,7 +269,7 @@ describe("installing update using tray", () => {
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
               builder.tray.get("check-for-updates")?.label,
-            ).toBe("Check for updates");
+            ).toBe("Check for Updates");
           });
 
           it("renders", () => {

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/installing-update-using-tray.test.ts
@@ -177,7 +177,7 @@ describe("installing update using tray", () => {
         it("name of tray item for checking updates no longer indicates that checking is happening", () => {
           expect(
             builder.tray.get("check-for-updates")?.label,
-          ).toBe("Check for Updates");
+          ).toBe("Check for Updates...");
         });
 
         it("renders", () => {
@@ -241,7 +241,7 @@ describe("installing update using tray", () => {
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
               builder.tray.get("check-for-updates")?.label,
-            ).toBe("Check for Updates");
+            ).toBe("Check for Updates...");
           });
 
           it("renders", () => {
@@ -269,7 +269,7 @@ describe("installing update using tray", () => {
           it("name of tray item for checking updates no longer indicates that downloading is happening", () => {
             expect(
               builder.tray.get("check-for-updates")?.label,
-            ).toBe("Check for Updates");
+            ).toBe("Check for Updates...");
           });
 
           it("renders", () => {

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
@@ -47,15 +47,15 @@ const checkForUpdatesTrayItemInjectable = getInjectable({
         }
 
         if (checkingForUpdatesState.value.get()) {
-          return "Checking for updates...";
+          return "Checking for Updates...";
         }
 
-        return "Check for updates";
+        return "Check for Updates";
       }),
 
       enabled: computed(() => !checkingForUpdatesState.value.get() && !downloadingUpdateState.value.get()),
 
-      visible: computed(() => updatingIsEnabled),
+      visible: computed(() => true),
 
       click: pipeline(
         async () => {

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
@@ -50,7 +50,7 @@ const checkForUpdatesTrayItemInjectable = getInjectable({
           return "Checking for Updates...";
         }
 
-        return "Check for Updates";
+        return "Check for Updates...";
       }),
 
       enabled: computed(() => !checkingForUpdatesState.value.get() && !downloadingUpdateState.value.get()),

--- a/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
+++ b/packages/core/src/features/application-update/child-features/application-update-using-tray/main/tray-items/check-for-updates-tray-item.injectable.ts
@@ -55,7 +55,7 @@ const checkForUpdatesTrayItemInjectable = getInjectable({
 
       enabled: computed(() => !checkingForUpdatesState.value.get() && !downloadingUpdateState.value.get()),
 
-      visible: computed(() => true),
+      visible: computed(() => updatingIsEnabled),
 
       click: pipeline(
         async () => {


### PR DESCRIPTION
Minor: follow same capitalisation rules as for other menu items.

`Check for updates` become `Check for Updates`.

<img width="321" alt="check for updates before" src="https://user-images.githubusercontent.com/9607060/226894016-12a1a038-167b-4633-ba48-9c99c11a6abc.png">
