### PR TITLE
Handle log responses as text

### DIFF
--- a/packages/core/src/common/k8s-api/endpoints/pod.api.ts
+++ b/packages/core/src/common/k8s-api/endpoints/pod.api.ts
@@ -57,6 +57,12 @@ export class PodApi extends KubeApi<Pod> {
   async getLogs(params: ResourceDescriptor, query?: PodLogsQuery): Promise<string> {
     const path = `${this.getUrl(params)}/log`;
 
-    return this.request.get(path, { query });
+    const logs = await this.request.get(path, { query });
+
+    if (typeof logs !== "string") {
+      return "";
+    }
+
+    return logs;
   }
 }


### PR DESCRIPTION
Logs are handled as string and log endpoint always responds as `Content-Type: text/plain` but empty responses are converted to empty objects in JsonApi.

In case of resolved non-string log response, consider it empty (string).

Fixes error:
![Screenshot 2023-05-25 at 11 13 18](https://github.com/lensapp/lens/assets/97873007/3346829f-d7bc-45b2-9b1b-0093d69f0a3a)
