### PR TITLE
Stop all extensions before quitting app

### DIFF
--- a/packages/core/src/features/extensions/stopping/main/stop-all.injectable.ts
+++ b/packages/core/src/features/extensions/stopping/main/stop-all.injectable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import extensionInjectable from "../../../../extensions/extension-loader/extension/extension.injectable";
+import extensionsInjectable from "../../../../extensions/extensions.injectable";
+
+const stopAllExtensionsInjectable = getInjectable({
+  id: "stop-all-extensions",
+  instantiate: (di) => {
+    const extensionInstances = di.inject(extensionsInjectable);
+
+    return async () => {
+      for (const instance of extensionInstances.get()) {
+        const extension = di.inject(extensionInjectable, instance);
+
+        await instance.disable();
+        extension.deregister();
+      }
+    };
+  },
+});
+
+export default stopAllExtensionsInjectable;

--- a/packages/core/src/main/stop-services-and-exit-app.injectable.ts
+++ b/packages/core/src/main/stop-services-and-exit-app.injectable.ts
@@ -8,6 +8,7 @@ import clusterManagerInjectable from "./cluster/manager.injectable";
 import loggerInjectable from "../common/logger.injectable";
 import closeAllWindowsInjectable from "./start-main-application/lens-window/hide-all-windows/close-all-windows.injectable";
 import emitAppEventInjectable from "../common/app-event-bus/emit-event.injectable";
+import stopAllExtensionsInjectable from "../features/extensions/stopping/main/stop-all.injectable";
 
 const stopServicesAndExitAppInjectable = getInjectable({
   id: "stop-services-and-exit-app",
@@ -18,11 +19,13 @@ const stopServicesAndExitAppInjectable = getInjectable({
     const logger = di.inject(loggerInjectable);
     const closeAllWindows = di.inject(closeAllWindowsInjectable);
     const emitAppEvent = di.inject(emitAppEventInjectable);
+    const stopAllExtensions = di.inject(stopAllExtensionsInjectable);
 
-    return () => {
+    return async () => {
       emitAppEvent({ name: "service", action: "close" });
       closeAllWindows();
       clusterManager.stop();
+      await stopAllExtensions();
       logger.info("SERVICE:QUIT");
       setTimeout(exitApp, 1000);
     };


### PR DESCRIPTION
Motivation: Perhaps some extensions are holding onto resources which are causing the application to crash loudly. This should help stop that.