### PR TITLE
Fix open-lens package address in prestart-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34116,20 +34116,20 @@
       }
     },
     "open-lens": {
-      "version": "6.5.0-alpha.9",
+      "version": "6.5.0-alpha.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@k8slens/application": "^6.5.0-alpha.5",
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.4",
-        "@k8slens/core": "^6.5.0-alpha.9",
+        "@k8slens/core": "^6.5.0-alpha.10",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.5",
         "@k8slens/event-emitter": "^1.0.0-alpha.2",
         "@k8slens/feature-core": "^6.5.0-alpha.4",
         "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.4",
         "@k8slens/kube-object": "^1.0.0-alpha.2",
         "@k8slens/kubectl-versions": "^1.0.0-alpha.3",
-        "@k8slens/legacy-extension-example": "^1.0.0-alpha.7",
+        "@k8slens/legacy-extension-example": "^1.0.0-alpha.8",
         "@k8slens/legacy-extensions": "^1.0.0-alpha.4",
         "@k8slens/legacy-global-di": "^1.0.0-alpha.1",
         "@k8slens/logger": "^1.0.0-alpha.6",
@@ -38274,6 +38274,7 @@
     },
     "packages/open-lens": {
       "version": "6.5.0-alpha.10",
+      "extraneous": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clean:node_modules": "lerna clean -y && rimraf node_modules",
     "dev": "cross-env NODE_ENV=development lerna run build --stream --skip-nx-cache",
     "postdev": "lerna watch -- lerna run build --stream --scope \\$LERNA_PACKAGE_NAME",
-    "prestart-dev": "cd packages/open-lens && rimraf static/build/ && npm run build:tray-icons && npm run download:binaries",
+    "prestart-dev": "cd ./open-lens && rimraf static/build/ && npm run build:tray-icons && npm run download:binaries",
     "start-dev": "lerna run start",
     "lint": "lerna run lint --stream --no-bail",
     "lint:fix": "lerna run lint:fix --stream",


### PR DESCRIPTION
Fixing `prestart-dev` to be able to run Open Lens.