### PR TITLE
Introduce watch-mode for lens-webpack-build

### DIFF
--- a/packages/infrastructure/webpack/bin/webpack-build
+++ b/packages/infrastructure/webpack/bin/webpack-build
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 const { doWebpackBuild } = require("../dist/index");
 
-doWebpackBuild();
+doWebpackBuild({ watch: process.argv.includes("--watch") });

--- a/packages/infrastructure/webpack/do-webpack-build.ts
+++ b/packages/infrastructure/webpack/do-webpack-build.ts
@@ -1,10 +1,10 @@
 import { getDi } from "./src/scripts/get-di";
 import { doWebpackBuildInjectable } from "./src/scripts/do-webpack-build";
 
-export const doWebpackBuild = () => {
+export const doWebpackBuild = ({ watch }: { watch: boolean }) => {
   const di = getDi();
 
   const doWebpackBuild = di.inject(doWebpackBuildInjectable);
 
-  doWebpackBuild();
+  doWebpackBuild({ watch });
 };

--- a/packages/infrastructure/webpack/src/__snapshots__/get-multi-export-config.test.ts.snap
+++ b/packages/infrastructure/webpack/src/__snapshots__/get-multi-export-config.test.ts.snap
@@ -25,7 +25,8 @@ exports[`get-multi-export-config given maximal package.json, when creating confi
             }
           }
         }
-      }
+      },
+      LinkablePushPlugin {}
     ],
     output: {
       path: '/some-working-directory/dist',
@@ -59,7 +60,8 @@ exports[`get-multi-export-config given maximal package.json, when creating confi
             }
           }
         }
