### PR TITLE
chore: Support running smoke tests against non-minikube clusters

### DIFF
--- a/open-lens/integration/__tests__/cluster-pages.tests.ts
+++ b/open-lens/integration/__tests__/cluster-pages.tests.ts
@@ -27,7 +27,7 @@ describeIf(minikubeReady(TEST_NAMESPACE))("Minikube based tests", () => {
     ({ window, cleanup } = await utils.start());
     await utils.clickWelcomeButton(window);
 
-    frame = await utils.launchMinikubeClusterFromCatalog(window);
+    frame = await utils.launchClusterFromCatalog(window);
   }, 10 * 60 * 1000);
 
   afterEach(async () => {

--- a/open-lens/integration/helpers/minikube.ts
+++ b/open-lens/integration/helpers/minikube.ts
@@ -3,8 +3,36 @@
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
 import { spawnSync } from "child_process";
+import { clusterName, kubeConfigPath } from "./utils";
 
 export function minikubeReady(testNamespace: string): boolean {
+  if (clusterName !== "minikube") {
+    console.log("Not running against minikube");
+
+    {
+      const { status } = spawnSync(`kubectl --kubeconfig "${kubeConfigPath}" get namespace ${testNamespace}`, { shell: true });
+
+      if (status === 0) {
+        console.warn(`Removing existing ${testNamespace} namespace`);
+
+        const { status, stdout, stderr } = spawnSync(
+          `kubectl --kubeconfig "${kubeConfigPath}" delete namespace ${testNamespace}`,
+          { shell: true },
+        );
+
+        if (status !== 0) {
+          console.warn(`Error removing ${testNamespace} namespace: ${stderr.toString()}`);
+
+          return false;
+        }
+
+        console.log(stdout.toString());
+      }
+    }
+
+    return true;
+  }
+
   // determine if minikube is running
   {
     const { status } = spawnSync("minikube status", { shell: true });


### PR DESCRIPTION
To use this you can use the following command:

```
LENS_INTEGRATION_TEST_KUBECONFIG="/Users/sebastianmalton/Library/Application Support/Lens/kubeconfigs/lens-desktop-kube" \
LENS_INTEGRATION_TEST_CLUSTER_NAME="Lens Desktop Kube" \
npm exec --workspace open-lens test:integration
```