### PR TITLE
Change dependabot updates directory to ./packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
+    directory: ./packages
     schedule:
       interval: daily
     open-pull-requests-limit: 4


### PR DESCRIPTION
Changing `directory` param to bump dependencies versions in `./packages` folder. If it works okay and dependabot will catch up internal packages, we can add separate `updates` section in `dependabot.yml` config file.

**Why this is needed?** 
After converting to monorepo model dependabot ignores packages and only bumps dependencies versions in the root. An example https://github.com/lensapp/lens/pull/7434