### PR TITLE
Fix metrics visibility logic

### DIFF
--- a/packages/core/src/renderer/api/catalog/entity/__tests__/metrics-enabled.test.ts
+++ b/packages/core/src/renderer/api/catalog/entity/__tests__/metrics-enabled.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+
+import { Cluster } from "../../../../../common/cluster/cluster";
+import { getDiForUnitTesting } from "../../../../getDiForUnitTesting";
+import enabledMetricsInjectable from "../metrics-enabled.injectable";
+import activeEntityInternalClusterInjectable from "../get-active-cluster-entity.injectable";
+import { observable } from "mobx";
+import { ClusterMetricsResourceType } from "../../../../../common/cluster-types";
+import type { DiContainer } from "@ogre-tools/injectable";
+
+describe("metrics-enabled", () => {
+  let cluster: Cluster;
+  let di: DiContainer;
+
+  beforeEach(() => {
+    di = getDiForUnitTesting();
+
+    cluster = new Cluster({ contextName: "irrelevant", id: "irrelevant", kubeConfigPath: "irrelevant" });
+    const observableCluster = observable.box(cluster);
+
+    di.override(activeEntityInternalClusterInjectable, () => observableCluster);
+  });
+
+  it("given cluster has no hidden metrics preferences, should be true for all resources", () => {
+    const resourceTypes = Object.values(ClusterMetricsResourceType);
+
+    delete cluster.preferences.hiddenMetrics;
+    resourceTypes.forEach((resourceType) => {
+      expect(di.inject(enabledMetricsInjectable, resourceType).get()).toBe(true);
+    });
+  });
+
+  it("given cluster has metrics preferences, but nothing is hidden, should be true for all resources", () => {
+    const resourceTypes = Object.values(ClusterMetricsResourceType);
+
+    cluster.preferences.hiddenMetrics = [];
+
+    resourceTypes.forEach((resourceType) => {
+      expect(di.inject(enabledMetricsInjectable, resourceType).get()).toBe(true);
+    });
+  });
+
+  it("given cluster has metrics preferences, and some resource is hidden, should be false", () => {
+    cluster.preferences.hiddenMetrics = [ClusterMetricsResourceType.Pod];
+
+    expect(di.inject(enabledMetricsInjectable, ClusterMetricsResourceType.Pod).get()).toBe(false);
+  });
+});
+

--- a/packages/core/src/renderer/api/catalog/entity/metrics-details-component-enabled.injectable.ts
+++ b/packages/core/src/renderer/api/catalog/entity/metrics-details-component-enabled.injectable.ts
@@ -21,7 +21,7 @@ const metricsDetailsComponentEnabledInjectable = getInjectable({
         return false;
       }
 
-      return current.object.kind == kind && metricsEnabled.get();
+      return metricsEnabled.get() && current.object.kind == kind;
     });
   },
   lifecycle: lifecycleEnum.keyedSingleton({

--- a/packages/core/src/renderer/api/catalog/entity/metrics-enabled.injectable.ts
+++ b/packages/core/src/renderer/api/catalog/entity/metrics-enabled.injectable.ts
@@ -16,10 +16,10 @@ const enabledMetricsInjectable = getInjectable({
       const cluster = activeEntityInternalCluster.get();
 
       if (!cluster?.preferences.hiddenMetrics) {
-        return false;
+        return true;
       }
 
-      return cluster.preferences.hiddenMetrics.includes(kind);
+      return !cluster.preferences.hiddenMetrics.includes(kind);
     });
   },
   lifecycle: lifecycleEnum.keyedSingleton({

--- a/packages/core/src/renderer/components/+cluster/cluster-overview.tsx
+++ b/packages/core/src/renderer/components/+cluster/cluster-overview.tsx
@@ -98,11 +98,12 @@ class NonInjectedClusterOverview extends React.Component<Dependencies> {
   render() {
     const { eventStore, nodeStore, clusterMetricsAreVisible } = this.props;
     const isLoaded = nodeStore.isLoaded && eventStore.isLoaded;
+    const isMetricsHidden = !clusterMetricsAreVisible.get();
 
     return (
       <TabLayout scrollable>
         <div className={styles.ClusterOverview} data-testid="cluster-overview-page">
-          {this.renderClusterOverview(isLoaded, clusterMetricsAreVisible.get())}
+          {this.renderClusterOverview(isLoaded, isMetricsHidden)}
         </div>
       </TabLayout>
     );

--- a/packages/core/src/renderer/components/+workloads-pods/pod-details-container.tsx
+++ b/packages/core/src/renderer/components/+workloads-pods/pod-details-container.tsx
@@ -97,7 +97,7 @@ class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainer
     const readiness = pod.getReadinessProbe(container);
     const startup = pod.getStartupProbe(container);
     const isInitContainer = !!pod.getInitContainers().find(c => c.name == name);
-    const isMetricHidden = containerMetricsVisible.get();
+    const isMetricVisible = containerMetricsVisible.get();
 
     return (
       <div className="PodDetailsContainer">
@@ -105,7 +105,7 @@ class NonInjectedPodDetailsContainer extends React.Component<PodDetailsContainer
           <StatusBrick className={cssNames(state, { ready })}/>
           {name}
         </div>
-        {(!isMetricHidden && !isInitContainer && metrics) && (
+        {(isMetricVisible && !isInitContainer && metrics) && (
           <ResourceMetrics
             object={pod}
             tabs={[


### PR DESCRIPTION
Fixes logic errors where the implementation is actually reversed, it was hiding metrics when they should visible and other way around. Added test for the `enabled-metrics` injectable to document the wanted behavior. There was also some bugs in the rendered components where they would the logic flipped using visible where it should be hidden.

---

I found another issue that the changing the hidden metrics preferences is not synchronised to the cluster frame. This does not fix that issue. There is a separate Github issue here: 

- https://github.com/lensapp/lens/issues/7461