### PR TITLE
Chore: extract event-emitter from core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3918,6 +3918,10 @@
       "resolved": "packages/infrastructure/eslint-config",
       "link": true
     },
+    "node_modules/@k8slens/event-emitter": {
+      "resolved": "packages/utility-features/event-emitter",
+      "link": true
+    },
     "node_modules/@k8slens/extensions": {
       "resolved": "packages/extension-api",
       "link": true
@@ -35963,6 +35967,7 @@
         "@k8slens/button": "^1.0.0-alpha.5",
         "@k8slens/cluster-settings": "^6.5.0-alpha.1",
         "@k8slens/error-boundary": "^1.0.0-alpha.5",
+        "@k8slens/event-emitter": "^1.0.0-alpha.1",
         "@k8slens/kubectl-versions": "^1.0.0-alpha.0",
         "@k8slens/legacy-extensions": "^1.0.0-alpha.0",
         "@k8slens/messaging": "^1.0.0-alpha.1",
@@ -36832,6 +36837,7 @@
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.3",
         "@k8slens/core": "^6.5.0-alpha.8",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.4",
+        "@k8slens/event-emitter": "^1.0.0-alpha.1",
         "@k8slens/feature-core": "^6.5.0-alpha.3",
         "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.3",
         "@k8slens/kubectl-versions": "^1.0.0-alpha.2",
@@ -37554,6 +37560,15 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "packages/utility-features/event-emitter": {
+      "version": "1.0.0-alpha.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@k8slens/eslint-config": "^6.5.0-alpha.2",
+        "@k8slens/jest": "^6.5.0-alpha.4",
+        "@k8slens/typescript": "^6.5.0-alpha.2"
       }
     },
     "packages/utility-features/react-testing-library-discovery": {
@@ -40764,6 +40779,14 @@
     "@k8slens/eslint-config": {
       "version": "file:packages/infrastructure/eslint-config",
       "requires": {}
+    },
+    "@k8slens/event-emitter": {
+      "version": "file:packages/utility-features/event-emitter",
+      "requires": {
+        "@k8slens/eslint-config": "^6.5.0-alpha.2",
+        "@k8slens/jest": "^6.5.0-alpha.4",
+        "@k8slens/typescript": "^6.5.0-alpha.2"
+      }
     },
     "@k8slens/extensions": {
       "version": "file:packages/extension-api",
@@ -59388,6 +59411,7 @@
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.3",
         "@k8slens/core": "^6.5.0-alpha.8",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.4",
+        "@k8slens/event-emitter": "^1.0.0-alpha.1",
         "@k8slens/feature-core": "^6.5.0-alpha.3",
         "@k8slens/generate-tray-icons": "^6.5.0-alpha.4",
         "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -316,6 +316,7 @@
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.0",
     "@k8slens/button": "^1.0.0-alpha.5",
     "@k8slens/error-boundary": "^1.0.0-alpha.5",
+    "@k8slens/event-emitter": "^1.0.0-alpha.1",
     "@k8slens/resizing-anchor": "^1.0.0-alpha.5",
     "@k8slens/routing": "^1.0.0-alpha.5",
     "@k8slens/cluster-settings": "^6.5.0-alpha.1",

--- a/packages/core/src/common/app-event-bus/app-event-bus.injectable.ts
+++ b/packages/core/src/common/app-event-bus/app-event-bus.injectable.ts
@@ -3,7 +3,7 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { getInjectable } from "@ogre-tools/injectable";
-import { EventEmitter } from "../event-emitter";
+import { EventEmitter } from "@k8slens/event-emitter";
 import type { AppEvent } from "./event-bus";
 
 const appEventBusInjectable = getInjectable({

--- a/packages/core/src/common/k8s-api/json-api.ts
+++ b/packages/core/src/common/k8s-api/json-api.ts
@@ -12,7 +12,7 @@ import type { Response, RequestInit } from "@k8slens/node-fetch";
 import { stringify } from "querystring";
 import type { Patch } from "rfc6902";
 import type { PartialDeep, ValueOf } from "type-fest";
-import { EventEmitter } from "../../common/event-emitter";
+import { EventEmitter } from "@k8slens/event-emitter";
 import type { Logger } from "../../common/logger";
 import type { Fetch } from "../fetch/fetch.injectable";
 import type { Defaulted } from "@k8slens/utilities";

--- a/packages/core/src/extensions/common-api/event-bus.ts
+++ b/packages/core/src/extensions/common-api/event-bus.ts
@@ -6,7 +6,7 @@
 import appEventBusInjectable from "../../common/app-event-bus/app-event-bus.injectable";
 import { asLegacyGlobalForExtensionApi } from "../as-legacy-globals-for-extension-api/as-legacy-global-object-for-extension-api";
 import type { AppEvent } from "../../common/app-event-bus/event-bus";
-import type { EventEmitter, EventEmitterCallback, EventEmitterOptions } from "../../common/event-emitter";
+import type { EventEmitter, EventEmitterCallback, EventEmitterOptions } from "@k8slens/event-emitter";
 
 export type {
   AppEvent,

--- a/packages/core/src/extensions/extension-loader/extension-loader.ts
+++ b/packages/core/src/extensions/extension-loader/extension-loader.ts
@@ -14,7 +14,7 @@ import type { LensExtension } from "../lens-extension";
 import { extensionLoaderFromMainChannel, extensionLoaderFromRendererChannel } from "../../common/ipc/extension-handling";
 import { requestExtensionLoaderInitialState } from "../../renderer/ipc";
 import assert from "assert";
-import { EventEmitter } from "../../common/event-emitter";
+import { EventEmitter } from "@k8slens/event-emitter";
 import type { Extension } from "./extension/extension.injectable";
 import type { Logger } from "../../common/logger";
 import type { JoinPaths } from "../../common/path/join-paths.injectable";

--- a/packages/open-lens/package.json
+++ b/packages/open-lens/package.json
@@ -184,6 +184,7 @@
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.3",
     "@k8slens/core": "^6.5.0-alpha.8",
     "@k8slens/ensure-binaries": "^6.5.0-alpha.4",
+    "@k8slens/event-emitter": "^1.0.0-alpha.1",
     "@k8slens/feature-core": "^6.5.0-alpha.3",
     "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.3",
     "@k8slens/kubectl-versions": "^1.0.0-alpha.2",

--- a/packages/utility-features/event-emitter/.eslintrc.js
+++ b/packages/utility-features/event-emitter/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: "@k8slens/eslint-config/eslint",
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
+};

--- a/packages/utility-features/event-emitter/.prettierrc
+++ b/packages/utility-features/event-emitter/.prettierrc
@@ -1,0 +1,1 @@
+"@k8slens/eslint-config/prettier"

--- a/packages/utility-features/event-emitter/index.ts
+++ b/packages/utility-features/event-emitter/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/event-emitter";

--- a/packages/utility-features/event-emitter/jest.config.js
+++ b/packages/utility-features/event-emitter/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@k8slens/jest").monorepoPackageConfig(__dirname).configForReact;

--- a/packages/utility-features/event-emitter/package.json
+++ b/packages/utility-features/event-emitter/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@k8slens/event-emitter",
+  "private": false,
+  "version": "1.0.0-alpha.1",
+  "description": "Event emitter",
+  "type": "commonjs",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lensapp/lens.git"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "author": {
+    "name": "OpenLens Authors",
+    "email": "info@k8slens.dev"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/lensapp/lens",
+  "scripts": {
+    "build": "webpack",
+    "clean": "rimraf dist/",
+    "dev": "webpack --mode=development --watch",
+    "test": "jest --coverage --runInBand",
+    "lint": "lens-lint",
+    "lint:fix": "lens-lint --fix"
+  },
+  "peerDependencies": {
+  },
+  "devDependencies": {
+    "@k8slens/eslint-config": "^6.5.0-alpha.2",
+    "@k8slens/jest": "^6.5.0-alpha.4",
+    "@k8slens/typescript": "^6.5.0-alpha.2"
+  }
+}

--- a/packages/utility-features/event-emitter/src/event-emitter.test.ts
+++ b/packages/utility-features/event-emitter/src/event-emitter.test.ts
@@ -1,9 +1,4 @@
-/**
- * Copyright (c) OpenLens Authors. All rights reserved.
- * Licensed under MIT License. See LICENSE in root directory for more information.
- */
-
-import { EventEmitter } from "../event-emitter";
+import { EventEmitter } from "./event-emitter";
 
 describe("EventEmitter", () => {
   it("should stop early if a listener returns false", () => {
@@ -11,7 +6,9 @@ describe("EventEmitter", () => {
     const e = new EventEmitter<[]>();
 
     e.addListener(() => false, {});
-    e.addListener(() => { called = true; }, {});
+    e.addListener(() => {
+      called = true;
+    }, {});
     e.emit();
 
     expect(called).toBe(false);
@@ -22,7 +19,9 @@ describe("EventEmitter", () => {
     const e = new EventEmitter<[]>();
 
     e.addListener(() => 0 as never, {});
-    e.addListener(() => { called = true; }, {});
+    e.addListener(() => {
+      called = true;
+    }, {});
     e.emit();
 
     expect(called).toBe(true);
@@ -32,9 +31,18 @@ describe("EventEmitter", () => {
     const callOrder: number[] = [];
     const e = new EventEmitter<[]>();
 
-    e.addListener(() => { callOrder.push(1); }, {});
-    e.addListener(() => { callOrder.push(2); }, {});
-    e.addListener(() => { callOrder.push(3); }, { prepend: true });
+    e.addListener(() => {
+      callOrder.push(1);
+    }, {});
+    e.addListener(() => {
+      callOrder.push(2);
+    }, {});
+    e.addListener(
+      () => {
+        callOrder.push(3);
+      },
+      { prepend: true },
+    );
     e.emit();
 
     expect(callOrder).toStrictEqual([3, 1, 2]);
@@ -44,9 +52,18 @@ describe("EventEmitter", () => {
     const callOrder: number[] = [];
     const e = new EventEmitter<[]>();
 
-    e.addListener(() => { callOrder.push(1); }, {});
-    e.addListener(() => { callOrder.push(2); }, {});
-    e.addListener(() => { callOrder.push(3); }, { once: true });
+    e.addListener(() => {
+      callOrder.push(1);
+    }, {});
+    e.addListener(() => {
+      callOrder.push(2);
+    }, {});
+    e.addListener(
+      () => {
+        callOrder.push(3);
+      },
+      { once: true },
+    );
     e.emit();
     e.emit();
 
@@ -56,10 +73,16 @@ describe("EventEmitter", () => {
   it("removeListener should stop the listener from being called", () => {
     const callOrder: number[] = [];
     const e = new EventEmitter<[]>();
-    const r = () => { callOrder.push(3); };
+    const r = () => {
+      callOrder.push(3);
+    };
 
-    e.addListener(() => { callOrder.push(1); }, {});
-    e.addListener(() => { callOrder.push(2); }, {});
+    e.addListener(() => {
+      callOrder.push(1);
+    }, {});
+    e.addListener(() => {
+      callOrder.push(2);
+    }, {});
     e.addListener(r);
 
     e.emit();
@@ -73,9 +96,15 @@ describe("EventEmitter", () => {
     const callOrder: number[] = [];
     const e = new EventEmitter<[]>();
 
-    e.addListener(() => { callOrder.push(1); });
-    e.addListener(() => { callOrder.push(2); });
-    e.addListener(() => { callOrder.push(3); });
+    e.addListener(() => {
+      callOrder.push(1);
+    });
+    e.addListener(() => {
+      callOrder.push(2);
+    });
+    e.addListener(() => {
+      callOrder.push(3);
+    });
 
     e.emit();
     e.removeAllListeners();

--- a/packages/utility-features/event-emitter/src/event-emitter.ts
+++ b/packages/utility-features/event-emitter/src/event-emitter.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) OpenLens Authors. All rights reserved.
- * Licensed under MIT License. See LICENSE in root directory for more information.
- */
-
-// Custom event emitter
-
 export interface EventEmitterOptions {
   once?: boolean; // call once and remove
   prepend?: boolean; // put listener to the beginning

--- a/packages/utility-features/event-emitter/tsconfig.json
+++ b/packages/utility-features/event-emitter/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@k8slens/typescript/config/base.json",
+  "include": ["**/*.ts"]
+}

--- a/packages/utility-features/event-emitter/webpack.config.js
+++ b/packages/utility-features/event-emitter/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@k8slens/webpack").configForNode;


### PR DESCRIPTION
First step on extracting `json-api` to a package from `core`.