### PR TITLE
Set status item `padding-inline` to 0 if there is no children elements

### DIFF
--- a/packages/core/src/renderer/components/status-bar/status-bar.module.scss
+++ b/packages/core/src/renderer/components/status-bar/status-bar.module.scss
@@ -35,6 +35,10 @@
   display: flex;
   align-items: center;
 
+  &:empty {
+    padding-inline: 0;
+  }
+
   &:hover {
     cursor: pointer;
     background-color: #ffffff33;


### PR DESCRIPTION
This avoid the empty space (see below, the semi-transparent block on status bar) when extension registers an item which returns `null`

<img width="243" alt="Screenshot 2023-04-11 at 14 14 12" src="https://user-images.githubusercontent.com/1474479/231145103-f3d791c4-3011-4559-b8f7-43138ebb62af.png">

e.g.
```tsx
class A extends Renderer.LensExtension  {
  private getStatusBarItems() {
    return [
      {
        components: {
          Item: () => null
        }
      }
    ]
  }
}
```