### PR TITLE
fix: Remove incorrect KubeObject validations

### DIFF
--- a/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/cluster-role-bindings/dialog/view.tsx
@@ -86,7 +86,7 @@ class NonInjectedClusterRoleBindingDialog extends React.Component<ClusterRoleBin
   }
 
   @observable selectedRoleRef: ClusterRole | undefined = undefined;
-  selectedAccounts = new ObservableHashSet<ServiceAccount>([], sa => sa.metadata.uid);
+  selectedAccounts = new ObservableHashSet<ServiceAccount>([], sa => sa.getId());
   selectedUsers = observable.set<string>([]);
   selectedGroups = observable.set<string>([]);
 

--- a/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
+++ b/packages/core/src/renderer/components/user-management/role-bindings/dialog/view.tsx
@@ -73,7 +73,7 @@ class NonInjectedRoleBindingDialog extends React.Component<RoleBindingDialogProp
   @observable.ref selectedRoleRef: Role | ClusterRole | null | undefined = null;
   @observable bindingName = "";
   @observable bindingNamespace: string | null = null;
-  selectedAccounts = new ObservableHashSet<ServiceAccount>([], sa => sa.metadata.uid);
+  selectedAccounts = new ObservableHashSet<ServiceAccount>([], sa => sa.getId());
   selectedUsers = observable.set<string>([]);
   selectedGroups = observable.set<string>([]);
 

