### PR TITLE
Setting per cluster for mountpoints in the filesystem metrics

### DIFF
--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -125,6 +125,7 @@ export interface ClusterPrometheusPreferences {
   prometheusProvider?: {
     type: string;
   };
+  filesystemMountpoints?: string;
 }
 
 /**

--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -176,6 +176,11 @@ export enum ClusterMetricsResourceType {
 }
 
 /**
+ * The default filesystem mountpoints for metrics
+ */
+export const initialFilesystemMountpoints = "/";
+
+/**
  * The default node shell image
  */
 export const initialNodeShellImage = "docker.io/alpine:3.13";

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
@@ -6,7 +6,7 @@
 import { apiPrefix } from "../../../common/vars";
 import { getRouteInjectable } from "../../router/router.injectable";
 import type { ClusterPrometheusMetadata } from "../../../common/cluster-types";
-import { ClusterMetadataKey } from "../../../common/cluster-types";
+import { ClusterMetadataKey, initialFilesystemMountpoints } from "../../../common/cluster-types";
 import type { Cluster } from "../../../common/cluster/cluster";
 import { clusterRoute } from "../../router/route";
 import { isObject } from "lodash";
@@ -69,7 +69,7 @@ const addMetricsRouteInjectable = getRouteInjectable({
       const queryParams: Partial<Record<string, string>> = Object.fromEntries(query.entries());
       const prometheusMetadata: ClusterPrometheusMetadata = {};
       const prometheusHandler = di.inject(prometheusHandlerInjectable, cluster);
-      const mountpoints = cluster.preferences.filesystemMountpoints || "/";
+      const mountpoints = cluster.preferences.filesystemMountpoints || initialFilesystemMountpoints;
 
       try {
         const { prometheusPath, provider } = await prometheusHandler.getPrometheusDetails();

--- a/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
+++ b/packages/core/src/main/routes/metrics/add-metrics-route.injectable.ts
@@ -69,6 +69,7 @@ const addMetricsRouteInjectable = getRouteInjectable({
       const queryParams: Partial<Record<string, string>> = Object.fromEntries(query.entries());
       const prometheusMetadata: ClusterPrometheusMetadata = {};
       const prometheusHandler = di.inject(prometheusHandlerInjectable, cluster);
+      const mountpoints = cluster.preferences.filesystemMountpoints || "/";
 
       try {
         const { prometheusPath, provider } = await prometheusHandler.getPrometheusDetails();
@@ -99,7 +100,7 @@ const addMetricsRouteInjectable = getRouteInjectable({
           const data = payload as Record<string, Record<string, string>>;
           const queries = object.entries(data)
             .map(([queryName, queryOpts]) => (
-              provider.getQuery(queryOpts, queryName)
+              provider.getQuery({ ...queryOpts, mountpoints }, queryName)
             ));
 
           const result = await loadMetrics(queries, cluster, prometheusPath, queryParams);

--- a/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import { observer, disposeOnUnmount } from "mobx-react";
 import type { Cluster } from "../../../common/cluster/cluster";
+import { initialFilesystemMountpoints } from "../../../common/cluster-types";
 import { SubTitle } from "../layout/sub-title";
 import type { SelectOption } from "../select";
 import { Select } from "../select";
@@ -36,6 +37,7 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
   @observable path = "";
   @observable selectedOption: ProviderValue = autoDetectPrometheus;
   @observable loading = true;
+  readonly initialFilesystemMountpoints = initialFilesystemMountpoints;
   readonly loadedOptions = observable.map<string, MetricProviderInfo>();
 
   @computed get options(): SelectOption<ProviderValue>[] {
@@ -183,7 +185,7 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
               value={this.mountpoints}
               onChange={(value) => this.mountpoints = value}
               onBlur={this.onSaveMountpoints}
-              placeholder="/"
+              placeholder={this.initialFilesystemMountpoints}
             />
             <small className="hint">
               {`A regexp for the label with the filesystem mountpoints that will create a graph for disk usage. For the root disk only use "/" and for all disks use ".*".`}

--- a/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/prometheus-setting.tsx
@@ -32,6 +32,7 @@ interface Dependencies {
 
 @observer
 class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometheusSettingProps & Dependencies> {
+  @observable mountpoints = "";
   @observable path = "";
   @observable selectedOption: ProviderValue = autoDetectPrometheus;
   @observable loading = true;
@@ -68,7 +69,7 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
   componentDidMount() {
     disposeOnUnmount(this,
       autorun(() => {
-        const { prometheus, prometheusProvider } = this.props.cluster.preferences;
+        const { prometheus, prometheusProvider, filesystemMountpoints } = this.props.cluster.preferences;
 
         if (prometheus) {
           const prefix = prometheus.prefix || "";
@@ -82,6 +83,10 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
           this.selectedOption = this.options.find(opt => opt.value === prometheusProvider.type)?.value ?? autoDetectPrometheus;
         } else {
           this.selectedOption = autoDetectPrometheus;
+        }
+
+        if (filesystemMountpoints) {
+          this.mountpoints = filesystemMountpoints;
         }
       }),
     );
@@ -120,6 +125,10 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
 
   onSavePath = () => {
     this.props.cluster.preferences.prometheus = this.parsePrometheusPath();
+  };
+
+  onSaveMountpoints = () => {
+    this.props.cluster.preferences.filesystemMountpoints = this.mountpoints;
   };
 
   render() {
@@ -165,6 +174,22 @@ class NonInjectedClusterPrometheusSetting extends React.Component<ClusterPrometh
             </section>
           </>
         )}
+        <>
+          <hr />
+          <section>
+            <SubTitle title="Filesystem mountpoints" />
+            <Input
+              theme="round-black"
+              value={this.mountpoints}
+              onChange={(value) => this.mountpoints = value}
+              onBlur={this.onSaveMountpoints}
+              placeholder="/"
+            />
+            <small className="hint">
+              {`A regexp for the label with the filesystem mountpoints that will create a graph for disk usage. For the root disk only use "/" and for all disks use ".*".`}
+            </small>
+          </section>
+        </>
       </>
     );
   }

--- a/packages/technical-features/prometheus/src/helm-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/helm-provider.injectable.ts
@@ -50,9 +50,9 @@ export const getHelmLikeQueryFor =
           case "podAllocatableCapacity":
             return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint="/"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
         }
         break;
       case "nodes":
@@ -72,9 +72,9 @@ export const getHelmLikeQueryFor =
           case "cpuAllocatableCapacity":
             return `sum(kube_node_status_allocatable{resource="cpu"}) by (node)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"}) by (node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"}) by (node)`;
         }
         break;
       case "pods":

--- a/packages/technical-features/prometheus/src/lens-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/lens-provider.injectable.ts
@@ -50,9 +50,9 @@ export const getLensLikeQueryFor =
           case "podAllocatableCapacity":
             return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint="/"}) by (kubernetes_node)`;
+            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint="/"} - node_filesystem_avail_bytes{kubernetes_node=~"${opts.nodes}", mountpoint="/"}) by (kubernetes_node)`;
+            return `sum(node_filesystem_size_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{kubernetes_node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
         }
         break;
       case "nodes":
@@ -72,9 +72,9 @@ export const getLensLikeQueryFor =
           case "cpuAllocatableCapacity":
             return `sum(kube_node_status_allocatable{resource="cpu"}) by (node)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"}) by (kubernetes_node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{mountpoint="/"}) by (kubernetes_node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"}) by (kubernetes_node)`;
         }
         break;
       case "pods":

--- a/packages/technical-features/prometheus/src/operator-provider.injectable.ts.ts
+++ b/packages/technical-features/prometheus/src/operator-provider.injectable.ts.ts
@@ -50,9 +50,9 @@ export const getOperatorLikeQueryFor =
           case "podAllocatableCapacity":
             return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"})`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"})`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"})`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"} - node_filesystem_avail_bytes{mountpoint="/"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"})`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) kube_pod_info{node=~"${opts.nodes}"})`;
         }
         break;
       case "nodes":
@@ -72,9 +72,9 @@ export const getOperatorLikeQueryFor =
           case "cpuAllocatableCapacity":
             return `sum(kube_node_status_allocatable{resource="cpu"}) by (node)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} * on (pod,namespace) group_left(node) kube_pod_info) by (node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} * on (pod,namespace) group_left(node) kube_pod_info) by (node)`;
           case "fsUsage":
-            return `sum((node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{mountpoint="/"}) * on (pod, namespace) group_left(node) kube_pod_info) by (node)`;
+            return `sum((node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"}) * on (pod, namespace) group_left(node) kube_pod_info) by (node)`;
         }
         break;
       case "pods":

--- a/packages/technical-features/prometheus/src/stacklight-provider.injectable.ts
+++ b/packages/technical-features/prometheus/src/stacklight-provider.injectable.ts
@@ -50,9 +50,9 @@ export const getStacklightLikeQueryFor =
           case "podAllocatableCapacity":
             return `sum(kube_node_status_allocatable{node=~"${opts.nodes}", resource="pods"}) by (component)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint="/"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{node=~"${opts.nodes}", mountpoint=~"${opts.mountpoints}"}) by (node)`;
         }
         break;
       case "nodes":
