### PR TITLE
chore: Update link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Lens
 
-See [Contributing to Lens](https://docs.k8slens.dev/contributing/) documentation.
+See [Contributing to Lens](https://docs.k8slens.dev/contributing/contribute-to-lens/) documentation.


### PR DESCRIPTION
The page the link is redirecting to returns a 404.
That's why a link to the most general sub-page is more ideal.