### PR TITLE
Update @electron/notarize

### DIFF
--- a/open-lens/build/notarize.js
+++ b/open-lens/build/notarize.js
@@ -2,7 +2,7 @@
  * Copyright (c) OpenLens Authors. All rights reserved.
  * Licensed under MIT License. See LICENSE in root directory for more information.
  */
-const { notarize } = require("electron-notarize");
+const { notarize } = require("@electron/notarize");
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
@@ -22,6 +22,8 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,
-    ascProvider:process.env.ASCPROVIDER,
+    ascProvider: process.env.ASCPROVIDER,
+    teamId: process.env.APPLETEAMID,
+    tool: process.env.NOTARIZE_TOOL || "legacy",
   });
 };

--- a/open-lens/package.json
+++ b/open-lens/package.json
@@ -297,6 +297,7 @@
     "xterm-link-provider": "^1.3.1"
   },
   "devDependencies": {
+    "@electron/notarize": "^1.2.3",
     "@electron/rebuild": "^3.2.10",
     "@k8slens/generate-tray-icons": "^6.5.0",
     "@k8slens/test-utils": "^1.0.0",
@@ -330,7 +331,6 @@
     "css-loader": "^6.7.2",
     "electron": "^22.3.10",
     "electron-builder": "^23.6.0",
-    "electron-notarize": "^0.3.0",
     "esbuild-loader": "^2.20.0",
     "fork-ts-checker-webpack-plugin": "^7.3.0",
     "html-webpack-plugin": "^5.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2188,6 +2188,19 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@electron/notarize": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
+      "integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@electron/rebuild": {
       "version": "3.2.13",
       "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.13.tgz",
@@ -12747,49 +12760,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/electron-notarize": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.3.0.tgz",
-      "integrity": "sha512-tuDw8H0gcDOalNLv6RM2CwGvUXU60MPGZRDEmd0ppX+yP5XqL8Ec2DuXyz9J7WQSA3aRCfzIgH8C5CAivDYWMw==",
-      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
-      }
-    },
-    "node_modules/electron-notarize/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/electron-notarize/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-notarize/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/electron-osx-sign": {
@@ -34110,6 +34080,7 @@
         "xterm-link-provider": "^1.3.1"
       },
       "devDependencies": {
+        "@electron/notarize": "^1.2.3",
         "@electron/rebuild": "^3.2.10",
         "@k8slens/generate-tray-icons": "^6.5.0",
         "@k8slens/test-utils": "^1.0.0",
@@ -34143,7 +34114,6 @@
         "css-loader": "^6.7.2",
         "electron": "^22.3.10",
         "electron-builder": "^23.6.0",
-        "electron-notarize": "^0.3.0",
         "esbuild-loader": "^2.20.0",
         "fork-ts-checker-webpack-plugin": "^7.3.0",
         "html-webpack-plugin": "^5.5.1",


### PR DESCRIPTION
Update to `@electron/notarize`. The breaking change for v1 was node 10 a minimun, no other API changes.