### PR TITLE
Make ServiceAccount kubeconfig context name differ from cluster context name

### DIFF
--- a/packages/core/src/main/routes/kubeconfig-route/get-service-account-route.injectable.ts
+++ b/packages/core/src/main/routes/kubeconfig-route/get-service-account-route.injectable.ts
@@ -84,7 +84,7 @@ function generateKubeConfig(username: string, secret: V1Secret, cluster: Cluster
     ],
     "contexts": [
       {
-        "name": cluster.contextName.get(),
+        "name": [cluster.contextName.get(), username].join("-"),
         "context": {
           "user": username,
           "cluster": cluster.contextName.get(),


### PR DESCRIPTION
The ServiceAccount kubeconfig is generated with a context that has the same name as the associated cluster, which is typically the cluster's context name too. This makes it difficult to distinguish the "clusters" in the cluster list. This PR appends the username (ServiceAccount name) to the cluster name to make it more unique.