### PR TITLE
Remove requirement for JSON of messages

### DIFF
--- a/packages/technical-features/messaging/computed-channel/index.ts
+++ b/packages/technical-features/messaging/computed-channel/index.ts
@@ -6,7 +6,4 @@ export {
 export type {
   ChannelObserver,
   ComputedChannelFactory,
-  JsonifiableObject,
-  JsonifiableArray,
-  Jsonifiable,
 } from "./src/computed-channel/computed-channel.injectable";

--- a/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel-administration-channel.injectable.ts
+++ b/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel-administration-channel.injectable.ts
@@ -1,14 +1,8 @@
 import { reaction } from "mobx";
-
 import { getMessageChannelListenerInjectable } from "@k8slens/messaging";
 import { sendMessageToChannelInjectionToken } from "@k8slens/messaging";
-import type { JsonPrimitive } from "type-fest";
 import { computedChannelObserverInjectionToken } from "./computed-channel.injectable";
 import { getMessageChannel } from "@k8slens/messaging";
-
-export type JsonifiableObject = { [Key in string]?: Jsonifiable } | { toJSON: () => Jsonifiable };
-export type JsonifiableArray = readonly Jsonifiable[];
-export type Jsonifiable = JsonPrimitive | JsonifiableObject | JsonifiableArray;
 
 export type ComputedChannelAdminMessage = {
   channelId: string;

--- a/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel.test.tsx
+++ b/packages/technical-features/messaging/computed-channel/src/computed-channel/computed-channel.test.tsx
@@ -292,14 +292,6 @@ const TestComponent = observer(({ someComputed }: { someComputed: IComputedValue
                       });
                     });
 
-                    it("when accessing the computed value outside of reactive context, throws", () => {
-                      expect(() => {
-                        computedTestChannel.get();
-                      }).toThrow(
-                        'Tried to access value of computed channel "some-channel-id" outside of reactive context. This is not possible, as the value is acquired asynchronously sometime *after* being observed. Not respecting that, the value could be stale.',
-                      );
-                    });
-
                     it("no value gets listened in di-1 anymore", () => {
                       expect(latestValueMessage).toBeUndefined();
                     });
@@ -380,14 +372,6 @@ const TestComponent = observer(({ someComputed }: { someComputed: IComputedValue
                       });
                     });
                   });
-                });
-
-                it("when accessing the computed value outside of reactive context, throws", () => {
-                  expect(() => {
-                    computedTestChannel.get();
-                  }).toThrow(
-                    'Tried to access value of computed channel "some-channel-id" outside of reactive context. This is not possible, as the value is acquired asynchronously sometime *after* being observed. Not respecting that, the value could be stale.',
-                  );
                 });
               });
 


### PR DESCRIPTION
- Remove backhanded requirements of reactive contexts, overriding application configurations.