### PR TITLE
Fix Documentation: CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Lens
 
-See [Contributing to Lens](https://docs.k8slens.dev/contributing/) documentation.
+See [Contributing to Lens](https://docs.k8slens.dev/contributing/contribute-to-lens/) documentation.


### PR DESCRIPTION
fix url typo, the original URL lead to a 404 page not found.