### PR TITLE
Stop file system watchers on application quit to prevent exit code !== 0 

### DIFF
--- a/packages/core/src/extensions/extension-discovery/stop-watching-extensions-on-quit.injectable.ts
+++ b/packages/core/src/extensions/extension-discovery/stop-watching-extensions-on-quit.injectable.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getInjectable } from "@ogre-tools/injectable";
+import { beforeQuitOfBackEndInjectionToken } from "../../main/start-main-application/runnable-tokens/before-quit-of-back-end-injection-token";
+import extensionDiscoveryInjectable from "./extension-discovery.injectable";
+
+const stopWatchingExtensionsOnQuitInjectable = getInjectable({
+  id: "stop-watching-extensions-on-quit",
+
+  instantiate: (di) => {
+    const extensionDiscovery = di.inject(extensionDiscoveryInjectable);
+
+    return {
+      id: "stop-watching-extensions-on-quit",
+
+      run: async () => {
+        await extensionDiscovery.stopWatchingExtensions();
+      },
+    };
+  },
+
+  injectionToken: beforeQuitOfBackEndInjectionToken,
+});
+
+export default stopWatchingExtensionsOnQuitInjectable;

--- a/packages/core/src/main/catalog-sources/kubeconfig-sync/manager.ts
+++ b/packages/core/src/main/catalog-sources/kubeconfig-sync/manager.ts
@@ -98,10 +98,18 @@ export class KubeconfigSyncManager {
 
   @action
   protected stopOldSync(filePath: string): void {
-    if (!this.sources.delete(filePath)) {
-      // already stopped
+    const source = this.sources.get(filePath);
+
+    // already stopped
+    if (!source) {
       return this.dependencies.logger.debug(`no syncing file/folder to stop`, { filePath });
     }
+
+    const [, disposer] = source;
+
+    disposer();
+
+    this.sources.delete(filePath);
 
     this.dependencies.logger.info(`stopping sync of file/folder`, { filePath });
     this.dependencies.logger.debug(`${this.sources.size} files/folders watched`, { files: Array.from(this.sources.keys()) });


### PR DESCRIPTION
On application quit, the watchers should be stopped to ensure clean exit. Previously the application quit resulted in exit code `134`. Before https://github.com/lensapp/lens/pull/3465, the exit code remained `0` but the watchers weren't cleaned explicitly.