### PR TITLE
fix: Use correct path for node-shell shell PTY

### DIFF
--- a/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
+++ b/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
@@ -95,7 +95,7 @@ export class NodeShellSession extends ShellSession {
         break;
     }
 
-    await this.openShellProcess(this.dependencies.directoryContainingKubectl, args, env);
+    await this.openShellProcess(await this.kubectl.getPath(), args, env);
   }
 
   protected createNodeShellPod(coreApi: CoreV1Api) {


### PR DESCRIPTION
closes https://github.com/lensapp/lens-desktop-kube-lens-extension/issues/787