### PR TITLE
Release 6.5.0-alpha.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35674,7 +35674,7 @@
     },
     "packages/bump-version-for-cron": {
       "name": "@k8slens/bump-version-for-cron",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",
@@ -35721,14 +35721,14 @@
     },
     "packages/core": {
       "name": "@k8slens/core",
-      "version": "6.5.0-alpha.7",
+      "version": "6.5.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "@astronautlabs/jsonpath": "^1.1.0",
         "@hapi/call": "^9.0.1",
         "@hapi/subtext": "^7.1.0",
-        "@k8slens/list-layout": "^1.0.0-alpha.0",
-        "@k8slens/metrics": "^6.5.0-alpha.3",
+        "@k8slens/list-layout": "^1.0.0-alpha.1",
+        "@k8slens/metrics": "^6.5.0-alpha.4",
         "@k8slens/node-fetch": "^6.5.0-alpha.3",
         "@k8slens/react-application": "^1.0.0-alpha.2",
         "@kubernetes/client-node": "^0.18.1",
@@ -35970,7 +35970,7 @@
     },
     "packages/ensure-binaries": {
       "name": "@k8slens/ensure-binaries",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",
@@ -36010,10 +36010,10 @@
     },
     "packages/extension-api": {
       "name": "@k8slens/extensions",
-      "version": "6.5.0-alpha.7",
+      "version": "6.5.0-alpha.8",
       "license": "MIT",
       "dependencies": {
-        "@k8slens/core": "6.5.0-alpha.7"
+        "@k8slens/core": "6.5.0-alpha.8"
       },
       "devDependencies": {
         "@types/node": "^16.18.6",
@@ -36246,7 +36246,7 @@
     },
     "packages/generate-tray-icons": {
       "name": "@k8slens/generate-tray-icons",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",
@@ -36298,7 +36298,7 @@
     },
     "packages/infrastructure/jest": {
       "name": "@k8slens/jest",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -36464,7 +36464,7 @@
     },
     "packages/infrastructure/webpack": {
       "name": "@k8slens/webpack",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@types/webpack-env": "^1.18.0",
@@ -36519,7 +36519,7 @@
     },
     "packages/kubectl-versions": {
       "name": "@k8slens/kubectl-versions",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@swc/cli": "^0.1.62",
@@ -36535,10 +36535,10 @@
     },
     "packages/legacy-extension-example": {
       "name": "@k8slens/legacy-extension-example",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "devDependencies": {
-        "@k8slens/extensions": "^6.5.0-alpha.7",
+        "@k8slens/extensions": "^6.5.0-alpha.8",
         "@types/node": "^16.18.16",
         "typescript": "^4.9.5",
         "webpack": "^5.80.0",
@@ -36669,11 +36669,11 @@
     },
     "packages/list-layout": {
       "name": "@k8slens/list-layout",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@k8slens/eslint-config": "^6.5.0-alpha.2",
-        "@k8slens/jest": "^6.5.0-alpha.2",
+        "@k8slens/jest": "^6.5.0-alpha.4",
         "@k8slens/typescript": "^6.5.0-alpha.2"
       },
       "peerDependencies": {
@@ -36683,11 +36683,11 @@
     },
     "packages/metrics": {
       "name": "@k8slens/metrics",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@k8slens/eslint-config": "^6.5.0-alpha.2",
-        "@k8slens/jest": "^6.5.0-alpha.3",
+        "@k8slens/jest": "^6.5.0-alpha.4",
         "@k8slens/typescript": "^6.5.0-alpha.2"
       },
       "peerDependencies": {
@@ -36724,18 +36724,18 @@
       }
     },
     "packages/open-lens": {
-      "version": "6.5.0-alpha.7",
+      "version": "6.5.0-alpha.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@k8slens/application": "^6.5.0-alpha.4",
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.3",
-        "@k8slens/core": "^6.5.0-alpha.7",
-        "@k8slens/ensure-binaries": "^6.5.0-alpha.3",
+        "@k8slens/core": "^6.5.0-alpha.8",
+        "@k8slens/ensure-binaries": "^6.5.0-alpha.4",
         "@k8slens/feature-core": "^6.5.0-alpha.3",
         "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.3",
-        "@k8slens/kubectl-versions": "^1.0.0-alpha.1",
-        "@k8slens/legacy-extension-example": "^1.0.0-alpha.5",
+        "@k8slens/kubectl-versions": "^1.0.0-alpha.2",
+        "@k8slens/legacy-extension-example": "^1.0.0-alpha.6",
         "@k8slens/legacy-extensions": "^1.0.0-alpha.3",
         "@k8slens/messaging": "^1.0.0-alpha.3",
         "@k8slens/messaging-for-main": "^1.0.0-alpha.3",
@@ -36755,7 +36755,7 @@
       },
       "devDependencies": {
         "@electron/rebuild": "^3.2.10",
-        "@k8slens/generate-tray-icons": "^6.5.0-alpha.3",
+        "@k8slens/generate-tray-icons": "^6.5.0-alpha.4",
         "@k8slens/test-utils": "^1.0.0-alpha.3",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@swc/cli": "^0.1.62",
@@ -36908,7 +36908,7 @@
     },
     "packages/release-tool": {
       "name": "@k8slens/release-tool",
-      "version": "6.5.0-alpha.4",
+      "version": "6.5.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
@@ -36937,7 +36937,7 @@
     },
     "packages/semver": {
       "name": "@k8slens/semver",
-      "version": "6.5.0-alpha.3",
+      "version": "6.5.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "command-line-args": "^5.2.1",
@@ -37131,7 +37131,7 @@
     },
     "packages/ui-components/button": {
       "name": "@k8slens/button",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@async-fn/jest": "^1.6.4",
@@ -37197,7 +37197,7 @@
     },
     "packages/ui-components/tooltip": {
       "name": "@k8slens/tooltip",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@async-fn/jest": "^1.6.4",

--- a/packages/bump-version-for-cron/package.json
+++ b/packages/bump-version-for-cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/bump-version-for-cron",
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "CLI to bump the version to during a cron daily alpha release",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.7",
+  "version": "6.5.0-alpha.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -112,10 +112,10 @@
     "@astronautlabs/jsonpath": "^1.1.0",
     "@hapi/call": "^9.0.1",
     "@hapi/subtext": "^7.1.0",
-    "@k8slens/metrics": "^6.5.0-alpha.3",
+    "@k8slens/list-layout": "^1.0.0-alpha.1",
+    "@k8slens/metrics": "^6.5.0-alpha.4",
     "@k8slens/node-fetch": "^6.5.0-alpha.3",
     "@k8slens/react-application": "^1.0.0-alpha.2",
-    "@k8slens/list-layout": "^1.0.0-alpha.0",
     "@kubernetes/client-node": "^0.18.1",
     "@material-ui/styles": "^4.11.5",
     "@sentry/electron": "^3.0.8",
@@ -313,6 +313,7 @@
   "peerDependencies": {
     "@k8slens/application": "^6.5.0-alpha.0",
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.0",
+    "@k8slens/button": "^1.0.0-alpha.0",
     "@k8slens/cluster-settings": "^6.5.0-alpha.1",
     "@k8slens/kubectl-versions": "^1.0.0-alpha.0",
     "@k8slens/legacy-extensions": "^1.0.0-alpha.0",
@@ -323,7 +324,6 @@
     "@k8slens/startable-stoppable": "^1.0.0-alpha.1",
     "@k8slens/test-utils": "^1.0.0-alpha.1",
     "@k8slens/tooltip": "^1.0.0-alpha.0",
-    "@k8slens/button": "^1.0.0-alpha.0",
     "@k8slens/utilities": "^1.0.0-alpha.1",
     "@ogre-tools/fp": "^15.3.1",
     "@ogre-tools/injectable": "^15.3.1",

--- a/packages/ensure-binaries/package.json
+++ b/packages/ensure-binaries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/ensure-binaries",
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "CLI for downloading configured versions of the bundled versions of CLIs",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.5.0-alpha.7",
+  "version": "6.5.0-alpha.8",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -25,7 +25,7 @@
     "clean": "rimraf dist/"
   },
   "dependencies": {
-    "@k8slens/core": "6.5.0-alpha.7"
+    "@k8slens/core": "6.5.0-alpha.8"
   },
   "devDependencies": {
     "@types/node": "^16.18.6",

--- a/packages/generate-tray-icons/package.json
+++ b/packages/generate-tray-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/generate-tray-icons",
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "CLI generating tray icons for building a lens-like application",
   "license": "MIT",
   "scripts": {

--- a/packages/infrastructure/jest/package.json
+++ b/packages/infrastructure/jest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/jest",
   "private": false,
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "Jest configuration and scripts for Lens packages.",
   "type": "commonjs",
   "publishConfig": {

--- a/packages/infrastructure/webpack/package.json
+++ b/packages/infrastructure/webpack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/webpack",
   "private": false,
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "Webpack configurations and scripts for Lens packages.",
   "type": "commonjs",
   "publishConfig": {

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/kubectl-versions",
   "private": false,
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "Package of kubectl versions at build time",
   "files": [
     "dist"

--- a/packages/legacy-extension-example/package.json
+++ b/packages/legacy-extension-example/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/legacy-extension-example",
   "private": false,
   "description": "An example bundled Lens extensions using the v1 API",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "type": "commonjs",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
     "lint:fix": "lens-lint --fix"
   },
   "devDependencies": {
-    "@k8slens/extensions": "^6.5.0-alpha.7",
+    "@k8slens/extensions": "^6.5.0-alpha.8",
     "@types/node": "^16.18.16",
     "typescript": "^4.9.5",
     "webpack": "^5.80.0",

--- a/packages/list-layout/package.json
+++ b/packages/list-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/list-layout",
   "private": false,
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Injection tokens for list layout",
   "type": "commonjs",
   "publishConfig": {
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@k8slens/eslint-config": "^6.5.0-alpha.2",
-    "@k8slens/jest": "^6.5.0-alpha.2",
+    "@k8slens/jest": "^6.5.0-alpha.4",
     "@k8slens/typescript": "^6.5.0-alpha.2"
   }
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/metrics",
   "private": false,
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "Injection tokens for implementing metrics for Lens",
   "type": "commonjs",
   "publishConfig": {
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@k8slens/eslint-config": "^6.5.0-alpha.2",
-    "@k8slens/jest": "^6.5.0-alpha.3",
+    "@k8slens/jest": "^6.5.0-alpha.4",
     "@k8slens/typescript": "^6.5.0-alpha.2"
   }
 }

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.7",
+  "version": "6.5.0-alpha.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -187,12 +187,12 @@
   "dependencies": {
     "@k8slens/application": "^6.5.0-alpha.4",
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.3",
-    "@k8slens/core": "^6.5.0-alpha.7",
-    "@k8slens/ensure-binaries": "^6.5.0-alpha.3",
+    "@k8slens/core": "^6.5.0-alpha.8",
+    "@k8slens/ensure-binaries": "^6.5.0-alpha.4",
     "@k8slens/feature-core": "^6.5.0-alpha.3",
     "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.3",
-    "@k8slens/kubectl-versions": "^1.0.0-alpha.1",
-    "@k8slens/legacy-extension-example": "^1.0.0-alpha.5",
+    "@k8slens/kubectl-versions": "^1.0.0-alpha.2",
+    "@k8slens/legacy-extension-example": "^1.0.0-alpha.6",
     "@k8slens/legacy-extensions": "^1.0.0-alpha.3",
     "@k8slens/messaging": "^1.0.0-alpha.3",
     "@k8slens/messaging-for-main": "^1.0.0-alpha.3",
@@ -212,7 +212,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^3.2.10",
-    "@k8slens/generate-tray-icons": "^6.5.0-alpha.3",
+    "@k8slens/generate-tray-icons": "^6.5.0-alpha.4",
     "@k8slens/test-utils": "^1.0.0-alpha.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@swc/cli": "^0.1.62",

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.5.0-alpha.4",
+  "version": "6.5.0-alpha.5",
   "description": "Release tool for lens monorepo",
   "license": "MIT",
   "private": true,

--- a/packages/release-tool/src/index.ts
+++ b/packages/release-tool/src/index.ts
@@ -330,6 +330,10 @@ async function pickRelevantPrs(prs: ExtendedGithubPrData[], isMasterBranch: bool
   return selectedPrs;
 }
 
+async function setExtensionApiDepAsExact(coreVersion: SemVer) {
+  await pipeExecFile("npm", ["install", "--save-exact", "--workspace=@k8slens/extensions", `@k8slens/core@${coreVersion.format()}`]);
+}
+
 async function createRelease(): Promise<void> {
   await checkCurrentWorkingDirectory();
 
@@ -358,6 +362,7 @@ async function createRelease(): Promise<void> {
 
   const newK8slensCoreVersion = await getCurrentVersionOfSubPackage("core");
 
+  await setExtensionApiDepAsExact(newK8slensCoreVersion);
   await createReleaseBranchAndCommit(prBase, newK8slensCoreVersion, prBody);
 }
 

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/semver",
-  "version": "6.5.0-alpha.3",
+  "version": "6.5.0-alpha.4",
   "description": "CLI over semver package for picking parts of a version",
   "license": "MIT",
   "private": true,

--- a/packages/ui-components/button/package.json
+++ b/packages/ui-components/button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/button",
   "private": false,
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Highly extendable button in the Lens.",
   "type": "commonjs",
   "files": [
@@ -29,8 +29,8 @@
     "lint:fix": "lens-lint --fix"
   },
   "peerDependencies": {
-    "@k8slens/utilities": "^1.0.0-alpha.1",
     "@k8slens/tooltip": "^1.0.0-alpha.0",
+    "@k8slens/utilities": "^1.0.0-alpha.1",
     "auto-bind": "^4.0.0",
     "lodash": "^4.17.21",
     "mobx": "^6.8.0",

--- a/packages/ui-components/tooltip/package.json
+++ b/packages/ui-components/tooltip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/tooltip",
   "private": false,
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "Highly extendable tooltip in the Lens.",
   "type": "commonjs",
   "files": [


### PR DESCRIPTION
## Changes since 6.5.0-alpha.7

## 🚀 Features

- List layout column injection token package (**[#7544](https://github.com/lensapp/lens/pull/7544)**) https://github.com/samitiilikainen

## 🐛 Bug Fixes

- Use strict dependency for extension-api -> core (**[#7579](https://github.com/lensapp/lens/pull/7579)**) https://github.com/panuhorsmalahti
- List more than 256 helm releases (**[#7594](https://github.com/lensapp/lens/pull/7594)**) https://github.com/panuhorsmalahti

## 🧰 Maintenance

- chore: Revert only running one cluster page e2e test (**[#7572](https://github.com/lensapp/lens/pull/7572)**) https://github.com/Nokel81
- chore(deps-dev): Bump fast-xml-parser from 4.2.0 to 4.2.2 (**[#7576](https://github.com/lensapp/lens/pull/7576)**) https://github.com/app/dependabot
- chore: extract tooltip from core (**[#7539](https://github.com/lensapp/lens/pull/7539)**) https://github.com/gabriel-mirantis
- Fix errors in CI about documentation (**[#7582](https://github.com/lensapp/lens/pull/7582)**) https://github.com/Nokel81
- chore: Fix unit tests by increasing coverage of tooltip to 100% (**[#7584](https://github.com/lensapp/lens/pull/7584)**) https://github.com/Nokel81
- docs: Add documentation for cluster connection flow (**[#7580](https://github.com/lensapp/lens/pull/7580)**) https://github.com/Nokel81
- chore(deps-dev): Bump @swc/core from 1.3.51 to 1.3.52 (**[#7586](https://github.com/lensapp/lens/pull/7586)**) https://github.com/app/dependabot
- chore(deps): Bump webpack from 5.79.0 to 5.80.0 (**[#7588](https://github.com/lensapp/lens/pull/7588)**) https://github.com/app/dependabot
- chore(deps-dev): Bump postcss from 8.4.22 to 8.4.23 (**[#7589](https://github.com/lensapp/lens/pull/7589)**) https://github.com/app/dependabot
- chore: Expand withTooltip unit tests (**[#7595](https://github.com/lensapp/lens/pull/7595)**) https://github.com/Nokel81
- chore: extract button from core for error-boundary (**[#7592](https://github.com/lensapp/lens/pull/7592)**) https://github.com/gabriel-mirantis
