### PR TITLE
Allow to run node shell on Bootlerocket and Windows nodes

### DIFF
--- a/packages/core/src/common/cluster-types.ts
+++ b/packages/core/src/common/cluster-types.ts
@@ -108,6 +108,7 @@ export interface ClusterPreferences extends ClusterPrometheusPreferences {
   httpsProxy?: string;
   hiddenMetrics?: string[];
   nodeShellImage?: string;
+  nodeShellWindowsImage?: string;
   imagePullSecret?: string;
   defaultNamespace?: string;
 }
@@ -177,7 +178,12 @@ export enum ClusterMetricsResourceType {
 /**
  * The default node shell image
  */
-export const initialNodeShellImage = "docker.io/alpine:3.13";
+export const initialNodeShellImage = "docker.io/library/alpine";
+
+/**
+ * The default node shell image for Windows
+ */
+export const initialNodeShellWindowsImage = "mcr.microsoft.com/powershell";
 
 /**
  * The data representing a cluster's state, for passing between main and renderer

--- a/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
+++ b/packages/core/src/main/shell-session/node-shell-session/node-shell-session.ts
@@ -99,7 +99,6 @@ export class NodeShellSession extends ShellSession {
 
     const nodeOs = node.getOperatingSystem();
     const nodeOsImage = node.getOperatingSystemImage();
-    const nodeKernelVersion = node.getKernelVersion();
 
     let image: string;
     let command: string[]; 
@@ -125,11 +124,7 @@ export class NodeShellSession extends ShellSession {
         };
         break;
       case "windows":
-        if (nodeKernelVersion) {
-          image = nodeShellImage || initialNodeShellWindowsImage;
-        } else {
-          throw new Error(`No status with kernel version for node ${this.nodeName} found`);
-        }
+        image = nodeShellImage || initialNodeShellWindowsImage;
         command = ["cmd.exe"];
         args = ["/c", "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\PowerShell\\latest\\pwsh.exe", "-nol", "-wd", "C:\\"];
         securityContext = {

--- a/packages/core/src/renderer/components/cluster-settings/node-shell-setting.tsx
+++ b/packages/core/src/renderer/components/cluster-settings/node-shell-setting.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import { Input } from "../input/input";
 import { observer } from "mobx-react";
 import { Icon } from "@k8slens/icon";
-import { initialNodeShellImage } from "../../../common/cluster-types";
+import { initialNodeShellImage, initialNodeShellWindowsImage } from "../../../common/cluster-types";
 import Gutter from "../gutter/gutter";
 
 export interface ClusterNodeShellSettingProps {
@@ -20,6 +20,7 @@ export interface ClusterNodeShellSettingProps {
 @observer
 export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSettingProps> {
   @observable nodeShellImage = this.props.cluster.preferences?.nodeShellImage || "";
+  @observable nodeShellWindowsImage = this.props.cluster.preferences?.nodeShellWindowsImage || "";
   @observable imagePullSecret = this.props.cluster.preferences?.imagePullSecret || "";
 
   constructor(props: ClusterNodeShellSettingProps) {
@@ -30,6 +31,7 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
   componentWillUnmount() {
     runInAction(() => {
       this.props.cluster.preferences.nodeShellImage = this.nodeShellImage || undefined;
+      this.props.cluster.preferences.nodeShellWindowsImage = this.nodeShellWindowsImage || undefined;
       this.props.cluster.preferences.imagePullSecret = this.imagePullSecret || undefined;
     });
   }
@@ -38,7 +40,7 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
     return (
       <>
         <section>
-          <SubTitle title="Node shell image" id="node-shell-image"/>
+          <SubTitle title="Node shell image for Linux" id="node-shell-image"/>
           <Input
             theme="round-black"
             placeholder={`Default image: ${initialNodeShellImage}`}
@@ -58,7 +60,32 @@ export class ClusterNodeShellSetting extends React.Component<ClusterNodeShellSet
             }
           />
           <small className="hint">
-            Node shell image. Used for creating node shell pod.
+            Node shell image. Used for creating node shell pod on Linux nodes.
+          </small>
+        </section>
+        <Gutter />
+        <section>
+          <SubTitle title="Node shell image for Windows" id="node-shell-windows-image"/>
+          <Input
+            theme="round-black"
+            placeholder={`Default image: ${initialNodeShellWindowsImage}`}
+            value={this.nodeShellWindowsImage}
+            onChange={value => this.nodeShellWindowsImage = value}
+            iconRight={
+              this.nodeShellWindowsImage
+                ? (
+                  <Icon
+                    smallest
+                    material="close"
+                    onClick={() => this.nodeShellWindowsImage = ""}
+                    tooltip="Reset"
+                  />
+                )
+                : undefined
+            }
+          />
+          <small className="hint">
+            Node shell image. Used for creating node shell pod on Windows nodes.
           </small>
         </section>
         <Gutter />

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -247,6 +247,14 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     );
   }
 
+  getOperatingSystemImage(): string | undefined {
+    return this.status?.nodeInfo?.osImage;
+  }
+
+  getKernelVersion(): string | undefined {
+    return this.status?.nodeInfo?.kernelVersion;
+  }
+
   isUnschedulable() {
     return this.spec.unschedulable;
   }

--- a/packages/kube-object/src/specifics/node.ts
+++ b/packages/kube-object/src/specifics/node.ts
@@ -251,10 +251,6 @@ export class Node extends KubeObject<ClusterScopedMetadata, NodeStatus, NodeSpec
     return this.status?.nodeInfo?.osImage;
   }
 
-  getKernelVersion(): string | undefined {
-    return this.status?.nodeInfo?.kernelVersion;
-  }
-
   isUnschedulable() {
     return this.spec.unschedulable;
   }


### PR DESCRIPTION
This is a reworked node-shell feature. It allows to run it on Bottlerocket OS and Windows nodes where there is no `sh` nor `bash` command.

Unfortunately, node-shell pods cannot be autoremoved anymore with `sleep` command. It is because now single pod is created and then `kubectl attach` is run. It is because `kubectl exec` with `nsenter` command won't work: Bottlerocket OS is SELinux hardened then `nsenter` won't have privileges to run in `kubectl exec` context.

Anyway: node-shell pods are correctly removed after the terminal is closed. 

Because Windows needs separate image, there is a separate setting now:

<img width="765" alt="image" src="https://github.com/lensapp/lens/assets/174367/226c727c-f154-49c0-8001-6cd647bea238">

Node shell for Ubuntu:

<img width="438" alt="image" src="https://github.com/lensapp/lens/assets/174367/0afc5daa-60ea-4ad3-a1a5-23061a96c6c2">

Node shell for Bottlerocket:

<img width="532" alt="image" src="https://github.com/lensapp/lens/assets/174367/776720f3-7a5d-4c91-b634-e9851d7d50df">

Node shell for Windows 2022:

<img width="639" alt="image" src="https://github.com/lensapp/lens/assets/174367/c6225d90-eeef-45a9-a22f-a1c52497a1e8">

