### PR TITLE
Fix Cannot find module '@k8slens/cluster-settings' while running in dev mode

### DIFF
--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -18,7 +18,10 @@
     "clean": "rimraf dist/",
     "generate-types": "tsc --d --declarationDir ./dist --declarationMap --emitDeclarationOnly",
     "build": "npm run generate-types && swc ./src/index.ts -d ./dist",
-    "prepare:test": "npm run build"
+    "prepare": "npm run build",
+    "prepare:dev": "npm run build",
+    "prepare:test": "npm run build",
+    "lint": "exit 0"
   },
   "devDependencies": {
     "@ogre-tools/injectable": "^15.1.2",

--- a/packages/cluster-settings/package.json
+++ b/packages/cluster-settings/package.json
@@ -20,8 +20,7 @@
     "build": "npm run generate-types && swc ./src/index.ts -d ./dist",
     "prepare": "npm run build",
     "prepare:dev": "npm run build",
-    "prepare:test": "npm run build",
-    "lint": "exit 0"
+    "prepare:test": "npm run build"
   },
   "devDependencies": {
     "@ogre-tools/injectable": "^15.1.2",


### PR DESCRIPTION

![can not find module err](https://user-images.githubusercontent.com/9607060/227857813-54169c30-ccfa-4694-8b24-ed6daad5f637.png)


Adding `prepare` commands to cluster-settings package solves `npm run dev` error.