### PR TITLE
Fix node metrics line progress

### DIFF
--- a/packages/core/src/renderer/components/+nodes/nodes.scss
+++ b/packages/core/src/renderer/components/+nodes/nodes.scss
@@ -16,6 +16,10 @@
       @include table-cell-warning;
     }
 
+    .LineProgress {
+      width: 100%;
+    }
+
     &.cpu {
       flex: 1.0;
       align-self: center;


### PR DESCRIPTION
Regression where the line would have 0 width regardless of the metric because the outer div had 0 width also.

Before 
<img width="1541" alt="image" src="https://user-images.githubusercontent.com/774344/229501756-2fae0d6e-c983-4b1f-91ac-20ef7686e6e4.png">

After

<img width="1546" alt="image" src="https://user-images.githubusercontent.com/774344/229501821-af1029f7-9835-488f-bf1f-c64f078d72ad.png">
