### PR TITLE
Release 6.5.0-alpha.15

### DIFF
--- a/open-lens/CHANGELOG.md
+++ b/open-lens/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.5.0-alpha.16 (2023-05-23)
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+### Reverts
+
+* Revert "chore: Extract sidebar item injection token into separate package" ([8f4aa49](https://github.com/lensapp/lens/commit/8f4aa497cc54655f83813d57c224f77dd1472141))
+* Revert "chore: Update integration tests to new testid format" ([be1fbcf](https://github.com/lensapp/lens/commit/be1fbcf8c3642fbf5a5ee06c3b03ac1756e4b1dd))
+* Revert "chore: Improve title formatting for Horizontal/Vertical Pod Autoscalers" ([d4c12be](https://github.com/lensapp/lens/commit/d4c12becfc9020009d64f48e4c8f9dd3b7725bb6))
+* Revert "chore: Fix integration tests failing due to helm testid's changing" ([96b7ecb](https://github.com/lensapp/lens/commit/96b7ecbaddedd45cc667cc2d6c25fdc0813557ec))
+
+
+
+# 6.5.0-alpha.13 (2023-05-16)
+
+
+### Bug Fixes
+
+* Copy fonts from @k8slens/core to open-lens correctly ([33a9f3e](https://github.com/lensapp/lens/commit/33a9f3ea3501c04738c8d74b82725bbe83e148bb))
+
+
+
+# 6.5.0-alpha.12 (2023-05-16)
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+### Bug Fixes
+
+* Add missing styles to fix terminal resizing ([6902851](https://github.com/lensapp/lens/commit/6902851026e74428f515fc5f3e01e6dc8a4c2d50))
+
+
+
+
+
 # 6.5.0-alpha.15 (2023-05-23)
 
 

--- a/open-lens/package.json
+++ b/open-lens/package.json
@@ -4,7 +4,7 @@
   "productName": "OpenLens",
   "description": "OpenLens - Open Source IDE for Kubernetes",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.15",
+  "version": "6.5.0-alpha.16",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -179,14 +179,14 @@
   "dependencies": {
     "@k8slens/application": "^6.5.0-alpha.9",
     "@k8slens/application-for-electron-main": "^6.5.0-alpha.8",
-    "@k8slens/core": "^6.5.0-alpha.14",
+    "@k8slens/core": "^6.5.0-alpha.15",
     "@k8slens/ensure-binaries": "^6.5.0-alpha.7",
     "@k8slens/event-emitter": "^1.0.0-alpha.6",
     "@k8slens/feature-core": "^6.5.0-alpha.8",
     "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.8",
     "@k8slens/kube-object": "^1.0.0-alpha.6",
-    "@k8slens/kubectl-versions": "^1.0.0-alpha.8",
-    "@k8slens/legacy-extension-example": "^1.0.0-alpha.12",
+    "@k8slens/kubectl-versions": "^1.0.0-alpha.9",
+    "@k8slens/legacy-extension-example": "^1.0.0-alpha.13",
     "@k8slens/legacy-extensions": "^1.0.0-alpha.8",
     "@k8slens/legacy-global-di": "^1.0.0-alpha.5",
     "@k8slens/logger": "^1.0.0-alpha.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "adr": "^1.4.3",
         "cross-env": "^7.0.3",
         "lerna": "^6.6.1",
+        "npm": "^9.6.7",
         "rimraf": "^4.4.1"
       },
       "engines": {
@@ -34060,20 +34061,20 @@
       }
     },
     "open-lens": {
-      "version": "6.5.0-alpha.15",
+      "version": "6.5.0-alpha.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@k8slens/application": "^6.5.0-alpha.9",
         "@k8slens/application-for-electron-main": "^6.5.0-alpha.8",
-        "@k8slens/core": "^6.5.0-alpha.14",
+        "@k8slens/core": "^6.5.0-alpha.15",
         "@k8slens/ensure-binaries": "^6.5.0-alpha.7",
         "@k8slens/event-emitter": "^1.0.0-alpha.6",
         "@k8slens/feature-core": "^6.5.0-alpha.8",
         "@k8slens/keyboard-shortcuts": "^1.0.0-alpha.8",
         "@k8slens/kube-object": "^1.0.0-alpha.6",
-        "@k8slens/kubectl-versions": "^1.0.0-alpha.8",
-        "@k8slens/legacy-extension-example": "^1.0.0-alpha.12",
+        "@k8slens/kubectl-versions": "^1.0.0-alpha.9",
+        "@k8slens/legacy-extension-example": "^1.0.0-alpha.13",
         "@k8slens/legacy-extensions": "^1.0.0-alpha.8",
         "@k8slens/legacy-global-di": "^1.0.0-alpha.5",
         "@k8slens/logger": "^1.0.0-alpha.7",
@@ -34190,7 +34191,7 @@
     },
     "packages/core": {
       "name": "@k8slens/core",
-      "version": "6.5.0-alpha.14",
+      "version": "6.5.0-alpha.15",
       "license": "MIT",
       "dependencies": {
         "@astronautlabs/jsonpath": "^1.1.0",
@@ -34236,7 +34237,7 @@
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40",
         "node-pty": "0.10.1",
-        "npm": "^9.6.5",
+        "npm": "^9.6.7",
         "p-limit": "^3.1.0",
         "path-to-regexp": "^6.2.0",
         "proper-lockfile": "^4.1.2",
@@ -34458,10 +34459,10 @@
     },
     "packages/extension-api": {
       "name": "@k8slens/extensions",
-      "version": "6.5.0-alpha.14",
+      "version": "6.5.0-alpha.15",
       "license": "MIT",
       "dependencies": {
-        "@k8slens/core": "6.5.0-alpha.14"
+        "@k8slens/core": "6.5.0-alpha.15"
       },
       "devDependencies": {
         "@types/node": "^16.18.25",
@@ -34958,7 +34959,7 @@
     },
     "packages/kubectl-versions": {
       "name": "@k8slens/kubectl-versions",
-      "version": "1.0.0-alpha.8",
+      "version": "1.0.0-alpha.9",
       "license": "MIT",
       "devDependencies": {
         "@k8slens/webpack": "^6.5.0-alpha.9",
@@ -34975,10 +34976,10 @@
     },
     "packages/legacy-extension-example": {
       "name": "@k8slens/legacy-extension-example",
-      "version": "1.0.0-alpha.12",
+      "version": "1.0.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
-        "@k8slens/extensions": "^6.5.0-alpha.14",
+        "@k8slens/extensions": "^6.5.0-alpha.15",
         "@types/node": "^16.18.25",
         "typescript": "^4.9.5",
         "webpack": "^5.81.0",
@@ -35231,7 +35232,7 @@
     },
     "packages/release-tool": {
       "name": "@k8slens/release-tool",
-      "version": "6.5.0-alpha.9",
+      "version": "6.5.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "lens-monorepo",
   "private": true,
-
   "workspaces": [
     "packages/**/*",
     "open-lens"
   ],
-
   "scripts": {
     "all:reinstall": "npm run clean:node_modules && npm run all:install",
     "all:install": "npx --yes --package npm@^9.6.7 npm install",
@@ -44,6 +42,7 @@
     "adr": "^1.4.3",
     "cross-env": "^7.0.3",
     "lerna": "^6.6.1",
+    "npm": "^9.6.7",
     "rimraf": "^4.4.1"
   },
   "engines": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,196 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.5.0-alpha.15 (2023-05-23)
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+### Bug Fixes
+
+* Use correct path for node-shell shell PTY ([99e6b77](https://github.com/lensapp/lens/commit/99e6b77fc1c5a74cfef90981b8b0162b46ecfb43))
+
+
+### Reverts
+
+* Revert "chore: Extract sidebar item injection token into separate package" ([8f4aa49](https://github.com/lensapp/lens/commit/8f4aa497cc54655f83813d57c224f77dd1472141))
+* Revert "chore: Rename sidebar item injectable files" ([cb0e876](https://github.com/lensapp/lens/commit/cb0e8764aca9e0d28e6e23c5ae87a5ab6d414065))
+* Revert "chore: Convert sidebarItemInjectionToken to use InjectWithMetadata instead of duplicating the IDs" ([93bc41f](https://github.com/lensapp/lens/commit/93bc41f9a3f47f5c777c882c9241f4fd5e3f1952))
+* Revert "chore: Fixup tests snapshots to match new testid behaviour" ([9276df0](https://github.com/lensapp/lens/commit/9276df05924794d30d7d97bc79cf701a6106e8ec))
+* Revert "chore: Fix lint" ([d90bdf6](https://github.com/lensapp/lens/commit/d90bdf6f1497cb25f17788a4170feba31d366b74))
+* Revert "chore: Fix more lint" ([813705f](https://github.com/lensapp/lens/commit/813705fe9097012cd7fc62a8d543d1f7bc2be2ed))
+* Revert "chore: Fix IDs for some sidebar items" ([753c8bf](https://github.com/lensapp/lens/commit/753c8bfa85ccc74980553bb512b5038ff18767a2))
+* Revert "chore: Improve title formatting for Horizontal/Vertical Pod Autoscalers" ([d4c12be](https://github.com/lensapp/lens/commit/d4c12becfc9020009d64f48e4c8f9dd3b7725bb6))
+* Revert "fix: Fix formatting of custom resource sidebar items" ([5608a19](https://github.com/lensapp/lens/commit/5608a199be1067039403b85abe776fab928a956c))
+* Revert "chore: Fix integration tests failing due to helm testid's changing" ([96b7ecb](https://github.com/lensapp/lens/commit/96b7ecbaddedd45cc667cc2d6c25fdc0813557ec))
+* Revert "chore: Fix tests after rebase" ([1b43de5](https://github.com/lensapp/lens/commit/1b43de50fe6431367bf259799f5e0b42f6b38ad9))
+* Revert "fix: Custom Resource Definitions should be the first entry in the side bar" ([1099e65](https://github.com/lensapp/lens/commit/1099e65c52c62153b3d28d0654fffaaa6f6715a7))
+* Revert "fix: Custom Resource Definitions sidebar item should navigate to the correct route" ([7d46cb8](https://github.com/lensapp/lens/commit/7d46cb845d0f1748c0f83a8dc34bbe783270ca2c))
+* Revert "chore: Cleanup custom resource route definition" ([40f1180](https://github.com/lensapp/lens/commit/40f118057925a3b946f5dcc60162bad7e8b12e58))
+* Revert "chore: Factor out NavigateToCustomResources type" ([d3cf708](https://github.com/lensapp/lens/commit/d3cf7088d6c37860984ce0295a3d8a5c528c2a66))
+* Revert "chore: Move around Custom Resource and Custom Resource Definition files to simplify names" ([5f4cdbc](https://github.com/lensapp/lens/commit/5f4cdbc51950c04804139e9b961cfe394ad4ae30))
+
+
+
+# 6.5.0-alpha.13 (2023-05-16)
+
+
+### Bug Fixes
+
+* Switch to using IAsyncComputed to resolve bad setState error within ClusterOverview from react ([4f8e470](https://github.com/lensapp/lens/commit/4f8e4707f929eee04ff1345c9e93f00d50ac0a92))
+
+
+
+# 6.5.0-alpha.12 (2023-05-16)
+
+
+### Bug Fixes
+
+* Don't crash when hovering hotbar menu index ([9d51ef2](https://github.com/lensapp/lens/commit/9d51ef2aa69c6c9df0fd57281b25131a10efd27a))
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+### Bug Fixes
+
+* Add test as repro, and fix bug about kube API details not opening ([bb400ae](https://github.com/lensapp/lens/commit/bb400ae66797fe160567e6b728d85d5e79caef4d))
+* Bring back search filters for pods which were accidentally removed previously ([9c7be39](https://github.com/lensapp/lens/commit/9c7be39eb135b747945f76f61811695d2f96c761))
+* Do not crash when opening details of a helm release ([40af0d3](https://github.com/lensapp/lens/commit/40af0d31c529e252a45c7370852755c4e63067a7))
+* Kludge cluster settings not opening when extension introduces new settings without ID when title contains spaces ([e8491ca](https://github.com/lensapp/lens/commit/e8491ca2d39971d06842f6741eae042554fbc9a0))
+
+
+
+# 6.5.0-alpha.10 (2023-05-09)
+
+
+
+# 6.5.0-alpha.9 (2023-05-04)
+
+
+### Bug Fixes
+
+* Add checks to KubeObject constructor to ensure shape ([bf6af58](https://github.com/lensapp/lens/commit/bf6af58d80552a16be7a547f772902b138a12fbd))
+* add routingFeature to getDiForUnitTesting ([b33a8b4](https://github.com/lensapp/lens/commit/b33a8b49607935450f70b1d5535431ba416fc22e))
+* change class name behaviour to limit snapshot diffs ([bfb2b8e](https://github.com/lensapp/lens/commit/bfb2b8e6591891b529d5cf0f8757ff8b7080e004))
+* **core:** hide update button if downloading of an update fails ([f697742](https://github.com/lensapp/lens/commit/f6977428daa3f61482e7066689ebf7092b0fb2b1))
+* Fix selfLink being missing from requestKubeResource ([b90e04e](https://github.com/lensapp/lens/commit/b90e04e02dfd18896d5f08f1bc36f90179635797))
+* lint:fix ([76c11aa](https://github.com/lensapp/lens/commit/76c11aa697e3ada81c876fe8a3ac6e33b4ce8cb9))
+* observableHistoryInjectionToken and 1 revert for GlobalOverride ([8c0220c](https://github.com/lensapp/lens/commit/8c0220c353c9047a2a4df570b598c31868b5f7e2))
+* Only show Update Channel preferences when applicable ([43cedae](https://github.com/lensapp/lens/commit/43cedae7b05eaa7f932f2718939f7b856a1b86c5))
+* Remove incorrect timeout on standard info notifications ([bcf95a6](https://github.com/lensapp/lens/commit/bcf95a65f1d2be91fa613f0da9d0ae978faaef75))
+* removed as-legacy-globals-for-extension-api ([f1f2634](https://github.com/lensapp/lens/commit/f1f26344900b99c70b2bed2f453ed27574d7b417))
+* removed dependencies: [reactApplicationFeature], ([0dae159](https://github.com/lensapp/lens/commit/0dae1594baabbd06e798f9a1b4c132cee998bb65))
+
+
+### Features
+
+* Add deleting subNamespaces to contextMenu ([89cf491](https://github.com/lensapp/lens/commit/89cf491bc0aa80ee398f8b5dc39ec7c69d00c7bb))
+* Add removing subNamespaces to Namespace route ([aa95002](https://github.com/lensapp/lens/commit/aa950026a3162abf6322afb4b5c5bf56f9f7e10f))
+* Adjust container status colors to be distinguable with red/green filter ([#7621](https://github.com/lensapp/lens/issues/7621)) ([3532fc1](https://github.com/lensapp/lens/commit/3532fc1dab918190fa76199a9d7b04d6efe40c47))
+* Compute the kubectl download version map at build time ([0bd7b1f](https://github.com/lensapp/lens/commit/0bd7b1fe92a173379c8a5a1ab7e13cf9e4f8223b))
+* Improve formatting error messages from apiKube ([3439472](https://github.com/lensapp/lens/commit/3439472065e6b850e286f6a34bccc23b827b8e28))
+* Introduce API for changing the status bar colour ([06a0dce](https://github.com/lensapp/lens/commit/06a0dce612b67084f8f36ba552ea23f8ac071201))
+* Introduce injectables to remove subNamespaces ([c557225](https://github.com/lensapp/lens/commit/c5572257bd6a32a2f05fc78f54ece428f54389fe))
+* Never auto-close error notifications ([561d8db](https://github.com/lensapp/lens/commit/561d8dbc09581ff21aa79e85f3903c45e99ac33b))
+
+
+
+# 6.5.0-alpha.6 (2023-04-12)
+
+
+
+# 6.5.0-alpha.5 (2023-04-12)
+
+
+
+# 6.5.0-alpha.4 (2023-04-12)
+
+
+### Bug Fixes
+
+* Fix tests by recreating non-specific injection token ([c0ebe60](https://github.com/lensapp/lens/commit/c0ebe605c4d36c0d98454e25565818f75ffb1b69))
+* Referencing apiManager should not throw ([#7468](https://github.com/lensapp/lens/issues/7468)) ([351f9d4](https://github.com/lensapp/lens/commit/351f9d492f6e52e9e97d17d71e2bbdbbde4ea2db))
+* remove platform specific injectable file names ([9b0318b](https://github.com/lensapp/lens/commit/9b0318b493fe2e49a34b8a4cb3d0bef1600759b8))
+
+
+### Features
+
+* Allow built versions to specify an environment ([#7495](https://github.com/lensapp/lens/issues/7495)) ([128b05d](https://github.com/lensapp/lens/commit/128b05d4d46344a511398f654865c133c6e36514))
+
+
+### Reverts
+
+* Revert "Renderer file logging through IPC" (#7393) ([5409324](https://github.com/lensapp/lens/commit/54093242367717292312df01905d052b66017953)), closes [#7393](https://github.com/lensapp/lens/issues/7393)
+
+
+
+# 6.5.0-alpha.3 (2023-03-15)
+
+
+
+# 6.5.0-alpha.2 (2023-03-14)
+
+
+
+# 6.5.0-alpha.1 (2023-03-14)
+
+
+### Reverts
+
+* Revert "Renderer file logging transport (#6795)" (#7245) ([ec81af4](https://github.com/lensapp/lens/commit/ec81af4e6c5f8d0c25469a56dfa602894f85734b)), closes [#6795](https://github.com/lensapp/lens/issues/6795) [#7245](https://github.com/lensapp/lens/issues/7245) [#544](https://github.com/lensapp/lens/issues/544)
+
+
+
+# 6.4.0-beta.13 (2023-02-03)
+
+
+
+# 6.4.0-beta.12 (2023-02-01)
+
+
+
+# 6.4.0-beta.11 (2023-02-01)
+
+
+
+# 6.4.0-beta.10 (2023-01-27)
+
+
+
+# 6.4.0-beta.9 (2023-01-27)
+
+
+
+# 6.4.0-beta.8 (2023-01-27)
+
+
+
+# 6.4.0-beta.7 (2023-01-27)
+
+
+
+# 6.4.0-beta.6 (2023-01-26)
+
+
+
+# 6.4.0-beta.5 (2023-01-26)
+
+
+
+# 6.4.0-beta.4 (2023-01-26)
+
+
+
+# 6.4.0-beta.3 (2023-01-26)
+
+
+
+
+
 # 6.5.0-alpha.13 (2023-05-16)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "productName": "",
   "description": "Lens Desktop Core",
   "homepage": "https://github.com/lensapp/lens",
-  "version": "6.5.0-alpha.14",
+  "version": "6.5.0-alpha.15",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lensapp/lens.git"
@@ -146,7 +146,7 @@
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.40",
     "node-pty": "0.10.1",
-    "npm": "^9.6.5",
+    "npm": "^9.6.7",
     "p-limit": "^3.1.0",
     "path-to-regexp": "^6.2.0",
     "proper-lockfile": "^4.1.2",

--- a/packages/extension-api/CHANGELOG.md
+++ b/packages/extension-api/CHANGELOG.md
@@ -3,6 +3,109 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.5.0-alpha.15 (2023-05-23)
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+
+# 6.5.0-alpha.13 (2023-05-16)
+
+
+
+# 6.5.0-alpha.12 (2023-05-16)
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+
+# 6.5.0-alpha.10 (2023-05-09)
+
+
+
+# 6.5.0-alpha.9 (2023-05-04)
+
+
+### Features
+
+* Compute the kubectl download version map at build time ([0bd7b1f](https://github.com/lensapp/lens/commit/0bd7b1fe92a173379c8a5a1ab7e13cf9e4f8223b))
+
+
+
+# 6.5.0-alpha.6 (2023-04-12)
+
+
+
+# 6.5.0-alpha.5 (2023-04-12)
+
+
+
+# 6.5.0-alpha.4 (2023-04-12)
+
+
+
+# 6.5.0-alpha.3 (2023-03-15)
+
+
+
+# 6.5.0-alpha.2 (2023-03-14)
+
+
+
+# 6.5.0-alpha.1 (2023-03-14)
+
+
+
+# 6.4.0-beta.13 (2023-02-03)
+
+
+
+# 6.4.0-beta.12 (2023-02-01)
+
+
+
+# 6.4.0-beta.11 (2023-02-01)
+
+
+
+# 6.4.0-beta.10 (2023-01-27)
+
+
+
+# 6.4.0-beta.9 (2023-01-27)
+
+
+
+# 6.4.0-beta.8 (2023-01-27)
+
+
+
+# 6.4.0-beta.7 (2023-01-27)
+
+
+
+# 6.4.0-beta.6 (2023-01-26)
+
+
+
+# 6.4.0-beta.5 (2023-01-26)
+
+
+
+# 6.4.0-beta.4 (2023-01-26)
+
+
+
+# 6.4.0-beta.3 (2023-01-26)
+
+
+
+
+
 # 6.5.0-alpha.13 (2023-05-16)
 
 

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/extensions",
   "productName": "OpenLens extensions",
   "description": "OpenLens - Open Source Kubernetes IDE: extensions",
-  "version": "6.5.0-alpha.14",
+  "version": "6.5.0-alpha.15",
   "copyright": "© 2022 OpenLens Authors",
   "license": "MIT",
   "main": "dist/extension-api.js",
@@ -25,7 +25,7 @@
     "clean": "rimraf dist/"
   },
   "dependencies": {
-    "@k8slens/core": "6.5.0-alpha.14"
+    "@k8slens/core": "6.5.0-alpha.15"
   },
   "devDependencies": {
     "@types/node": "^16.18.25",

--- a/packages/kubectl-versions/CHANGELOG.md
+++ b/packages/kubectl-versions/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.0-alpha.9 (2023-05-23)
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+
+# 6.5.0-alpha.13 (2023-05-16)
+
+
+
+# 6.5.0-alpha.12 (2023-05-16)
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+
+# 6.5.0-alpha.9 (2023-05-04)
+
+
+### Features
+
+* Compute the kubectl download version map at build time ([0bd7b1f](https://github.com/lensapp/lens/commit/0bd7b1fe92a173379c8a5a1ab7e13cf9e4f8223b))
+
+
+
+
+
 # 1.0.0-alpha.8 (2023-05-23)
 
 

--- a/packages/kubectl-versions/package.json
+++ b/packages/kubectl-versions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8slens/kubectl-versions",
   "private": false,
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "Package of kubectl versions at build time",
   "files": [
     "dist"

--- a/packages/legacy-extension-example/CHANGELOG.md
+++ b/packages/legacy-extension-example/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 1.0.0-alpha.13 (2023-05-23)
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+
+# 6.5.0-alpha.13 (2023-05-16)
+
+
+
+# 6.5.0-alpha.12 (2023-05-16)
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+
+# 6.5.0-alpha.10 (2023-05-09)
+
+
+
+# 6.5.0-alpha.9 (2023-05-04)
+
+
+
+# 6.5.0-alpha.6 (2023-04-12)
+
+
+
+# 6.5.0-alpha.5 (2023-04-12)
+
+
+
+# 6.5.0-alpha.4 (2023-04-12)
+
+
+
+# 6.5.0-alpha.3 (2023-03-15)
+
+**Note:** Version bump only for package @k8slens/legacy-extension-example
+
+
+
+
+
 # 1.0.0-alpha.11 (2023-05-16)
 
 

--- a/packages/legacy-extension-example/package.json
+++ b/packages/legacy-extension-example/package.json
@@ -2,7 +2,7 @@
   "name": "@k8slens/legacy-extension-example",
   "private": false,
   "description": "An example bundled Lens extensions using the v1 API",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "type": "commonjs",
   "files": [
     "dist"
@@ -36,7 +36,7 @@
     "lint:fix": "lens-lint --fix"
   },
   "devDependencies": {
-    "@k8slens/extensions": "^6.5.0-alpha.14",
+    "@k8slens/extensions": "^6.5.0-alpha.15",
     "@types/node": "^16.18.25",
     "typescript": "^4.9.5",
     "webpack": "^5.81.0",

--- a/packages/release-tool/CHANGELOG.md
+++ b/packages/release-tool/CHANGELOG.md
@@ -3,6 +3,114 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.5.0-alpha.10 (2023-05-23)
+
+
+### Bug Fixes
+
+* Fix setting milestone on new release PRs ([597dd36](https://github.com/lensapp/lens/commit/597dd365807e53bccf6926927ab03bd5194c7ee8))
+* Switch to using authenticated GitHub API to increase rate limit ([84f6a6a](https://github.com/lensapp/lens/commit/84f6a6a5ac2c731e03fe9994ae37dc1d83d429ed))
+
+
+
+# 6.5.0-alpha.14 (2023-05-23)
+
+
+
+# 6.5.0-alpha.11 (2023-05-11)
+
+
+
+# 6.5.0-alpha.9 (2023-05-04)
+
+
+
+# 6.5.0-alpha.8 (2023-04-20)
+
+
+### Bug Fixes
+
+* Make sure that the @k8slens/core dep in @k8slens/extensions is exact ([799a3cb](https://github.com/lensapp/lens/commit/799a3cbd1cc025514d822db8263c3e1ef747a446))
+
+
+
+# 6.5.0-alpha.7 (2023-04-18)
+
+
+### Bug Fixes
+
+* Fix running release tool ([03349c2](https://github.com/lensapp/lens/commit/03349c232b14c3b5085fc994ecbf2fe4ba56e98a))
+
+
+### Features
+
+* Compute the kubectl download version map at build time ([0bd7b1f](https://github.com/lensapp/lens/commit/0bd7b1fe92a173379c8a5a1ab7e13cf9e4f8223b))
+
+
+
+# 6.5.0-alpha.4 (2023-04-12)
+
+
+### Bug Fixes
+
+* Add check in release-tool for no relevant PRs ([#7478](https://github.com/lensapp/lens/issues/7478)) ([b22d7af](https://github.com/lensapp/lens/commit/b22d7af2915bbaccc1d8a8c2c3ff247667f5d61b))
+
+
+
+# 6.5.0-alpha.2 (2023-03-14)
+
+
+
+# 6.5.0-alpha.1 (2023-03-14)
+
+
+
+# 6.4.0-beta.13 (2023-02-03)
+
+
+
+# 6.4.0-beta.12 (2023-02-01)
+
+
+
+# 6.4.0-beta.11 (2023-02-01)
+
+
+
+# 6.4.0-beta.10 (2023-01-27)
+
+
+
+# 6.4.0-beta.9 (2023-01-27)
+
+
+
+# 6.4.0-beta.8 (2023-01-27)
+
+
+
+# 6.4.0-beta.7 (2023-01-27)
+
+
+
+# 6.4.0-beta.6 (2023-01-26)
+
+
+
+# 6.4.0-beta.5 (2023-01-26)
+
+
+
+# 6.4.0-beta.4 (2023-01-26)
+
+
+
+# 6.4.0-beta.3 (2023-01-26)
+
+
+
+
+
 # 6.5.0-alpha.9 (2023-05-23)
 
 

--- a/packages/release-tool/package.json
+++ b/packages/release-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8slens/release-tool",
-  "version": "6.5.0-alpha.9",
+  "version": "6.5.0-alpha.10",
   "description": "Release tool for lens monorepo",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Changes since 6.5.0-alpha.14

## 🐛 Bug Fixes

- fix: Switch to using authenticated GitHub API to increase rate limit (**[#7762](https://github.com/lensapp/lens/pull/7762)**) https://github.com/Nokel81
- fix: Fix setting milestone on new release PRs (**[#7766](https://github.com/lensapp/lens/pull/7766)**) https://github.com/Nokel81

## 🧰 Maintenance

- chore: Support and switch to using ^9.6.7 version of NPM (**[#7757](https://github.com/lensapp/lens/pull/7757)**) https://github.com/gabriel-mirantis
