### PR TITLE
Fixing creating Pod integration tests 

### DIFF
--- a/packages/open-lens/integration/__tests__/cluster-pages.tests.ts
+++ b/packages/open-lens/integration/__tests__/cluster-pages.tests.ts
@@ -141,14 +141,14 @@ describeIf(minikubeReady(TEST_NAMESPACE))("Minikube based tests", () => {
       await monacoEditor.press("Enter", { delay: 10 });
       await monacoEditor.type("metadata:", { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });
-      await monacoEditor.type(`  name: ${testPodName}`, { delay: 10 });
+      await monacoEditor.type(`name: ${testPodName}`, { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });
       await monacoEditor.type(`namespace: ${TEST_NAMESPACE}`, { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });
       await monacoEditor.press("Backspace", { delay: 10 });
       await monacoEditor.type("spec:", { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });
-      await monacoEditor.type("  containers:", { delay: 10 });
+      await monacoEditor.type("containers:", { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });
       await monacoEditor.type(`- name: ${testPodName}`, { delay: 10 });
       await monacoEditor.press("Enter", { delay: 10 });


### PR DESCRIPTION
Fixes recent integration tests breakdowns such as https://github.com/lensapp/lens/actions/runs/4718018810/jobs/8369163153?pr=7544 by tweaking monaco editor lines