--- a/packages/kube-object/src/api-types.ts
+++ b/packages/kube-object/src/api-types.ts
@@ -25,8 +25,8 @@ export interface KubeJsonApiData<
   Status = unknown,
   Spec = unknown,
 > {
-  kind: string;
-  apiVersion: string;
+  readonly kind: string;
+  readonly apiVersion: string;
   metadata: Metadata;
   status?: Status;
   spec?: Spec;
@@ -227,9 +227,6 @@ export type KubeJsonApiObjectMetadata<Namespaced extends KubeObjectScope = KubeO
 export type KubeObjectMetadata<Namespaced extends KubeObjectScope = KubeObjectScope> =
   KubeJsonApiObjectMetadata<Namespaced> & {
     readonly selfLink: string;
-    readonly uid: string;
-    readonly name: string;
-    readonly resourceVersion: string;
   };
 
 export type NamespaceScopedMetadata = KubeObjectMetadata<KubeObjectScope.Namespace>;

--- a/packages/kube-object/src/kube-object.test.ts
+++ b/packages/kube-object/src/kube-object.test.ts
@@ -14,21 +14,21 @@ const getStubData = () => ({
 });
 
 describe("kube object tests", () => {
-  it("should allow an object to be created when missing uid", () => {
+  it("given '.metadata.uid' is missing, then KubeObject constructor does not throw", () => {
     const data = getStubData();
 
     delete data.metadata.uid;
     expect(() => new KubeObject(data)).not.toThrow();
   });
 
-  it("should allow an object to be created when missing resourceVersion", () => {
+  it("given '.metadata.resourceVersion' is missing, then KubeObject constructor does not throw", () => {
     const data = getStubData();
 
     delete data.metadata.resourceVersion;
     expect(() => new KubeObject(data)).not.toThrow();
   });
 
-  it("should allow an object to be created when missing resourceVersion and uid", () => {
+  it("given both '.metadata.resourceVersion' and '.metadata.uid' are missing, then KubeObject constructor does not throw", () => {
     const data = getStubData();
 
     delete data.metadata.uid;
@@ -36,14 +36,14 @@ describe("kube object tests", () => {
     expect(() => new KubeObject(data)).not.toThrow();
   });
 
-  it("KubeObject.getId() should return the uid if present", () => {
+  it("given '.metadata.uid' exist, then KubeObject.getId() should return it", () => {
     const data = getStubData();
     const obj = new KubeObject(data);
 
     expect(obj.getId()).toEqual("123");
   });
 
-  it("KubeObject.getId() should return the selfLink if uid is missing", () => {
+  it("given '.metadata.uid' is missing, then KubeObject.getId() should return '.metadata.selfLink'", () => {
     const data = getStubData();
 
     delete data.metadata.uid;
@@ -54,14 +54,14 @@ describe("kube object tests", () => {
     );
   });
 
-  it("KubeObject.getResourceVersion() should return the resourceVersion if it is present", () => {
+  it("given '.metadata.resourceVersion' exist, then KubeObject.getResourceVersion() should return it", () => {
     const data = getStubData();
     const obj = new KubeObject(data);
 
     expect(obj.getResourceVersion()).toEqual("foobar");
   });
 
-  it("KubeObject.getResourceVersion() should return '' if the resourceVersion is missing", () => {
+  it("given '.metadata.resourceVersion' is missing, then KubeObject.getResourceVersion() should return an empty string", () => {
     const data = getStubData();
 
     delete data.metadata.resourceVersion;

--- a/packages/kube-object/src/kube-object.test.ts
+++ b/packages/kube-object/src/kube-object.test.ts
@@ -1,83 +1,53 @@
 import { KubeObject } from "./kube-object";
 
+const getStubData = () => ({
+  apiVersion: "metrics.k8s.io/v1beta1",
+  kind: "PodMetrics",
+  metadata: {
+    creationTimestamp: "2023-05-24T14:17:01Z",
+    name: "cert-manager-54cbdfb45c-n4kp9",
+    namespace: "cert-manager",
+    selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+    uid: "123" as string | undefined,
+    resourceVersion: "foobar" as string | undefined,
+  },
+});
+
 describe("kube object tests", () => {
   it("should allow an object to be created when missing uid", () => {
-    expect(
-      () =>
-        new KubeObject({
-          apiVersion: "metrics.k8s.io/v1beta1",
-          kind: "PodMetrics",
-          metadata: {
-            creationTimestamp: "2023-05-24T14:17:01Z",
-            name: "cert-manager-54cbdfb45c-n4kp9",
-            namespace: "cert-manager",
-            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-            resourceVersion: "123",
-          },
-        }),
-    ).not.toThrow();
+    const data = getStubData();
+
+    delete data.metadata.uid;
+    expect(() => new KubeObject(data)).not.toThrow();
   });
 
   it("should allow an object to be created when missing resourceVersion", () => {
-    expect(
-      () =>
-        new KubeObject({
-          apiVersion: "metrics.k8s.io/v1beta1",
-          kind: "PodMetrics",
-          metadata: {
-            creationTimestamp: "2023-05-24T14:17:01Z",
-            name: "cert-manager-54cbdfb45c-n4kp9",
-            namespace: "cert-manager",
-            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-            uid: "123",
-          },
-        }),
-    ).not.toThrow();
+    const data = getStubData();
+
+    delete data.metadata.resourceVersion;
+    expect(() => new KubeObject(data)).not.toThrow();
   });
 
   it("should allow an object to be created when missing resourceVersion and uid", () => {
-    expect(
-      () =>
-        new KubeObject({
-          apiVersion: "metrics.k8s.io/v1beta1",
-          kind: "PodMetrics",
-          metadata: {
-            creationTimestamp: "2023-05-24T14:17:01Z",
-            name: "cert-manager-54cbdfb45c-n4kp9",
-            namespace: "cert-manager",
-            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-          },
-        }),
-    ).not.toThrow();
+    const data = getStubData();
+
+    delete data.metadata.uid;
+    delete data.metadata.resourceVersion;
+    expect(() => new KubeObject(data)).not.toThrow();
   });
 
   it("KubeObject.getId() should return the uid if present", () => {
-    const obj = new KubeObject({
-      apiVersion: "metrics.k8s.io/v1beta1",
-      kind: "PodMetrics",
-      metadata: {
-        creationTimestamp: "2023-05-24T14:17:01Z",
-        name: "cert-manager-54cbdfb45c-n4kp9",
-        namespace: "cert-manager",
-        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-        uid: "foobar",
-      },
-    });
+    const data = getStubData();
+    const obj = new KubeObject(data);
 
-    expect(obj.getId()).toEqual("foobar");
+    expect(obj.getId()).toEqual("123");
   });
 
   it("KubeObject.getId() should return the selfLink if uid is missing", () => {
-    const obj = new KubeObject({
-      apiVersion: "metrics.k8s.io/v1beta1",
-      kind: "PodMetrics",
-      metadata: {
-        creationTimestamp: "2023-05-24T14:17:01Z",
-        name: "cert-manager-54cbdfb45c-n4kp9",
-        namespace: "cert-manager",
-        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-      },
-    });
+    const data = getStubData();
+
+    delete data.metadata.uid;
+    const obj = new KubeObject(data);
 
     expect(obj.getId()).toEqual(
       "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
@@ -85,32 +55,17 @@ describe("kube object tests", () => {
   });
 
   it("KubeObject.getResourceVersion() should return the resourceVersion if it is present", () => {
-    const obj = new KubeObject({
-      apiVersion: "metrics.k8s.io/v1beta1",
-      kind: "PodMetrics",
-      metadata: {
-        creationTimestamp: "2023-05-24T14:17:01Z",
-        name: "cert-manager-54cbdfb45c-n4kp9",
-        namespace: "cert-manager",
-        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-        resourceVersion: "foobar",
-      },
-    });
+    const data = getStubData();
+    const obj = new KubeObject(data);
 
     expect(obj.getResourceVersion()).toEqual("foobar");
   });
 
   it("KubeObject.getResourceVersion() should return '' if the resourceVersion is missing", () => {
-    const obj = new KubeObject({
-      apiVersion: "metrics.k8s.io/v1beta1",
-      kind: "PodMetrics",
-      metadata: {
-        creationTimestamp: "2023-05-24T14:17:01Z",
-        name: "cert-manager-54cbdfb45c-n4kp9",
-        namespace: "cert-manager",
-        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
-      },
-    });
+    const data = getStubData();
+
+    delete data.metadata.resourceVersion;
+    const obj = new KubeObject(data);
 
     expect(obj.getResourceVersion()).toEqual("");
   });

--- a/packages/kube-object/src/kube-object.test.ts
+++ b/packages/kube-object/src/kube-object.test.ts
@@ -6,35 +6,14 @@ describe("kube object tests", () => {
       () =>
         new KubeObject({
           apiVersion: "metrics.k8s.io/v1beta1",
-          containers: [
-            {
-              name: "cert-manager",
-              usage: {
-                cpu: "472721n",
-                memory: "74404Ki",
-              },
-            },
-          ],
           kind: "PodMetrics",
           metadata: {
             creationTimestamp: "2023-05-24T14:17:01Z",
-            labels: {
-              app: "cert-manager",
-              "app.kubernetes.io/component": "controller",
-              "app.kubernetes.io/instance": "cert-manager",
-              "app.kubernetes.io/managed-by": "Helm",
-              "app.kubernetes.io/name": "cert-manager",
-              "app.kubernetes.io/version": "v1.5.5",
-              "helm.sh/chart": "cert-manager-v1.5.5",
-              "pod-template-hash": "54cbdfb45c",
-            },
             name: "cert-manager-54cbdfb45c-n4kp9",
             namespace: "cert-manager",
             selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
             resourceVersion: "123",
           },
-          timestamp: "2023-05-24T14:16:39Z",
-          window: "16s",
         }),
     ).not.toThrow();
   });
@@ -44,35 +23,14 @@ describe("kube object tests", () => {
       () =>
         new KubeObject({
           apiVersion: "metrics.k8s.io/v1beta1",
-          containers: [
-            {
-              name: "cert-manager",
-              usage: {
-                cpu: "472721n",
-                memory: "74404Ki",
-              },
-            },
-          ],
           kind: "PodMetrics",
           metadata: {
             creationTimestamp: "2023-05-24T14:17:01Z",
-            labels: {
-              app: "cert-manager",
-              "app.kubernetes.io/component": "controller",
-              "app.kubernetes.io/instance": "cert-manager",
-              "app.kubernetes.io/managed-by": "Helm",
-              "app.kubernetes.io/name": "cert-manager",
-              "app.kubernetes.io/version": "v1.5.5",
-              "helm.sh/chart": "cert-manager-v1.5.5",
-              "pod-template-hash": "54cbdfb45c",
-            },
             name: "cert-manager-54cbdfb45c-n4kp9",
             namespace: "cert-manager",
             selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
             uid: "123",
           },
-          timestamp: "2023-05-24T14:16:39Z",
-          window: "16s",
         }),
     ).not.toThrow();
   });
@@ -82,35 +40,78 @@ describe("kube object tests", () => {
       () =>
         new KubeObject({
           apiVersion: "metrics.k8s.io/v1beta1",
-          containers: [
-            {
-              name: "cert-manager",
-              usage: {
-                cpu: "472721n",
-                memory: "74404Ki",
-              },
-            },
-          ],
           kind: "PodMetrics",
           metadata: {
             creationTimestamp: "2023-05-24T14:17:01Z",
-            labels: {
-              app: "cert-manager",
-              "app.kubernetes.io/component": "controller",
-              "app.kubernetes.io/instance": "cert-manager",
-              "app.kubernetes.io/managed-by": "Helm",
-              "app.kubernetes.io/name": "cert-manager",
-              "app.kubernetes.io/version": "v1.5.5",
-              "helm.sh/chart": "cert-manager-v1.5.5",
-              "pod-template-hash": "54cbdfb45c",
-            },
             name: "cert-manager-54cbdfb45c-n4kp9",
             namespace: "cert-manager",
             selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
           },
-          timestamp: "2023-05-24T14:16:39Z",
-          window: "16s",
         }),
     ).not.toThrow();
+  });
+
+  it("KubeObject.getId() should return the uid if present", () => {
+    const obj = new KubeObject({
+      apiVersion: "metrics.k8s.io/v1beta1",
+      kind: "PodMetrics",
+      metadata: {
+        creationTimestamp: "2023-05-24T14:17:01Z",
+        name: "cert-manager-54cbdfb45c-n4kp9",
+        namespace: "cert-manager",
+        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+        uid: "foobar",
+      },
+    });
+
+    expect(obj.getId()).toEqual("foobar");
+  });
+
+  it("KubeObject.getId() should return the selfLink if uid is missing", () => {
+    const obj = new KubeObject({
+      apiVersion: "metrics.k8s.io/v1beta1",
+      kind: "PodMetrics",
+      metadata: {
+        creationTimestamp: "2023-05-24T14:17:01Z",
+        name: "cert-manager-54cbdfb45c-n4kp9",
+        namespace: "cert-manager",
+        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+      },
+    });
+
+    expect(obj.getId()).toEqual(
+      "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+    );
+  });
+
+  it("KubeObject.getResourceVersion() should return the resourceVersion if it is present", () => {
+    const obj = new KubeObject({
+      apiVersion: "metrics.k8s.io/v1beta1",
+      kind: "PodMetrics",
+      metadata: {
+        creationTimestamp: "2023-05-24T14:17:01Z",
+        name: "cert-manager-54cbdfb45c-n4kp9",
+        namespace: "cert-manager",
+        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+        resourceVersion: "foobar",
+      },
+    });
+
+    expect(obj.getResourceVersion()).toEqual("foobar");
+  });
+
+  it("KubeObject.getResourceVersion() should return '' if the resourceVersion is missing", () => {
+    const obj = new KubeObject({
+      apiVersion: "metrics.k8s.io/v1beta1",
+      kind: "PodMetrics",
+      metadata: {
+        creationTimestamp: "2023-05-24T14:17:01Z",
+        name: "cert-manager-54cbdfb45c-n4kp9",
+        namespace: "cert-manager",
+        selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+      },
+    });
+
+    expect(obj.getResourceVersion()).toEqual("");
   });
 });

--- a/packages/kube-object/src/kube-object.test.ts
+++ b/packages/kube-object/src/kube-object.test.ts
@@ -1,0 +1,116 @@
+import { KubeObject } from "./kube-object";
+
+describe("kube object tests", () => {
+  it("should allow an object to be created when missing uid", () => {
+    expect(
+      () =>
+        new KubeObject({
+          apiVersion: "metrics.k8s.io/v1beta1",
+          containers: [
+            {
+              name: "cert-manager",
+              usage: {
+                cpu: "472721n",
+                memory: "74404Ki",
+              },
+            },
+          ],
+          kind: "PodMetrics",
+          metadata: {
+            creationTimestamp: "2023-05-24T14:17:01Z",
+            labels: {
+              app: "cert-manager",
+              "app.kubernetes.io/component": "controller",
+              "app.kubernetes.io/instance": "cert-manager",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "cert-manager",
+              "app.kubernetes.io/version": "v1.5.5",
+              "helm.sh/chart": "cert-manager-v1.5.5",
+              "pod-template-hash": "54cbdfb45c",
+            },
+            name: "cert-manager-54cbdfb45c-n4kp9",
+            namespace: "cert-manager",
+            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+            resourceVersion: "123",
+          },
+          timestamp: "2023-05-24T14:16:39Z",
+          window: "16s",
+        }),
+    ).not.toThrow();
+  });
+
+  it("should allow an object to be created when missing resourceVersion", () => {
+    expect(
+      () =>
+        new KubeObject({
+          apiVersion: "metrics.k8s.io/v1beta1",
+          containers: [
+            {
+              name: "cert-manager",
+              usage: {
+                cpu: "472721n",
+                memory: "74404Ki",
+              },
+            },
+          ],
+          kind: "PodMetrics",
+          metadata: {
+            creationTimestamp: "2023-05-24T14:17:01Z",
+            labels: {
+              app: "cert-manager",
+              "app.kubernetes.io/component": "controller",
+              "app.kubernetes.io/instance": "cert-manager",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "cert-manager",
+              "app.kubernetes.io/version": "v1.5.5",
+              "helm.sh/chart": "cert-manager-v1.5.5",
+              "pod-template-hash": "54cbdfb45c",
+            },
+            name: "cert-manager-54cbdfb45c-n4kp9",
+            namespace: "cert-manager",
+            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+            uid: "123",
+          },
+          timestamp: "2023-05-24T14:16:39Z",
+          window: "16s",
+        }),
+    ).not.toThrow();
+  });
+
+  it("should allow an object to be created when missing resourceVersion and uid", () => {
+    expect(
+      () =>
+        new KubeObject({
+          apiVersion: "metrics.k8s.io/v1beta1",
+          containers: [
+            {
+              name: "cert-manager",
+              usage: {
+                cpu: "472721n",
+                memory: "74404Ki",
+              },
+            },
+          ],
+          kind: "PodMetrics",
+          metadata: {
+            creationTimestamp: "2023-05-24T14:17:01Z",
+            labels: {
+              app: "cert-manager",
+              "app.kubernetes.io/component": "controller",
+              "app.kubernetes.io/instance": "cert-manager",
+              "app.kubernetes.io/managed-by": "Helm",
+              "app.kubernetes.io/name": "cert-manager",
+              "app.kubernetes.io/version": "v1.5.5",
+              "helm.sh/chart": "cert-manager-v1.5.5",
+              "pod-template-hash": "54cbdfb45c",
+            },
+            name: "cert-manager-54cbdfb45c-n4kp9",
+            namespace: "cert-manager",
+            selfLink: "/apis/metrics.k8s.io/v1beta1/namespaces/cert-manager/pods/cert-manager-54cbdfb45c-n4kp9",
+          },
+          timestamp: "2023-05-24T14:16:39Z",
+          window: "16s",
+        }),
+    ).not.toThrow();
+  });
+});

--- a/packages/kube-object/src/kube-object.ts
+++ b/packages/kube-object/src/kube-object.ts
@@ -111,20 +111,6 @@ export class KubeObject<
       );
     }
 
-    if (!isString(data.metadata.uid)) {
-      throw new KubeCreationError(
-        `Cannot create a KubeObject from an object without metadata.uid being a string`,
-        data,
-      );
-    }
-
-    if (!isString(data.metadata.resourceVersion)) {
-      throw new KubeCreationError(
-        `Cannot create a KubeObject from an object without metadata.resourceVersion being a string`,
-        data,
-      );
-    }
-
     if (!isString(data.metadata.selfLink)) {
       throw new KubeCreationError(
         `Cannot create a KubeObject from an object without metadata.selfLink being a string`,
@@ -136,23 +122,23 @@ export class KubeObject<
     autoBind(this);
   }
 
-  get selfLink() {
+  get selfLink(): string {
     return this.metadata.selfLink;
   }
 
-  getId() {
-    return this.metadata.uid;
+  getId(): string {
+    return this.metadata.uid ?? this.metadata.selfLink;
   }
 
-  getResourceVersion() {
-    return this.metadata.resourceVersion;
+  getResourceVersion(): string {
+    return this.metadata.resourceVersion ?? "";
   }
 
   getScopedName() {
     return [this.getNs(), this.getName()].filter(Boolean).join("/");
   }
 
-  getName() {
+  getName(): string {
     return this.metadata.name;
   }
 


### PR DESCRIPTION
Error in console:

```
> await podMetricsApi.list({ name: "cert-manager-webhook-549c989579-sjkkk", namespace: "cert-manager" })
renderer.js:102558 Uncaught Error: Cannot create a KubeObject from an object without metadata.uid being a string
    at new P (renderer.js:102558:5777)
    at new oe (renderer.js:102558:36682)
    at renderer.js:14735:1
    at Array.map (<anonymous>)
    at PodMetricsApi.parseResponse (renderer.js:14728:1)
    at PodMetricsApi.list (renderer.js:14771:1)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async <anonymous>:1:1
```