### PR TITLE
Kludge fix for application crash when quitting

### DIFF
--- a/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.injectable.ts
+++ b/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-from-electron.injectable.ts
@@ -12,11 +12,15 @@ const resolveSystemProxyFromElectronInjectable = getInjectable({
   instantiate: (di) => {
     const withErrorLoggingFor = di.inject(withErrorLoggingInjectable);
     const withErrorLogging = withErrorLoggingFor(() => "Error resolving proxy");
-    
+
     return withErrorLogging(async (url: string) => {
       const helperWindow = await di.inject(resolveSystemProxyWindowInjectable);
 
-      return await helperWindow.webContents.session.resolveProxy(url);
+      const proxy = await helperWindow.webContents.session.resolveProxy(url);
+
+      helperWindow.close();
+
+      return proxy;
     });
   },
 });

--- a/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-window.injectable.ts
+++ b/packages/core/src/main/utils/resolve-system-proxy/resolve-system-proxy-window.injectable.ts
@@ -2,7 +2,7 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-import { getInjectable } from "@ogre-tools/injectable";
+import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { BrowserWindow } from "electron";
 import electronAppInjectable from "../../electron-app/electron-app.injectable";
 
@@ -22,6 +22,9 @@ const resolveSystemProxyWindowInjectable = getInjectable({
 
     return window;
   },
+
+  lifecycle: lifecycleEnum.transient,
+
   causesSideEffects: true,
 });
 


### PR DESCRIPTION
Kludge crash of application when quitting by closing the helper window explicitly after resolving the proxy.

fixes lensapp/lens-ide#639