### PR TITLE
Fix "Details" not opening

### DIFF
--- a/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/api-manager.test.ts
@@ -58,7 +58,7 @@ describe("ApiManager", () => {
 
   describe("registerApi", () => {
     it("re-register store if apiBase changed", () => {
-      const apiBase = "apis/v1/foo";
+      const apiBase = "api/v1/foo";
       const fallbackApiBase = "/apis/extensions/v1beta1/foo";
       const kubeApi = new TestApi({
         logger: di.inject(loggerInjectionToken),

--- a/packages/core/src/common/k8s-api/__tests__/kube-api-parse.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-api-parse.test.ts
@@ -21,96 +21,130 @@ import { parseKubeApi } from "../kube-api-parse";
 type KubeApiParseTestData = [string, IKubeApiParsed];
 
 const tests: KubeApiParseTestData[] = [
-  ["/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com", {
-    apiBase: "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions",
-    apiPrefix: "/apis",
-    apiGroup: "apiextensions.k8s.io",
-    apiVersion: "v1beta1",
-    apiVersionWithGroup: "apiextensions.k8s.io/v1beta1",
-    namespace: undefined,
-    resource: "customresourcedefinitions",
-    name: "prometheuses.monitoring.coreos.com",
-  }],
-  ["/api/v1/namespaces/kube-system/pods/coredns-6955765f44-v8p27", {
-    apiBase: "/api/v1/pods",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "v1",
-    apiVersionWithGroup: "v1",
-    namespace: "kube-system",
-    resource: "pods",
-    name: "coredns-6955765f44-v8p27",
-  }],
-  ["/apis/stable.example.com/foo1/crontabs", {
-    apiBase: "/apis/stable.example.com/foo1/crontabs",
-    apiPrefix: "/apis",
-    apiGroup: "stable.example.com",
-    apiVersion: "foo1",
-    apiVersionWithGroup: "stable.example.com/foo1",
-    resource: "crontabs",
-    name: undefined,
-    namespace: undefined,
-  }],
-  ["/apis/cluster.k8s.io/v1alpha1/clusters", {
-    apiBase: "/apis/cluster.k8s.io/v1alpha1/clusters",
-    apiPrefix: "/apis",
-    apiGroup: "cluster.k8s.io",
-    apiVersion: "v1alpha1",
-    apiVersionWithGroup: "cluster.k8s.io/v1alpha1",
-    resource: "clusters",
-    name: undefined,
-    namespace: undefined,
-  }],
-  ["/api/v1/namespaces", {
-    apiBase: "/api/v1/namespaces",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "v1",
-    apiVersionWithGroup: "v1",
-    resource: "namespaces",
-    name: undefined,
-    namespace: undefined,
-  }],
-  ["/api/v1/secrets", {
-    apiBase: "/api/v1/secrets",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "v1",
-    apiVersionWithGroup: "v1",
-    resource: "secrets",
-    name: undefined,
-    namespace: undefined,
-  }],
-  ["/api/v1/nodes/minikube", {
-    apiBase: "/api/v1/nodes",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "v1",
-    apiVersionWithGroup: "v1",
-    resource: "nodes",
-    name: "minikube",
-    namespace: undefined,
-  }],
-  ["/api/foo-bar/nodes/minikube", {
-    apiBase: "/api/foo-bar/nodes",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "foo-bar",
-    apiVersionWithGroup: "foo-bar",
-    resource: "nodes",
-    name: "minikube",
-    namespace: undefined,
-  }],
-  ["/api/v1/namespaces/kube-public", {
-    apiBase: "/api/v1/namespaces",
-    apiPrefix: "/api",
-    apiGroup: "",
-    apiVersion: "v1",
-    apiVersionWithGroup: "v1",
-    resource: "namespaces",
-    name: "kube-public",
-    namespace: undefined,
-  }],
+  [
+    "http://some-irrelevant-domain/api/v1/secrets?some-irrelevant-parameter=some-irrelevant-value",
+    {
+      apiBase: "/api/v1/secrets",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      resource: "secrets",
+      name: undefined,
+      namespace: undefined,
+    },
+  ],
+  [
+    "/api/v1/secrets",
+    {
+      apiBase: "/api/v1/secrets",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      resource: "secrets",
+      name: undefined,
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/api/v1/namespaces",
+    {
+      apiBase: "/api/v1/namespaces",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      resource: "namespaces",
+      name: undefined,
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/api/v1/nodes/minikube",
+    {
+      apiBase: "/api/v1/nodes",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      resource: "nodes",
+      name: "minikube",
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/api/foo-bar/nodes/minikube",
+    {
+      apiBase: "/api/foo-bar/nodes",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "foo-bar",
+      apiVersionWithGroup: "foo-bar",
+      resource: "nodes",
+      name: "minikube",
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/api/v1/namespaces/kube-public",
+    {
+      apiBase: "/api/v1/namespaces",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      resource: "namespaces",
+      name: "kube-public",
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/apis/stable.example.com/foo1/crontabs",
+    {
+      apiBase: "/apis/stable.example.com/foo1/crontabs",
+      apiPrefix: "/apis",
+      apiGroup: "stable.example.com",
+      apiVersion: "foo1",
+      apiVersionWithGroup: "stable.example.com/foo1",
+      resource: "crontabs",
+      name: undefined,
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/apis/cluster.k8s.io/v1alpha1/clusters",
+    {
+      apiBase: "/apis/cluster.k8s.io/v1alpha1/clusters",
+      apiPrefix: "/apis",
+      apiGroup: "cluster.k8s.io",
+      apiVersion: "v1alpha1",
+      apiVersionWithGroup: "cluster.k8s.io/v1alpha1",
+      resource: "clusters",
+      name: undefined,
+      namespace: undefined,
+    },
+  ],
+
+  [
+    "/api/v1/namespaces/kube-system/pods/coredns-6955765f44-v8p27",
+    {
+      apiBase: "/api/v1/pods",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      namespace: "kube-system",
+      resource: "pods",
+      name: "coredns-6955765f44-v8p27",
+    },
+  ],
 
   [
     "/apis/apps/v1/namespaces/default/deployments/some-deployment",
@@ -125,20 +159,73 @@ const tests: KubeApiParseTestData[] = [
       resource: "deployments",
     },
   ],
+
+  [
+    "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+    {
+      apiBase: "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions",
+      apiPrefix: "/apis",
+      apiGroup: "apiextensions.k8s.io",
+      apiVersion: "v1beta1",
+      apiVersionWithGroup: "apiextensions.k8s.io/v1beta1",
+      namespace: undefined,
+      resource: "customresourcedefinitions",
+      name: "prometheuses.monitoring.coreos.com",
+    },
+  ],
+
+  [
+    "/api/v1/namespaces/kube-system/pods",
+    {
+      apiBase: "/api/v1/pods",
+      apiPrefix: "/api",
+      apiGroup: "",
+      apiVersion: "v1",
+      apiVersionWithGroup: "v1",
+      namespace: "kube-system",
+      resource: "pods",
+      name: undefined,
+    },
+  ],
+
+  [
+    "/apis/cluster.k8s.io/v1/namespaces/kube-system/pods",
+    {
+      apiBase: "/apis/cluster.k8s.io/v1/pods",
+      apiPrefix: "/apis",
+      apiGroup: "cluster.k8s.io",
+      apiVersion: "v1",
+      apiVersionWithGroup: "cluster.k8s.io/v1",
+      namespace: "kube-system",
+      resource: "pods",
+      name: undefined,
+    },
+  ],
 ];
 
 const invalidTests = [
   undefined,
   "",
-  "ajklsmh",
+  "some-invalid-path",
+  "//apiextensions.k8s.io/v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/apis//v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/apis/apiextensions.k8s.io//customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/apis/apiextensions.k8s.io/v1beta1//prometheuses.monitoring.coreos.com",
+  "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/",
+
+  "//v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/api//v1beta1/customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/api//customresourcedefinitions/prometheuses.monitoring.coreos.com",
+  "/api/v1beta1//prometheuses.monitoring.coreos.com",
+  "/api/v1beta1/customresourcedefinitions/",
 ];
 
 describe("parseApi unit tests", () => {
-  it.each(tests)("testing %j", (url, expected) => {
+  it.each(tests)(`given path %j, parses as expected`, (url, expected) => {
     expect(parseKubeApi(url)).toStrictEqual(expected);
   });
 
-  it.each(invalidTests)("testing %j should throw", (url) => {
+  it.each(invalidTests)(`given path %j, parses as undefined`, (url) => {
     expect(parseKubeApi(url as never)).toBe(undefined);
   });
 });

--- a/packages/core/src/common/k8s-api/__tests__/kube-api-parse.test.ts
+++ b/packages/core/src/common/k8s-api/__tests__/kube-api-parse.test.ts
@@ -111,6 +111,20 @@ const tests: KubeApiParseTestData[] = [
     name: "kube-public",
     namespace: undefined,
   }],
+
+  [
+    "/apis/apps/v1/namespaces/default/deployments/some-deployment",
+    {
+      apiBase: "/apis/apps/v1/deployments",
+      apiGroup: "apps",
+      apiPrefix: "/apis",
+      apiVersion: "v1",
+      apiVersionWithGroup: "apps/v1",
+      name: "some-deployment",
+      namespace: "default",
+      resource: "deployments",
+    },
+  ],
 ];
 
 const invalidTests = [

--- a/packages/core/src/common/k8s-api/get-match-for.test.ts
+++ b/packages/core/src/common/k8s-api/get-match-for.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+import { getMatchFor } from "./get-match-for";
+
+describe("get-match-for", () => {
+  it("given non-matching and matching regex, when called with a string, returns match", () => {
+    const getMatch = getMatchFor(/some-match/, /some-non-match/);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const match = [...getMatch("some-match")!];
+
+    expect(match).toEqual(["some-match"]);
+  });
+
+  it("given multiple matching regex, when called with a string, returns first match", () => {
+    const getMatch = getMatchFor(/match/, /some-match/);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const match = [...getMatch("match")!];
+
+    expect(match).toEqual(["match"]);
+  });
+
+  it("given multiple matching regex, when called with a string, returns first match", () => {
+    const getMatch = getMatchFor(/non-match/, /some-match/, /match/);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [...match] = getMatch("some-match")!;
+
+    expect(match).toEqual(["some-match"]);
+  });
+
+  it("given no matching regex, when called with a string, returns undefined", () => {
+    const getMatch = getMatchFor(/match/, /some-match/);
+
+    const match = getMatch("some-other-string");
+
+    expect(match).toBeUndefined();
+  });
+});

--- a/packages/core/src/common/k8s-api/get-match-for.ts
+++ b/packages/core/src/common/k8s-api/get-match-for.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+export const getMatchFor =
+  (...patterns: RegExp[]) =>
+    (reference: string) => {
+      for (const pattern of patterns) {
+        const match = reference.match(pattern);
+
+        if (match) {
+          return match;
+        }
+      }
+
+      return undefined;
+    };

--- a/packages/core/src/common/k8s-api/kube-api-parse.ts
+++ b/packages/core/src/common/k8s-api/kube-api-parse.ts
@@ -92,10 +92,6 @@ export function parseKubeApi(path: string): IKubeApiParsed | undefined {
   const apiVersionWithGroup = [apiGroup, apiVersion].filter(v => v).join("/");
   const apiBase = [apiPrefix, apiGroup, apiVersion, resource].filter(v => v).join("/");
 
-  if (!apiBase) {
-    return undefined;
-  }
-
   return {
     apiBase,
     apiPrefix, apiGroup,

--- a/packages/core/src/common/k8s-api/kube-api-parse.ts
+++ b/packages/core/src/common/k8s-api/kube-api-parse.ts
@@ -46,9 +46,10 @@ export function parseKubeApi(path: string): IKubeApiParsed | undefined {
         break;
     }
 
-    let rest: string[];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    apiVersion = left.at(-1)!;
+    const rest = left.slice(0, -1);
 
-    [apiVersion, ...rest] = left;
     apiGroup = rest.join("/");
   } else {
     if (left.length === 0) {

--- a/packages/core/src/common/k8s-api/prepend.ts
+++ b/packages/core/src/common/k8s-api/prepend.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) OpenLens Authors. All rights reserved.
+ * Licensed under MIT License. See LICENSE in root directory for more information.
+ */
+export const prepend = (prependWith: string) => (what: string) =>
+  `${prependWith}${what}`;

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               class="value"
             >
               <a
-                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapis%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
+                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapi%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
               >
                 some-namespace
               </a>
@@ -702,7 +702,7 @@ exports[`disable kube object detail items when cluster is not relevant given ext
               class="value"
             >
               <a
-                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapis%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
+                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapi%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
               >
                 some-namespace
               </a>
@@ -1318,7 +1318,7 @@ exports[`disable kube object detail items when cluster is not relevant given not
               class="value"
             >
               <a
-                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapis%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
+                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapi%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
               >
                 some-namespace
               </a>

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/__snapshots__/reactively-hide-kube-object-detail-item.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`reactively hide kube object detail item renders 1`] = `
               class="value"
             >
               <a
-                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapis%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
+                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapi%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
               >
                 some-namespace
               </a>
@@ -697,7 +697,7 @@ exports[`reactively hide kube object detail item when the item is shown renders 
               class="value"
             >
               <a
-                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapis%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
+                href="/workloads?kube-details=%2Fapi%2Fv1%2Fnamespaces%2Fsome-namespace&kube-selected=%2Fapi%2Fsome-api-version%2Fnamespaces%2Fsome-namespace%2Fsome-kind%2Fsome-name"
               >
                 some-namespace
               </a>

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/disable-kube-object-detail-items-when-cluster-is-not-relevant.test.tsx
@@ -26,7 +26,7 @@ describe("disable kube object detail items when cluster is not relevant", () => 
     builder.afterWindowStart(({ windowDi }) => {
       const apiManager = windowDi.inject(apiManagerInjectable);
       const api = {
-        apiBase: "/apis/some-api-version/some-kind",
+        apiBase: "/api/some-api-version/some-kind",
       } as Partial<KubeApi<KubeObject>> as KubeApi<KubeObject>;
       const store = {
         api,
@@ -66,7 +66,7 @@ describe("disable kube object detail items when cluster is not relevant", () => 
     const windowDi = builder.applicationWindow.only.di;
     const showDetails = windowDi.inject(showDetailsInjectable);
 
-    showDetails("/apis/some-api-version/namespaces/some-namespace/some-kind/some-name");
+    showDetails("/api/some-api-version/namespaces/some-namespace/some-kind/some-name");
 
     builder.extensions.enable(testExtension);
   });

--- a/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
+++ b/packages/core/src/features/cluster/kube-object-details/extension-api/reactively-hide-kube-object-detail-item.test.tsx
@@ -29,7 +29,7 @@ describe("reactively hide kube object detail item", () => {
     builder.afterWindowStart(({ windowDi }) => {
       const apiManager = windowDi.inject(apiManagerInjectable);
       const api = {
-        apiBase: "/apis/some-api-version/some-kind",
+        apiBase: "/api/some-api-version/some-kind",
       } as Partial<KubeApi<KubeObject>> as KubeApi<KubeObject>;
       const store = {
         api,
@@ -73,7 +73,7 @@ describe("reactively hide kube object detail item", () => {
     const windowDi = builder.applicationWindow.only.di;
     const showDetails = windowDi.inject(showDetailsInjectable);
 
-    showDetails("/apis/some-api-version/namespaces/some-namespace/some-kind/some-name");
+    showDetails("/api/some-api-version/namespaces/some-namespace/some-kind/some-name");
 
     builder.extensions.enable(testExtension);
   });
@@ -96,7 +96,7 @@ describe("reactively hide kube object detail item", () => {
 
       const apiManager = builder.applicationWindow.only.di.inject(apiManagerInjectable);
 
-      assert(apiManager.getStore("/apis/some-api-version/some-kind"));
+      assert(apiManager.getStore("/api/some-api-version/some-kind"));
     });
 
     it("renders", () => {

--- a/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
+++ b/packages/core/src/features/cluster/namespaces/__snapshots__/edit-namespace-from-new-tab.test.tsx.snap
@@ -2101,7 +2101,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeChanged: some-changed-value
   someAddedProperty: some-new-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -3633,7 +3633,7 @@ metadata:
   uid: some-other-uid
   name: some-other-name
   resourceVersion: some-resource-version
-  selfLink: /apis/some-api-version/namespaces/some-other-uid
+  selfLink: /api/some-api-version/namespaces/some-other-uid
 
               </textarea>
             </div>
@@ -4437,7 +4437,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -5964,7 +5964,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -6716,7 +6716,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -7468,7 +7468,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
   labels:
     k8slens-edit-resource-version: some-api-version
 
@@ -8222,7 +8222,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -9570,7 +9570,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -10322,7 +10322,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>
@@ -11074,7 +11074,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 
               </textarea>
             </div>

--- a/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
+++ b/packages/core/src/features/cluster/namespaces/edit-namespace-from-new-tab.test.tsx
@@ -161,7 +161,7 @@ describe("cluster/namespaces - edit namespace from new tab", () => {
 
           it("calls for namespace", () => {
             expect(apiKubeGetMock).toHaveBeenCalledWith(
-              "/apis/some-api-version/namespaces/some-uid",
+              "/api/some-api-version/namespaces/some-uid",
             );
           });
 
@@ -208,7 +208,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `);
             });
 
@@ -227,7 +227,7 @@ metadata:
 
               it("calls for save with just the adding version label", () => {
                 expect(apiKubePatchMock).toHaveBeenCalledWith(
-                  "/apis/some-api-version/namespaces/some-uid",
+                  "/api/some-api-version/namespaces/some-uid",
                   {
                     data: [{
                       op: "add",
@@ -509,7 +509,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeChanged: some-changed-value
   someAddedProperty: some-new-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `,
                   },
                 });
@@ -532,7 +532,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeChanged: some-changed-value
   someAddedProperty: some-new-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `);
               });
 
@@ -548,7 +548,7 @@ metadata:
                 expect(
                   actual.edit_resource_store["some-first-tab-id"],
                 ).toEqual({
-                  resource: "/apis/some-api-version/namespaces/some-uid",
+                  resource: "/api/some-api-version/namespaces/some-uid",
                   firstDraft: `apiVersion: some-api-version
 kind: Namespace
 metadata:
@@ -557,7 +557,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `,
                   draft: `apiVersion: some-api-version
 kind: Namespace
@@ -567,7 +567,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeChanged: some-changed-value
   someAddedProperty: some-new-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `,
                 });
               });
@@ -583,7 +583,7 @@ metadata:
 
                 it("calls for save with changed configuration", () => {
                   expect(apiKubePatchMock).toHaveBeenCalledWith(
-                    "/apis/some-api-version/namespaces/some-uid",
+                    "/api/some-api-version/namespaces/some-uid",
                     {
                       data: [
                         {
@@ -637,7 +637,7 @@ metadata:
   uid: some-uid
   name: some-name
   resourceVersion: some-resource-version
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
   somePropertyToBeChanged: some-changed-value
   someAddedProperty: some-new-value
   someOtherAddedProperty: some-other-new-value
@@ -655,7 +655,7 @@ metadata:
                   fireEvent.click(saveButton);
 
                   expect(apiKubePatchMock).toHaveBeenCalledWith(
-                    "/apis/some-api-version/namespaces/some-uid",
+                    "/api/some-api-version/namespaces/some-uid",
                     {
                       data: [
                         {
@@ -732,7 +732,7 @@ metadata:
   uid: some-uid
   name: some-name
   resourceVersion: some-resource-version
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `,
                     },
                   });
@@ -794,7 +794,7 @@ metadata:
 
               it("calls for second namespace", () => {
                 expect(apiKubeGetMock).toHaveBeenCalledWith(
-                  "/apis/some-api-version/namespaces/some-other-uid",
+                  "/api/some-api-version/namespaces/some-other-uid",
                 );
               });
 
@@ -811,7 +811,7 @@ metadata:
                       name: "some-other-name",
                       resourceVersion: "some-resource-version",
                       selfLink:
-                        "/apis/some-api-version/namespaces/some-other-uid",
+                        "/api/some-api-version/namespaces/some-other-uid",
                     },
                   });
 
@@ -833,7 +833,7 @@ metadata:
   uid: some-other-uid
   name: some-other-name
   resourceVersion: some-resource-version
-  selfLink: /apis/some-api-version/namespaces/some-other-uid
+  selfLink: /api/some-api-version/namespaces/some-other-uid
 `);
                 });
 
@@ -847,7 +847,7 @@ metadata:
                   fireEvent.click(saveButton);
 
                   expect(apiKubePatchMock).toHaveBeenCalledWith(
-                    "/apis/some-api-version/namespaces/some-other-uid",
+                    "/api/some-api-version/namespaces/some-other-uid",
                     {
                       data: [{
                         op: "add",
@@ -897,7 +897,7 @@ metadata:
                   });
 
                   it("does not call for namespace", () => {
-                    expect(apiKubeGetMock).not.toHaveBeenCalledWith("/apis/some-api-version/namespaces/some-uid");
+                    expect(apiKubeGetMock).not.toHaveBeenCalledWith("/api/some-api-version/namespaces/some-uid");
                   });
 
                   it("has configuration in the editor", () => {
@@ -913,7 +913,7 @@ metadata:
   resourceVersion: some-resource-version
   somePropertyToBeRemoved: some-value
   somePropertyToBeChanged: some-old-value
-  selfLink: /apis/some-api-version/namespaces/some-uid
+  selfLink: /api/some-api-version/namespaces/some-uid
 `);
                   });
 
@@ -927,7 +927,7 @@ metadata:
                     fireEvent.click(saveButton);
 
                     expect(apiKubePatchMock).toHaveBeenCalledWith(
-                      "/apis/some-api-version/namespaces/some-uid",
+                      "/api/some-api-version/namespaces/some-uid",
                       {
                         data: [{
                           op: "add",
@@ -987,7 +987,7 @@ const someNamespaceDataStub = {
     uid: "some-uid",
     name: "some-name",
     resourceVersion: "some-resource-version",
-    selfLink: "/apis/some-api-version/namespaces/some-uid",
+    selfLink: "/api/some-api-version/namespaces/some-uid",
   },
 };
 
@@ -998,6 +998,6 @@ const someOtherNamespaceDataStub = {
     uid: "some-other-uid",
     name: "some-other-name",
     resourceVersion: "some-resource-version",
-    selfLink: "/apis/some-api-version/namespaces/some-other-uid",
+    selfLink: "/api/some-api-version/namespaces/some-other-uid",
   },
 };


### PR DESCRIPTION
The problem was in parsing of Kube API URLs, where a recent change extracted **first value** from an array using destructuring, instead of getting **last value** using `.pop()`, like before.

Added the missing unit test to repro. Also added a bunch of other missing unit tests for parsing, but still not sure if all cases are covered.

The production code for parsing was a mess, refactored for cleanliness. That being said, extra care is wished from reviewer to check that all realistic scenarios of Kube API URLs are now covered with unit tests.

Fixes #7657 