### PR TITLE
Use strict dependency for extension-api -> core

### DIFF
--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -25,7 +25,7 @@
     "clean": "rimraf dist/"
   },
   "dependencies": {
-    "@k8slens/core": "^6.5.0-alpha.7"
+    "@k8slens/core": "6.5.0-alpha.7"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",


### PR DESCRIPTION
* I installed @k8slens/extensions@6.5.0-alpha.7. It depends on @k8slens/core@^6.5.0-alpha.7. npm installs @k8slens/core@6.5.0-cron.f88555a under @k8slens/extensions, which is too old. It should install @k8slens/core@6.5.0-alpha.7 so that extension builds could work.