@@ -72,9 +72,9 @@ export const getStacklightLikeQueryFor =
           case "cpuAllocatableCapacity":
             return `sum(kube_node_status_allocatable{resource="cpu"}) by (node)`;
           case "fsSize":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"}) by (node)`;
           case "fsUsage":
-            return `sum(node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_avail_bytes{mountpoint="/"}) by (node)`;
+            return `sum(node_filesystem_size_bytes{mountpoint=~"${opts.mountpoints}"} - node_filesystem_avail_bytes{mountpoint=~"${opts.mountpoints}"}) by (node)`;
         }
         break;
       case "pods":


### PR DESCRIPTION
This is extra setting per cluster that allows to change the mountpoints in the filesystem metrics.

It is a must for a Bottlerocket EKS nodes (and possibly for COS GCP, but I didn't test it yet) because in this OS the `"/"` is a read-only small filesystem (~ 1GB) and the containers and ephemeral data on another mountpoints.

The setting:

<img width="848" alt="image" src="https://github.com/lensapp/lens/assets/174367/ed24606c-30e0-438e-bf7b-c10e82c6f0fa">

With the default value `"/"`:

<img width="703" alt="image" src="https://github.com/lensapp/lens/assets/174367/06561db1-87b6-4283-abb9-356de697ca4b">

With the changed value to `".*"`:

<img width="700" alt="image" src="https://github.com/lensapp/lens/assets/174367/c61a0260-a8cf-407e-b730-378561e16b57">

