### PR TITLE
Replace StatusBar bgcolor from --colorInfo to --primary

### DIFF
--- a/packages/core/src/renderer/components/status-bar/status-bar.module.scss
+++ b/packages/core/src/renderer/components/status-bar/status-bar.module.scss
@@ -13,7 +13,7 @@
 
   display: inline-grid;
   grid-template-columns: 1fr 1fr;
-  background-color: var(--colorInfo);
+  background-color: var(--primary);
 
   &.status-warning {
     background-color: var(--colorWarning);


### PR DESCRIPTION
`var(--colorInfo)` is a bit different between light and dark theme. While `var(--primary)` stays same.

![primary color for status bar](https://github.com/lensapp/lens/assets/9607060/93115d0a-a05b-40ca-a0f8-70e7ea6ac90f)
