### PR TITLE
Make webpack respect dependencies vs peerDependencies when deciding dependency is external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@async-fn/jest/-/jest-1.6.4.tgz",
       "integrity": "sha512-m3T/m6a39f5dbqFj79BGCqudkm42McgMXD7M0ZorKeqqdAbNazay7t+VDOz5qqFHO12frFbbhAB5GnFPoGADPA==",
-      "dev": true,
       "peerDependencies": {
         "jest": ">= 24.9.0"
       }
@@ -38127,7 +38126,9 @@
         "@ogre-tools/fp": "^15.1.2",
         "@ogre-tools/injectable": "^15.1.2",
         "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
-        "lodash": "^4.17.21"
+        "@ogre-tools/injectable-react": "^15.1.2",
+        "lodash": "^4.17.21",
+        "react": "^17"
       }
     },
     "packages/cluster-settings": {
@@ -45038,6 +45039,7 @@
       },
       "peerDependencies": {
         "@k8slens/feature-core": "^6.5.0-alpha.0",
+        "@k8slens/run-many": "^1.0.0-alpha.1",
         "@ogre-tools/fp": "^15.1.2",
         "@ogre-tools/injectable": "^15.1.2",
         "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
@@ -45056,9 +45058,11 @@
       "peerDependencies": {
         "@k8slens/application": "^6.5.0-alpha.0",
         "@k8slens/feature-core": "^6.5.0-alpha.0",
+        "@k8slens/run-many": "^1.0.0-alpha.1",
         "@ogre-tools/injectable": "^15.1.2",
         "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
-        "electron": "^22.3.3"
+        "electron": "^22.3.3",
+        "lodash": "^4.17.21"
       }
     },
     "packages/technical-features/application/legacy-extensions": {
@@ -45133,6 +45137,7 @@
         "@k8slens/application": "^6.5.0-alpha.0",
         "@k8slens/feature-core": "^6.5.0-alpha.0",
         "@k8slens/messaging": "^1.0.0-alpha.1",
+        "@ogre-tools/fp": "^15.1.2",
         "@ogre-tools/injectable": "^15.1.2",
         "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
         "electron": "^22.3.3",
@@ -45148,6 +45153,7 @@
       },
       "peerDependencies": {
         "@k8slens/application": "^6.5.0-alpha.0",
+        "@k8slens/feature-core": "^6.5.0-alpha.0",
         "@k8slens/messaging": "^1.0.0-alpha.1",
         "@k8slens/run-many": "^1.0.0-alpha.1",
         "@k8slens/startable-stoppable": "^1.0.0-alpha.1",
@@ -45162,13 +45168,13 @@
       "version": "1.0.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
-        "@async-fn/jest": "^1.6.4",
         "@k8slens/eslint-config": "^6.5.0-alpha.2",
         "@k8slens/feature-core": "^6.5.0-alpha.2",
         "@ogre-tools/injectable-extension-for-mobx": "^15.3.0",
         "mobx": "^6.7.0"
       },
       "peerDependencies": {
+        "@async-fn/jest": "^1.6.4",
         "@k8slens/messaging": "^1.0.0-alpha.1",
         "@ogre-tools/fp": "^15.1.2",
         "@ogre-tools/injectable": "^15.1.2",
@@ -45195,6 +45201,7 @@
         "@ogre-tools/injectable-react": "^15.1.2",
         "lodash": "^4.17.15",
         "mobx": "^6.8.0",
+        "mobx-react": "^7.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       }
@@ -45228,7 +45235,7 @@
       "name": "@k8slens/react-testing-library-discovery",
       "version": "1.0.0-alpha.2",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@testing-library/dom": "^8.19.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0"
@@ -45238,6 +45245,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
       "integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -45256,6 +45264,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
       "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",
@@ -45272,12 +45281,14 @@
     "packages/utility-features/react-testing-library-discovery/node_modules/@types/aria-query": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "peer": true
     },
     "packages/utility-features/react-testing-library-discovery/node_modules/@types/react-dom": {
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -45286,6 +45297,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -45297,6 +45309,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "peer": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -45305,6 +45318,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -45391,6 +45405,7 @@
         "@ogre-tools/injectable-react": "^15.1.2",
         "@testing-library/react": "^12.1.5",
         "lodash": "^4.17.21",
+        "mobx": "^6.8.0",
         "react": "^17.0.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37282,6 +37282,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
       "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -42278,8 +42279,7 @@
         "tailwindcss": "^3.3.1",
         "ts-loader": "^9.4.1",
         "webpack": "^5.77.0",
-        "webpack-cli": "^4.10.0",
-        "webpack-node-externals": "^3.0.0"
+        "webpack-cli": "^4.10.0"
       }
     },
     "packages/infrastructure/webpack/node_modules/@types/estree": {

--- a/packages/business-features/keyboard-shortcuts/package.json
+++ b/packages/business-features/keyboard-shortcuts/package.json
@@ -36,7 +36,9 @@
     "@ogre-tools/fp": "^15.1.2",
     "@ogre-tools/injectable": "^15.1.2",
     "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
-    "lodash": "^4.17.21"
+    "@ogre-tools/injectable-react": "^15.1.2",
+    "lodash": "^4.17.21",
+    "react": "^17"
   },
   "devDependencies": {
     "@async-fn/jest": "^1.6.4",

--- a/packages/infrastructure/webpack/package.json
+++ b/packages/infrastructure/webpack/package.json
@@ -33,7 +33,6 @@
     "tailwindcss": "^3.3.1",
     "ts-loader": "^9.4.1",
     "webpack": "^5.77.0",
-    "webpack-cli": "^4.10.0",
-    "webpack-node-externals": "^3.0.0"
+    "webpack-cli": "^4.10.0"
   }
 }