-      }
+      },
+      LinkablePushPlugin {}
     ],
     output: {
       path: '/some-working-directory/dist/some-entrypoint',
@@ -94,6 +96,7 @@ exports[`get-multi-export-config given maximal package.json, when creating confi
           }
         }
       },
+      LinkablePushPlugin {},
       MiniCssExtractPlugin {
         _sortedModulesCache: WeakMap { <items unknown> },
         options: {

--- a/packages/infrastructure/webpack/src/get-node-config.ts
+++ b/packages/infrastructure/webpack/src/get-node-config.ts
@@ -2,6 +2,7 @@ import ForkTsCheckerPlugin from "fork-ts-checker-webpack-plugin";
 import type { Configuration } from "webpack";
 import { MakePeerDependenciesExternalPlugin } from "./plugins/make-peer-dependencies-external";
 import { ProtectFromImportingNonDependencies } from "./plugins/protect-from-importing-non-dependencies";
+import { LinkablePushPlugin } from "./plugins/linkable-push-plugin";
 
 export type Paths = {
   entrypointFilePath: string;
@@ -44,6 +45,8 @@ export const getNodeConfig = ({
         },
       },
     }),
+
+    new LinkablePushPlugin(),
   ],
 
   output: {

--- a/packages/infrastructure/webpack/src/plugins/linkable-push-plugin.ts
+++ b/packages/infrastructure/webpack/src/plugins/linkable-push-plugin.ts
@@ -1,0 +1,10 @@
+import { pushLink } from "@ogre-tools/linkable";
+import type { Compiler } from "webpack";
+
+export class LinkablePushPlugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.afterEmit.tap("LinkablePushPlugin", async () => {
+      await pushLink();
+    });
+  }
+}

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
@@ -31,15 +31,27 @@ describe("do-webpack-build", () => {
     doWebpackBuild = di.inject(doWebpackBuildInjectable);
   });
 
-  describe("when called", () => {
+  it('given watching, when called, calls webpack with watch', () => {
+    doWebpackBuild({ watch: true});
+
+    expect(execMock).toHaveBeenCalledWith("webpack --watch");
+  });
+
+  it('given not watching, when called, calls webpack without watch', () => {
+    doWebpackBuild({ watch: false});
+
+    expect(execMock).toHaveBeenCalledWith("webpack");
+  });
+
+  describe("normally, when called", () => {
     let actualPromise: Promise<void>;
 
     beforeEach(() => {
-      actualPromise = doWebpackBuild();
+      actualPromise = doWebpackBuild({ watch: true});
     });
 
     it("calls webpack", () => {
-      expect(execMock).toHaveBeenCalledWith("webpack");
+      expect(execMock).toHaveBeenCalled();
     });
 
     it("data in stdout logs as success", () => {

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
@@ -1,5 +1,5 @@
 import { getDi } from "./get-di";
-import { Exec, execInjectable } from "./exec.injectable";
+import { execInjectable } from "./exec.injectable";
 import asyncFn, { AsyncFnMock } from "@async-fn/jest";
 import { DoWebpackBuild, doWebpackBuildInjectable } from "./do-webpack-build";
 import { getPromiseStatus } from "@ogre-tools/test-utils";
@@ -7,16 +7,22 @@ import { LogSuccess, logSuccessInjectable } from "./log-success.injectable";
 import { LogWarning, logWarningInjectable } from "./log-warning.injectable";
 
 describe("do-webpack-build", () => {
-  let execMock: AsyncFnMock<Exec>;
+  let execMock: jest.Mock;
   let doWebpackBuild: DoWebpackBuild;
   let logSuccessMock: AsyncFnMock<LogSuccess>;
   let logWarningMock: AsyncFnMock<LogWarning>;
+  let execResultStub: { stdout: { on: any }; stderr: { on: any }; on: any };
 
   beforeEach(() => {
     const di = getDi();
 
-    execMock = asyncFn();
-    di.override(execInjectable, () => execMock);
+    execResultStub = {
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn(),
+    };
+    execMock = jest.fn().mockReturnValue(execResultStub);
+    di.override(execInjectable, () => execMock as any);
     logSuccessMock = asyncFn();
     di.override(logSuccessInjectable, () => logSuccessMock);
     logWarningMock = asyncFn();
@@ -36,58 +42,32 @@ describe("do-webpack-build", () => {
       expect(execMock).toHaveBeenCalledWith("webpack");
     });
 
-    it("does not resolve yet", async () => {
+    it("data in stdout logs as success", () => {
+      const listeners = execResultStub.stdout.on.mock.calls;
+
+      expect(listeners).toEqual([["data", logSuccessMock]]);
+    });
+
+    it("data in stderr logs as warning", () => {
+      const listeners = execResultStub.stderr.on.mock.calls;
+
+      expect(listeners).toEqual([["data", logWarningMock]]);
+    });
+
+    it("script is not done yet", async () => {
       const promiseStatus = await getPromiseStatus(actualPromise);
 
       expect(promiseStatus.fulfilled).toBe(false);
     });
 
-    describe("when webpack resolves with stdout", () => {
-      beforeEach(async () => {
-        await execMock.resolve({ stdout: "some-stdout", stderr: "" });
-      });
+    it("when execution of webpack exits, script is done", async () => {
+      const [[eventName, finishWebpack]] = execResultStub.on.mock.calls;
 
-      it("logs the stdout", () => {
-        expect(logSuccessMock).toHaveBeenCalledWith("some-stdout");
-      });
+      eventName === "exit" && finishWebpack();
 
-      it("script is done", async () => {
-        const promiseStatus = await getPromiseStatus(actualPromise);
+      const promiseStatus = await getPromiseStatus(actualPromise);
 
-        expect(promiseStatus.fulfilled).toBe(true);
-      });
-    });
-
-    describe("when webpack resolves with stderr", () => {
-      beforeEach(() => {
-        execMock.resolve({ stdout: "", stderr: "some-stderr" });
-      });
-
-      it("does not log success", () => {
-        actualPromise.catch(() => {});
-
-        expect(logSuccessMock).not.toHaveBeenCalled();
-      });
-
-      it("logs a warning", () => {
-        expect(logWarningMock).toBeCalledWith("Warning while executing \"webpack\": some-stderr");
-      });
-    });
-
-    describe("when webpack rejects", () => {
-      beforeEach(async () => {
-        execMock.reject(new Error("some-error"));
-      });
-
-      it("does not log success", () => {
-        actualPromise.catch(() => {});
-
-        expect(logSuccessMock).not.toHaveBeenCalled();
-      });
-
-      it("throws", () => {
-        return expect(actualPromise).rejects.toThrow("some-error");
-      });
+      expect(promiseStatus.fulfilled).toBe(true);
     });
   });
 });

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.test.ts
@@ -51,68 +51,10 @@ describe("do-webpack-build", () => {
         expect(logSuccessMock).toHaveBeenCalledWith("some-stdout");
       });
 
-      it("makes the built package available for local packages in development that link to it", () => {
-        expect(execMock).toHaveBeenCalledWith("linkable-push");
-      });
-
-      it("does not finish script yet", async () => {
+      it("script is done", async () => {
         const promiseStatus = await getPromiseStatus(actualPromise);
 
-        expect(promiseStatus.fulfilled).toBe(false);
-      });
-
-      describe("when linking resolves with stdout", () => {
-        beforeEach(async () => {
-          logSuccessMock.mockClear();
-
-          await execMock.resolve({ stdout: "some-other-stdout", stderr: "" });
-        });
-
-        it("logs the stdout", () => {
-          expect(logSuccessMock).toHaveBeenCalledWith("some-other-stdout");
-        });
-
-        it("script finishes", async () => {
-          const promiseStatus = await getPromiseStatus(actualPromise);
-
-          expect(promiseStatus.fulfilled).toBe(true);
-        });
-      });
-
-      describe("when linking resolves with stderr", () => {
-        beforeEach(() => {
-          logSuccessMock.mockClear();
-
-          execMock.resolve({ stdout: "", stderr: "some-other-stderr" });
-        });
-
-        it("does not log success", () => {
-          actualPromise.catch(() => {});
-
-          expect(logSuccessMock).not.toHaveBeenCalled();
-        });
-
-        it("logs a warning", () => {
-          expect(logWarningMock).toBeCalledWith("Warning while executing \"linkable-push\": some-other-stderr");
-        });
-      });
-
-      describe("when linking rejects", () => {
-        beforeEach(() => {
-          logSuccessMock.mockClear();
-
-          execMock.reject(new Error("some-other-error"));
-        });
-
-        it("does not log success", () => {
-          actualPromise.catch(() => {});
-
-          expect(logSuccessMock).not.toHaveBeenCalled();
-        });
-
-        it("throws", () => {
-          return expect(actualPromise).rejects.toThrow("some-other-error");
-        });
+        expect(promiseStatus.fulfilled).toBe(true);
       });
     });
 

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
@@ -3,18 +3,18 @@ import { execInjectable } from "./exec.injectable";
 import { logSuccessInjectable } from "./log-success.injectable";
 import { logWarningInjectable } from "./log-warning.injectable";
 
-export type DoWebpackBuild = () => Promise<void>;
+export type DoWebpackBuild = ({ watch }: { watch: boolean }) => Promise<void>;
 
 export const doWebpackBuildInjectable = getInjectable({
   id: "do-webpack-build",
 
-  instantiate: (di) => {
+  instantiate: (di): DoWebpackBuild => {
     const exec = di.inject(execInjectable);
     const logSuccess = di.inject(logSuccessInjectable);
     const logWarning = di.inject(logWarningInjectable);
 
-    return async () => {
-      const execResult = exec("webpack");
+    return async ({ watch }) => {
+      const execResult = exec(watch ? "webpack --watch" : "webpack");
 
       execResult.stdout?.on("data", logSuccess);
       execResult.stderr?.on("data", logWarning);

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
@@ -25,8 +25,6 @@ export const doWebpackBuildInjectable = getInjectable({
 
     return async () => {
       await execWithResultHandling("webpack");
-
-      await execWithResultHandling("linkable-push");
     };
   },
 });

--- a/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
+++ b/packages/infrastructure/webpack/src/scripts/do-webpack-build.ts
@@ -13,18 +13,15 @@ export const doWebpackBuildInjectable = getInjectable({
     const logSuccess = di.inject(logSuccessInjectable);
     const logWarning = di.inject(logWarningInjectable);
 
-    const execWithResultHandling = async (command: string) => {
-      const { stdout, stderr } = await exec(command);
-
-      if (stderr) {
-        logWarning(`Warning while executing "${command}": ${stderr}`);
-      } else if (stdout) {
-        logSuccess(stdout);
-      }
-    };
-
     return async () => {
-      await execWithResultHandling("webpack");
+      const execResult = exec("webpack");
+
+      execResult.stdout?.on("data", logSuccess);
+      execResult.stderr?.on("data", logWarning);
+
+      return new Promise<void>((resolve) => {
+        execResult.on("exit", resolve);
+      });
     };
   },
 });

--- a/packages/infrastructure/webpack/src/scripts/exec.injectable.ts
+++ b/packages/infrastructure/webpack/src/scripts/exec.injectable.ts
@@ -1,12 +1,9 @@
 import { getInjectable } from "@ogre-tools/injectable";
 import { exec } from "child_process";
-import { promisify } from "util";
 
-const promisifiedExec = promisify(exec);
-
-export type Exec = typeof promisifiedExec;
+export type Exec = typeof exec;
 
 export const execInjectable = getInjectable({
   id: "exec",
-  instantiate: () => promisifiedExec,
+  instantiate: () => exec,
 });


### PR DESCRIPTION
The motivation is to enhance Developer Experience by having changes in builds propagate automatically using `linkable-push`, even when watching.

Additionally: watching with `linkable-push` also now works using normal `webpack --watch`, provided that the shared `webpack.config.ts` is used.