### PR TITLE
Fix download all logs for pod with few containers

### DIFF
--- a/packages/core/src/features/pod-logs/download-logs.test.tsx
+++ b/packages/core/src/features/pod-logs/download-logs.test.tsx
@@ -190,12 +190,12 @@ describe("download logs options in logs dock tab", () => {
             it("logs have been called with query", () => {
               expect(callForLogsMock).toHaveBeenCalledWith(
                 { name: "dockerExporter", namespace: "default" },
-                { "previous": true, "timestamps": false },
+                { "previous": true, "timestamps": false, container: "docker-exporter" },
               );
             });
 
             it("shows save dialog with proper attributes", async () => {
-              expect(openSaveFileDialogMock).toHaveBeenCalledWith("dockerExporter.log", "all-logs", "text/plain");
+              expect(openSaveFileDialogMock).toHaveBeenCalledWith("docker-exporter.log", "all-logs", "text/plain");
             });
 
             it("doesn't block download dropdown for interaction after click", async () => {
@@ -265,7 +265,7 @@ describe("download logs options in logs dock tab", () => {
             it("logs have been called", () => {
               expect(callForLogsMock).toHaveBeenCalledWith(
                 { name: "dockerExporter", namespace: "default" },
-                { "previous": true, "timestamps": false },
+                { "previous": true, "timestamps": false, container: "docker-exporter" },
               );
             });
 

--- a/packages/core/src/renderer/components/dock/logs/download-all-logs.injectable.ts
+++ b/packages/core/src/renderer/components/dock/logs/download-all-logs.injectable.ts
@@ -25,7 +25,7 @@ const downloadAllLogsInjectable = getInjectable({
       });
 
       if (logs) {
-        openSaveFileDialog(`${params.name}.log`, logs, "text/plain");
+        openSaveFileDialog(`${query.container}.log`, logs, "text/plain");
       } else {
         showErrorNotification("No logs to download");
       }

--- a/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
+++ b/packages/core/src/renderer/components/dock/logs/logs-view-model.ts
@@ -101,7 +101,7 @@ export class LogTabViewModel {
 
     if (pod && tabData) {
       const params = { name: pod.getName(), namespace: pod.getNs() };
-      const query = { timestamps: tabData.showTimestamps, previous: tabData.showPrevious };
+      const query = { timestamps: tabData.showTimestamps, previous: tabData.showPrevious, container: tabData.selectedContainer };
 
       return this.dependencies.downloadAllLogs(params, query);
     }


### PR DESCRIPTION
Fixes https://github.com/lensapp/lens/issues/7391

https://user-images.githubusercontent.com/9607060/227883054-12566dfc-cbe9-4462-ba54-e1e24adbb986.mov


---

A `container` param should be specified to kube API server if more than 1 containers presented. 

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#read-log-pod-v1-core