--- a/packages/infrastructure/webpack/src/__snapshots__/get-multi-export-config.test.js.snap
+++ b/packages/infrastructure/webpack/src/__snapshots__/get-multi-export-config.test.js.snap
@@ -6,10 +6,6 @@ Array [
     "entry": Object {
       "index": "./index.ts",
     },
-    "externals": Array [
-      [Function],
-      [Function],
-    ],
     "externalsPresets": Object {
       "node": true,
     },
@@ -37,6 +33,8 @@ Array [
       "maxEntrypointSize": 100000,
     },
     "plugins": Array [
+      MakePeerDependenciesExternalPlugin {},
+      ProtectFromImportingNonDependencies {},
       ForkTsCheckerWebpackPlugin {
         "options": Object {
           "typescript": Object {
@@ -58,6 +56,7 @@ Array [
       "extensions": Array [
         ".ts",
         ".tsx",
+        ".js",
       ],
     },
     "target": "node",
@@ -66,10 +65,6 @@ Array [
     "entry": Object {
       "index": "./some-entrypoint/index.ts",
     },
-    "externals": Array [
-      [Function],
-      [Function],
-    ],
     "externalsPresets": Object {
       "node": true,
     },
@@ -97,6 +92,8 @@ Array [
       "maxEntrypointSize": 100000,
     },
     "plugins": Array [
+      MakePeerDependenciesExternalPlugin {},
+      ProtectFromImportingNonDependencies {},
       ForkTsCheckerWebpackPlugin {
         "options": Object {
           "typescript": Object {
@@ -118,6 +115,7 @@ Array [
       "extensions": Array [
         ".ts",
         ".tsx",
+        ".js",
       ],
     },
     "target": "node",
@@ -126,10 +124,6 @@ Array [
     "entry": Object {
       "index": "./some-other-entrypoint/index.ts",
     },
-    "externals": Array [
-      [Function],
-      [Function],
-    ],
     "externalsPresets": Object {
       "node": true,
     },
@@ -205,6 +199,8 @@ Array [
       "maxEntrypointSize": 100000,
     },
     "plugins": Array [
+      MakePeerDependenciesExternalPlugin {},
+      ProtectFromImportingNonDependencies {},
       ForkTsCheckerWebpackPlugin {
         "options": Object {
           "typescript": Object {
@@ -241,6 +237,7 @@ Array [
       "extensions": Array [
         ".ts",
         ".tsx",
+        ".js",
       ],
     },
     "target": "node",

--- a/packages/infrastructure/webpack/src/get-node-config.js
+++ b/packages/infrastructure/webpack/src/get-node-config.js
@@ -1,4 +1,5 @@
 const ForkTsCheckerPlugin = require("fork-ts-checker-webpack-plugin");
+const { MakePeerDependenciesExternalPlugin } = require("./plugins/make-peer-dependencies-external");
 const { ProtectFromImportingNonDependencies } = require("./plugins/protect-from-importing-non-dependencies");
 
 module.exports = ({ entrypointFilePath, outputDirectory }) => ({
@@ -17,6 +18,7 @@ module.exports = ({ entrypointFilePath, outputDirectory }) => ({
   },
 
   plugins: [
+    new MakePeerDependenciesExternalPlugin(),
     new ProtectFromImportingNonDependencies(),
 
     new ForkTsCheckerPlugin({
@@ -45,21 +47,6 @@ module.exports = ({ entrypointFilePath, outputDirectory }) => ({
 
     libraryTarget: "commonjs2",
   },
-
-  externals: [
-    nodeExternals({ modulesFromFile: true }),
-
-    nodeExternals({
-      modulesDir: path.resolve(
-        __dirname,
-        "..",
-        "..",
-        "..",
-        "..",
-        "node_modules"
-      ),
-    }),
-  ],
 
   externalsPresets: { node: true },
 

--- a/packages/infrastructure/webpack/src/get-node-config.js
+++ b/packages/infrastructure/webpack/src/get-node-config.js
@@ -1,6 +1,5 @@
 const ForkTsCheckerPlugin = require("fork-ts-checker-webpack-plugin");
-const nodeExternals = require("webpack-node-externals");
-const path = require("path");
+const { ProtectFromImportingNonDependencies } = require("./plugins/protect-from-importing-non-dependencies");
 
 module.exports = ({ entrypointFilePath, outputDirectory }) => ({
   name: entrypointFilePath,
@@ -14,10 +13,12 @@ module.exports = ({ entrypointFilePath, outputDirectory }) => ({
   },
 
   resolve: {
-    extensions: [".ts", ".tsx"],
+    extensions: [".ts", ".tsx", ".js"],
   },
 
   plugins: [
+    new ProtectFromImportingNonDependencies(),
+
     new ForkTsCheckerPlugin({
       typescript: {
         mode: "write-dts",

--- a/packages/infrastructure/webpack/src/plugins/get-dependency-name/get-dependency-name.js
+++ b/packages/infrastructure/webpack/src/plugins/get-dependency-name/get-dependency-name.js
@@ -1,0 +1,9 @@
+const getDependencyName = (requireString) => {
+  const [a, b] = requireString.split("/");
+
+  const scoped = a.startsWith("@");
+
+  return scoped ? `${a}/${b}` : a;
+};
+
+module.exports = { getDependencyName };

--- a/packages/infrastructure/webpack/src/plugins/get-dependency-name/get-dependency-name.test.js
+++ b/packages/infrastructure/webpack/src/plugins/get-dependency-name/get-dependency-name.test.js
@@ -1,0 +1,27 @@
+import { getDependencyName } from "./get-dependency-name";
+
+describe("get-dependency-name", () => {
+  it("given scoped dependency with entrypoint, returns dependency name", () => {
+    const actual = getDependencyName("@some-scope/some-package/entrypoint");
+
+    expect(actual).toBe("@some-scope/some-package");
+  });
+
+  it("given scoped dependency but no entrypoint, returns dependency name", () => {
+    const actual = getDependencyName("@some-scope/some-package");
+
+    expect(actual).toBe("@some-scope/some-package");
+  });
+
+  it("given non scoped dependency with entrypoint, returns dependency name", () => {
+    const actual = getDependencyName("some-package/some-entrypoint");
+
+    expect(actual).toBe("some-package");
+  });
+
+  it("given non scoped dependency but no entrypoint, returns dependency name", () => {
+    const actual = getDependencyName("some-package");
+
+    expect(actual).toBe("some-package");
+  });
+});

--- a/packages/infrastructure/webpack/src/plugins/make-peer-dependencies-external.js
+++ b/packages/infrastructure/webpack/src/plugins/make-peer-dependencies-external.js
@@ -1,0 +1,29 @@
+const ExternalModuleFactoryPlugin = require("webpack/lib/ExternalModuleFactoryPlugin");
+const path = require("path");
+
+const {
+  toModuleMatcherRegExp,
+} = require("./to-module-matcher-reg-exp/to-module-matcher-reg-exp");
+
+class MakePeerDependenciesExternalPlugin {
+  apply(compiler) {
+    compiler.hooks.compile.tap("compile", (params) => {
+      const peerDependencies = getPeerDependencies();
+
+      new ExternalModuleFactoryPlugin(
+        compiler.options.output.library.type,
+        peerDependencies.map(toModuleMatcherRegExp)
+      ).apply(params.normalModuleFactory);
+    });
+  }
+}
+
+const getPeerDependencies = () => {
+  const pathToPackageJson = path.resolve(process.cwd(), "package.json");
+
+  const packageJson = require(pathToPackageJson);
+
+  return Object.keys(packageJson.peerDependencies || {});
+};
+
+module.exports = { MakePeerDependenciesExternalPlugin };

--- a/packages/infrastructure/webpack/src/plugins/protect-from-importing-non-dependencies.js
+++ b/packages/infrastructure/webpack/src/plugins/protect-from-importing-non-dependencies.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const { getDependencyName } = require("./get-dependency-name/get-dependency-name");
+
+const pathToPackageJson = path.resolve(process.cwd(), "package.json");
+
+class ProtectFromImportingNonDependencies {
+  apply(compiler) {
+    const dependencies = getDependenciesAndPeerDependencies();
+
+    const nodeModulesToBeResolved = new Set();
+
+    compiler.hooks.normalModuleFactory.tap("irrelevant", (normalModuleFactory) => {
+      normalModuleFactory.hooks.resolve.tap("irrelevant", (toBeResolved) => {
+
+        const isLocalDependency = toBeResolved.request.startsWith(".");
+        const isDependencyOfDependency =
+          toBeResolved.context.includes("node_modules");
+
+        if (!isLocalDependency && !isDependencyOfDependency) {
+
+          const dependencyName = getDependencyName(toBeResolved.request);
+
+          nodeModulesToBeResolved.add(dependencyName);
+        }
+      });
+    });
+
+    compiler.hooks.afterCompile.tap("compile", () => {
+      const notSpecifiedDependencies = [...nodeModulesToBeResolved].filter(
+        (x) => !dependencies.includes(x)
+      );
+
+      if (notSpecifiedDependencies.length) {
+        throw new Error(
+          `Tried to import dependencies that are not specified in the package.json "${pathToPackageJson}". Add "${notSpecifiedDependencies.join(
+            '", "'
+          )}" to dependencies or peerDependencies.`
+        );
+      }
+    });
+  }
+}
+const getDependenciesAndPeerDependencies = () => {
+  const packageJson = require(pathToPackageJson);
+
+  const dependencies = Object.keys(packageJson.dependencies || {});
+  const peerDependencies = Object.keys(packageJson.peerDependencies || {});
+
+  return [...dependencies, ...peerDependencies];
+};
+
+module.exports = {
+  ProtectFromImportingNonDependencies,
+};

--- a/packages/infrastructure/webpack/src/plugins/to-module-matcher-reg-exp/to-module-matcher-reg-exp.js
+++ b/packages/infrastructure/webpack/src/plugins/to-module-matcher-reg-exp/to-module-matcher-reg-exp.js
@@ -1,0 +1,3 @@
+const toModuleMatcherRegExp = x => new RegExp(`^${x}(/.*)*$`);
+
+module.exports = { toModuleMatcherRegExp };

--- a/packages/infrastructure/webpack/src/plugins/to-module-matcher-reg-exp/to-module-matcher-reg-exp.test.js
+++ b/packages/infrastructure/webpack/src/plugins/to-module-matcher-reg-exp/to-module-matcher-reg-exp.test.js
@@ -1,0 +1,57 @@
+import { toModuleMatcherRegExp } from "./to-module-matcher-reg-exp";
+
+describe('to-module-matcher-reg-exp', () => {
+  let regExp;
+
+  beforeEach(() => {
+    regExp = toModuleMatcherRegExp("some-package");
+  });
+
+  it('given exactly matching package, matches', () => {
+    const targetString = 'some-package';
+
+    const [match] = targetString.match(regExp);
+
+    expect(match).toBeTruthy()
+  });
+
+  it('given matching package with entrypoint, matches', () => {
+    const targetString = 'some-package/some-entrypoint';
+
+    const [match] = targetString.match(regExp);
+
+    expect(match).toBeTruthy()
+  });
+
+  it('given matching package with directory, matches', () => {
+    const targetString = 'some-package/some-directory/some-other-directory';
+
+    const [match] = targetString.match(regExp);
+
+    expect(match).toBeTruthy()
+  });
+
+  it('given package that starts with same name but is still different, does not match', () => {
+    const targetString = 'some-package-but-still-different';
+
+    const actual = targetString.match(regExp);
+
+    expect(actual).toBeNull()
+  });
+
+  it('given package that starts with something else, does not match', () => {
+    const targetString = 'different-some-package';
+
+    const actual = targetString.match(regExp);
+
+    expect(actual).toBeNull()
+  });
+
+  it('given irrelevant package, does not match', () => {
+    const targetString = 'some-other-package';
+
+    const actual = targetString.match(regExp);
+
+    expect(actual).toBeNull()
+  });
+});

--- a/packages/technical-features/application/agnostic/package.json
+++ b/packages/technical-features/application/agnostic/package.json
@@ -32,6 +32,7 @@
   },
   "peerDependencies": {
     "@k8slens/feature-core": "^6.5.0-alpha.0",
+    "@k8slens/run-many": "^1.0.0-alpha.1",
     "@ogre-tools/fp": "^15.1.2",
     "@ogre-tools/injectable": "^15.1.2",
     "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",

--- a/packages/technical-features/application/electron-main/package.json
+++ b/packages/technical-features/application/electron-main/package.json
@@ -33,9 +33,11 @@
   "peerDependencies": {
     "@k8slens/application": "^6.5.0-alpha.0",
     "@k8slens/feature-core": "^6.5.0-alpha.0",
+    "@k8slens/run-many": "^1.0.0-alpha.1",
     "@ogre-tools/injectable": "^15.1.2",
     "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
-    "electron": "^22.3.3"
+    "electron": "^22.3.3",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@async-fn/jest": "^1.6.4",

--- a/packages/technical-features/messaging/electron/main/package.json
+++ b/packages/technical-features/messaging/electron/main/package.json
@@ -36,6 +36,7 @@
     "@k8slens/messaging": "^1.0.0-alpha.1",
     "@ogre-tools/injectable": "^15.1.2",
     "@ogre-tools/injectable-extension-for-auto-registration": "^15.1.2",
+    "@ogre-tools/fp": "^15.1.2",
     "electron": "^22.3.3",
     "lodash": "^4.17.21"
   },

--- a/packages/technical-features/messaging/electron/renderer/package.json
+++ b/packages/technical-features/messaging/electron/renderer/package.json
@@ -32,6 +32,7 @@
   },
   "peerDependencies": {
     "@k8slens/application": "^6.5.0-alpha.0",
+    "@k8slens/feature-core": "^6.5.0-alpha.0",
     "@k8slens/messaging": "^1.0.0-alpha.1",
     "@k8slens/run-many": "^1.0.0-alpha.1",
     "@k8slens/startable-stoppable": "^1.0.0-alpha.1",

--- a/packages/technical-features/messaging/message-bridge-fake/package.json
+++ b/packages/technical-features/messaging/message-bridge-fake/package.json
@@ -31,13 +31,13 @@
     "lint": "lens-lint"
   },
   "peerDependencies": {
+    "@async-fn/jest": "^1.6.4",
     "@k8slens/messaging": "^1.0.0-alpha.1",
     "@ogre-tools/fp": "^15.1.2",
     "@ogre-tools/injectable": "^15.1.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@async-fn/jest": "^1.6.4",
     "@k8slens/eslint-config": "^6.5.0-alpha.2",
     "@k8slens/feature-core": "^6.5.0-alpha.2",
     "@ogre-tools/injectable-extension-for-mobx": "^15.3.0",

--- a/packages/technical-features/react-application/package.json
+++ b/packages/technical-features/react-application/package.json
@@ -40,6 +40,7 @@
     "@ogre-tools/injectable-react": "^15.1.2",
     "lodash": "^4.17.15",
     "mobx": "^6.8.0",
+    "mobx-react": "^7.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/utility-features/react-testing-library-discovery/package.json
+++ b/packages/utility-features/react-testing-library-discovery/package.json
@@ -29,7 +29,7 @@
     "lint": "lens-lint",
     "lint:fix": "lens-lint --fix"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0"

--- a/packages/utility-features/test-utils/package.json
+++ b/packages/utility-features/test-utils/package.json
@@ -28,6 +28,7 @@
     "@ogre-tools/injectable-react": "^15.1.2",
     "@testing-library/react": "^12.1.5",
     "lodash": "^4.17.21",
+    "mobx": "^6.8.0",
     "react": "^17.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR contains two enhancements for reusable webpack configurations:

1. It now respects `dependencies` vs `peerDependencies`. `dependencies` are bundled to the package and `peerDependencies` are not. 

2. It now automatically detects if you import some dependency which is not defined in the `package.json` and fails the build with helpful error message. The motivation here is that developer has to decide whether dependency is bundled (`dependency`) or not (`peerDependency`) 

Notice that `devDependencies` are not considered in the 2. point at all, so it means that build will crash if implementation code imports (something else than types) from `devDependency`

The 2. point lead to commit that adds missing dependencies to current packages.