### PR TITLE
Fix: Support metrics for Pods with multiple containers

### DIFF
--- a/packages/core/src/common/k8s-api/endpoints/metrics.api/request-pod-metrics.injectable.ts
+++ b/packages/core/src/common/k8s-api/endpoints/metrics.api/request-pod-metrics.injectable.ts
@@ -4,7 +4,7 @@
  */
 import { getInjectable } from "@ogre-tools/injectable";
 import type { MetricData } from "../metrics.api";
-import type { Pod } from "@k8slens/kube-object";
+import type { Pod, Container } from "@k8slens/kube-object";
 import requestMetricsInjectable from "./request-metrics.injectable";
 
 export interface PodMetricData {
@@ -21,16 +21,16 @@ export interface PodMetricData {
   memoryLimits: MetricData;
 }
 
-export type RequestPodMetrics = (pods: Pod[], namespace: string, selector?: string) => Promise<PodMetricData>;
+export type RequestPodMetrics = (pods: Pod[], namespace: string, container?: Container, selector?: string) => Promise<PodMetricData>;
 
 const requestPodMetricsInjectable = getInjectable({
   id: "request-pod-metrics",
   instantiate: (di): RequestPodMetrics => {
     const requestMetrics = di.inject(requestMetricsInjectable);
 
-    return (pods, namespace, selector = "pod, namespace") => {
+    return (pods, namespace, container, selector = "pod, namespace") => {
       const podSelector = pods.map(pod => pod.getName()).join("|");
-      const opts = { category: "pods", pods: podSelector, namespace, selector };
+      const opts = { category: "pods", pods: podSelector, container: container?.name, namespace, selector };
 
       return requestMetrics({
         cpuUsage: opts,

--- a/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.ts
@@ -15,7 +15,7 @@ interface PodContainerParams {
 
 const podContainerMetricsInjectable = getInjectable({
   id: "pod-container-metrics",
-  instantiate: (di, pod) => {
+  instantiate: (di, { pod, container }) => {
     const requestPodMetrics = di.inject(requestPodMetricsInjectable);
 
     return asyncComputed({

--- a/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.ts
+++ b/packages/core/src/renderer/components/workloads-pods/container-metrics.injectable.ts
@@ -5,8 +5,13 @@
 import { getInjectable, lifecycleEnum } from "@ogre-tools/injectable";
 import { asyncComputed } from "@ogre-tools/injectable-react";
 import { now } from "mobx-utils";
-import type { Pod } from "@k8slens/kube-object";
+import type { Pod, Container } from "@k8slens/kube-object";
 import requestPodMetricsInjectable from "../../../common/k8s-api/endpoints/metrics.api/request-pod-metrics.injectable";
+
+interface PodContainerParams {
+  pod: Pod;
+  container: Container;
+}
 
 const podContainerMetricsInjectable = getInjectable({
   id: "pod-container-metrics",
@@ -17,12 +22,14 @@ const podContainerMetricsInjectable = getInjectable({
       getValueFromObservedPromise: () => {
         now(60 * 1000);
 
-        return requestPodMetrics([pod], pod.getNs(), "container, namespace");
+        return requestPodMetrics([pod], pod.getNs(), container, "pod, container, namespace");
       },
     });
   },
   lifecycle: lifecycleEnum.keyedSingleton({
-    getInstanceKey: (di, pod: Pod) => pod.getId(),
+    getInstanceKey: (di, { pod, container }: PodContainerParams) => {
+      return `${pod.getId()}-${container.name}`;
+    },
   }),
 });
 

--- a/packages/core/src/renderer/components/workloads-pods/pod-details-container-metrics.tsx
+++ b/packages/core/src/renderer/components/workloads-pods/pod-details-container-metrics.tsx
@@ -48,6 +48,6 @@ const NonInjectedPodDetailsContainerMetrics = observer(({ pod, container, podCon
 export const PodDetailsContainerMetrics = withInjectables<Dependencies, ContainerMetricsProps>(NonInjectedPodDetailsContainerMetrics, {
   getProps: (di, props) => ({
     ...props,
-    podContainerMetrics: di.inject(podContainerMetricsInjectable, props.pod),
+    podContainerMetrics: di.inject(podContainerMetricsInjectable, { pod: props.pod, container: props.container }),
   }),
 });


### PR DESCRIPTION
Passing the `container` prop from `PodDetailsContainerMetrics` to `podContainerMetricsInjectable` so that we can query for metrics at the `container` level.

Fixes: https://github.com/lensapp/lens/issues/7854