### PR TITLE
Restore disk metrics to PersistentVolumeClaim details page

### DIFF
--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -167,7 +167,7 @@ export enum ClusterMetricsResourceType {
   StatefulSet = "StatefulSet",
   Container = "Container",
   Ingress = "Ingress",
-  VolumeClaim = "VolumeClaim",
+  VolumeClaim = "PersistentVolumeClaim",
   ReplicaSet = "ReplicaSet",
   DaemonSet = "DaemonSet",
   Job = "Job",


### PR DESCRIPTION
should fix #7417. Don't know because I cannot build Lens Desktop locally or through CI. Opening PR to see if tests still pass.