### PR TITLE
Release 6.5.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38095,12 +38095,12 @@
     },
     "packages/business-features/keyboard-shortcuts": {
       "name": "@k8slens/keyboard-shortcuts",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@async-fn/jest": "^1.6.4",
         "@k8slens/eslint-config": "^6.5.0-alpha.2",
-        "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.1"
+        "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.2"
       },
       "peerDependencies": {
         "@k8slens/feature-core": "^6.5.0-alpha.0",
@@ -38318,7 +38318,7 @@
     },
     "packages/core": {
       "name": "@k8slens/core",
-      "version": "6.5.0-alpha.4",
+      "version": "6.5.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@astronautlabs/jsonpath": "^1.1.0",
@@ -38395,7 +38395,7 @@
       "devDependencies": {
         "@async-fn/jest": "1.6.4",
         "@k8slens/messaging-fake-bridge": "^1.0.0-alpha.2",
-        "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.1",
+        "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.2",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.60",
@@ -40177,10 +40177,10 @@
     },
     "packages/extension-api": {
       "name": "@k8slens/extensions",
-      "version": "6.5.0-alpha.4",
+      "version": "6.5.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@k8slens/core": "^6.5.0-alpha.4"
+        "@k8slens/core": "^6.5.0-alpha.5"
       },
       "devDependencies": {
         "@types/node": "^16.18.6",
@@ -42389,10 +42389,10 @@
     },
     "packages/legacy-extension-example": {
       "name": "@k8slens/legacy-extension-example",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
-        "@k8slens/extensions": "^6.5.0-alpha.4",
+        "@k8slens/extensions": "^6.5.0-alpha.5",
         "@types/node": "^16.18.16",
         "typescript": "^4.9.5",
         "webpack": "^5.77.0",
@@ -42802,17 +42802,17 @@
       }
     },
     "packages/open-lens": {
-      "version": "6.5.0-alpha.4",
+      "version": "6.5.0-alpha.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@k8slens/application": "^6.5.0-alpha.3",
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.2",
-        "@k8slens/core": "^6.5.0-alpha.4",
+        "@k8slens/core": "^6.5.0-alpha.5",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.2",
         "@k8slens/feature-core": "^6.5.0-alpha.2",
-        "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.1",
-        "@k8slens/legacy-extension-example": "^1.0.0-alpha.2",
+        "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.2",
+        "@k8slens/legacy-extension-example": "^1.0.0-alpha.3",
         "@k8slens/legacy-extensions": "^1.0.0-alpha.2",
         "@k8slens/messaging": "^1.0.0-alpha.2",
         "@k8slens/messaging-for-main": "^1.0.0-alpha.2",
@@ -45235,7 +45235,7 @@
     },
     "packages/utility-features/react-testing-library-discovery": {
       "name": "@k8slens/react-testing-library-discovery",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "^8.19.0",

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/keyboard-shortcuts",
   "private": false,
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Keyboard shortcuts for Lens",
   "type": "commonjs",
   "files": [
@@ -41,6 +41,6 @@
   "devDependencies": {
     "@async-fn/jest": "^1.6.4",
     "@k8slens/eslint-config": "^6.5.0-alpha.2",
-    "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.1"
+    "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.4",
+  "version": "6.5.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -183,7 +183,7 @@
   "devDependencies": {
     "@async-fn/jest": "1.6.4",
     "@k8slens/messaging-fake-bridge": "^1.0.0-alpha.2",
-    "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.1",
+    "@k8slens/react-testing-library-discovery": "^1.0.0-alpha.2",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.5.0-alpha.4",
+  "version": "6.5.0-alpha.5",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -26,7 +26,7 @@
     "prepare:dev": "npm run build"
   },
   "dependencies": {
-    "@k8slens/core": "^6.5.0-alpha.4"
+    "@k8slens/core": "^6.5.0-alpha.5"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/legacy-extension-example/package.json
+++ b/packages/legacy-extension-example/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/legacy-extension-example",
   "private": false,
   "description": "An example bundled Lens extensions using the v1 API",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "type": "commonjs",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
     "lint:fix": "lens-lint --fix"
   },
   "devDependencies": {
-    "@k8slens/extensions": "^6.5.0-alpha.4",
+    "@k8slens/extensions": "^6.5.0-alpha.5",
     "@types/node": "^16.18.16",
     "typescript": "^4.9.5",
     "webpack": "^5.77.0",

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.4",
+  "version": "6.5.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -187,11 +187,11 @@
   "dependencies": {
     "@k8slens/application": "^6.5.0-alpha.3",
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.2",
-    "@k8slens/core": "^6.5.0-alpha.4",
+    "@k8slens/core": "^6.5.0-alpha.5",
     "@k8slens/ensure-binaries": "^6.5.0-alpha.2",
     "@k8slens/feature-core": "^6.5.0-alpha.2",
-    "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.1",
-    "@k8slens/legacy-extension-example": "^1.0.0-alpha.2",
+    "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.2",
+    "@k8slens/legacy-extension-example": "^1.0.0-alpha.3",
     "@k8slens/legacy-extensions": "^1.0.0-alpha.2",
     "@k8slens/messaging": "^1.0.0-alpha.2",
     "@k8slens/messaging-for-main": "^1.0.0-alpha.2",

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/react-testing-library-discovery",
   "private": false,
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "A way to discover HTML-elements using react-testing-library",
   "type": "commonjs",
   "files": [


### PR DESCRIPTION
## Changes since 6.5.0-alpha.4

## 🧰 Maintenance

- Bump underscore from 1.7.0 to 1.13.6 (**[#7533](https://github.com/lensapp/lens/pull/7533)**) https://github.com/app/dependabot
- Fix publishing alpha failing due to accidental private package (**[#7537](https://github.com/lensapp/lens/pull/7537)**) https://github.com/Nokel81
